### PR TITLE
build: add go build,test commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .artifacts
+/bin
 /build
 /bazel-bin
 /bazel-bucketeer

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,18 @@ endif
 DELETED_PACKAGES := //proto/external/googleapis/googleapis/83e756a66b80b072bd234abcfe89edf459090974/google/rpc,//proto/external/protocolbuffers/protobuf/v3.18.1/google/protobuf
 LOCAL_IMPORT_PATH := github.com/bucketeer-io/bucketeer
 
+# go applications
+GO_APP_DIRS := $(wildcard cmd/*)
+GO_APP_BUILD_TARGETS := $(addprefix build-,$(notdir $(GO_APP_DIRS)))
+
+ifndef GOOS
+	GOOS := $(shell go env GOOS)
+endif
+
+ifndef GOARCH
+	GOARCH=$(shell go env GOARCH)
+endif
+
 #############################
 # All
 #############################
@@ -137,6 +149,19 @@ diff-check:
 .PHONY: tidy-deps
 tidy-deps:
 	go mod tidy
+
+.PHONY: $(GO_APP_BUILD_TARGETS)
+$(GO_APP_BUILD_TARGETS): build-%:
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) \
+		go build -ldflags "-s -w" \
+		-o bin/$* -mod=vendor cmd/$*/$*.go
+
+.PHONY: build-go-apps
+build-go-apps: $(GO_APP_BUILD_TARGETS)
+
+.PHONY: test-go-apps
+test-go-apps:
+	TZ=UTC CGO_ENABLED=0 go test -v ./pkg/...
 
 #############################
 # UI/WEB

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ ifndef GOOS
 endif
 
 ifndef GOARCH
-	GOARCH=$(shell go env GOARCH)
+	GOARCH := $(shell go env GOARCH)
 endif
 
 #############################
@@ -156,11 +156,11 @@ $(GO_APP_BUILD_TARGETS): build-%:
 		go build -ldflags "-s -w" \
 		-o bin/$* -mod=vendor cmd/$*/$*.go
 
-.PHONY: build-go-apps
-build-go-apps: $(GO_APP_BUILD_TARGETS)
+.PHONY: build-go
+build-go: $(GO_APP_BUILD_TARGETS)
 
-.PHONY: test-go-apps
-test-go-apps:
+.PHONY: test-go
+test-go:
 	TZ=UTC CGO_ENABLED=0 go test -v ./pkg/...
 
 #############################


### PR DESCRIPTION
- added `go build` and `go test` commands to Makefile.
- `make build-go-apps` creates the executable files (such as `account`, `auditlog`, ... ) in `./bin` directory. 



