### PR TITLE
chore: update eventpersister to store mau to mysql

### DIFF
--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
@@ -124,6 +124,16 @@ spec:
               value: "{{ .Values.env.postgresPort }}"
             - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_NAME
               value: "{{ .Values.env.postgresDbName }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_USER
+              value: "{{ .Values.env.mysqlUser }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_PASS
+              value: "{{ .Values.env.mysqlPass}}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_HOST
+              value: "{{ .Values.env.mysqlHost }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_PORT
+              value: "{{ .Values.env.mysqlPort }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_DBNAME
+              value: "{{ .Values.env.mysqlDbName }}"
           volumeMounts:
             - name: service-cert-secret
               mountPath: /usr/local/certs/service

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
@@ -45,6 +45,11 @@ env:
   postgresHost:
   postgresPort:
   postgresDbName:
+  mysqlUser:
+  mysqlPass:
+  mysqlHost:
+  mysqlPort: 3306
+  mysqlDbName:
 
 affinity: {}
 

--- a/manifests/bucketeer/values.yaml
+++ b/manifests/bucketeer/values.yaml
@@ -1272,6 +1272,11 @@ event-persister-user-events-kafka:
     postgresHost:
     postgresPort:
     postgresDbName:
+    mysqlUser:
+    mysqlPass:
+    mysqlHost:
+    mysqlPort: 3306
+    mysqlDbName:
 
   affinity: {}
   nodeSelector: {}

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
 	v2ec "github.com/bucketeer-io/bucketeer/pkg/eventcounter/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/eventpersister/datastore"
+	storage "github.com/bucketeer-io/bucketeer/pkg/eventpersister/storage/v2"
 	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
 	featurestorage "github.com/bucketeer-io/bucketeer/pkg/feature/storage"
 	"github.com/bucketeer-io/bucketeer/pkg/health"
@@ -36,6 +37,7 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
 	bigtable "github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigtable"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/postgres"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	esproto "github.com/bucketeer-io/bucketeer/proto/event/service"
@@ -115,6 +117,7 @@ type Persister struct {
 	cancel                func()
 	doneCh                chan struct{}
 	postgresClient        postgres.Client
+	mysqlClient           mysql.Client
 }
 
 func NewPersister(
@@ -123,6 +126,7 @@ func NewPersister(
 	ds datastore.Writer,
 	bt bigtable.Client,
 	postgresClient postgres.Client,
+	mysqlClient mysql.Client,
 	opts ...Option,
 ) *Persister {
 	dopts := &options{
@@ -151,6 +155,7 @@ func NewPersister(
 		cancel:                cancel,
 		doneCh:                make(chan struct{}),
 		postgresClient:        postgresClient,
+		mysqlClient:           mysqlClient,
 	}
 }
 
@@ -248,6 +253,18 @@ func (p *Persister) send(messages map[string]*puller.Message) {
 					)
 				}
 			}
+
+			if err := p.upsertMAU(ctx, event, environmentNamespace); err != nil {
+				p.logger.Error(
+					"failed to store a mau",
+					zap.Error(err),
+					zap.String("id", id),
+					zap.String("environmentNamespace", environmentNamespace),
+				)
+				fails[id] = false
+				continue
+			}
+
 			eventJSON, repeatable, err := p.marshalEvent(event, environmentNamespace)
 			if err != nil {
 				if !repeatable {
@@ -318,6 +335,17 @@ func (p *Persister) extractEvents(messages map[string]*puller.Message) environme
 		envEvents[event.EnvironmentNamespace] = eventMap{event.Id: innerEvent.Message}
 	}
 	return envEvents
+}
+
+func (p *Persister) upsertMAU(ctx context.Context, event proto.Message, environmentNamespace string) error {
+	if p.mysqlClient == nil {
+		return nil
+	}
+	if e, ok := event.(*esproto.UserEvent); ok {
+		s := storage.NewMysqlMAUStorage(p.mysqlClient)
+		return s.UpsertMAU(ctx, e, environmentNamespace)
+	}
+	return nil
 }
 
 func (p *Persister) marshalEvent(event interface{}, environmentNamespace string) (string, bool, error) {

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -253,7 +253,6 @@ func (p *Persister) send(messages map[string]*puller.Message) {
 					)
 				}
 			}
-
 			if err := p.upsertMAU(ctx, event, environmentNamespace); err != nil {
 				p.logger.Error(
 					"failed to store a mau",
@@ -264,7 +263,6 @@ func (p *Persister) send(messages map[string]*puller.Message) {
 				fails[id] = false
 				continue
 			}
-
 			eventJSON, repeatable, err := p.marshalEvent(event, environmentNamespace)
 			if err != nil {
 				if !repeatable {

--- a/pkg/eventpersister/storage/v2/mau.go
+++ b/pkg/eventpersister/storage/v2/mau.go
@@ -53,7 +53,6 @@ func (s *mysqlMAUStorage) UpsertMAU(ctx context.Context, event *esproto.UserEven
 		event_count = event_count + 1,
 		updated_at = VALUES(updated_at)
 	`
-
 	now := time.Now()
 	yearMonth := fmt.Sprintf("%d%d", now.Year(), now.Month())
 	_, err := s.qe.ExecContext(

--- a/pkg/eventpersister/storage/v2/mau.go
+++ b/pkg/eventpersister/storage/v2/mau.go
@@ -1,0 +1,74 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
+	esproto "github.com/bucketeer-io/bucketeer/proto/event/service"
+)
+
+type MAUStorage interface {
+	UpsertMAU(ctx context.Context, event *esproto.UserEvent, environmentNamespace string) error
+}
+
+// mysqlMAUStorage is the temporal implementation.
+// We plan to replace the mysql with the postgresql.
+type mysqlMAUStorage struct {
+	qe mysql.QueryExecer
+}
+
+func NewMysqlMAUStorage(qe mysql.QueryExecer) MAUStorage {
+	return &mysqlMAUStorage{qe: qe}
+}
+
+func (s *mysqlMAUStorage) UpsertMAU(ctx context.Context, event *esproto.UserEvent, environmentNamespace string) error {
+	query := `
+	INSERT INTO mau (
+		user_id,
+		yearmonth,
+		source_id,
+		event_count,
+		created_at,
+		updated_at,
+		environment_namespace
+	) VALUES (
+		?, ?, ?, ?, ?, ?, ?
+	) ON DUPLICATE KEY UPDATE
+		event_count = event_count + 1,
+		updated_at = VALUES(updated_at)
+	`
+
+	now := time.Now()
+	yearMonth := fmt.Sprintf("%d%d", now.Year(), now.Month())
+	_, err := s.qe.ExecContext(
+		ctx,
+		query,
+		event.UserId,
+		yearMonth,
+		event.SourceId,
+		1,
+		now.Unix(),
+		now.Unix(),
+		environmentNamespace,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/eventpersister/storage/v2/mau_test.go
+++ b/pkg/eventpersister/storage/v2/mau_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
+)
+
+func TestNewMysqlMAUStorage(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	storage := NewMysqlMAUStorage(mock.NewMockQueryExecer(mockController))
+	assert.IsType(t, &mysqlMAUStorage{}, storage)
+}


### PR DESCRIPTION
- I updated the event persister to store MAU to MySQL.
- This app works without MySQL-related environment vars.
  - `event-persister-evaluation-event` and `event-persister-goal-event` don't have to set the env vars.
- If storing to MySQL fails, storing to kafka is not executed.
