### PR TITLE
chore: remove unnecessary health checks in the envoy settings

### DIFF
--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
         - name: environment
           type: strict_dns
           connect_timeout: 5s
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/account/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
       listeners:
         - address:
             socket_address:

--- a/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
@@ -119,14 +119,6 @@ data:
         - name: feature
           connect_timeout: 5s
           ignore_health_on_host_removal: true
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           circuit_breakers:
             thresholds:
               - priority: DEFAULT
@@ -165,14 +157,6 @@ data:
         - name: account
           connect_timeout: 5s
           ignore_health_on_host_removal: true
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           circuit_breakers:
             thresholds:
               - priority: DEFAULT

--- a/manifests/bucketeer/charts/auditlog/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auditlog/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
       listeners:
         - name: ingress
           address:

--- a/manifests/bucketeer/charts/auth/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auth/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
       listeners:
         - name: ingress
           address:

--- a/manifests/bucketeer/charts/auto-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auto-ops/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: auth
           type: strict_dns
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: experiment
           type: strict_dns
@@ -173,14 +157,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: feature
           type: strict_dns
@@ -213,14 +189,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
@@ -64,14 +64,6 @@ data:
           ignore_health_on_host_removal: true
         - connect_timeout: 5s
           dns_lookup_family: V4_ONLY
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
           lb_policy: round_robin
           load_assignment:
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: experiment
           type: strict_dns
@@ -173,14 +157,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: event-counter-server
           type: strict_dns
@@ -213,14 +189,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/environment/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/environment/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/event-counter/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-counter/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: feature
           connect_timeout: 5s
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: account
           type: strict_dns
@@ -173,14 +157,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/experiment/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/experiment/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: account
           type: strict_dns
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/feature-tag-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature-tag-cacher/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/feature/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: experiment
           type: strict_dns
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/goal-batch-transformer/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/goal-batch-transformer/templates/envoy-configmap.yaml
@@ -93,14 +93,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: user
           type: strict_dns
@@ -133,14 +125,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
@@ -95,14 +95,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: environment
@@ -136,14 +128,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: experiment
@@ -177,14 +161,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: event-counter-server
@@ -218,14 +194,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: feature
@@ -259,14 +227,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
       listeners:

--- a/manifests/bucketeer/charts/notification/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
       listeners:

--- a/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: auto-ops
@@ -135,14 +127,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: event-counter-server
@@ -176,14 +160,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: feature
@@ -217,14 +193,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
       listeners:

--- a/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: push
@@ -135,14 +127,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: experiment
@@ -135,14 +127,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: feature
@@ -176,14 +160,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/user-persister/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/user-persister/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress

--- a/manifests/bucketeer/charts/user/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/user/templates/envoy-configmap.yaml
@@ -94,14 +94,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress


### PR DESCRIPTION
I'm removing unnecessary health checks that overwhelm other services when it deploys many pods.
For example, the api-gateway also checks for feature and account services, but they already check their health status.