### PR TITLE
chore: display variation name in the variation label

### DIFF
--- a/ui/web-v2/apps/admin/src/components/FeatureTargetingForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureTargetingForm/index.tsx
@@ -1,3 +1,4 @@
+import { createVariationLabel } from '@/utils/variation';
 import { MinusCircleIcon, XIcon } from '@heroicons/react/solid';
 import { SerializedError } from '@reduxjs/toolkit';
 import React, { FC, memo, useCallback, useEffect, useState } from 'react';
@@ -55,7 +56,7 @@ export const FeatureTargetingForm: FC<FeatureTargetingFormProps> = memo(
     const strategyOptions = feature.variationsList.map((v) => {
       return {
         value: v.id,
-        label: v.value,
+        label: createVariationLabel(v),
       };
     });
     strategyOptions.push({
@@ -65,7 +66,7 @@ export const FeatureTargetingForm: FC<FeatureTargetingFormProps> = memo(
     const offVariationOptions = feature.variationsList.map((v) => {
       return {
         value: v.id,
-        label: v.value,
+        label: createVariationLabel(v),
       };
     });
     const isValid = Object.keys(errors).length == 0;
@@ -98,11 +99,11 @@ export const FeatureTargetingForm: FC<FeatureTargetingFormProps> = memo(
                   return (
                     <div key={idx} className="col-span-1">
                       <label htmlFor={`${idx}`} className="input-label">
-                        {`${
+                        {createVariationLabel(
                           feature.variationsList.find(
                             (v) => v.id == t.variationId
-                          )?.value
-                        }`}
+                          )
+                        )}
                       </label>
                       <Controller
                         name={`targets.[${idx}].users`}
@@ -227,7 +228,7 @@ export const RuleInput: FC<RuleInputProps> = memo(({ feature }) => {
       strategy: {
         option: {
           value: feature.variationsList[0].id,
-          label: feature.variationsList[0].value,
+          label: createVariationLabel(feature.variationsList[0]),
         },
         rolloutStrategy: newRolloutStrategy,
       },
@@ -750,7 +751,7 @@ export const StrategyInput: FC<StrategyInputProps> = memo(
     const strategyOptions = feature.variationsList.map((v) => {
       return {
         value: v.id,
-        label: v.value,
+        label: createVariationLabel(v),
       };
     });
     strategyOptions.push({
@@ -813,7 +814,9 @@ export const StrategyInput: FC<StrategyInputProps> = memo(
                     </span>
                   </div>
                   <label className="inline-flex items-center ml-3 text-sm text-gray-700">
-                    {feature.variationsList.find((v) => v.id == s.id).value}
+                    {createVariationLabel(
+                      feature.variationsList.find((v) => v.id == s.id)
+                    )}
                   </label>
                 </div>
               );

--- a/ui/web-v2/apps/admin/src/pages/feature/targeting.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/targeting.tsx
@@ -1,3 +1,4 @@
+import { createVariationLabel } from '@/utils/variation';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { SerializedError } from '@reduxjs/toolkit';
 import deepEqual from 'deep-equal';
@@ -48,7 +49,6 @@ import {
 } from '../../proto/feature/command_pb';
 import { Feature } from '../../proto/feature/feature_pb';
 import { Rule } from '../../proto/feature/rule_pb';
-import { Segment } from '../../proto/feature/segment_pb';
 import {
   FixedStrategy,
   RolloutStrategy,
@@ -146,8 +146,9 @@ export const FeatureTargetingPage: FC<FeatureTargetingPageProps> = memo(
       ),
       offVariation: feature.offVariation && {
         value: feature.offVariation,
-        label: feature.variationsList.find((v) => v.id === feature.offVariation)
-          .value,
+        label: createVariationLabel(
+          feature.variationsList.find((v) => v.id === feature.offVariation)
+        ),
       },
     };
     const methods = useForm({
@@ -259,9 +260,9 @@ const createStrategyDefaultValue = (
       strategy.type === Strategy.Type.FIXED
         ? {
             value: strategy.fixedStrategy.variation,
-            label: variations.find(
-              (v) => v.id === strategy.fixedStrategy.variation
-            ).value,
+            label: createVariationLabel(
+              variations.find((v) => v.id === strategy.fixedStrategy.variation)
+            ),
           }
         : {
             value: Strategy.Type.ROLLOUT,

--- a/ui/web-v2/apps/admin/src/utils/variation.ts
+++ b/ui/web-v2/apps/admin/src/utils/variation.ts
@@ -1,0 +1,16 @@
+import { Variation } from '@/proto/feature/variation_pb';
+
+export const createVariationLabel = (variation: Variation.AsObject) => {
+  if (variation == null) {
+    return 'None';
+  }
+  const maxLength = 150;
+  const ellipsis = '...';
+  const label = variation.name
+    ? variation.name + ' - ' + variation.value
+    : variation.value;
+  if (label.length > maxLength) {
+    return label.slice(0, maxLength - ellipsis.length) + ellipsis;
+  }
+  return label;
+};


### PR DESCRIPTION
I'm adding the variation name in the input variation label to make it easier to understand which variation is, as a user suggested.

E.g.

```
variation_name - variation_value
```

![Screen Shot 2022-11-09 at 14 24 37](https://user-images.githubusercontent.com/2486691/200745935-44c3235d-4b14-495e-9c74-fcd9b69b36f7.png)

