### PR TITLE
build: fix not found error while generating proto web files

### DIFF
--- a/.github/workflows/pr-ui-web.yaml
+++ b/.github/workflows/pr-ui-web.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: Generate proto files
         run: make gen_proto
       - name: Build
-        run: make build-ui-web-v2
+        run: make build
 
   buildifier-check:
     runs-on: ubuntu-latest

--- a/ui/web-v2/Makefile
+++ b/ui/web-v2/Makefile
@@ -51,7 +51,7 @@ gen_proto: clean_proto
 	--ts_out=service=grpc-web:$(SRC_DIR) \
 	-I $(ROOT_DIR) \
 	-I $(PROTOBUF_INCLUDE_DIR) \
-	$(shell find $(ROOT_DIR)/proto -type f -name "*.proto" -not -path "**/gateway/*.proto" -not -path "**/google/protobuf/*.proto")
+	$(shell find $(ROOT_DIR)/proto -type f -name "*.proto" -not -path "**/gateway/*.proto" -not -path "**/google/protobuf/*.proto" -not -path "**/google/api/*.proto")
 
 .PHONY: clean_proto
 clean_proto:


### PR DESCRIPTION
Because I added the [external](https://github.com/bucketeer-io/bucketeer/pull/25) `google/api` import files, the CI for the web was failing.