### PR TITLE
build: remove go_embed_data rule

### DIFF
--- a/pkg/locale/BUILD.bazel
+++ b/pkg/locale/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-load("@io_bazel_rules_go//extras:embed_data.bzl", "go_embed_data")
 
 go_library(
     name = "go_default_library",
@@ -7,8 +6,8 @@ go_library(
         "locale.go",
         "localizer.go",
         "options.go",
-        ":embed",  # keep
     ],
+    embedsrcs = glob(["localizedata/*.yaml"]),
     importpath = "github.com/bucketeer-io/bucketeer/pkg/locale",
     visibility = ["//visibility:public"],
     deps = [
@@ -16,14 +15,6 @@ go_library(
         "@in_gopkg_yaml_v2//:go_default_library",
         "@org_golang_x_text//language:go_default_library",
     ],
-)
-
-go_embed_data(
-    name = "embed",
-    srcs = glob(["localizedata/*.yaml"]),
-    flatten = True,
-    package = "locale",
-    visibility = ["//visibility:public"],
 )
 
 go_test(

--- a/pkg/locale/localizer.go
+++ b/pkg/locale/localizer.go
@@ -15,6 +15,7 @@
 package locale
 
 import (
+	"embed"
 	"fmt"
 	"strconv"
 
@@ -25,6 +26,9 @@ import (
 
 var (
 	bundle *i18n.Bundle
+
+	//go:embed localizedata
+	localizedata embed.FS
 )
 
 const (
@@ -43,9 +47,8 @@ func init() {
 		"ja.yaml",
 	}
 	for _, f := range files {
-		//nolint:typecheck
-		data, ok := Data[f]
-		if !ok {
+		data, err := localizedata.ReadFile(fmt.Sprintf("localizedata/%s", f))
+		if err != nil {
 			panic(fmt.Errorf("Failed to load translation data: %s", f))
 		}
 		bundle.MustParseMessageFileBytes(data, f)


### PR DESCRIPTION
- Removed `go_embed_data` rule from `pkg/locale/BUILD.bazel`.
- Introduced //go:embed to read files instead.
  - We need //go:embed to replace Bazel with `go build`.
- Even if this PR is merged, it can be still built with both `bazelisk` and `go build`.