### PR TITLE
ci: fix ci-ui-web not building ui/web-v2

### DIFF
--- a/.github/workflows/pr-ui-web.yaml
+++ b/.github/workflows/pr-ui-web.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Generate proto files
         run: make gen_proto
       - name: Build
-        run: make build
+        run: make build-ui-web-v2
 
   buildifier-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I replace `make build` to `make build-ui-web-v2` because it doesn't build /ui/web-v2.
