### PR TITLE
fix: goal event not being acknowledged correctly

### DIFF
--- a/pkg/eventpersister/persister/metrics.go
+++ b/pkg/eventpersister/persister/metrics.go
@@ -26,7 +26,6 @@ const (
 	codeFailedToGetUserEvaluation          = "FailedToGetUserEvaluation"
 	codeFailedToListAutoOpsRules           = "FailedToListAutoOpsRules"
 	codeFailedToListExperiments            = "FailedToListExperiments"
-	codeInvalidGoalEventTimestamp          = "InvalidGoalEventTimestamp"
 	codeNothingToLink                      = "NothingToLink"
 	codeUpsertUserEvaluationFailed         = "UpsertUserEvaluationFailed"
 	codeUserEvaluationNotFound             = "UserEvaluationNotFound"

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -569,20 +569,6 @@ func (p *Persister) newEvaluationCountkey(
 	)
 }
 
-// validateTimestamp limits date range of the given timestamp
-func (p *Persister) validateTimestamp(
-	timestamp int64,
-	oldestTimestampDuration, furthestTimestampDuration time.Duration,
-) bool {
-	given := time.Unix(timestamp, 0)
-	maxPast := time.Now().Add(-oldestTimestampDuration)
-	if given.Before(maxPast) {
-		return false
-	}
-	maxFuture := time.Now().Add(furthestTimestampDuration)
-	return !given.After(maxFuture)
-}
-
 func (p *Persister) linkGoalEvent(
 	ctx context.Context,
 	event *eventproto.GoalEvent,

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/golang/protobuf/proto" // nolint:staticcheck
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 
@@ -780,7 +779,6 @@ func (p *Persister) listExperiments(
 					Statuses: []exproto.Experiment_Status{
 						exproto.Experiment_RUNNING,
 					},
-					Archived: &wrappers.BoolValue{Value: false},
 				})
 				if err != nil {
 					return nil, err

--- a/pkg/eventpersister/persister/persister_test.go
+++ b/pkg/eventpersister/persister/persister_test.go
@@ -236,8 +236,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -271,8 +269,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -314,8 +310,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -364,8 +358,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -416,8 +408,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -468,8 +458,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -520,8 +508,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -641,8 +627,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -684,8 +668,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -727,8 +709,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -785,8 +765,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -844,8 +822,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -918,8 +894,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -992,8 +966,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -1066,8 +1038,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -1119,8 +1089,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -1264,7 +1232,6 @@ func TestMarshalGoalEventWithExperimentsAndAutoOpsRules(t *testing.T) {
 		clauses = append(clauses, &aoproto.Clause{Clause: c})
 		return clauses
 	}
-	timeMoreThan24Hours := timeNow.AddDate(0, 0, -2)
 	environmentNamespace := "ns"
 	patterns := []struct {
 		desc               string
@@ -1282,26 +1249,6 @@ func TestMarshalGoalEventWithExperimentsAndAutoOpsRules(t *testing.T) {
 			expectedRepeatable: false,
 		},
 		{
-			desc:  "err: invalid goal event timestamp",
-			setup: nil,
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_GO_SERVER,
-				Timestamp: timeMoreThan24Hours.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected:           "",
-			expectedErr:        ErrInvalidGoalEventTimestamp,
-			expectedRepeatable: false,
-		},
-		{
 			desc: "success: using same feature flag id, version and goal id in the experiments and in the auto ops",
 			setup: func(ctx context.Context, p *Persister) {
 				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
@@ -1312,8 +1259,6 @@ func TestMarshalGoalEventWithExperimentsAndAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},
@@ -1411,8 +1356,6 @@ func TestMarshalGoalEventWithExperimentsAndAutoOpsRules(t *testing.T) {
 						EnvironmentNamespace: environmentNamespace,
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
-							exproto.Experiment_FORCE_STOPPED,
-							exproto.Experiment_STOPPED,
 						},
 						Archived: &wrappers.BoolValue{Value: false},
 					},

--- a/pkg/eventpersister/persister/persister_test.go
+++ b/pkg/eventpersister/persister/persister_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -237,7 +236,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(nil, errors.New("internal"))
 			},
@@ -270,7 +268,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -311,7 +308,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -359,7 +355,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -409,7 +404,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -459,7 +453,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -509,7 +502,6 @@ func TestMarshalGoalEventWithExperiments(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -628,7 +620,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -669,7 +660,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -710,7 +700,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -766,7 +755,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -823,7 +811,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -895,7 +882,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -967,7 +953,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -1039,7 +1024,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -1090,7 +1074,6 @@ func TestMarshalGoalEventWithAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{}, nil)
 				p.autoOpsClient.(*aomock.MockClient).EXPECT().ListAutoOpsRules(
@@ -1260,7 +1243,6 @@ func TestMarshalGoalEventWithExperimentsAndAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{
@@ -1357,7 +1339,6 @@ func TestMarshalGoalEventWithExperimentsAndAutoOpsRules(t *testing.T) {
 						Statuses: []exproto.Experiment_Status{
 							exproto.Experiment_RUNNING,
 						},
-						Archived: &wrappers.BoolValue{Value: false},
 					},
 				).Return(&exproto.ListExperimentsResponse{
 					Experiments: []*exproto.Experiment{


### PR DESCRIPTION
Because the calculator service already adds a buffer of 48 hours before stopping the running experiments, there is no need to validate the timestamp. Also, there is no need to list stopped experiments.

- Changed to list only running experiments
- Removed timestamp validation