### PR TITLE
chore: remove unnecessary health check in the envoy egress settings

### DIFF
--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
@@ -222,19 +222,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                            environment:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/account/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account/templates/envoy-configmap.yaml
@@ -181,17 +181,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            environment:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
@@ -315,19 +315,6 @@ data:
                       path: /dev/stdout
                   codec_type: auto
                   http_filters:
-                    - name: envoy.filters.http.health_check
-                      typed_config:
-                        "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                        cluster_min_healthy_percentages:
-                          account:
-                            value: 25
-                          feature:
-                            value: 25
-                        pass_through_mode: false
-                        headers:
-                          - name: :path
-                            string_match:
-                              exact: /health
                     - name: envoy.filters.http.router
                   route_config:
                     virtual_hosts:

--- a/manifests/bucketeer/charts/auditlog/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auditlog/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/auth/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auth/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/auto-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auto-ops/templates/envoy-configmap.yaml
@@ -304,23 +304,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                            auth:
-                              value: 25
-                            experiment:
-                              value: 25
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
@@ -302,23 +302,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            environment:
-                              value: 25
-                            event-counter-server:
-                              value: 25
-                            experiment:
-                              value: 25
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/environment/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/environment/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/event-counter/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-counter/templates/envoy-configmap.yaml
@@ -262,21 +262,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                            experiment:
-                              value: 25
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/experiment/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/experiment/templates/envoy-configmap.yaml
@@ -222,19 +222,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/feature-tag-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature-tag-cacher/templates/envoy-configmap.yaml
@@ -182,17 +182,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/feature/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature/templates/envoy-configmap.yaml
@@ -222,19 +222,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                            experiment:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/goal-batch-transformer/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/goal-batch-transformer/templates/envoy-configmap.yaml
@@ -222,19 +222,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                            user:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
@@ -350,25 +350,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            environment:
-                              value: 25
-                            event-counter-server:
-                              value: 25
-                            experiment:
-                              value: 25
-                            feature:
-                              value: 25
-                            notification:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/notification/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification/templates/envoy-configmap.yaml
@@ -185,17 +185,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
@@ -307,23 +307,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            auto-ops:
-                              value: 25
-                            environment:
-                              value: 25
-                            event-counter-server:
-                              value: 25
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
@@ -225,19 +225,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                            push:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
@@ -266,21 +266,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                            experiment:
-                              value: 25
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/user-persister/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/user-persister/templates/envoy-configmap.yaml
@@ -184,17 +184,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:

--- a/manifests/bucketeer/charts/user/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/user/templates/envoy-configmap.yaml
@@ -184,17 +184,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                     route_config:
                       virtual_hosts:


### PR DESCRIPTION
The health check in the egress settings is overwhelming the other services unnecessarily. All services have their own health check in the ingress settings.