### PR TITLE
chore: remove whitespaces from the tag before upserting it

### DIFF
--- a/pkg/feature/api/tag.go
+++ b/pkg/feature/api/tag.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -136,10 +137,11 @@ func (s *FeatureService) upsertTags(
 ) error {
 	tagStorage := v2fs.NewTagStorage(tx)
 	for _, tag := range tags {
-		if tag == "" {
+		trimed := strings.TrimSpace(tag)
+		if trimed == "" {
 			continue
 		}
-		t := domain.NewTag(tag)
+		t := domain.NewTag(trimed)
 		if err := tagStorage.UpsertTag(ctx, t, environmentNamespace); err != nil {
 			s.logger.Error(
 				"Failed to store tag",

--- a/pkg/feature/api/tag_test.go
+++ b/pkg/feature/api/tag_test.go
@@ -118,11 +118,13 @@ func TestUpsertTags(t *testing.T) {
 	internalErr := errors.New("test")
 	patterns := []struct {
 		desc        string
+		tags        []string
 		setup       func(*mysqlmock.MockTransaction)
 		expectedErr error
 	}{
 		{
 			desc: "error: internal error when creating tag",
+			tags: []string{"tag"},
 			setup: func(mt *mysqlmock.MockTransaction) {
 				mt.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
@@ -131,7 +133,13 @@ func TestUpsertTags(t *testing.T) {
 			expectedErr: internalErr,
 		},
 		{
+			desc:        "success: tag consisting only of whitespace is not be inserted into DB",
+			tags:        []string{" "},
+			expectedErr: nil,
+		},
+		{
 			desc: "success: create new tag",
+			tags: []string{"tag"},
 			setup: func(mt *mysqlmock.MockTransaction) {
 				mt.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
@@ -143,9 +151,11 @@ func TestUpsertTags(t *testing.T) {
 
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			p.setup(transaction)
-			err := service.upsertTags(ctx, transaction, []string{"tag"}, environmentNamespace)
-			assert.Equal(t, p.expectedErr, err, p.desc)
+			if p.setup != nil {
+				p.setup(transaction)
+			}
+			err := service.upsertTags(ctx, transaction, p.tags, environmentNamespace)
+			assert.Equal(t, p.expectedErr, err)
 		})
 	}
 }

--- a/pkg/feature/api/tag_test.go
+++ b/pkg/feature/api/tag_test.go
@@ -133,7 +133,7 @@ func TestUpsertTags(t *testing.T) {
 			expectedErr: internalErr,
 		},
 		{
-			desc:        "success: tag consisting only of whitespace is not be inserted into DB",
+			desc:        "success: tag with whitespaces",
 			tags:        []string{" "},
 			expectedErr: nil,
 		},


### PR DESCRIPTION
Currently, bucketeer server accepts tag consisting only of whitespace such as `"     "`. This PR fixes it.