### PR TITLE
chore: add expiration to keys for evaluation counts

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -18,6 +18,7 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/bucketeer-io/bucketeer/pkg/storage"
 )
@@ -41,6 +42,8 @@ type MultiGetDeleteCountCache interface {
 	MultiGetCache
 	Deleter
 	Counter
+	Exister
+	Setter
 }
 
 type Getter interface {
@@ -63,6 +66,14 @@ type Deleter interface {
 type Counter interface {
 	Increment(key string) (int64, error)
 	PFAdd(key string, els ...string) (int64, error)
+}
+
+type Exister interface {
+	Exists(keys ...string) (int64, error)
+}
+
+type Setter interface {
+	Set(key interface{}, value interface{}, expiration time.Duration) error
 }
 
 // FIXME: remove after persistent-redis migration

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -43,8 +43,6 @@ type MultiGetDeleteCountCache interface {
 	MultiGetCache
 	Deleter
 	Counter
-	Exister
-	Setter
 	PipeLiner
 	Expirer
 }
@@ -69,14 +67,6 @@ type Deleter interface {
 type Counter interface {
 	Increment(key string) (int64, error)
 	PFAdd(key string, els ...string) (int64, error)
-}
-
-type Exister interface {
-	Exists(keys ...string) (int64, error)
-}
-
-type Setter interface {
-	Set(key interface{}, value interface{}, expiration time.Duration) error
 }
 
 type PipeLiner interface {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"time"
 
+	redis "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
 	"github.com/bucketeer-io/bucketeer/pkg/storage"
 )
 
@@ -44,6 +45,8 @@ type MultiGetDeleteCountCache interface {
 	Counter
 	Exister
 	Setter
+	PipeLiner
+	Expirer
 }
 
 type Getter interface {
@@ -74,6 +77,14 @@ type Exister interface {
 
 type Setter interface {
 	Set(key interface{}, value interface{}, expiration time.Duration) error
+}
+
+type PipeLiner interface {
+	Pipeline() redis.PipeClient
+}
+
+type Expirer interface {
+	Expire(key string, expiration time.Duration) (bool, error)
 }
 
 // FIXME: remove after persistent-redis migration

--- a/pkg/cache/testing/cache.go
+++ b/pkg/cache/testing/cache.go
@@ -85,16 +85,6 @@ func (c *inMemoryCache) PFAdd(key string, els ...string) (int64, error) {
 	return 0, nil
 }
 
-func (c *inMemoryCache) Exists(keys ...string) (int64, error) {
-	// TODO: implement
-	return 0, nil
-}
-
-func (c *inMemoryCache) Set(key interface{}, value interface{}, expiration time.Duration) error {
-	// TODO: implement
-	return nil
-}
-
 func (c *inMemoryCache) Expire(key string, expiration time.Duration) (bool, error) {
 	// TODO: implement
 	return true, nil

--- a/pkg/cache/testing/cache.go
+++ b/pkg/cache/testing/cache.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
+	redis "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
 )
 
 type inMemoryCache struct {
@@ -90,6 +91,16 @@ func (c *inMemoryCache) Exists(keys ...string) (int64, error) {
 }
 
 func (c *inMemoryCache) Set(key interface{}, value interface{}, expiration time.Duration) error {
+	// TODO: implement
+	return nil
+}
+
+func (c *inMemoryCache) Expire(key string, expiration time.Duration) (bool, error) {
+	// TODO: implement
+	return true, nil
+}
+
+func (c *inMemoryCache) Pipeline() redis.PipeClient {
 	// TODO: implement
 	return nil
 }

--- a/pkg/cache/testing/cache.go
+++ b/pkg/cache/testing/cache.go
@@ -16,6 +16,7 @@ package testing
 
 import (
 	"sync"
+	"time"
 
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
 )
@@ -81,4 +82,14 @@ func (c *inMemoryCache) Increment(key string) (int64, error) {
 func (c *inMemoryCache) PFAdd(key string, els ...string) (int64, error) {
 	// TODO: implement
 	return 0, nil
+}
+
+func (c *inMemoryCache) Exists(keys ...string) (int64, error) {
+	// TODO: implement
+	return 0, nil
+}
+
+func (c *inMemoryCache) Set(key interface{}, value interface{}, expiration time.Duration) error {
+	// TODO: implement
+	return nil
 }

--- a/pkg/cache/v3/redis_cache.go
+++ b/pkg/cache/v3/redis_cache.go
@@ -91,3 +91,11 @@ func (r *redisCache) Exists(keys ...string) (int64, error) {
 func (r *redisCache) Set(key interface{}, value interface{}, expiration time.Duration) error {
 	return r.client.Set(key.(string), value, expiration)
 }
+
+func (r *redisCache) Pipeline() redis.PipeClient {
+	return r.client.Pipeline()
+}
+
+func (r *redisCache) Expire(key string, expiration time.Duration) (bool, error) {
+	return r.client.Expire(key, expiration)
+}

--- a/pkg/cache/v3/redis_cache.go
+++ b/pkg/cache/v3/redis_cache.go
@@ -84,14 +84,6 @@ func (r *redisCache) PFAdd(key string, els ...string) (int64, error) {
 	return r.client.PFAdd(key, els...)
 }
 
-func (r *redisCache) Exists(keys ...string) (int64, error) {
-	return r.client.Exists(keys...)
-}
-
-func (r *redisCache) Set(key interface{}, value interface{}, expiration time.Duration) error {
-	return r.client.Set(key.(string), value, expiration)
-}
-
 func (r *redisCache) Pipeline() redis.PipeClient {
 	return r.client.Pipeline()
 }

--- a/pkg/cache/v3/redis_cache.go
+++ b/pkg/cache/v3/redis_cache.go
@@ -15,6 +15,8 @@
 package v3
 
 import (
+	"time"
+
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
 	redis "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
 )
@@ -80,4 +82,12 @@ func (r *redisCache) Increment(key string) (int64, error) {
 
 func (r *redisCache) PFAdd(key string, els ...string) (int64, error) {
 	return r.client.PFAdd(key, els...)
+}
+
+func (r *redisCache) Exists(keys ...string) (int64, error) {
+	return r.client.Exists(keys...)
+}
+
+func (r *redisCache) Set(key interface{}, value interface{}, expiration time.Duration) error {
+	return r.client.Set(key.(string), value, expiration)
 }

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -534,15 +534,12 @@ func getVariationID(reason featureproto.Reason_Type, vID string) string {
 
 func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamespace string) error {
 	if e, ok := event.(*eventproto.EvaluationEvent); ok {
-		vID := getVariationID(e.Reason.Type, e.VariationId)
-		eck := p.newEvaluationCountkey(eventCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
-		_, err := p.evaluationCountCacher.Increment(eck)
-		if err != nil {
+		eck := p.newEvaluationCountkey(eventCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
+		if err := p.countEvent(eck); err != nil {
 			return err
 		}
-		uck := p.newEvaluationCountkey(userCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
-		_, err = p.evaluationCountCacher.PFAdd(uck, e.UserId)
-		if err != nil {
+		uck := p.newEvaluationCountkey(userCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
+		if err := p.countUser(uck, e.UserId); err != nil {
 			return err
 		}
 	}

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -534,11 +534,12 @@ func getVariationID(reason featureproto.Reason_Type, vID string) string {
 
 func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamespace string) error {
 	if e, ok := event.(*eventproto.EvaluationEvent); ok {
-		eck := p.newEvaluationCountkey(eventCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
+		vID := getVariationID(e.Reason.Type, e.VariationId)
+		eck := p.newEvaluationCountkey(eventCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
 		if err := p.countEvent(eck); err != nil {
 			return err
 		}
-		uck := p.newEvaluationCountkey(userCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
+		uck := p.newEvaluationCountkey(userCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
 		if err := p.countUser(uck, e.UserId); err != nil {
 			return err
 		}

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -72,6 +72,7 @@ const (
 	eventCountKey      = "ec"
 	userCountKey       = "uc"
 	defaultVariationID = "default"
+	oneMonth           = 24 * time.Hour * 31
 )
 
 type eventMap map[string]proto.Message
@@ -849,4 +850,17 @@ func (p *Persister) getUserEvaluation(
 		return nil, err
 	}
 	return evaluation, nil
+}
+
+func (p *Persister) setExpiration(key string) error {
+	exist, err := p.evaluationCountCacher.Exists(key)
+	if err != nil {
+		return err
+	}
+	if exist == 0 {
+		if err := p.evaluationCountCacher.Set(key, 0, oneMonth); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/redis/v3/redis.go
+++ b/pkg/redis/v3/redis.go
@@ -39,7 +39,6 @@ const (
 	incrByFloatCmdName = "INCR_BY_FLOAT"
 	delCmdName         = "DEL"
 	incr               = "INCR"
-	exists             = "EXISTS"
 	expire             = "EXPIRE"
 	exec               = "EXEC"
 )
@@ -72,7 +71,6 @@ type Client interface {
 	IncrByFloat(key string, value float64) (float64, error)
 	Del(key string) error
 	Incr(key string) (int64, error)
-	Exists(keys ...string) (int64, error)
 	Pipeline() PipeClient
 	Expire(key string, expiration time.Duration) (bool, error)
 }
@@ -386,21 +384,6 @@ func (c *client) Incr(key string) (int64, error) {
 	}
 	redis.HandledCounter.WithLabelValues(clientVersion, c.opts.serverName, incr, code).Inc()
 	redis.HandledHistogram.WithLabelValues(clientVersion, c.opts.serverName, incr, code).Observe(
-		time.Since(startTime).Seconds())
-	return v, err
-}
-
-func (c *client) Exists(keys ...string) (int64, error) {
-	startTime := time.Now()
-	redis.ReceivedCounter.WithLabelValues(clientVersion, c.opts.serverName, incr).Inc()
-	v, err := c.rc.Exists(keys...).Result()
-	code := redis.CodeFail
-	switch err {
-	case nil:
-		code = redis.CodeSuccess
-	}
-	redis.HandledCounter.WithLabelValues(clientVersion, c.opts.serverName, exists, code).Inc()
-	redis.HandledHistogram.WithLabelValues(clientVersion, c.opts.serverName, exists, code).Observe(
 		time.Since(startTime).Seconds())
 	return v, err
 }

--- a/pkg/redis/v3/redis.go
+++ b/pkg/redis/v3/redis.go
@@ -40,6 +40,8 @@ const (
 	delCmdName         = "DEL"
 	incr               = "INCR"
 	exists             = "EXISTS"
+	expire             = "EXPIRE"
+	exec               = "EXEC"
 )
 
 var (
@@ -71,10 +73,25 @@ type Client interface {
 	Del(key string) error
 	Incr(key string) (int64, error)
 	Exists(keys ...string) (int64, error)
+	Pipeline() PipeClient
+	Expire(key string, expiration time.Duration) (bool, error)
 }
 
 type client struct {
 	rc     *goredis.Client
+	opts   *options
+	logger *zap.Logger
+}
+
+type PipeClient interface {
+	PFAdd(key string, els ...string) *goredis.IntCmd
+	Incr(key string) *goredis.IntCmd
+	TTL(key string) *goredis.DurationCmd
+	Exec() ([]goredis.Cmder, error)
+}
+
+type pipeClient struct {
+	pipe   goredis.Pipeliner
 	opts   *options
 	logger *zap.Logger
 }
@@ -384,6 +401,56 @@ func (c *client) Exists(keys ...string) (int64, error) {
 	}
 	redis.HandledCounter.WithLabelValues(clientVersion, c.opts.serverName, exists, code).Inc()
 	redis.HandledHistogram.WithLabelValues(clientVersion, c.opts.serverName, exists, code).Observe(
+		time.Since(startTime).Seconds())
+	return v, err
+}
+
+func (c *client) Expire(key string, expiration time.Duration) (bool, error) {
+	startTime := time.Now()
+	redis.ReceivedCounter.WithLabelValues(clientVersion, c.opts.serverName, incr).Inc()
+	v, err := c.rc.Expire(key, expiration).Result()
+	code := redis.CodeFail
+	switch err {
+	case nil:
+		code = redis.CodeSuccess
+	}
+	redis.HandledCounter.WithLabelValues(clientVersion, c.opts.serverName, expire, code).Inc()
+	redis.HandledHistogram.WithLabelValues(clientVersion, c.opts.serverName, expire, code).Observe(
+		time.Since(startTime).Seconds())
+	return v, err
+}
+
+func (c *client) Pipeline() PipeClient {
+	return &pipeClient{
+		pipe:   c.rc.Pipeline(),
+		opts:   c.opts,
+		logger: c.logger,
+	}
+}
+
+func (c *pipeClient) Incr(key string) *goredis.IntCmd {
+	return c.pipe.Incr(key)
+}
+
+func (c *pipeClient) PFAdd(key string, els ...string) *goredis.IntCmd {
+	return c.pipe.PFAdd(key, els)
+}
+
+func (c *pipeClient) TTL(key string) *goredis.DurationCmd {
+	return c.pipe.TTL(key)
+}
+
+func (c *pipeClient) Exec() ([]goredis.Cmder, error) {
+	startTime := time.Now()
+	redis.ReceivedCounter.WithLabelValues(clientVersion, c.opts.serverName, incr).Inc()
+	v, err := c.pipe.Exec()
+	code := redis.CodeFail
+	switch err {
+	case nil:
+		code = redis.CodeSuccess
+	}
+	redis.HandledCounter.WithLabelValues(clientVersion, c.opts.serverName, exec, code).Inc()
+	redis.HandledHistogram.WithLabelValues(clientVersion, c.opts.serverName, exec, code).Observe(
 		time.Since(startTime).Seconds())
 	return v, err
 }


### PR DESCRIPTION
Sample script to try this implementation

```go
func ExampleClient() {
	rdb := goredis.NewClient(&goredis.Options{
		Addr:     "localhost:6379",
		Password: "", // no password set
		DB:       0,  // use default DB
	})

	key := "key"

	pipe := rdb.Pipeline()

	d := pipe.TTL(ctx, key)

	incr := pipe.Incr(ctx, key)

	_, err := pipe.Exec(ctx)

	if d.Val() == -1 {
		rdb.Expire(ctx, key, time.Second*5)
	}

	fmt.Println(incr.Val(), err)
}


```