### PR TITLE
chore: add event counter and experiment service's envoy config in the event persister

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: BUCKETEER_EVENT_PERSISTER_PROJECT
               value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_EXPERIMENT_SERVICE
+              value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_EVENT_PERSISTER_BIGTABLE_INSTANCE

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
@@ -62,6 +62,38 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
+        - name: experiment
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: experiment
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
         - name: feature
           type: strict_dns
           connect_timeout: 5s
@@ -181,6 +213,18 @@ data:
                             - '*'
                           name: egress_services
                           routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.experiment.ExperimentService
+                              route:
+                                cluster: experiment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
                             - match:
                                 headers:
                                   - name: content-type

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/values.yaml
@@ -9,6 +9,7 @@ namespace:
 
 env:
   project:
+  experimentService: localhost:9001
   featureService: localhost:9001
   bigtableInstance:
   location: asia-northeast1

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: BUCKETEER_EVENT_PERSISTER_PROJECT
               value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_EXPERIMENT_SERVICE
+              value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_EVENT_PERSISTER_BIGTABLE_INSTANCE

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
@@ -62,6 +62,38 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
+        - name: experiment
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: experiment
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
         - name: feature
           type: strict_dns
           lb_policy: round_robin
@@ -181,6 +213,18 @@ data:
                             - '*'
                           name: egress_services
                           routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.experiment.ExperimentService
+                              route:
+                                cluster: experiment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
                             - match:
                                 headers:
                                   - name: content-type

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/values.yaml
@@ -9,6 +9,7 @@ namespace:
 
 env:
   project:
+  experimentService: localhost:9001
   featureService: localhost:9001
   bigtableInstance:
   location: asia-northeast1

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
           env:
             - name: BUCKETEER_EVENT_PERSISTER_PROJECT
               value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_EXPERIMENT_SERVICE
+              value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_EVENT_PERSISTER_BIGTABLE_INSTANCE

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
@@ -62,6 +62,38 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
+        - name: experiment
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: experiment
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
         - name: feature
           type: strict_dns
           lb_policy: round_robin
@@ -181,6 +213,18 @@ data:
                             - '*'
                           name: egress_services
                           routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.experiment.ExperimentService
+                              route:
+                                cluster: experiment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
                             - match:
                                 headers:
                                   - name: content-type

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
@@ -9,6 +9,7 @@ namespace:
 
 env:
   project:
+  experimentService: localhost:9001
   featureService: localhost:9001
   bigtableInstance:
   location: asia-northeast1


### PR DESCRIPTION
I'm adding these services as part of removing the Bigtable dependency.