### PR TITLE
fix: internal error when there is no value in the event count

### DIFF
--- a/pkg/eventcounter/storage/v2/user_count.go
+++ b/pkg/eventcounter/storage/v2/user_count.go
@@ -43,7 +43,7 @@ func (s *userCountStorage) GetMAUCount(
 	query := `
 		SELECT
 			count(*) as user_count,
-			SUM(event_count) as event_count
+			IFNULL(SUM(event_count), 0) as event_count
 		FROM
 			mau
 		WHERE


### PR DESCRIPTION
The service returns an error because SUM returns NULL when there is no value.