### PR TITLE
chore: change grpc track api name temporarily for testing

### DIFF
--- a/proto/gateway/service.proto
+++ b/proto/gateway/service.proto
@@ -104,7 +104,7 @@ service Gateway {
   }
   rpc Track(TrackRequest) returns (TrackResponse) {
     option (google.api.http) = {
-      get: "/track"
+      get: "/track_v2"
     };
   }
 }

--- a/proto/proto.lock
+++ b/proto/proto.lock
@@ -12554,7 +12554,7 @@
                     "aggregated": [
                       {
                         "name": "get",
-                        "value": "/track"
+                        "value": "/track_v2"
                       }
                     ]
                   }


### PR DESCRIPTION
I forgot to use a different name for this because we already have the `track` API running on the HTTP server.