### PR TITLE
chore: configure renovate for automerge and assigning reviewers

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,16 @@
     "config:base",
     ":timezone(Asia/Tokyo)",
     "schedule:monthly"
-  ]
+  ],
+  "labels": ["renovate"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true,
+      "addLabels": ["automerge by renovate"]
+    }
+  ],
+  "automergeSchedule": ["* 11 * * tue-thu"],
+  "automergeStrategy": "squash",
+  "reviewers": ["team:renovate-reviewers"]
 }


### PR DESCRIPTION
- renovate raises the PR [on the first day of the month](https://docs.renovatebot.com/presets-schedule/#schedulemonthly).
- renovate adds the label `renovate` to the PR.
- if updateType is minor, patch, pin or digest
  - renovate adds the label `automerge by renovate` to the PR.
  - renovate merges the PR automatically on Tuesday through Friday at 11 a.m. Japan time.
  - FYI: [updateType](https://github.com/renovatebot/renovate/discussions/15360)
- renovate assigns the team [renovate-reviewers](https://github.com/orgs/bucketeer-io/teams/renovate-reviewers) to review the PR by human. 
  - renovate doesn't assign a reviewer on the PR to be automerged.
  - a reviewer is selected one person from the team with a round-robin strategy.  