### PR TITLE
chore: add sdk version property to proto metrics events

### DIFF
--- a/proto/event/client/event.proto
+++ b/proto/event/client/event.proto
@@ -41,6 +41,7 @@ message EvaluationEvent {
   bucketeer.feature.Reason reason = 7;
   string tag = 8;
   SourceId source_id = 9;
+  string sdk_version = 10;
 }
 
 message GoalEvent {
@@ -52,6 +53,7 @@ message GoalEvent {
   repeated bucketeer.feature.Evaluation evaluations = 6 [deprecated = true];
   string tag = 7;
   SourceId source_id = 8;
+  string sdk_version = 9;
 }
 
 enum SourceId {
@@ -67,6 +69,7 @@ enum SourceId {
 message MetricsEvent {
   int64 timestamp = 1;
   google.protobuf.Any event = 2;
+  string sdk_version = 3;
 }
 
 message GetEvaluationLatencyMetricsEvent {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -3697,6 +3697,11 @@
                 "id": 9,
                 "name": "source_id",
                 "type": "SourceId"
+              },
+              {
+                "id": 10,
+                "name": "sdk_version",
+                "type": "string"
               }
             ]
           },
@@ -3749,6 +3754,11 @@
                 "id": 8,
                 "name": "source_id",
                 "type": "SourceId"
+              },
+              {
+                "id": 9,
+                "name": "sdk_version",
+                "type": "string"
               }
             ]
           },
@@ -3764,6 +3774,11 @@
                 "id": 2,
                 "name": "event",
                 "type": "google.protobuf.Any"
+              },
+              {
+                "id": 3,
+                "name": "sdk_version",
+                "type": "string"
               }
             ]
           },


### PR DESCRIPTION
I'm adding `sdk_version` to the proto message so we can monitor the metrics by version instead of all SDKs.