### PR TITLE
chore: link the goal event to the experiment before sending it to kafka

### DIFF
--- a/pkg/eventpersister/persister/metrics.go
+++ b/pkg/eventpersister/persister/metrics.go
@@ -21,7 +21,13 @@ import (
 )
 
 const (
+	codeExperimentNotFound         = "ExperimentNotFound"
+	codeFailedToListExperiments    = "FailedToListExperiments"
+	codeFailedToGetUserEvaluation  = "FailedToGetUserEvaluation"
+	codeInvalidGoalEventTimestamp  = "InvalidGoalEventTimestamp"
+	codeNoExperiments              = "NoExperiments"
 	codeUpsertUserEvaluationFailed = "UpsertUserEvaluationFailed"
+	codeUserEvaluationNotFound     = "UserEvaluationNotFound"
 )
 
 var (

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/protobuf/proto" // nolint:staticcheck
 	"github.com/golang/protobuf/ptypes"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 
@@ -632,6 +633,7 @@ func (p *Persister) listExperiments(
 						exproto.Experiment_FORCE_STOPPED,
 						exproto.Experiment_STOPPED,
 					},
+					Archived: &wrappers.BoolValue{Value: false},
 				})
 				if err != nil {
 					return nil, err

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/protobuf/proto" // nolint:staticcheck
 	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
 	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
@@ -42,11 +43,21 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	esproto "github.com/bucketeer-io/bucketeer/proto/event/service"
+	exproto "github.com/bucketeer-io/bucketeer/proto/experiment"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
 var (
-	ErrUnexpectedMessageType = errors.New("eventpersister: unexpected message type")
+	ErrUnexpectedMessageType     = errors.New("eventpersister: unexpected message type")
+	ErrExperimentNotFound        = errors.New("eventpersister: experiment not found")
+	ErrNoExperiments             = errors.New("eventpersister: no experiments")
+	ErrInvalidGoalEventTimestamp = errors.New("eventpersister: invalid goal event timestamp")
+)
+
+const (
+	listRequestSize        = 500
+	furthestEventTimestamp = 24 * time.Hour
+	oldestEventTimestamp   = 24 * time.Hour
 )
 
 const (
@@ -125,6 +136,7 @@ type Persister struct {
 	doneCh                chan struct{}
 	mysqlClient           mysql.Client
 	evaluationCountCacher cache.MultiGetDeleteCountCache
+	flightgroup           singleflight.Group
 }
 
 func NewPersister(
@@ -362,7 +374,7 @@ func (p *Persister) marshalEvent(
 	case *eventproto.EvaluationEvent:
 		return p.marshalEvaluationEvent(ctx, event, environmentNamespace)
 	case *eventproto.GoalEvent:
-		return p.marshalGoalEvent(event, environmentNamespace)
+		return p.marshalGoalEvent(ctx, event, environmentNamespace)
 	case *esproto.UserEvent:
 		return p.marshalUserEvent(event, environmentNamespace)
 	}
@@ -404,7 +416,19 @@ func (p *Persister) marshalEvaluationEvent(
 	return string(b), false, nil
 }
 
-func (p *Persister) marshalGoalEvent(e *eventproto.GoalEvent, environmentNamespace string) (string, bool, error) {
+func (p *Persister) marshalGoalEvent(
+	ctx context.Context,
+	e *eventproto.GoalEvent,
+	environmentNamespace string,
+) (string, bool, error) {
+	if !p.validateTimestamp(e.Timestamp, oldestEventTimestamp, furthestEventTimestamp) {
+		handledCounter.WithLabelValues(codeInvalidGoalEventTimestamp).Inc()
+		return "", false, ErrInvalidGoalEventTimestamp
+	}
+	ev, retriable, err := p.getEvaluation(ctx, e, environmentNamespace)
+	if err != nil {
+		return "", retriable, err
+	}
 	m := map[string]interface{}{}
 	m["environmentNamespace"] = environmentNamespace
 	m["sourceId"] = e.SourceId.String()
@@ -419,90 +443,17 @@ func (p *Persister) marshalGoalEvent(e *eventproto.GoalEvent, environmentNamespa
 		}
 	}
 	m["value"] = strconv.FormatFloat(e.Value, 'f', -1, 64)
-	ue, retriable, err := p.getEvaluations(e, environmentNamespace)
-	if err != nil {
-		return "", retriable, err
+	reason := ""
+	if ev.Reason != nil {
+		reason = ev.Reason.Type.String()
 	}
-	evaluations := []string{}
-	for _, eval := range ue {
-		reason := ""
-		if eval.Reason != nil {
-			reason = eval.Reason.Type.String()
-		}
-		evaluations = append(
-			evaluations,
-			fmt.Sprintf("%s:%d:%s:%s", eval.FeatureId, eval.FeatureVersion, eval.VariationId, reason),
-		)
-	}
-	if len(evaluations) == 0 {
-		p.logger.Warn(
-			"Goal event has no evaluations",
-			zap.String("environmentNamespace", environmentNamespace),
-			zap.String("sourceId", e.SourceId.String()),
-			zap.String("goalId", e.GoalId),
-			zap.String("userId", e.UserId),
-			zap.String("tag", e.Tag),
-			zap.String("timestamp", time.Unix(e.Timestamp, 0).Format(time.RFC3339)),
-		)
-	}
-	m["evaluations"] = evaluations
+	eval := fmt.Sprintf("%s:%d:%s:%s", ev.FeatureId, ev.FeatureVersion, ev.VariationId, reason)
+	m["evaluations"] = []string{eval}
 	b, err := json.Marshal(m)
 	if err != nil {
 		return "", false, err
 	}
 	return string(b), false, nil
-}
-
-func (p *Persister) getEvaluations(
-	e *eventproto.GoalEvent,
-	environmentNamespace string,
-) ([]*featureproto.Evaluation, bool, error) {
-	// Evaluations field in the GoalEvent is deprecated.
-	// The following conditions should be removed once all client SDKs are updated.
-	if e.SourceId == eventproto.SourceId_GOAL_BATCH {
-		// Because the Goal Batch Transformer includes events from the new and old SDKs
-		// we need to check both cases.
-		// If both cases fail, it will save the event with no evaluations
-		var ue []*featureproto.Evaluation
-		ue, err := p.getCurrentUserEvaluations(environmentNamespace, e.UserId, e.Tag)
-		if err != nil {
-			if err == bigtable.ErrKeyNotFound {
-				// Old SDK
-				resp, err := p.featureClient.EvaluateFeatures(p.ctx, &featureproto.EvaluateFeaturesRequest{
-					User:                 e.User,
-					EnvironmentNamespace: environmentNamespace,
-					Tag:                  e.Tag,
-				})
-				if err != nil {
-					return nil, false, err
-				}
-				return resp.UserEvaluations.Evaluations, false, nil
-			}
-			// Retry
-			return nil, true, err
-		}
-		return ue, false, nil
-	}
-	// Old SDK implementation doesn't include the Tag, so we use the evaluations from the client
-	if e.Tag == "" {
-		return e.Evaluations, false, nil
-	}
-	// New SDK implementation
-	ue, err := p.getCurrentUserEvaluations(environmentNamespace, e.UserId, e.Tag)
-	if err != nil && err != bigtable.ErrKeyNotFound {
-		p.logger.Error(
-			"Failed to get user evaluations",
-			zap.Error(err),
-			zap.String("environmentNamespace", environmentNamespace),
-			zap.String("sourceId", e.SourceId.String()),
-			zap.String("goalId", e.GoalId),
-			zap.String("userId", e.UserId),
-			zap.String("tag", e.Tag),
-			zap.String("timestamp", time.Unix(e.Timestamp, 0).Format(time.RFC3339)),
-		)
-		return nil, true, err
-	}
-	return ue, false, nil
 }
 
 func (p *Persister) convToEvaluation(
@@ -548,23 +499,6 @@ func (p *Persister) upsertUserEvaluation(
 	return nil
 }
 
-func (p *Persister) getCurrentUserEvaluations(
-	environmentNamespace,
-	userID,
-	tag string,
-) ([]*featureproto.Evaluation, error) {
-	evaluations, err := p.userEvaluationStorage.GetUserEvaluations(
-		p.ctx,
-		userID,
-		environmentNamespace,
-		tag,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return evaluations, nil
-}
-
 func (p *Persister) marshalUserEvent(e *esproto.UserEvent, environmentNamespace string) (string, bool, error) {
 	m := map[string]interface{}{}
 	m["environmentNamespace"] = environmentNamespace
@@ -588,12 +522,12 @@ func userMetadataColumn(environmentNamespace string, key string) string {
 
 func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamespace string) error {
 	if e, ok := event.(*eventproto.EvaluationEvent); ok {
-		eck := p.key(eventCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
+		eck := p.newEvaluationCountkey(eventCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
 		_, err := p.evaluationCountCacher.Increment(eck)
 		if err != nil {
 			return err
 		}
-		uck := p.key(userCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
+		uck := p.newEvaluationCountkey(userCountKey, e.FeatureId, e.VariationId, environmentNamespace, e.Timestamp)
 		_, err = p.evaluationCountCacher.PFAdd(uck, e.UserId)
 		if err != nil {
 			return err
@@ -602,7 +536,7 @@ func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamesp
 	return nil
 }
 
-func (p *Persister) key(
+func (p *Persister) newEvaluationCountkey(
 	kind, featureID, variationID, environmentNamespace string,
 	timestamp int64,
 ) string {
@@ -613,4 +547,142 @@ func (p *Persister) key(
 		fmt.Sprintf("%s:%s:%d", featureID, variationID, date.Unix()),
 		environmentNamespace,
 	)
+}
+
+// validateTimestamp limits date range of the given timestamp
+func (p *Persister) validateTimestamp(
+	timestamp int64,
+	oldestTimestampDuration, furthestTimestampDuration time.Duration,
+) bool {
+	given := time.Unix(timestamp, 0)
+	maxPast := time.Now().Add(-oldestTimestampDuration)
+	if given.Before(maxPast) {
+		return false
+	}
+	maxFuture := time.Now().Add(furthestTimestampDuration)
+	return !given.After(maxFuture)
+}
+
+func (p *Persister) getEvaluation(
+	ctx context.Context,
+	event *eventproto.GoalEvent,
+	environmentNamespace string,
+) (*featureproto.Evaluation, bool, error) {
+	// List experiments with the following status RUNNING, FORCE_STOPPED, and STOPPED
+	experiments, err := p.listExperiments(ctx, environmentNamespace)
+	if err != nil {
+		return nil, true, err
+	}
+	if len(experiments) == 0 {
+		handledCounter.WithLabelValues(codeNoExperiments).Inc()
+		return nil, false, ErrNoExperiments
+	}
+	// Find the experiment by goal ID
+	// TODO: we must change the console UI not to allow creating
+	// multiple experiments running at the same time,
+	// using the same feature flag id and goal id
+	var experiment *exproto.Experiment
+	for _, exp := range experiments {
+		if p.findGoalID(event.GoalId, exp.GoalIds) {
+			experiment = exp
+			break
+		}
+	}
+	if experiment == nil {
+		handledCounter.WithLabelValues(codeExperimentNotFound).Inc()
+		return nil, false, ErrExperimentNotFound
+	}
+	// For requests with no tag, it will insert "none" instead, until all old SDK clients are updated
+	var tag string
+	if event.Tag == "" {
+		tag = "none"
+	} else {
+		tag = event.Tag
+	}
+	// Get the user evaluation using the experiment info
+	ev, err := p.getUserEvaluation(
+		environmentNamespace,
+		event.UserId,
+		tag,
+		experiment.FeatureId,
+		experiment.FeatureVersion,
+	)
+	if err != nil {
+		return nil, true, err
+	}
+	return ev, false, nil
+}
+
+func (p *Persister) listExperiments(
+	ctx context.Context,
+	environmentNamespace string,
+) ([]*exproto.Experiment, error) {
+	exp, err, _ := p.flightgroup.Do(
+		fmt.Sprintf("%s:%s", environmentNamespace, "listExperiments"),
+		func() (interface{}, error) {
+			experiments := []*exproto.Experiment{}
+			cursor := ""
+			for {
+				resp, err := p.experimentClient.ListExperiments(ctx, &exproto.ListExperimentsRequest{
+					PageSize:             listRequestSize,
+					Cursor:               cursor,
+					EnvironmentNamespace: environmentNamespace,
+					Statuses: []exproto.Experiment_Status{
+						exproto.Experiment_RUNNING,
+						exproto.Experiment_FORCE_STOPPED,
+						exproto.Experiment_STOPPED,
+					},
+				})
+				if err != nil {
+					return nil, err
+				}
+				experiments = append(experiments, resp.Experiments...)
+				experimentSize := len(resp.Experiments)
+				if experimentSize == 0 || experimentSize < listRequestSize {
+					return experiments, nil
+				}
+				cursor = resp.Cursor
+			}
+		},
+	)
+	if err != nil {
+		handledCounter.WithLabelValues(codeFailedToListExperiments).Inc()
+		return nil, err
+	}
+	return exp.([]*exproto.Experiment), nil
+}
+
+func (p *Persister) findGoalID(id string, goalIDs []string) bool {
+	for _, goalID := range goalIDs {
+		if id == goalID {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Persister) getUserEvaluation(
+	environmentNamespace,
+	userID,
+	tag,
+	featureID string,
+	featureVersion int32,
+) (*featureproto.Evaluation, error) {
+	evaluation, err := p.userEvaluationStorage.GetUserEvaluation(
+		p.ctx,
+		userID,
+		environmentNamespace,
+		tag,
+		featureID,
+		featureVersion,
+	)
+	if err != nil {
+		if err == bigtable.ErrKeyNotFound {
+			handledCounter.WithLabelValues(codeUserEvaluationNotFound).Inc()
+		} else {
+			handledCounter.WithLabelValues(codeFailedToGetUserEvaluation).Inc()
+		}
+		return nil, err
+	}
+	return evaluation, nil
 }

--- a/pkg/eventpersister/persister/persister_test.go
+++ b/pkg/eventpersister/persister/persister_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -254,7 +255,17 @@ func TestMarshaGoalEvent(t *testing.T) {
 			setup: func(ctx context.Context, p *Persister) {
 				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
 					ctx,
-					gomock.Any(),
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+						Archived: &wrappers.BoolValue{Value: false},
+					},
 				).Return(nil, errors.New("internal"))
 			},
 			input: &eventproto.GoalEvent{
@@ -288,6 +299,7 @@ func TestMarshaGoalEvent(t *testing.T) {
 							exproto.Experiment_FORCE_STOPPED,
 							exproto.Experiment_STOPPED,
 						},
+						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 			},
@@ -322,6 +334,7 @@ func TestMarshaGoalEvent(t *testing.T) {
 							exproto.Experiment_FORCE_STOPPED,
 							exproto.Experiment_STOPPED,
 						},
+						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -363,6 +376,7 @@ func TestMarshaGoalEvent(t *testing.T) {
 							exproto.Experiment_FORCE_STOPPED,
 							exproto.Experiment_STOPPED,
 						},
+						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -414,6 +428,7 @@ func TestMarshaGoalEvent(t *testing.T) {
 							exproto.Experiment_FORCE_STOPPED,
 							exproto.Experiment_STOPPED,
 						},
+						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -465,6 +480,7 @@ func TestMarshaGoalEvent(t *testing.T) {
 							exproto.Experiment_FORCE_STOPPED,
 							exproto.Experiment_STOPPED,
 						},
+						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -516,6 +532,7 @@ func TestMarshaGoalEvent(t *testing.T) {
 							exproto.Experiment_FORCE_STOPPED,
 							exproto.Experiment_STOPPED,
 						},
+						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{

--- a/pkg/eventpersister/persister/persister_test.go
+++ b/pkg/eventpersister/persister/persister_test.go
@@ -38,6 +38,7 @@ import (
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	esproto "github.com/bucketeer-io/bucketeer/proto/event/service"
+	exproto "github.com/bucketeer-io/bucketeer/proto/experiment"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 	userproto "github.com/bucketeer-io/bucketeer/proto/user"
 )
@@ -46,13 +47,60 @@ var defaultOptions = options{
 	logger: zap.NewNop(),
 }
 
-func TestMarshaEvent(t *testing.T) {
+func TestMarshalUserEvent(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 	layout := "2006-01-02 15:04:05 -0700 MST"
 	t1, err := time.Parse(layout, "2014-01-17 23:02:03 +0000 UTC")
 	require.NoError(t, err)
+	patterns := []struct {
+		desc               string
+		input              interface{}
+		expected           string
+		expectedErr        error
+		expectedRepeatable bool
+	}{
+		{
+			desc: "success: user event",
+			input: &esproto.UserEvent{
+				UserId:   "uid",
+				SourceId: eventproto.SourceId_ANDROID,
+				Tag:      "tag",
+				LastSeen: t1.Unix(),
+			},
+			expected: `{
+				"environmentNamespace": "ns",
+				"sourceId": "ANDROID",
+				"tag": "tag",
+				"timestamp": "2014-01-17T23:02:03Z",
+				"userId":"uid"
+			}`,
+			expectedErr:        nil,
+			expectedRepeatable: false,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			persister := newPersister(mockController)
+			actual, repeatable, err := persister.marshalEvent(persister.ctx, p.input, "ns")
+			assert.Equal(t, p.expectedErr, err)
+			assert.Equal(t, p.expectedRepeatable, repeatable)
+			buf := new(bytes.Buffer)
+			err = json.Compact(buf, []byte(p.expected))
+			assert.Equal(t, buf.String(), actual)
+		})
+	}
+}
+
+func TestMarshalEvaluationEvent(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	layout := "2006-01-02 15:04:05 -0700 MST"
+	t1, err := time.Parse(layout, "2014-01-17 23:02:03 +0000 UTC")
+	require.NoError(t, err)
+	environmentNamespace := "ns"
 	evaluation := &featureproto.Evaluation{
 		Id: featuredomain.EvaluationID(
 			"fid",
@@ -87,31 +135,12 @@ func TestMarshaEvent(t *testing.T) {
 		expectedRepeatable bool
 	}{
 		{
-			desc:  "success: user event",
-			setup: nil,
-			input: &esproto.UserEvent{
-				UserId:   "uid",
-				SourceId: eventproto.SourceId_ANDROID,
-				Tag:      "tag",
-				LastSeen: t1.Unix(),
-			},
-			expected: `{
-				"environmentNamespace": "ns",
-				"sourceId": "ANDROID",
-				"tag": "tag",
-				"timestamp": "2014-01-17T23:02:03Z",
-				"userId":"uid"
-			}`,
-			expectedErr:        nil,
-			expectedRepeatable: false,
-		},
-		{
 			desc: "error: failed to upsert evaluation event",
 			setup: func(ctx context.Context, p *Persister) {
 				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().UpsertUserEvaluation(
 					ctx,
 					evaluation,
-					"ns",
+					environmentNamespace,
 					"tag",
 				).Return(btstorage.ErrInternal)
 			},
@@ -126,7 +155,7 @@ func TestMarshaEvent(t *testing.T) {
 				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().UpsertUserEvaluation(
 					ctx,
 					evaluation,
-					"ns",
+					environmentNamespace,
 					"tag",
 				).Return(nil)
 			},
@@ -148,347 +177,6 @@ func TestMarshaEvent(t *testing.T) {
 			expectedRepeatable: false,
 		},
 		{
-			desc: "err goal batch event: internal error from bigtable",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return(nil, btstorage.ErrInternal).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_GOAL_BATCH,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected:           "",
-			expectedErr:        btstorage.ErrInternal,
-			expectedRepeatable: true,
-		},
-		{
-			desc: "success goal batch event: getting evaluations from bigtable",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return([]*featureproto.Evaluation{
-					{
-						FeatureId:      "fid-0",
-						FeatureVersion: int32(0),
-						VariationId:    "vid-0",
-						Reason:         &featureproto.Reason{Type: featureproto.Reason_CLIENT},
-					},
-					{
-						FeatureId:      "fid-1",
-						FeatureVersion: int32(1),
-						VariationId:    "vid-1",
-						Reason:         &featureproto.Reason{Type: featureproto.Reason_TARGET},
-					},
-				}, nil).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_GOAL_BATCH,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected: `{
-				"environmentNamespace": "ns",
-				"evaluations": ["fid-0:0:vid-0:CLIENT","fid-1:1:vid-1:TARGET"],
-				"goalId": "gid",
-				"metric.userId": "uid",
-				"ns.user.data.atr":"av",
-				"sourceId":"GOAL_BATCH",
-				"tag": "tag",
-				"timestamp": "2014-01-17T23:02:03Z",
-				"userId":"uid",
-				"value": "1.2"
-			}`,
-			expectedErr:        nil,
-			expectedRepeatable: false,
-		},
-		{
-			desc: "success goal batch event: getting evaluations from evaluate process with segment users",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return(nil, btstorage.ErrKeyNotFound).Times(1)
-				p.featureClient.(*fcmock.MockClient).EXPECT().EvaluateFeatures(
-					ctx,
-					&featureproto.EvaluateFeaturesRequest{
-						User: &userproto.User{
-							Id:   "uid",
-							Data: map[string]string{"atr": "av"},
-						},
-						EnvironmentNamespace: "ns",
-						Tag:                  "tag",
-					},
-				).Return(
-					&featureproto.EvaluateFeaturesResponse{
-						UserEvaluations: &featureproto.UserEvaluations{
-							Id: "uid",
-							Evaluations: []*featureproto.Evaluation{
-								{
-									FeatureId:      "fid",
-									FeatureVersion: int32(1),
-									VariationId:    "vid-1",
-									Reason:         &featureproto.Reason{Type: featureproto.Reason_RULE},
-								},
-							},
-						},
-					}, nil,
-				).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_GOAL_BATCH,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected: `{
-				"environmentNamespace": "ns",
-				"evaluations": ["fid:1:vid-1:RULE"],
-				"goalId": "gid",
-				"metric.userId": "uid",
-				"ns.user.data.atr":"av",
-				"sourceId":"GOAL_BATCH",
-				"tag": "tag",
-				"timestamp": "2014-01-17T23:02:03Z",
-				"userId":"uid",
-				"value": "1.2"
-			}`,
-			expectedErr:        nil,
-			expectedRepeatable: false,
-		},
-		{
-			desc: "err goal batch event: internal error from feature api",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return(nil, btstorage.ErrKeyNotFound).Times(1)
-				p.featureClient.(*fcmock.MockClient).EXPECT().EvaluateFeatures(
-					ctx,
-					&featureproto.EvaluateFeaturesRequest{
-						User: &userproto.User{
-							Id:   "uid",
-							Data: map[string]string{"atr": "av"},
-						},
-						EnvironmentNamespace: "ns",
-						Tag:                  "tag",
-					},
-				).Return(
-					nil, btstorage.ErrInternal,
-				).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_GOAL_BATCH,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected:           "",
-			expectedErr:        btstorage.ErrInternal,
-			expectedRepeatable: false,
-		},
-		{
-			desc:  "success goal event: no tag info",
-			setup: nil,
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value: float64(1.2),
-				Evaluations: []*featureproto.Evaluation{
-					{
-						FeatureId:      "fid-0",
-						FeatureVersion: int32(0),
-						VariationId:    "vid-0",
-						Reason:         &featureproto.Reason{Type: featureproto.Reason_CLIENT},
-					},
-					{
-						FeatureId:      "fid-1",
-						FeatureVersion: int32(1),
-						VariationId:    "vid-1",
-						Reason:         &featureproto.Reason{Type: featureproto.Reason_TARGET},
-					},
-				},
-				Tag: "",
-			},
-			expected: `{
-				"environmentNamespace": "ns",
-				"evaluations": ["fid-0:0:vid-0:CLIENT","fid-1:1:vid-1:TARGET"],
-				"goalId": "gid",
-				"metric.userId": "uid",
-				"ns.user.data.atr":"av",
-				"sourceId":"ANDROID",
-				"tag": "",
-				"timestamp": "2014-01-17T23:02:03Z",
-				"userId":"uid",
-				"value": "1.2"
-			}`,
-			expectedErr:        nil,
-			expectedRepeatable: false,
-		},
-		{
-			desc: "err goal event: internal",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return(nil, btstorage.ErrInternal).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected:           "",
-			expectedErr:        btstorage.ErrInternal,
-			expectedRepeatable: true,
-		},
-		{
-			desc: "success goal event: key not found not in bigtable",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return(nil, btstorage.ErrKeyNotFound).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected: `{
-				"environmentNamespace": "ns",
-				"evaluations": [],
-				"goalId": "gid",
-				"metric.userId": "uid",
-				"ns.user.data.atr":"av",
-				"sourceId":"ANDROID",
-				"tag": "tag",
-				"timestamp": "2014-01-17T23:02:03Z",
-				"userId":"uid",
-				"value": "1.2"
-			}`,
-			expectedErr:        nil,
-			expectedRepeatable: false,
-		},
-		{
-			desc: "success goal event: getting evaluations from bigtable",
-			setup: func(ctx context.Context, p *Persister) {
-				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluations(
-					ctx,
-					"uid",
-					"ns",
-					"tag",
-				).Return([]*featureproto.Evaluation{
-					{
-						FeatureId:      "fid-0",
-						FeatureVersion: int32(0),
-						VariationId:    "vid-0",
-						Reason:         &featureproto.Reason{Type: featureproto.Reason_CLIENT},
-					},
-					{
-						FeatureId:      "fid-1",
-						FeatureVersion: int32(1),
-						VariationId:    "vid-1",
-						Reason:         &featureproto.Reason{Type: featureproto.Reason_TARGET},
-					},
-				}, nil).Times(1)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: t1.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected: `{
-				"environmentNamespace": "ns",
-				"evaluations": ["fid-0:0:vid-0:CLIENT","fid-1:1:vid-1:TARGET"],
-				"goalId": "gid",
-				"metric.userId": "uid",
-				"ns.user.data.atr":"av",
-				"sourceId":"ANDROID",
-				"tag": "tag",
-				"timestamp": "2014-01-17T23:02:03Z",
-				"userId":"uid",
-				"value": "1.2"
-			}`,
-			expectedErr:        nil,
-			expectedRepeatable: false,
-		},
-		{
 			desc:               "err: ErrUnexpectedMessageType",
 			input:              "",
 			expected:           "",
@@ -502,7 +190,393 @@ func TestMarshaEvent(t *testing.T) {
 			if p.setup != nil {
 				p.setup(persister.ctx, persister)
 			}
-			actual, repeatable, err := persister.marshalEvent(persister.ctx, p.input, "ns")
+			actual, repeatable, err := persister.marshalEvent(persister.ctx, p.input, environmentNamespace)
+			assert.Equal(t, p.expectedRepeatable, repeatable)
+			if err != nil {
+				assert.Equal(t, actual, "")
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				assert.Equal(t, p.expectedErr, err)
+				buf := new(bytes.Buffer)
+				err = json.Compact(buf, []byte(p.expected))
+				require.NoError(t, err)
+				assert.Equal(t, buf.String(), actual)
+			}
+		})
+	}
+}
+
+func TestMarshaGoalEvent(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	timeNow := time.Now()
+	timeFormated := time.Unix(timeNow.Unix(), 0).Format(time.RFC3339)
+	timeMoreThan24Hours := timeNow.AddDate(0, 0, -2)
+	environmentNamespace := "ns"
+	patterns := []struct {
+		desc               string
+		setup              func(context.Context, *Persister)
+		input              interface{}
+		expected           string
+		expectedErr        error
+		expectedRepeatable bool
+	}{
+		{
+			desc:               "err: ErrUnexpectedMessageType",
+			input:              "",
+			expected:           "",
+			expectedErr:        ErrUnexpectedMessageType,
+			expectedRepeatable: false,
+		},
+		{
+			desc:  "err: invalid goal event timestamp",
+			setup: nil,
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: timeMoreThan24Hours.Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected:           "",
+			expectedErr:        ErrInvalidGoalEventTimestamp,
+			expectedRepeatable: false,
+		},
+		{
+			desc: "err: list experiment internal",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					gomock.Any(),
+				).Return(nil, errors.New("internal"))
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: time.Now().Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected:           "",
+			expectedErr:        errors.New("internal"),
+			expectedRepeatable: true,
+		},
+		{
+			desc: "err: list experiment empty",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{}, nil)
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: time.Now().Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected:           "",
+			expectedErr:        ErrNoExperiments,
+			expectedRepeatable: false,
+		},
+		{
+			desc: "err: experiment not found",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:      "experiment-id",
+							GoalIds: []string{"goal-id"},
+						},
+					},
+				}, nil)
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: time.Now().Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected:           "",
+			expectedErr:        ErrExperimentNotFound,
+			expectedRepeatable: false,
+		},
+		{
+			desc: "err: get evaluation not found",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"gid"},
+							FeatureId:      "fid",
+							FeatureVersion: int32(1),
+						},
+					},
+				}, nil)
+				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluation(
+					ctx,
+					"uid",
+					"ns",
+					"tag",
+					"fid",
+					int32(1),
+				).Return(nil, btstorage.ErrKeyNotFound)
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: time.Now().Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected:           "",
+			expectedErr:        btstorage.ErrKeyNotFound,
+			expectedRepeatable: true,
+		},
+		{
+			desc: "err: get evaluation internal",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"gid"},
+							FeatureId:      "fid",
+							FeatureVersion: int32(1),
+						},
+					},
+				}, nil)
+				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluation(
+					ctx,
+					"uid",
+					environmentNamespace,
+					"tag",
+					"fid",
+					int32(1),
+				).Return(nil, errors.New("internal"))
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: time.Now().Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected:           "",
+			expectedErr:        errors.New("internal"),
+			expectedRepeatable: true,
+		},
+		{
+			desc: "err: get evaluation internal using empty tag",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"gid"},
+							FeatureId:      "fid",
+							FeatureVersion: int32(1),
+						},
+					},
+				}, nil)
+				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluation(
+					ctx,
+					"uid",
+					environmentNamespace,
+					"none",
+					"fid",
+					int32(1),
+				).Return(nil, errors.New("internal"))
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_GOAL_BATCH,
+				Timestamp: time.Now().Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "",
+			},
+			expected:           "",
+			expectedErr:        errors.New("internal"),
+			expectedRepeatable: true,
+		},
+		{
+			desc: "success",
+			setup: func(ctx context.Context, p *Persister) {
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             listRequestSize,
+						Cursor:               "",
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_FORCE_STOPPED,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"gid"},
+							FeatureId:      "fid",
+							FeatureVersion: int32(1),
+						},
+					},
+				}, nil)
+				p.userEvaluationStorage.(*ftmock.MockUserEvaluationsStorage).EXPECT().GetUserEvaluation(
+					ctx,
+					"uid",
+					environmentNamespace,
+					"tag",
+					"fid",
+					int32(1),
+				).Return(&featureproto.Evaluation{
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					VariationId:    "vid",
+					Reason:         &featureproto.Reason{Type: featureproto.Reason_TARGET},
+				}, nil)
+			},
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_ANDROID,
+				Timestamp: timeNow.Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: map[string]string{"atr": "av"},
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "tag",
+			},
+			expected: fmt.Sprintf(`{
+				"environmentNamespace": "ns",
+				"evaluations": ["fid:1:vid:TARGET"],
+				"goalId": "gid",
+				"metric.userId": "uid",
+				"ns.user.data.atr":"av",
+				"sourceId":"ANDROID",
+				"tag": "tag",
+				"timestamp": "%s",
+				"userId":"uid",
+				"value": "1.2"
+			}`, timeFormated),
+			expectedErr:        nil,
+			expectedRepeatable: false,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			persister := newPersister(mockController)
+			if p.setup != nil {
+				p.setup(persister.ctx, persister)
+			}
+			actual, repeatable, err := persister.marshalEvent(persister.ctx, p.input, environmentNamespace)
 			assert.Equal(t, p.expectedRepeatable, repeatable)
 			if err != nil {
 				assert.Equal(t, actual, "")
@@ -655,7 +729,7 @@ func TestConvToEvaluation(t *testing.T) {
 	}
 }
 
