### PR TITLE
ci: use a sha as an action's ref instead of a release tag

### DIFF
--- a/.github/workflows/pr-title-validation.yaml
+++ b/.github/workflows/pr-title-validation.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v4
+      - uses: amannn/action-semantic-pull-request@505e44b4f33b4c801f063838b3f053990ee46ea7 #v4.6.0
         with:
           # Use the following release types to match the same rules in the PR title lint
           # https://github.com/googleapis/release-please/blob/main/src/changelog-notes.ts#L42-L55

--- a/.github/workflows/publish_chart.yaml
+++ b/.github/workflows/publish_chart.yaml
@@ -55,7 +55,7 @@ jobs:
             echo "BUCKETEER_VERSION=$(git describe --tags --always --abbrev=7)" >> $GITHUB_ENV
           fi
       - name: Install helm
-        uses: Azure/setup-helm@v1
+        uses: Azure/setup-helm@18bc76811624f360dbd7f18c2d4ecb32c7b87bab #v1
         with:
           version: ${{ env.HELM_VERSION }}
       - name: Login to OCI using Helm

--- a/.github/workflows/publish_chart.yaml
+++ b/.github/workflows/publish_chart.yaml
@@ -40,7 +40,7 @@ jobs:
           # Because the version is based on the tag, if the publish_chart starts before
           # the release workflow, it will create a chart with an old version.
       - name: Wait for release note to succeed
-        uses: lewagon/wait-on-check-action@v1.0.0
+        uses: lewagon/wait-on-check-action@0179dfc359f90a703c41240506f998ee1603f9ea #v1.0.0
         with:
           ref: ${{ github.ref }}
           # DO NOT CHANGE the check-name. This name is based on the workflow name defined in the release.yaml


### PR DESCRIPTION
This is a just suggestion to be more secure.

This might be helpful when a release tag is overridden or deleted suddenly, especially for un-official actions.
And I also highly recommend configuring `Actions permissions` to allow all actions that this project wanna use explicitly if you have not configured it yet.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#allowing-select-actions-and-reusable-workflows-to-run