### PR TITLE
chore: update ingress api version

### DIFF
--- a/manifests/bucketeer/charts/api-gateway/templates/ingress.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "api-gateway.fullname" . }}
@@ -19,6 +19,9 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - backend:
-              serviceName: {{ template "api-gateway.fullname" . }}
-              servicePort: {{ .Values.service.externalPort }}
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ template "api-gateway.fullname" . }}
+                port:
+                  number: {{ .Values.service.externalPort }}


### PR DESCRIPTION
- I updated the ingress API version from `extensions/v1beta1` to `networking.k8s.io/v1`.


- related:
  - https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22#ingress-v122
  - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#ingress-v1-networking-k8s-io