### PR TITLE
chore: add json transcoding to track api for testing

### DIFF
--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -190,6 +190,22 @@ func (s *grpcGatewayService) Ping(ctx context.Context, req *gwproto.PingRequest)
 	return &gwproto.PingResponse{Time: time.Now().Unix()}, nil
 }
 
+func (s *grpcGatewayService) Track(ctx context.Context, req *gwproto.TrackRequest) (*gwproto.TrackResponse, error) {
+	// TODO: Implement API
+	s.logger.Info(
+		"Track API has been called",
+		log.FieldsFromImcomingContext(ctx).AddFields(
+			zap.String("apiKey", req.Apikey),
+			zap.String("userid", req.Userid),
+			zap.String("goalid", req.Goalid),
+			zap.String("tag", req.Tag),
+			zap.Int64("timestamp", req.Timestamp),
+			zap.Float64("value", req.Value),
+		)...,
+	)
+	return &gwproto.TrackResponse{}, nil
+}
+
 func (s *grpcGatewayService) GetEvaluations(
 	ctx context.Context,
 	req *gwproto.GetEvaluationsRequest,

--- a/proto/gateway/service.proto
+++ b/proto/gateway/service.proto
@@ -66,6 +66,17 @@ message RegisterEventsResponse {
   map<string, Error> errors = 1;
 }
 
+message TrackRequest {
+  string apikey = 1;
+  string userid = 2;
+  string goalid = 3;
+  string tag = 4;
+  int64 timestamp = 5;
+  double value = 6;
+}
+
+message TrackResponse {}
+
 service Gateway {
   rpc Ping(PingRequest) returns (PingResponse) {
     option (google.api.http) = {
@@ -89,6 +100,11 @@ service Gateway {
     option (google.api.http) = {
       post: "/register_events"
       body: "*"
+    };
+  }
+  rpc Track(TrackRequest) returns (TrackResponse) {
+    option (google.api.http) = {
+      get: "/track"
     };
   }
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -12400,6 +12400,44 @@
                 ]
               }
             ]
+          },
+          {
+            "name": "TrackRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "apikey",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "userid",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "goalid",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "tag",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "timestamp",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "value",
+                "type": "double"
+              }
+            ]
+          },
+          {
+            "name": "TrackResponse"
           }
         ],
         "services": [
@@ -12481,6 +12519,22 @@
                       {
                         "name": "body",
                         "value": "*"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "Track",
+                "in_type": "TrackRequest",
+                "out_type": "TrackResponse",
+                "options": [
+                  {
+                    "name": "(google.api.http)",
+                    "aggregated": [
+                      {
+                        "name": "get",
+                        "value": "/track"
                       }
                     ]
                   }


### PR DESCRIPTION
I'm adding JSON transcoding to track API for testing.
According to the google documentation, it will convert all query parameters automatically as defined in the `TrackRequest`.

Reference:
`
Any fields in the request message which are not bound by the path template automatically become HTTP query parameters if there is no HTTP request body.
`
https://cloud.google.com/endpoints/docs/grpc-service-config/reference/rpc/google.api#httprule