-func TestKey(t *testing.T) {
+func TestEvaluationCountkey(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
@@ -696,7 +770,7 @@ func TestKey(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			persister := newPersister(mockController)
-			actual := persister.key(p.kind, p.featureID, p.variationID, p.environmentNamespace, p.timestamp)
+			actual := persister.newEvaluationCountkey(p.kind, p.featureID, p.variationID, p.environmentNamespace, p.timestamp)
 			assert.Equal(t, p.expected, actual)
 		})
 	}

--- a/test/e2e/autoops/auto_ops_test.go
+++ b/test/e2e/autoops/auto_ops_test.go
@@ -295,11 +295,11 @@ func TestOpsEventRateBatchWithoutTag(t *testing.T) {
 	time.Sleep(40 * time.Second)
 
 	userIDs := createUserIDs(t, 10)
-	for _, uid := range userIDs {
-		grpcRegisterEvaluationEvent(t, featureID, feature.Version, uid, feature.Variations[0].Id, "")
-	}
 	for _, uid := range userIDs[:6] {
 		registerGoalEventWithEvaluations(t, featureID, feature.Version, goalID, uid, feature.Variations[0].Id)
+	}
+	for _, uid := range userIDs {
+		grpcRegisterEvaluationEvent(t, featureID, feature.Version, uid, feature.Variations[0].Id, "")
 	}
 	for i := 0; i < retryTimes; i++ {
 		feature = getFeature(t, featureClient, featureID)
@@ -342,11 +342,11 @@ func TestGrpcOpsEventRateBatch(t *testing.T) {
 	time.Sleep(40 * time.Second)
 
 	userIDs := createUserIDs(t, 10)
-	for _, uid := range userIDs {
-		grpcRegisterEvaluationEvent(t, featureID, feature.Version, uid, feature.Variations[0].Id, feature.Tags[0])
-	}
 	for _, uid := range userIDs[:6] {
 		grpcRegisterGoalEvent(t, goalID, uid, feature.Tags[0])
+	}
+	for _, uid := range userIDs {
+		grpcRegisterEvaluationEvent(t, featureID, feature.Version, uid, feature.Variations[0].Id, feature.Tags[0])
 	}
 	for i := 0; i < retryTimes; i++ {
 		feature = getFeature(t, featureClient, featureID)
@@ -389,11 +389,11 @@ func TestOpsEventRateBatch(t *testing.T) {
 	time.Sleep(40 * time.Second)
 
 	userIDs := createUserIDs(t, 10)
-	for _, uid := range userIDs {
-		registerEvaluationEvent(t, featureID, feature.Version, uid, feature.Variations[0].Id, feature.Tags[0])
-	}
 	for _, uid := range userIDs[:6] {
 		registerGoalEvent(t, goalID, uid, feature.Tags[0])
+	}
+	for _, uid := range userIDs {
+		registerEvaluationEvent(t, featureID, feature.Version, uid, feature.Variations[0].Id, feature.Tags[0])
 	}
 	for i := 0; i < retryTimes; i++ {
 		feature = getFeature(t, featureClient, featureID)

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -93,10 +93,11 @@ func TestGrpcGoalCountV2(t *testing.T) {
 		variationIDs = append(variationIDs, v.Id)
 		variations[v.Value] = v
 	}
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
 
 	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.2))
 	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
+
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -186,10 +187,11 @@ func TestGoalCountV2(t *testing.T) {
 		variationIDs = append(variationIDs, v.Id)
 		variations[v.Value] = v
 	}
-	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
 
 	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.2))
 	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
+
+	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -281,6 +283,10 @@ func TestExperimentResultWithoutTag(t *testing.T) {
 	experiment := createExperimentWithMultiGoals(ctx, t, experimentClient, "ExperimentResult", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
 
 	// CVRs is 3/4
+	// Register goal variation
+	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[0], experiment.Variations[0].Id, float64(0.3))
+	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[1], experiment.Variations[0].Id, float64(0.2))
+	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[2], experiment.Variations[0].Id, float64(0.1))
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, "")
@@ -288,21 +294,17 @@ func TestExperimentResultWithoutTag(t *testing.T) {
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, "")
 	// Increment evaluation event count
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, "")
-	// Register goal variation
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[0], experiment.Variations[0].Id, float64(0.3))
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[1], experiment.Variations[0].Id, float64(0.2))
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[2], experiment.Variations[0].Id, float64(0.1))
 
 	// CVRs is 2/3
