### PR TITLE
refactor: move extract api key calling to checkRequest func

### DIFF
--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -842,7 +842,10 @@ func (s *grpcGatewayService) checkRequest(ctx context.Context) (*accountproto.En
 	return envAPIKey, nil
 }
 
-func (s *grpcGatewayService) getEnvironmentAPIKey(ctx context.Context, apiKey string) (*accountproto.EnvironmentAPIKey, error) {
+func (s *grpcGatewayService) getEnvironmentAPIKey(
+	ctx context.Context,
+	apiKey string,
+) (*accountproto.EnvironmentAPIKey, error) {
 	k, err, _ := s.flightgroup.Do(
 		environmentAPIKeyFlightID(apiKey),
 		func() (interface{}, error) {

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -828,7 +828,11 @@ func (s *grpcGatewayService) checkRequest(ctx context.Context) (*accountproto.En
 		)
 		return nil, ErrContextCanceled
 	}
-	envAPIKey, err := s.getEnvironmentAPIKey(ctx)
+	id, err := s.extractAPIKeyID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	envAPIKey, err := s.getEnvironmentAPIKey(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -838,17 +842,13 @@ func (s *grpcGatewayService) checkRequest(ctx context.Context) (*accountproto.En
 	return envAPIKey, nil
 }
 
-func (s *grpcGatewayService) getEnvironmentAPIKey(ctx context.Context) (*accountproto.EnvironmentAPIKey, error) {
-	id, err := s.extractAPIKeyID(ctx)
-	if err != nil {
-		return nil, err
-	}
+func (s *grpcGatewayService) getEnvironmentAPIKey(ctx context.Context, apiKey string) (*accountproto.EnvironmentAPIKey, error) {
 	k, err, _ := s.flightgroup.Do(
-		environmentAPIKeyFlightID(id),
+		environmentAPIKeyFlightID(apiKey),
 		func() (interface{}, error) {
 			return getEnvironmentAPIKey(
 				ctx,
-				id,
+				apiKey,
 				s.accountClient,
 				s.environmentAPIKeyCache,
 				callerGatewayService,

--- a/pkg/gateway/api/api_grpc_test.go
+++ b/pkg/gateway/api/api_grpc_test.go
@@ -223,7 +223,9 @@ func TestGrpcGetEnvironmentAPIKey(t *testing.T) {
 	for _, p := range patterns {
 		gs := newGrpcGatewayServiceWithMock(t, mockController)
 		p.setup(gs)
-		actual, err := gs.getEnvironmentAPIKey(p.ctx)
+		id, err := gs.extractAPIKeyID(p.ctx)
+		assert.NoError(t, err)
+		actual, err := gs.getEnvironmentAPIKey(p.ctx, id)
 		assert.Equal(t, p.expected, actual, "%s", p.desc)
 		assert.Equal(t, p.expectedErr, err, "%s", p.desc)
 	}


### PR DESCRIPTION
I'm moving the `extractAPIKeyID` because the query parameter passes the API key in the Track API instead of the request header. 
So I'm refactoring the `getEnvironmentAPIKey` to work for both cases.