### PR TITLE
fix: json cannot unmarshal array while trying to create a feature flag

### DIFF
--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -478,9 +478,11 @@ func validateVariation(variationType feature.Feature_VariationType, value string
 		}
 	case feature.Feature_JSON:
 		var js map[string]interface{}
-		if json.Unmarshal([]byte(value), &js) != nil {
-			return errVariationTypeUnmatched
+		var jsArray []interface{}
+		if json.Unmarshal([]byte(value), &js) == nil || json.Unmarshal([]byte(value), &jsArray) == nil {
+			return nil
 		}
+		return errVariationTypeUnmatched
 	}
 	return nil
 }

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -1624,6 +1624,11 @@ func TestValidateVariation(t *testing.T) {
 			value:         `{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}`,
 			expected:      nil,
 		},
+		"valid json array": {
+			variationType: feature.Feature_JSON,
+			value:         `[{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}]`,
+			expected:      nil,
+		},
 		"valid string": {
 			variationType: feature.Feature_STRING,
 			value:         `{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}`,


### PR DESCRIPTION
When the feature flag type is JSON, and the JSON value is an array, it fails because it tries to unmarshal into a map.