### PR TITLE
chore: remove postgreSQL test implementation from the event persister

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/deployment.yaml
@@ -104,16 +104,6 @@ spec:
               value: /usr/local/certs/service/tls.key
             - name: BUCKETEER_EVENT_PERSISTER_SERVICE_TOKEN
               value: /usr/local/service-token/token
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_USER
-              value: "{{ .Values.env.postgresUser }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_PASS
-              value: "{{ .Values.env.postgresPass}}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_HOST
-              value: "{{ .Values.env.postgresHost }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_PORT
-              value: "{{ .Values.env.postgresPort }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_NAME
-              value: "{{ .Values.env.postgresDbName }}"
             - name: BUCKETEER_EVENT_PERSISTER_REDIS_SERVER_NAME
               value: "{{ .Values.env.redis.serverName }}"
             - name: BUCKETEER_EVENT_PERSISTER_REDIS_ADDR

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/values.yaml
@@ -37,11 +37,6 @@ env:
   pullerNumGoroutines: 5
   pullerMaxOutstandingMessages: "1000"
   pullerMaxOutstandingBytes: "1000000000"
-  postgresUser:
-  postgresPass:
-  postgresHost:
-  postgresPort:
-  postgresDbName:
 
 affinity: {}
 

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/deployment.yaml
@@ -104,16 +104,6 @@ spec:
               value: /usr/local/certs/service/tls.key
             - name: BUCKETEER_EVENT_PERSISTER_SERVICE_TOKEN
               value: /usr/local/service-token/token
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_USER
-              value: "{{ .Values.env.postgresUser }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_PASS
-              value: "{{ .Values.env.postgresPass}}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_HOST
-              value: "{{ .Values.env.postgresHost }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_PORT
-              value: "{{ .Values.env.postgresPort }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_NAME
-              value: "{{ .Values.env.postgresDbName }}"
             - name: BUCKETEER_EVENT_PERSISTER_REDIS_SERVER_NAME
               value: "{{ .Values.env.redis.serverName }}"
             - name: BUCKETEER_EVENT_PERSISTER_REDIS_ADDR

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/values.yaml
@@ -37,11 +37,6 @@ env:
   pullerNumGoroutines: 5
   pullerMaxOutstandingMessages: "1000"
   pullerMaxOutstandingBytes: "1000000000"
-  postgresUser:
-  postgresPass:
-  postgresHost:
-  postgresPort:
-  postgresDbName:
 
 affinity: {}
 

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
@@ -104,16 +104,6 @@ spec:
               value: /usr/local/certs/service/tls.key
             - name: BUCKETEER_EVENT_PERSISTER_SERVICE_TOKEN
               value: /usr/local/service-token/token
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_USER
-              value: "{{ .Values.env.postgresUser }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_PASS
-              value: "{{ .Values.env.postgresPass}}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_HOST
-              value: "{{ .Values.env.postgresHost }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_PORT
-              value: "{{ .Values.env.postgresPort }}"
-            - name: BUCKETEER_EVENT_PERSISTER_POSTGRES_NAME
-              value: "{{ .Values.env.postgresDbName }}"
             - name: BUCKETEER_EVENT_PERSISTER_MYSQL_USER
               value: "{{ .Values.env.mysqlUser }}"
             - name: BUCKETEER_EVENT_PERSISTER_MYSQL_PASS

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
@@ -37,11 +37,6 @@ env:
   pullerNumGoroutines: 5
   pullerMaxOutstandingMessages: "1000"
   pullerMaxOutstandingBytes: "1000000000"
-  postgresUser:
-  postgresPass:
-  postgresHost:
-  postgresPort:
-  postgresDbName:
   mysqlUser:
   mysqlPass:
   mysqlHost:

--- a/pkg/eventpersister/cmd/server/server.go
+++ b/pkg/eventpersister/cmd/server/server.go
@@ -69,11 +69,6 @@ type server struct {
 	pullerNumGoroutines          *int
 	pullerMaxOutstandingMessages *int
 	pullerMaxOutstandingBytes    *int
-	postgresUser                 *string
-	postgresPass                 *string
-	postgresHost                 *string
-	postgresPort                 *int
-	postgresDbName               *string
 	mysqlUser                    *string
 	mysqlPass                    *string
 	mysqlHost                    *string
@@ -128,11 +123,6 @@ func RegisterServerCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Comma
 			"puller-max-outstanding-bytes",
 			"Maximum size of unprocessed messages.",
 		).Int(),
-		postgresUser:    cmd.Flag("postgres-user", "").Required().String(),
-		postgresPass:    cmd.Flag("postgres-pass", "").Required().String(),
-		postgresHost:    cmd.Flag("postgres-host", "").Required().String(),
-		postgresPort:    cmd.Flag("postgres-port", "").Required().Int(),
-		postgresDbName:  cmd.Flag("postgres-name", "").Required().String(),
 		mysqlUser:       cmd.Flag("mysql-user", "").String(),
 		mysqlPass:       cmd.Flag("mysql-pass", "").String(),
 		mysqlHost:       cmd.Flag("mysql-host", "").String(),
@@ -221,20 +211,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer redisV3Client.Close()
 	redisV3Cache := cachev3.NewRedisCache(redisV3Client)
 
-	// postgresClient, err := postgres.NewClient(
-	// 	ctx,
-	// 	*s.postgresUser,
-	// 	*s.postgresPass,
-	// 	*s.postgresHost,
-	// 	*s.postgresPort,
-	// 	*s.postgresDbName,
-	// 	postgres.WithLogger(logger),
-	// )
-	// if err != nil {
-	// 	return err
-	// }
-	// defer postgresClient.Close()
-
 	mysqlClient, err := s.createMySQLClient(ctx, registerer, logger)
 	if err != nil {
 		return err
@@ -251,7 +227,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		puller,
 		datastore,
 		btClient,
-		nil, // Disable PostgreSQL temporarily due to instability issues on the Google side.
 		mysqlClient,
 		redisV3Cache,
 		persister.WithMaxMPS(*s.maxMPS),


### PR DESCRIPTION
I'm removing the PostgreSQL test implementation from the event persister because we decided to use BigQuery.