### PR TITLE
chore: add auto ops service in the event persister envoy settings

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_AUTO_OPS_SERVICE
+              value: "{{ .Values.env.autoOpsService }}"
             - name: BUCKETEER_EVENT_PERSISTER_BIGTABLE_INSTANCE
               value: "{{ .Values.env.bigtableInstance }}"
             - name: BUCKETEER_EVENT_PERSISTER_LOCATION

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/templates/envoy-configmap.yaml
@@ -126,6 +126,38 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+        - name: auto-ops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: auto-ops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -233,6 +265,18 @@ data:
                                 prefix: /bucketeer.feature.FeatureService
                               route:
                                 cluster: feature
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.autoops.AutoOpsService
+                              route:
+                                cluster: auto-ops
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-kafka/values.yaml
@@ -11,6 +11,7 @@ env:
   project:
   experimentService: localhost:9001
   featureService: localhost:9001
+  autoOpsService: localhost:9001
   bigtableInstance:
   location: asia-northeast1
   topic:

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_AUTO_OPS_SERVICE
+              value: "{{ .Values.env.autoOpsService }}"
             - name: BUCKETEER_EVENT_PERSISTER_BIGTABLE_INSTANCE
               value: "{{ .Values.env.bigtableInstance }}"
             - name: BUCKETEER_EVENT_PERSISTER_LOCATION

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
@@ -126,19 +126,19 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: autoops
+        - name: auto-ops
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: autoops
+            cluster_name: auto-ops
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: autoops.{{ .Values.namespace }}.svc.cluster.local
+                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -276,7 +276,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.autoops.AutoOpsService
                               route:
-                                cluster: autoops
+                                cluster: auto-ops
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/templates/envoy-configmap.yaml
@@ -126,6 +126,38 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+        - name: autoops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: autoops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: autoops.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -233,6 +265,18 @@ data:
                                 prefix: /bucketeer.feature.FeatureService
                               route:
                                 cluster: feature
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.autoops.AutoOpsService
+                              route:
+                                cluster: autoops
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-goal-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-kafka/values.yaml
@@ -11,6 +11,7 @@ env:
   project:
   experimentService: localhost:9001
   featureService: localhost:9001
+  autoOpsService: localhost:9001
   bigtableInstance:
   location: asia-northeast1
   topic:

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_AUTO_OPS_SERVICE
+              value: "{{ .Values.env.autoOpsService }}"
             - name: BUCKETEER_EVENT_PERSISTER_BIGTABLE_INSTANCE
               value: "{{ .Values.env.bigtableInstance }}"
             - name: BUCKETEER_EVENT_PERSISTER_LOCATION

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
@@ -126,19 +126,19 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: autoops
+        - name: auto-ops
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: autoops
+            cluster_name: auto-ops
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: autoops.{{ .Values.namespace }}.svc.cluster.local
+                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -276,7 +276,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.autoops.AutoOpsService
                               route:
-                                cluster: autoops
+                                cluster: auto-ops
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/templates/envoy-configmap.yaml
@@ -126,6 +126,38 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+        - name: autoops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: autoops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: autoops.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -233,6 +265,18 @@ data:
                                 prefix: /bucketeer.feature.FeatureService
                               route:
                                 cluster: feature
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.autoops.AutoOpsService
+                              route:
+                                cluster: autoops
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-user-events-kafka/values.yaml
@@ -11,6 +11,7 @@ env:
   project:
   experimentService: localhost:9001
   featureService: localhost:9001
+  autoOpsService: localhost:9001
   bigtableInstance:
   location: asia-northeast1
   topic:


### PR DESCRIPTION
Adding the auto ops service in the event persister as part of linking the goal event to auto ops rules.