### PR TITLE
refactor: do not use localizedError

### DIFF
--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -96,7 +96,8 @@ func (s *auditlogService) ListAuditLogs(
 	ctx context.Context,
 	req *proto.ListAuditLogsRequest,
 ) (*proto.ListAuditLogsResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +261,8 @@ func (s *auditlogService) ListFeatureHistory(
 	ctx context.Context,
 	req *proto.ListFeatureHistoryRequest,
 ) (*proto.ListFeatureHistoryResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -346,6 +348,7 @@ func (s *auditlogService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -114,7 +114,8 @@ func (s *AutoOpsService) CreateAutoOpsRule(
 	ctx context.Context,
 	req *autoopsproto.CreateAutoOpsRuleRequest,
 ) (*autoopsproto.CreateAutoOpsRuleResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +300,8 @@ func (s *AutoOpsService) DeleteAutoOpsRule(
 	ctx context.Context,
 	req *autoopsproto.DeleteAutoOpsRuleRequest,
 ) (*autoopsproto.DeleteAutoOpsRuleResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -358,7 +360,8 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 	ctx context.Context,
 	req *autoopsproto.UpdateAutoOpsRuleRequest,
 ) (*autoopsproto.UpdateAutoOpsRuleResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -553,7 +556,8 @@ func (s *AutoOpsService) GetAutoOpsRule(
 	ctx context.Context,
 	req *autoopsproto.GetAutoOpsRuleRequest,
 ) (*autoopsproto.GetAutoOpsRuleResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -587,7 +591,8 @@ func (s *AutoOpsService) ListAutoOpsRules(
 	ctx context.Context,
 	req *autoopsproto.ListAutoOpsRulesRequest,
 ) (*autoopsproto.ListAutoOpsRulesResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -657,7 +662,8 @@ func (s *AutoOpsService) ExecuteAutoOps(
 	ctx context.Context,
 	req *autoopsproto.ExecuteAutoOpsRequest,
 ) (*autoopsproto.ExecuteAutoOpsResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -725,7 +731,8 @@ func (s *AutoOpsService) ListOpsCounts(
 	ctx context.Context,
 	req *autoopsproto.ListOpsCountsRequest,
 ) (*autoopsproto.ListOpsCountsResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -836,6 +843,7 @@ func (s *AutoOpsService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/autoops/api/webhook.go
+++ b/pkg/autoops/api/webhook.go
@@ -43,11 +43,11 @@ func (s *AutoOpsService) CreateWebhook(
 	ctx context.Context,
 	req *autoopspb.CreateWebhookRequest,
 ) (*autoopspb.CreateWebhookResponse, error) {
-	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
-	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	status, err := validateCreateWebhook(req, localizer)
 	if err != nil {
 		return nil, s.reportInternalServerError(ctx, err, req.EnvironmentNamespace, localizer)
@@ -161,11 +161,11 @@ func (s *AutoOpsService) GetWebhook(
 	ctx context.Context,
 	req *autoopspb.GetWebhookRequest,
 ) (*autoopspb.GetWebhookResponse, error) {
-	_, err := s.checkRole(ctx, accountpb.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountpb.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
-	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	status, err := validateGetWebhookRequest(req, localizer)
 	if err != nil {
 		return nil, s.reportInternalServerError(ctx, err, req.EnvironmentNamespace, localizer)
@@ -230,11 +230,11 @@ func (s *AutoOpsService) ListWebhooks(
 	ctx context.Context,
 	req *autoopspb.ListWebhooksRequest,
 ) (*autoopspb.ListWebhooksResponse, error) {
-	_, err := s.checkRole(ctx, accountpb.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountpb.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
-	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	whereParts := []mysql.WherePart{
 		mysql.NewFilter("environment_namespace", "=", req.EnvironmentNamespace),
 	}
@@ -328,11 +328,11 @@ func (s *AutoOpsService) UpdateWebhook(
 	ctx context.Context,
 	req *autoopspb.UpdateWebhookRequest,
 ) (*autoopspb.UpdateWebhookResponse, error) {
-	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
-	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	status, err := validateUpdateWebhookRequest(req, localizer)
 	if err != nil {
 		return nil, s.reportInternalServerError(ctx, err, req.EnvironmentNamespace, localizer)
@@ -430,11 +430,11 @@ func (s *AutoOpsService) DeleteWebhook(
 	ctx context.Context,
 	req *autoopspb.DeleteWebhookRequest,
 ) (*autoopspb.DeleteWebhookResponse, error) {
-	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
-	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	status, err := validateDeleteWebhookRequest(req, localizer)
 	if err != nil {
 		return nil, s.reportInternalServerError(ctx, err, req.EnvironmentNamespace, localizer)

--- a/pkg/eventcounter/api/api.go
+++ b/pkg/eventcounter/api/api.go
@@ -90,7 +90,8 @@ func (s *eventCounterService) GetEvaluationCountV2(
 	ctx context.Context,
 	req *ecproto.GetEvaluationCountV2Request,
 ) (*ecproto.GetEvaluationCountV2Response, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -214,7 +215,8 @@ func (s *eventCounterService) GetEvaluationTimeseriesCount(
 	ctx context.Context,
 	req *ecproto.GetEvaluationTimeseriesCountRequest,
 ) (*ecproto.GetEvaluationTimeseriesCountResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +288,8 @@ func (s *eventCounterService) GetExperimentResult(
 	ctx context.Context,
 	req *ecproto.GetExperimentResultRequest,
 ) (*ecproto.GetExperimentResultResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -317,7 +320,8 @@ func (s *eventCounterService) ListExperimentResults(
 	ctx context.Context,
 	req *ecproto.ListExperimentResultsRequest,
 ) (*ecproto.ListExperimentResultsResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -400,7 +404,8 @@ func (s *eventCounterService) GetGoalCount(
 	ctx context.Context,
 	req *ecproto.GetGoalCountRequest,
 ) (*ecproto.GetGoalCountResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -462,7 +467,8 @@ func (s *eventCounterService) GetGoalCountV2(
 	ctx context.Context,
 	req *ecproto.GetGoalCountV2Request,
 ) (*ecproto.GetGoalCountV2Response, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -528,7 +534,8 @@ func (s *eventCounterService) GetUserCountV2(
 	ctx context.Context,
 	req *ecproto.GetUserCountV2Request,
 ) (*ecproto.GetUserCountV2Response, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -588,7 +595,8 @@ func (s *eventCounterService) ListUserMetadata(
 	ctx context.Context,
 	req *ecproto.ListUserMetadataRequest,
 ) (*ecproto.ListUserMetadataResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -631,6 +639,7 @@ func (s *eventCounterService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/experiment/api/api.go
+++ b/pkg/experiment/api/api.go
@@ -87,6 +87,7 @@ func (s *experimentService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/experiment/api/experiment.go
+++ b/pkg/experiment/api/experiment.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -43,7 +44,8 @@ func (s *experimentService) GetExperiment(
 	ctx context.Context,
 	req *proto.GetExperimentRequest,
 ) (*proto.GetExperimentResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +76,8 @@ func (s *experimentService) ListExperiments(
 	ctx context.Context,
 	req *proto.ListExperimentsRequest,
 ) (*proto.ListExperimentsResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +184,8 @@ func (s *experimentService) CreateExperiment(
 	ctx context.Context,
 	req *proto.CreateExperimentRequest,
 ) (*proto.CreateExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +315,8 @@ func (s *experimentService) UpdateExperiment(
 	ctx context.Context,
 	req *proto.UpdateExperimentRequest,
 ) (*proto.UpdateExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -414,14 +419,15 @@ func (s *experimentService) StartExperiment(
 	ctx context.Context,
 	req *proto.StartExperimentRequest,
 ) (*proto.StartExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateStartExperimentRequest(req); err != nil {
 		return nil, err
 	}
-	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace, localizer); err != nil {
 		return nil, err
 	}
 	return &proto.StartExperimentResponse{}, nil
@@ -441,14 +447,15 @@ func (s *experimentService) FinishExperiment(
 	ctx context.Context,
 	req *proto.FinishExperimentRequest,
 ) (*proto.FinishExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateFinishExperimentRequest(req); err != nil {
 		return nil, err
 	}
-	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace, localizer); err != nil {
 		return nil, err
 	}
 	return &proto.FinishExperimentResponse{}, nil
@@ -468,14 +475,15 @@ func (s *experimentService) StopExperiment(
 	ctx context.Context,
 	req *proto.StopExperimentRequest,
 ) (*proto.StopExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateStopExperimentRequest(req); err != nil {
 		return nil, err
 	}
-	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace, localizer); err != nil {
 		return nil, err
 	}
 	return &proto.StopExperimentResponse{}, nil
@@ -495,7 +503,8 @@ func (s *experimentService) ArchiveExperiment(
 	ctx context.Context,
 	req *proto.ArchiveExperimentRequest,
 ) (*proto.ArchiveExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -511,6 +520,7 @@ func (s *experimentService) ArchiveExperiment(
 		req.Command,
 		req.Id,
 		req.EnvironmentNamespace,
+		localizer,
 	)
 	if err != nil {
 		s.logger.Error(
@@ -529,14 +539,15 @@ func (s *experimentService) DeleteExperiment(
 	ctx context.Context,
 	req *proto.DeleteExperimentRequest,
 ) (*proto.DeleteExperimentResponse, error) {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
 	if err := validateDeleteExperimentRequest(req); err != nil {
 		return nil, err
 	}
-	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	if err := s.updateExperiment(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace, localizer); err != nil {
 		return nil, err
 	}
 	return &proto.DeleteExperimentResponse{}, nil
@@ -557,6 +568,7 @@ func (s *experimentService) updateExperiment(
 	editor *eventproto.Editor,
 	cmd command.Command,
 	id, environmentNamespace string,
+	localizer locale.Localizer,
 ) error {
 	tx, err := s.mysqlClient.BeginTx(ctx)
 	if err != nil {
@@ -566,7 +578,14 @@ func (s *experimentService) updateExperiment(
 				zap.Error(err),
 			)...,
 		)
-		return localizedError(statusInternal, locale.JaJP)
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return statusInternal.Err()
+		}
+		return dt.Err()
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		experimentStorage := v2es.NewExperimentStorage(tx)
@@ -605,7 +624,14 @@ func (s *experimentService) updateExperiment(
 				zap.String("environmentNamespace", environmentNamespace),
 			)...,
 		)
-		return localizedError(statusInternal, locale.JaJP)
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return statusInternal.Err()
+		}
+		return dt.Err()
 	}
 	return nil
 }

--- a/pkg/feature/api/api.go
+++ b/pkg/feature/api/api.go
@@ -104,6 +104,7 @@ func (s *FeatureService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -382,6 +382,7 @@ func TestSetFeatureToLastUsedInfosByChunk(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	patterns := []struct {
 		setup                func(*FeatureService)
 		input                []*featureproto.Feature
@@ -411,13 +412,14 @@ func TestSetFeatureToLastUsedInfosByChunk(t *testing.T) {
 	for _, p := range patterns {
 		fs := createFeatureServiceNew(mockController)
 		p.setup(fs)
-		err := fs.setLastUsedInfosToFeatureByChunk(context.Background(), p.input, p.environmentNamespace)
+		err := fs.setLastUsedInfosToFeatureByChunk(context.Background(), p.input, p.environmentNamespace, localizer)
 		assert.Equal(t, p.expected, err)
 	}
 }
 
 func TestConvUpdateFeatureError(t *testing.T) {
 	t.Parallel()
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	patterns := []struct {
 		input       error
 		expectedErr error
@@ -449,7 +451,7 @@ func TestConvUpdateFeatureError(t *testing.T) {
 	}
 	for _, p := range patterns {
 		fs := &FeatureService{}
-		err := fs.convUpdateFeatureError(p.input)
+		err := fs.convUpdateFeatureError(p.input, localizer)
 		assert.Equal(t, p.expectedErr, err)
 	}
 }
@@ -2475,6 +2477,7 @@ func TestValidateFeatureVariationsCommand(t *testing.T) {
 
 func TestValidateAddPrerequisite(t *testing.T) {
 	t.Parallel()
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	fID0 := "fID-0"
 	fID1 := "fID-1"
 	fID2 := "fID-2"
@@ -2753,7 +2756,7 @@ func TestValidateAddPrerequisite(t *testing.T) {
 		},
 	}
 	for _, p := range pattens {
-		err := validateAddPrerequisite(p.fs, p.fs[0], p.prerequisite)
+		err := validateAddPrerequisite(p.fs, p.fs[0], p.prerequisite, localizer)
 		assert.Equal(t, p.expectedErr, err)
 	}
 }

--- a/pkg/feature/api/tag.go
+++ b/pkg/feature/api/tag.go
@@ -34,11 +34,11 @@ func (s *FeatureService) ListTags(
 	ctx context.Context,
 	req *featureproto.ListTagsRequest,
 ) (*featureproto.ListTagsResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
-	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	whereParts := []mysql.WherePart{
 		mysql.NewFilter("environment_namespace", "=", req.EnvironmentNamespace),
 	}

--- a/pkg/feature/api/user_evaluations.go
+++ b/pkg/feature/api/user_evaluations.go
@@ -29,7 +29,8 @@ func (s *FeatureService) GetUserEvaluations(
 	ctx context.Context,
 	req *featureproto.GetUserEvaluationsRequest,
 ) (*featureproto.GetUserEvaluationsResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +64,8 @@ func (s *FeatureService) UpsertUserEvaluation(
 	ctx context.Context,
 	req *featureproto.UpsertUserEvaluationRequest,
 ) (*featureproto.UpsertUserEvaluationResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/notification/api/api.go
+++ b/pkg/notification/api/api.go
@@ -109,6 +109,7 @@ func (s *NotificationService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/user/api/api.go
+++ b/pkg/user/api/api.go
@@ -81,6 +81,7 @@ func (s *userService) checkRole(
 	ctx context.Context,
 	requiredRole accountproto.Account_Role,
 	environmentNamespace string,
+	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
 	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
 		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{

--- a/pkg/user/api/user.go
+++ b/pkg/user/api/user.go
@@ -32,7 +32,8 @@ import (
 const maxPageSizePerRequest = 50
 
 func (s *userService) GetUser(ctx context.Context, req *userproto.GetUserRequest) (*userproto.GetUserResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,8 @@ func (s *userService) ListUsers(
 	ctx context.Context,
 	req *userproto.ListUsersRequest,
 ) (*userproto.ListUsersResponse, error) {
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace)
+	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
+	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To support multiple languages in the error message, we have to stop using `localizedError`. This PR fixes one part of them.