### PR TITLE
ci: add action workflow to valid pull request for ui/web-v2

### DIFF
--- a/.github/workflows/pr-ui-web.yaml
+++ b/.github/workflows/pr-ui-web.yaml
@@ -29,6 +29,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Set yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v3
         id: yarn-cache
         with:
@@ -53,6 +56,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Set yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v3
         id: yarn-cache
         with:
@@ -77,6 +83,9 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Set yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
       - uses: actions/cache@v3
         id: yarn-cache
         with:

--- a/.github/workflows/pr-ui-web.yaml
+++ b/.github/workflows/pr-ui-web.yaml
@@ -1,0 +1,108 @@
+name: pr-ui-web
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "ui/web-v2/**"
+      - "!**/**.md"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: 16
+  PROTOC_VERSION: 3.18.1
+  BUILDIFIER_VERSION: 5.1.0
+  WEB_DIRECTORY: "ui/web-v2"
+
+jobs:
+  install-dependencies:
+    defaults:
+      run:
+        working-directory: ${{ env.WEB_DIRECTORY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            **/node_modules
+            **/.eslintcache
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: make install
+
+  lint:
+    needs: install-dependencies
+    defaults:
+      run:
+        working-directory: ${{ env.WEB_DIRECTORY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            **/node_modules
+            **/.eslintcache
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Lint
+        run: make lint
+
+  build:
+    needs: install-dependencies
+    defaults:
+      run:
+        working-directory: ${{ env.WEB_DIRECTORY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - uses: actions/cache@v3
+        id: yarn-cache
+        with:
+          path: |
+            **/node_modules
+            **/.eslintcache
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: ${{ env.PROTOC_VERSION }}
+      - name: Generate proto files
+        run: make gen_proto
+      - name: Build
+        run: make build
+
+  buildifier-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check Bazel file formatting
+        uses: thompsonja/bazel-buildifier@v0.4.0
+        with:
+          warnings: -function-docstring,-function-docstring-header,-function-docstring-args,-function-docstring-return,-module-docstring,-skylark-docstring,-rule-impl-return
+          buildifier_version: ${{ env.BUILDIFIER_VERSION }}
+          excludes: ${{ env.WEB_DIRECTORY }}/node_modules

--- a/ui/web-v2/Makefile
+++ b/ui/web-v2/Makefile
@@ -1,3 +1,6 @@
+.PHONY: all
+all: install buildifier-check lint gen_proto build
+
 ####################################
 # Yarn
 ####################################
@@ -17,6 +20,18 @@ start:
 .PHONY: lint
 lint:
 	yarn lint
+
+####################################
+# Bazel
+####################################
+
+.PHONY: buildifier
+buildifier-fix:
+	bazelisk run //:buildifier-fix
+
+.PHONY: buildifier-check
+buildifier-check:
+	bazelisk run //:buildifier-check
 
 ####################################
 # Generate proto definition files


### PR DESCRIPTION
The current CI for the `ui/web-v2` pull request runs on the Argo workflow. Because the CI website is for internal use only, I'm migrating it from Argo to GitHub Actions so everyone can see the result logs.

Results from the action workflow.
https://github.com/bucketeer-io/bucketeer/actions/runs/3172891781