### PR TITLE
chore: change experiment updater cronjob settings

### DIFF
--- a/pkg/experiment/cmd/batch/batch.go
+++ b/pkg/experiment/cmd/batch/batch.go
@@ -142,7 +142,7 @@ func (b *batch) registerJobs(
 		job  job.Job
 	}{
 		{
-			cron: "0 * * * * *",
+			cron: "0,10,20,30,40,50 * * * * *",
 			name: "experiment_status_updater",
 			job: experimentjob.NewExperimentStatusUpdater(
 				environmentClient,


### PR DESCRIPTION
Since there is no cost or performance issue, by executing it every 10 seconds, I'm changing it to improve the e2e test stability.