### PR TITLE
chore: add metadata property to proto client events

### DIFF
--- a/proto/event/client/event.proto
+++ b/proto/event/client/event.proto
@@ -42,6 +42,7 @@ message EvaluationEvent {
   string tag = 8;
   SourceId source_id = 9;
   string sdk_version = 10;
+  map<string, string> metadata = 11;
 }
 
 message GoalEvent {
@@ -54,6 +55,7 @@ message GoalEvent {
   string tag = 7;
   SourceId source_id = 8;
   string sdk_version = 9;
+  map<string, string> metadata = 10;
 }
 
 enum SourceId {

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -3703,6 +3703,16 @@
                 "name": "sdk_version",
                 "type": "string"
               }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 11,
+                  "name": "metadata",
+                  "type": "string"
+                }
+              }
             ]
           },
           {
@@ -3759,6 +3769,16 @@
                 "id": 9,
                 "name": "sdk_version",
                 "type": "string"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 10,
+                  "name": "metadata",
+                  "type": "string"
+                }
               }
             ]
           },


### PR DESCRIPTION
I'm adding the metadata property to gather additional information from the client and server SDK to improve data analysis.
This will deliver to Kafka to ingest into Druid.

### Kafka

- [EvaluationEvent](https://github.com/bucketeer-io/bucketeer/blob/main/pkg/eventpersister/persister/persister.go#L336-L363)
- [GoalEvent](https://github.com/bucketeer-io/bucketeer/blob/main/pkg/eventpersister/persister/persister.go#L365-L412)
