### PR TITLE
fix: insert timestamp correctly in bigquery

### DIFF
--- a/pkg/eventpersisterdwh/persister/evaluation_event.go
+++ b/pkg/eventpersisterdwh/persister/evaluation_event.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -174,7 +175,7 @@ func (w *evalEvtWriter) convToEvaluationEvent(
 		Tag:                  tag,
 		SourceId:             e.SourceId.String(),
 		EnvironmentNamespace: environmentNamespace,
-		Timestamp:            e.Timestamp,
+		Timestamp:            time.Unix(e.Timestamp, 0).UnixMicro(),
 	}, false, nil
 }
 

--- a/pkg/eventpersisterdwh/persister/goal_event.go
+++ b/pkg/eventpersisterdwh/persister/goal_event.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -166,7 +167,7 @@ func (w *goalEvtWriter) convToGoalEvent(
 		Tag:                  tag,
 		SourceId:             e.SourceId.String(),
 		EnvironmentNamespace: environmentNamespace,
-		Timestamp:            e.Timestamp,
+		Timestamp:            time.Unix(e.Timestamp, 0).UnixMicro(),
 		FeatureId:            eval.FeatureId,
 		FeatureVersion:       eval.FeatureVersion,
 		VariationId:          eval.VariationId,

--- a/pkg/eventpersisterdwh/persister/persister_test.go
+++ b/pkg/eventpersisterdwh/persister/persister_test.go
@@ -62,7 +62,7 @@ func TestConvToEvaluationEvent(t *testing.T) {
 	}
 	evaluationEvent := &eventproto.EvaluationEvent{
 		Tag:            "tag",
-		Timestamp:      t1.Unix(),
+		Timestamp:      t1.UnixMicro(),
 		FeatureId:      "fid",
 		FeatureVersion: int32(1),
 		UserId:         "uid",
@@ -233,7 +233,7 @@ func TestConvToEvaluationEvent(t *testing.T) {
 				Tag:                  evaluationEvent.Tag,
 				SourceId:             evaluationEvent.SourceId.String(),
 				EnvironmentNamespace: environmentNamespace,
-				Timestamp:            evaluationEvent.Timestamp,
+				Timestamp:            time.Unix(evaluationEvent.Timestamp, 0).UnixMicro(),
 			},
 			expectedErr:        nil,
 			expectedRepeatable: false,
@@ -257,6 +257,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
+	now := time.Now()
 
 	environmentNamespace := "ns"
 	ctx, cancel := context.WithCancel(context.Background())
@@ -293,7 +294,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: time.Now().Unix(),
+				Timestamp: now.Unix(),
 				GoalId:    "gid",
 				UserId:    "uid",
 				User: &userproto.User{
@@ -325,7 +326,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: time.Now().Unix(),
+				Timestamp: now.Unix(),
 				GoalId:    "gid",
 				UserId:    "uid",
 				User: &userproto.User{
@@ -364,7 +365,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: time.Now().Unix(),
+				Timestamp: now.Unix(),
 				GoalId:    "gid",
 				UserId:    "uid",
 				User: &userproto.User{
@@ -413,7 +414,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: time.Now().Unix(),
+				Timestamp: now.Unix(),
 				GoalId:    "gid",
 				UserId:    "uid",
 				User: &userproto.User{
@@ -462,7 +463,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: time.Now().Unix(),
+				Timestamp: now.Unix(),
 				GoalId:    "gid",
 				UserId:    "uid",
 				User: &userproto.User{
@@ -511,7 +512,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: time.Now().Unix(),
+				Timestamp: now.Unix(),
 				GoalId:    "gid",
 				UserId:    "uid",
 				User: &userproto.User{
@@ -565,7 +566,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			input: &eventproto.GoalEvent{
 				SourceId:    eventproto.SourceId_ANDROID,
-				Timestamp:   time.Now().Unix(),
+				Timestamp:   now.Unix(),
 				GoalId:      "gid",
 				UserId:      "uid",
 				User:        user,
@@ -586,7 +587,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Reason:               featureproto.Reason_TARGET.String(),
 				UserData:             string(userData),
 				EnvironmentNamespace: environmentNamespace,
-				Timestamp:            time.Now().Unix(),
+				Timestamp:            time.Unix(now.Unix(), 0).UnixMicro(),
 			},
 			expectedErr:        nil,
 			expectedRepeatable: false,


### PR DESCRIPTION
Here is a screen shot to prove this implementation works.
<img width="199" alt="Screen Shot 2023-01-19 at 19 43 12" src="https://user-images.githubusercontent.com/59436572/213422350-d3ac37f8-e36d-4335-9505-98d9099e5dcf.png">