+	// Register goal
+	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[3], experiment.Variations[1].Id, float64(0.1))
+	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[4], experiment.Variations[1].Id, float64(0.15))
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, "")
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, "")
 	// Increment evaluation event count
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, "")
-	// Register goal
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[3], experiment.Variations[1].Id, float64(0.1))
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[4], experiment.Variations[1].Id, float64(0.15))
 
 	for i := 0; i < retryTimes; i++ {
 		resp := getExperimentResult(t, ecClient, experiment.Id)
@@ -467,6 +469,12 @@ func TestGrpcExperimentResult(t *testing.T) {
 	experiment := createExperimentWithMultiGoals(ctx, t, experimentClient, "ExperimentResult", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
 
 	// CVRs is 3/4
+	// Register goal variation
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1))
+	// Increment experiment event count
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
@@ -474,25 +482,19 @@ func TestGrpcExperimentResult(t *testing.T) {
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, tag)
 	// Increment evaluation event count
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
-	// Register goal variation
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1))
-	// Increment experiment event count
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
 
 	// CVRs is 2/3
+	// Register goal
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15))
+	// Increment experiment event count
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, tag)
 	// Increment evaluation event count
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
-	// Register goal
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15))
-	// Increment experiment event count
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
 
 	for i := 0; i < retryTimes; i++ {
 		resp := getExperimentResult(t, ecClient, experiment.Id)
@@ -663,6 +665,12 @@ func TestExperimentResult(t *testing.T) {
 	experiment := createExperimentWithMultiGoals(ctx, t, experimentClient, "ExperimentResult", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
 
 	// CVRs is 3/4
+	// Register goal variation
+	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
+	registerGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2))
+	registerGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1))
+	// Increment experiment event count
+	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
@@ -670,25 +678,19 @@ func TestExperimentResult(t *testing.T) {
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, tag)
 	// Increment evaluation event count
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
-	// Register goal variation
-	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	registerGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2))
-	registerGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1))
-	// Increment experiment event count
-	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
 
 	// CVRs is 2/3
