### PR TITLE
ci: add the CLA job for contributors to sign it

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,27 @@
+name: cla
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  sign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == '/cla sign') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@b3bbab0a75fa27270069933cec6f369c0b373b4e #v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}
+        with:
+          remote-organization-name: bucketeer-io
+          remote-repository-name: bucketeer-cla
+          path-to-signatures: 'cla/signatures.json'
+          custom-notsigned-prcomment: "Welcome!\nThanks for your contributing. It looks like this is your first PR to this repository 🎉. Before we can look at your pull request, you'll need to sign a Contributor License Agreement (CLA). Please read the [CLA](https://github.com/bucketeer-io/bucketeer/blob/main/CLA.md) and leave a below comment on this pull request to sign the CLA."
+          custom-pr-sign-comment: '/cla sign'
+          custom-allsigned-prcomment: 'All Contributors have signed the CLA.'
+          lock-pullrequest-aftermerge: false
+          branch: 'main'
+          allowlist: github-actions

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -19,7 +19,7 @@ jobs:
           remote-organization-name: bucketeer-io
           remote-repository-name: bucketeer-cla
           path-to-signatures: 'cla/signatures.json'
-          custom-notsigned-prcomment: "Welcome!\nThanks for your contributing. It looks like this is your first PR to this repository 🎉. Before we can look at your pull request, you'll need to sign a Contributor License Agreement (CLA). Please read the [CLA](https://github.com/bucketeer-io/bucketeer/blob/main/CLA.md) and leave a below comment on this pull request to sign the CLA."
+          custom-notsigned-prcomment: "Welcome!\nThanks for your contribution. It looks like this is your first PR to this repository 🎉. Before we can look at your pull request, you'll need to sign a Contributor License Agreement (CLA). Please read the [CLA](https://github.com/bucketeer-io/bucketeer/blob/main/CLA.md) and leave a below comment on this pull request to sign the CLA."
           custom-pr-sign-comment: '/cla sign'
           custom-allsigned-prcomment: 'All Contributors have signed the CLA.'
           lock-pullrequest-aftermerge: false


### PR DESCRIPTION
This makes it possible to sign the CLA for all contributors before merging a PR.

Before merging this PR, there are two requirements the followings.
- [x] Create a repository to store a user's sign, like `bucketeer-cla` as a private repository.
- [x] Create an Actions Secret `CLA_PAT`, which has the write permission of this repository and the above repository. For more detail, please see [here](https://github.com/contributor-assistant/github-action#6-adding-personal-access-token-as-a-secret).