+	// Register goal
+	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
+	registerGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15))
+	// Increment experiment event count
+	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, tag)
 	// Increment evaluation event count
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
-	// Register goal
-	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
-	registerGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15))
-	// Increment experiment event count
-	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
 
 	for i := 0; i < retryTimes; i++ {
 		resp := getExperimentResult(t, ecClient, experiment.Id)
@@ -859,11 +861,11 @@ func TestGrpcMultiGoalsEventCounterRealtime(t *testing.T) {
 		variationIDs = append(variationIDs, v.Id)
 		variations[v.Value] = v
 	}
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
-	grpcRegisterEvaluationEvent(t, featureID, f.Version+1, userID, f.Variations[1].Id, tag)
-
 	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
 	grpcRegisterGoalEvent(t, goalIDs[1], userID, tag, float64(0.2))
+
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version+1, userID, f.Variations[1].Id, tag)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -1016,11 +1018,11 @@ func TestMultiGoalsEventCounterRealtime(t *testing.T) {
 		variationIDs = append(variationIDs, v.Id)
 		variations[v.Value] = v
 	}
-	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version+1, userID, f.Variations[1].Id, tag)
-
 	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
 	registerGoalEvent(t, goalIDs[1], userID, tag, float64(0.2))
+
+	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version+1, userID, f.Variations[1].Id, tag)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -1187,9 +1189,10 @@ func TestGoalBatchEventCounter(t *testing.T) {
 	}
 	time.Sleep(5 * time.Second)
 
-	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
 	// Send goal batch events.
 	registerGoalBatchEvent(t, tag, goalIDs[0], userID)
+
+	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
 
 	// Check the count
 	for i := 0; i < retryTimes; i++ {


### PR DESCRIPTION
To solve the ordering of the events published from the api-gateway to Pubsub, I'm changing the event persister to link the goal event to the experiment before sending it to Kafka. 

To link the goal event, we need the evaluation event. If the goal event comes before the evaluation event, it will not acknowledge the Pubsub message until the evaluation event is sent to Kafka. If the evaluation event never came for some reason in the client after 24 hours, the persister will acknowledge the goal event, but it will not send to Kafka.

Also, I have changed the e2e tests to send the goal events before sending the evaluation events to ensure that implementation works.

