### PR TITLE
chore: add cmd for event persister ops

### DIFF
--- a/cmd/eventpersisterops/eventpersisterops.go
+++ b/cmd/eventpersisterops/eventpersisterops.go
@@ -1,0 +1,41 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"log"
+
+	"github.com/bucketeer-io/bucketeer/pkg/cli"
+	"github.com/bucketeer-io/bucketeer/pkg/eventpersisterops/cmd/server"
+)
+
+var (
+	name    = "bucketeer-event-persister-ops"
+	version = ""
+	build   = ""
+)
+
+func main() {
+	app := cli.NewApp(name, "A/B Testing Microservice", version, build)
+	registerCommands(app)
+	err := app.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func registerCommands(app *cli.App) {
+	server.RegisterServerCommand(app, app)
+}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/.helmignore
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/Chart.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for bucketeer-event-persister-evaluation-events-ops
+name: event-persister-evaluation-events-ops
+version: 1.0.0

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/_helpers.tpl
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "event-persister-evaluation-events-ops.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "event-persister-evaluation-events-ops.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "event-persister-evaluation-events-ops.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "service-cert-secret" -}}
+{{- if .Values.tls.service.secret }}
+{{- printf "%s" .Values.tls.service.secret -}}
+{{- else -}}
+{{ template "event-persister-evaluation-events-ops.fullname" . }}-service-cert
+{{- end -}}
+{{- end -}}
+
+{{- define "service-token-secret" -}}
+{{- if .Values.serviceToken.secret }}
+{{- printf "%s" .Values.serviceToken.secret -}}
+{{- else -}}
+{{ template "event-persister-evaluation-events-ops.fullname" . }}-service-token
+{{- end -}}
+{{- end -}}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/deployment.yaml
@@ -1,0 +1,168 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    chart: {{ template "event-persister-evaluation-events-ops.chart" . }}
+    release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "event-persister-evaluation-events-ops.name" . }}
+      release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "event-persister-evaluation-events-ops.name" . }}
+        release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/envoy-configmap.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.global.image.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: {{ template "event-persister-evaluation-events-ops.fullname" . }}-envoy-config
+        - name: service-cert-secret
+          secret:
+            secretName: {{ template "service-cert-secret" . }}
+        - name: service-token-secret
+          secret:
+            secretName: {{ template "service-token-secret" . }}
+      serviceAccountName: {{ template "event-persister-evaluation-events-ops.name" . }}
+      containers:
+        - name: "event-persister-ops"
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["server"]
+          env:
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_SERVICE_NAME
+              value: "{{ template "event-persister-evaluation-events-ops.fullname" . }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PROJECT
+              value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FEATURE_SERVICE
+              value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_AUTO_OPS_SERVICE
+              value: "{{ .Values.env.autoOpsService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_TOPIC
+              value: "{{ .Values.env.topic }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_SUBSCRIPTION
+              value: "{{ .Values.env.subscription }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PORT
+              value: "{{ .Values.env.port }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_METRICS_PORT
+              value: "{{ .Values.env.metricsPort }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_LOG_LEVEL
+              value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_MAX_MPS
+              value: "{{ .Values.env.maxMps }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_NUM_WORKERS
+              value: "{{ .Values.env.numWorkers }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FLUSH_SIZE
+              value: "{{ .Values.env.flushSize }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FLUSH_INTERVAL
+              value: "{{ .Values.env.flushInterval }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FLUSH_TIMEOUT
+              value: "{{ .Values.env.flushTimeout }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PULLER_NUM_GOROUTINES
+              value: "{{ .Values.env.pullerNumGoroutines }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PULLER_MAX_OUTSTANDING_MESSAGES
+              value: "{{ .Values.env.pullerMaxOutstandingMessages }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PULLER_MAX_OUTSTANDING_BYTES
+              value: "{{ .Values.env.pullerMaxOutstandingBytes }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_CERT
+              value: /usr/local/certs/service/tls.crt
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_KEY
+              value: /usr/local/certs/service/tls.key
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_SERVICE_TOKEN
+              value: /usr/local/service-token/token
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_SERVER_NAME
+              value: "{{ .Values.env.redis.serverName }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_ADDR
+              value: "{{ .Values.env.redis.addr }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_POOL_MAX_IDLE
+              value: "{{ .Values.env.redis.poolMaxIdle }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_POOL_MAX_ACTIVE
+              value: "{{ .Values.env.redis.poolMaxActive }}"
+          volumeMounts:
+            - name: service-cert-secret
+              mountPath: /usr/local/certs/service
+              readOnly: true
+            - name: service-token-secret
+              mountPath: /usr/local/service-token
+              readOnly: true
+          ports:
+            - name: service
+              containerPort: {{ .Values.env.port }}
+            - name: metrics
+              containerPort: {{ .Values.env.metricsPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            failureThreshold: {{ .Values.health.failureThreshold }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+        - name: envoy
+          image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+          imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l) -ne 0 ]; do sleep 1; done;"
+          command: ["envoy"]
+          args:
+            - "-c"
+            - "/usr/local/conf/config.yaml"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /usr/local/conf/
+              readOnly: true
+            - name: service-cert-secret
+              mountPath: /usr/local/certs/service
+              readOnly: true
+          ports:
+            - name: envoy
+              containerPort: {{ .Values.envoy.port }}
+            - name: admin
+              containerPort: {{ .Values.envoy.adminPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            failureThreshold: {{ .Values.health.failureThreshold }}
+            httpGet:
+              path: /health
+              port: envoy
+              scheme: HTTPS
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: /health
+              port: envoy
+              scheme: HTTPS
+          resources: {{ toYaml .Values.envoy.resources | nindent 12 }}
+  strategy:
+    type: RollingUpdate

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
@@ -1,0 +1,254 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "event-persister-evaluation-events-ops.fullname" . }}-envoy-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    chart: {{ template "event-persister-evaluation-events-ops.chart" . }}
+    release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yaml: |-
+    admin:
+      access_log:
+        name: envoy.access_loggers.file
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          path: /dev/stdout
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8001
+    static_resources:
+      clusters:
+        - name: event-persister-evaluation-events-ops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: event-persister-evaluation-events-ops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9090
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          health_checks:
+            - grpc_health_check: {}
+              healthy_threshold: 1
+              interval: 10s
+              interval_jitter: 1s
+              no_traffic_interval: 2s
+              timeout: 1s
+              unhealthy_threshold: 2
+          ignore_health_on_host_removal: true
+        - name: feature
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: feature
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: feature.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+        - name: auto-ops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: auto-ops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+      listeners:
+        - name: ingress
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    access_log:
+                      name: envoy.access_loggers.file
+                      typed_config:
+                        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                    codec_type: auto
+                    http_filters:
+                      - name: envoy.filters.http.health_check
+                        typed_config:
+                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                          cluster_min_healthy_percentages:
+                            event-persister-evaluation-events-ops:
+                              value: 25
+                          headers:
+                            - name: :path
+                              string_match:
+                                exact: /health
+                          pass_through_mode: false
+                      - name: envoy.filters.http.router
+                    route_config:
+                      virtual_hosts:
+                        - domains:
+                            - '*'
+                          name: ingress_services
+                          routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /
+                              route:
+                                cluster: event-persister-evaluation-events-ops
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                    stat_prefix: ingress_http
+                    stream_idle_timeout: 300s
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    alpn_protocols:
+                      - h2
+                    tls_certificates:
+                      - certificate_chain:
+                          filename: /usr/local/certs/service/tls.crt
+                        private_key:
+                          filename: /usr/local/certs/service/tls.key
+                  require_client_certificate: true
+        - name: egress
+          address:
+            socket_address:
+              address: 127.0.0.1
+              port_value: 9001
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    access_log:
+                      name: envoy.access_loggers.file
+                      typed_config:
+                        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                    codec_type: auto
+                    http_filters:
+                      - name: envoy.filters.http.router
+                    route_config:
+                      virtual_hosts:
+                        - domains:
+                            - '*'
+                          name: egress_services
+                          routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.feature.FeatureService
+                              route:
+                                cluster: feature
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.autoops.AutoOpsService
+                              route:
+                                cluster: auto-ops
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                    stat_prefix: egress_http
+                    stream_idle_timeout: 300s
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    alpn_protocols:
+                      - h2
+                    tls_certificates:
+                      - certificate_chain:
+                          filename: /usr/local/certs/service/tls.crt
+                        private_key:
+                          filename: /usr/local/certs/service/tls.key
+                  require_client_certificate: true

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/hpa.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.hpa.metrics.cpu.targetAverageUtilization }}
+{{ end }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    namespace: {{ .Values.namespace }}
+    name: {{ template "event-persister-evaluation-events-ops.name" . }}
+    annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-cert-secret.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-cert-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.tls.service.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "event-persister-evaluation-events-ops.fullname" . }}-service-cert
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    chart: {{ template "event-persister-evaluation-events-ops.chart" . }}
+    release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  tls.crt: {{ required "Service TLS certificate is required" .Values.tls.service.cert | b64enc | quote }}
+  tls.key: {{ required "Service TLS key is required" .Values.tls.service.key | b64enc | quote }}
+{{- end }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-token-secret.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-token-secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.serviceToken.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "event-persister-evaluation-events-ops.fullname" . }}-service-token
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-evaluation-events-ops.name" . }}
+    chart: {{ template "event-persister-evaluation-events-ops.chart" . }}
+    release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  token: {{ required "Service token is required" .Values.serviceToken.token | b64enc | quote }}
+{{- end }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    chart: {{ template "event-persister-evaluation-events-ops.chart" . }}
+    release: {{ template "event-persister-evaluation-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+    envoy: "true"
+    metrics: "true"
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - name: service
+      port: {{ .Values.service.externalPort }}
+      targetPort: envoy
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.env.metricsPort }}
+      protocol: TCP
+    - name: admin
+      port: {{ .Values.envoy.adminPort }}
+      protocol: TCP
+  selector:
+    app: {{ template "event-persister-evaluation-events-ops.name" . }}
+    release: {{ template "event-persister-evaluation-events-ops.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/values.yaml
@@ -1,0 +1,80 @@
+image:
+  repository: ghcr.io/bucketeer-io/bucketeer-event-persister-ops
+  pullPolicy: IfNotPresent
+
+nameOverride: "event-persister-ops"
+fullnameOverride: "event-persister-evaluation-events-ops"
+
+namespace:
+
+env:
+  logLevel: info
+  # egress services
+  featureService: localhost:9001
+  autoOpsService: localhost:9001
+  # rpc
+  port: 9090
+  metricsPort: 9002
+  # pubsub
+  project:
+  topic:
+  subscription:
+  pullerNumGoroutines: 5
+  pullerMaxOutstandingMessages: "1000"
+  pullerMaxOutstandingBytes: "1000000000"
+  # redis
+  redis:
+    serverName:
+    addr:
+    poolMaxIdle: 25
+    poolMaxActive: 25
+  # batch options
+  maxMps: "1000"
+  numWorkers: 5
+  flushSize: 100
+  flushInterval: 2s
+  flushTimeout: 30s
+
+affinity: {}
+
+nodeSelector: {}
+
+hpa:
+  enabled:
+  minReplicas:
+  maxReplicas:
+  metrics:
+    cpu:
+      targetAverageUtilization:
+
+envoy:
+  image:
+    repository: envoyproxy/envoy-alpine
+    tag: v1.21.1
+    pullPolicy: IfNotPresent
+  config:
+  port: 9000
+  adminPort: 8001
+  resources: {}
+
+tls:
+  service:
+    secret:
+    cert:
+    key:
+
+serviceToken:
+  secret:
+  token:
+
+health:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 10
+
+resources: {}
+
+service:
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9000

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/.helmignore
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/Chart.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for bucketeer-event-persister-goal-events-ops
+name: event-persister-goal-events-ops
+version: 1.0.0

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/_helpers.tpl
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "event-persister-goal-events-ops.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "event-persister-goal-events-ops.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "event-persister-goal-events-ops.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "service-cert-secret" -}}
+{{- if .Values.tls.service.secret }}
+{{- printf "%s" .Values.tls.service.secret -}}
+{{- else -}}
+{{ template "event-persister-goal-events-ops.fullname" . }}-service-cert
+{{- end -}}
+{{- end -}}
+
+{{- define "service-token-secret" -}}
+{{- if .Values.serviceToken.secret }}
+{{- printf "%s" .Values.serviceToken.secret -}}
+{{- else -}}
+{{ template "event-persister-goal-events-ops.fullname" . }}-service-token
+{{- end -}}
+{{- end -}}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/deployment.yaml
@@ -1,0 +1,168 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "event-persister-goal-events-ops.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-goal-events-ops.fullname" . }}
+    chart: {{ template "event-persister-goal-events-ops.chart" . }}
+    release: {{ template "event-persister-goal-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "event-persister-goal-events-ops.name" . }}
+      release: {{ template "event-persister-goal-events-ops.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "event-persister-goal-events-ops.name" . }}
+        release: {{ template "event-persister-goal-events-ops.fullname" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/envoy-configmap.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.global.image.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity: {{ toYaml .Values.affinity | nindent 8 }}
+      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8 }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: {{ template "event-persister-goal-events-ops.fullname" . }}-envoy-config
+        - name: service-cert-secret
+          secret:
+            secretName: {{ template "service-cert-secret" . }}
+        - name: service-token-secret
+          secret:
+            secretName: {{ template "service-token-secret" . }}
+      serviceAccountName: {{ template "event-persister-goal-events-ops.name" . }}
+      containers:
+        - name: "event-persister-ops"
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["server"]
+          env:
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_SERVICE_NAME
+              value: "{{ template "event-persister-goal-events-ops.fullname" . }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PROJECT
+              value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FEATURE_SERVICE
+              value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_AUTO_OPS_SERVICE
+              value: "{{ .Values.env.autoOpsService }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_TOPIC
+              value: "{{ .Values.env.topic }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_SUBSCRIPTION
+              value: "{{ .Values.env.subscription }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PORT
+              value: "{{ .Values.env.port }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_METRICS_PORT
+              value: "{{ .Values.env.metricsPort }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_LOG_LEVEL
+              value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_MAX_MPS
+              value: "{{ .Values.env.maxMps }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_NUM_WORKERS
+              value: "{{ .Values.env.numWorkers }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FLUSH_SIZE
+              value: "{{ .Values.env.flushSize }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FLUSH_INTERVAL
+              value: "{{ .Values.env.flushInterval }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_FLUSH_TIMEOUT
+              value: "{{ .Values.env.flushTimeout }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PULLER_NUM_GOROUTINES
+              value: "{{ .Values.env.pullerNumGoroutines }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PULLER_MAX_OUTSTANDING_MESSAGES
+              value: "{{ .Values.env.pullerMaxOutstandingMessages }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_PULLER_MAX_OUTSTANDING_BYTES
+              value: "{{ .Values.env.pullerMaxOutstandingBytes }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_CERT
+              value: /usr/local/certs/service/tls.crt
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_KEY
+              value: /usr/local/certs/service/tls.key
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_SERVICE_TOKEN
+              value: /usr/local/service-token/token
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_SERVER_NAME
+              value: "{{ .Values.env.redis.serverName }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_ADDR
+              value: "{{ .Values.env.redis.addr }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_POOL_MAX_IDLE
+              value: "{{ .Values.env.redis.poolMaxIdle }}"
+            - name: BUCKETEER_EVENT_PERSISTER_OPS_REDIS_POOL_MAX_ACTIVE
+              value: "{{ .Values.env.redis.poolMaxActive }}"
+          volumeMounts:
+            - name: service-cert-secret
+              mountPath: /usr/local/certs/service
+              readOnly: true
+            - name: service-token-secret
+              mountPath: /usr/local/service-token
+              readOnly: true
+          ports:
+            - name: service
+              containerPort: {{ .Values.env.port }}
+            - name: metrics
+              containerPort: {{ .Values.env.metricsPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            failureThreshold: {{ .Values.health.failureThreshold }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
+          resources: {{ toYaml .Values.resources | nindent 12 }}
+        - name: envoy
+          image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+          imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l) -ne 0 ]; do sleep 1; done;"
+          command: ["envoy"]
+          args:
+            - "-c"
+            - "/usr/local/conf/config.yaml"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /usr/local/conf/
+              readOnly: true
+            - name: service-cert-secret
+              mountPath: /usr/local/certs/service
+              readOnly: true
+          ports:
+            - name: envoy
+              containerPort: {{ .Values.envoy.port }}
+            - name: admin
+              containerPort: {{ .Values.envoy.adminPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            failureThreshold: {{ .Values.health.failureThreshold }}
+            httpGet:
+              path: /health
+              port: envoy
+              scheme: HTTPS
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: /health
+              port: envoy
+              scheme: HTTPS
+          resources: {{ toYaml .Values.envoy.resources | nindent 12 }}
+  strategy:
+    type: RollingUpdate

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
@@ -1,0 +1,254 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "event-persister-goal-events-ops.fullname" . }}-envoy-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-goal-events-ops.fullname" . }}
+    chart: {{ template "event-persister-goal-events-ops.chart" . }}
+    release: {{ template "event-persister-goal-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yaml: |-
+    admin:
+      access_log:
+        name: envoy.access_loggers.file
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          path: /dev/stdout
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8001
+    static_resources:
+      clusters:
+        - name: event-persister-goal-events-ops
+          type: strict_dns
+          lb_policy: round_robin
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          load_assignment:
+            cluster_name: event-persister-goal-events-ops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9090
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          health_checks:
+            - grpc_health_check: {}
+              healthy_threshold: 1
+              interval: 10s
+              interval_jitter: 1s
+              no_traffic_interval: 2s
+              timeout: 1s
+              unhealthy_threshold: 2
+          ignore_health_on_host_removal: true
+        - name: feature
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: feature
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: feature.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+        - name: auto-ops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: auto-ops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+      listeners:
+        - name: ingress
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    access_log:
+                      name: envoy.access_loggers.file
+                      typed_config:
+                        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                    codec_type: auto
+                    http_filters:
+                      - name: envoy.filters.http.health_check
+                        typed_config:
+                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                          cluster_min_healthy_percentages:
+                            event-persister-goal-events-ops:
+                              value: 25
+                          headers:
+                            - name: :path
+                              string_match:
+                                exact: /health
+                          pass_through_mode: false
+                      - name: envoy.filters.http.router
+                    route_config:
+                      virtual_hosts:
+                        - domains:
+                            - '*'
+                          name: ingress_services
+                          routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /
+                              route:
+                                cluster: event-persister-goal-events-ops
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                    stat_prefix: ingress_http
+                    stream_idle_timeout: 300s
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    alpn_protocols:
+                      - h2
+                    tls_certificates:
+                      - certificate_chain:
+                          filename: /usr/local/certs/service/tls.crt
+                        private_key:
+                          filename: /usr/local/certs/service/tls.key
+                  require_client_certificate: true
+        - name: egress
+          address:
+            socket_address:
+              address: 127.0.0.1
+              port_value: 9001
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    access_log:
+                      name: envoy.access_loggers.file
+                      typed_config:
+                        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                    codec_type: auto
+                    http_filters:
+                      - name: envoy.filters.http.router
+                    route_config:
+                      virtual_hosts:
+                        - domains:
+                            - '*'
+                          name: egress_services
+                          routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.feature.FeatureService
+                              route:
+                                cluster: feature
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.autoops.AutoOpsService
+                              route:
+                                cluster: auto-ops
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                    stat_prefix: egress_http
+                    stream_idle_timeout: 300s
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    alpn_protocols:
+                      - h2
+                    tls_certificates:
+                      - certificate_chain:
+                          filename: /usr/local/certs/service/tls.crt
+                        private_key:
+                          filename: /usr/local/certs/service/tls.key
+                  require_client_certificate: true

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/hpa.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "event-persister-goal-events-ops.fullname" . }}
+  namespace: {{ .Values.namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "event-persister-goal-events-ops.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      targetAverageUtilization: {{ .Values.hpa.metrics.cpu.targetAverageUtilization }}
+{{ end }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    namespace: {{ .Values.namespace }}
+    name: {{ template "event-persister-goal-events-ops.name" . }}
+    annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-cert-secret.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-cert-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.tls.service.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "event-persister-goal-events-ops.fullname" . }}-service-cert
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-goal-events-ops.fullname" . }}
+    chart: {{ template "event-persister-goal-events-ops.chart" . }}
+    release: {{ template "event-persister-goal-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  tls.crt: {{ required "Service TLS certificate is required" .Values.tls.service.cert | b64enc | quote }}
+  tls.key: {{ required "Service TLS key is required" .Values.tls.service.key | b64enc | quote }}
+{{- end }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-token-secret.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-token-secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.serviceToken.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "event-persister-goal-events-ops.fullname" . }}-service-token
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-goal-events-ops.name" . }}
+    chart: {{ template "event-persister-goal-events-ops.chart" . }}
+    release: {{ template "event-persister-goal-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  token: {{ required "Service token is required" .Values.serviceToken.token | b64enc | quote }}
+{{- end }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "event-persister-goal-events-ops.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "event-persister-goal-events-ops.fullname" . }}
+    chart: {{ template "event-persister-goal-events-ops.chart" . }}
+    release: {{ template "event-persister-goal-events-ops.fullname" . }}
+    heritage: {{ .Release.Service }}
+    envoy: "true"
+    metrics: "true"
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - name: service
+      port: {{ .Values.service.externalPort }}
+      targetPort: envoy
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.env.metricsPort }}
+      protocol: TCP
+    - name: admin
+      port: {{ .Values.envoy.adminPort }}
+      protocol: TCP
+  selector:
+    app: {{ template "event-persister-goal-events-ops.name" . }}
+    release: {{ template "event-persister-goal-events-ops.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/values.yaml
@@ -1,0 +1,80 @@
+image:
+  repository: ghcr.io/bucketeer-io/bucketeer-event-persister-ops
+  pullPolicy: IfNotPresent
+
+nameOverride: "event-persister-ops"
+fullnameOverride: "event-persister-goal-events-ops"
+
+namespace:
+
+env:
+  logLevel: info
+  # egress services
+  featureService: localhost:9001
+  autoOpsService: localhost:9001
+  # rpc
+  port: 9090
+  metricsPort: 9002
+  # pubsub
+  project:
+  topic:
+  subscription:
+  pullerNumGoroutines: 5
+  pullerMaxOutstandingMessages: "1000"
+  pullerMaxOutstandingBytes: "1000000000"
+  # redis
+  redis:
+    serverName:
+    addr:
+    poolMaxIdle: 25
+    poolMaxActive: 25
+  # batch options
+  maxMps: "1000"
+  numWorkers: 5
+  flushSize: 100
+  flushInterval: 2s
+  flushTimeout: 30s
+
+affinity: {}
+
+nodeSelector: {}
+
+hpa:
+  enabled:
+  minReplicas:
+  maxReplicas:
+  metrics:
+    cpu:
+      targetAverageUtilization:
+
+envoy:
+  image:
+    repository: envoyproxy/envoy-alpine
+    tag: v1.21.1
+    pullPolicy: IfNotPresent
+  config:
+  port: 9000
+  adminPort: 8001
+  resources: {}
+
+tls:
+  service:
+    secret:
+    cert:
+    key:
+
+serviceToken:
+  secret:
+  token:
+
+health:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 10
+
+resources: {}
+
+service:
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9000

--- a/manifests/bucketeer/values.yaml
+++ b/manifests/bucketeer/values.yaml
@@ -1336,6 +1336,144 @@ event-persister-user-events-kafka:
   serviceAccount:
     annotations: {}
 
+event-persister-evaluation-events-ops:
+  image:
+    repository: ghcr.io/bucketeer-io/bucketeer-event-persister-ops
+    pullPolicy: IfNotPresent
+  nameOverride: "event-persister-ops"
+  fullnameOverride: "event-persister-evaluation-events-ops"
+  namespace: default
+  env:
+    project:
+    logLevel: info
+    port: 9090
+    metricsPort: 9002
+    featureService: localhost:9001
+    autoOpsService: localhost:9001
+    # options
+    maxMps: "1000"
+    numWorkers: 5
+    flushSize: 100
+    flushInterval: 2s
+    flushTimeout: 30s
+    # pubsub
+    topic:
+    subscription:
+    pullerNumGoroutines: 5
+    pullerMaxOutstandingMessages: "1000"
+    pullerMaxOutstandingBytes: "1000000000"
+    # redis
+    redis:
+      serverName:
+      addr:
+      poolMaxIdle: 25
+      poolMaxActive: 25
+  affinity: {}
+  nodeSelector: {}
+  hpa:
+    enabled: false
+    namespace:
+    minReplicas:
+    maxReplicas:
+    metrics: {}
+  envoy:
+    image:
+      repository: envoyproxy/envoy-alpine
+      tag: v1.21.1
+      pullPolicy: IfNotPresent
+    config:
+    port: 9000
+    adminPort: 8001
+    resources: {}
+  tls:
+    service:
+      secret:
+      cert:
+      key:
+  serviceToken:
+    secret:
+    token:
+  health:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 10
+  resources: {}
+  service:
+    type: ClusterIP
+    clusterIP: None
+    externalPort: 9000
+  serviceAccount:
+    annotations: {}
+
+event-persister-goal-events-ops:
+  image:
+    repository: ghcr.io/bucketeer-io/bucketeer-event-persister-ops
+    pullPolicy: IfNotPresent
+  nameOverride: "event-persister-ops"
+  fullnameOverride: "event-persister-goal-events-ops"
+  namespace: default
+  env:
+    project:
+    logLevel: info
+    port: 9090
+    metricsPort: 9002
+    featureService: localhost:9001
+    autoOpsService: localhost:9001
+    # options
+    maxMps: "1000"
+    numWorkers: 5
+    flushSize: 100
+    flushInterval: 2s
+    flushTimeout: 30s
+    # pubsub
+    topic:
+    subscription:
+    pullerNumGoroutines: 5
+    pullerMaxOutstandingMessages: "1000"
+    pullerMaxOutstandingBytes: "1000000000"
+    # redis
+    redis:
+      serverName:
+      addr:
+      poolMaxIdle: 25
+      poolMaxActive: 25
+  affinity: {}
+  nodeSelector: {}
+  hpa:
+    enabled: false
+    namespace:
+    minReplicas:
+    maxReplicas:
+    metrics: {}
+  envoy:
+    image:
+      repository: envoyproxy/envoy-alpine
+      tag: v1.21.1
+      pullPolicy: IfNotPresent
+    config:
+    port: 9000
+    adminPort: 8001
+    resources: {}
+  tls:
+    service:
+      secret:
+      cert:
+      key:
+  serviceToken:
+    secret:
+    token:
+  health:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    failureThreshold: 10
+  resources: {}
+  service:
+    type: ClusterIP
+    clusterIP: None
+    externalPort: 9000
+  serviceAccount:
+    annotations: {}
+
 experiment:
   image:
     repository: ghcr.io/bucketeer-io/bucketeer-experiment

--- a/pkg/eventpersisterops/cmd/server/eventpersisterops.go
+++ b/pkg/eventpersisterops/cmd/server/eventpersisterops.go
@@ -1,0 +1,95 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+	kingpin "gopkg.in/alecthomas/kingpin.v2"
+
+	"github.com/bucketeer-io/bucketeer/pkg/cli"
+	"github.com/bucketeer-io/bucketeer/pkg/eventpersisterops/persister"
+	"github.com/bucketeer-io/bucketeer/pkg/health"
+	"github.com/bucketeer-io/bucketeer/pkg/metrics"
+	"github.com/bucketeer-io/bucketeer/pkg/rpc"
+)
+
+const (
+	command = "server"
+)
+
+type server struct {
+	*kingpin.CmdClause
+	port *int
+	// option
+	maxMPS        *int
+	numWorkers    *int
+	flushSize     *int
+	flushInterval *time.Duration
+	flushTimeout  *time.Duration
+	// rpc
+	serviceTokenPath *string
+	certPath         *string
+	keyPath          *string
+}
+
+func RegisterServerCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
+	cmd := p.Command(command, "Start the server")
+	server := &server{
+		CmdClause:  cmd,
+		port:       cmd.Flag("port", "Port to bind to.").Default("9090").Int(),
+		maxMPS:     cmd.Flag("max-mps", "Maximum messages should be handled in a second.").Default("1000").Int(),
+		numWorkers: cmd.Flag("num-workers", "Number of workers.").Default("2").Int(),
+		flushSize: cmd.Flag(
+			"flush-size",
+			"Maximum number of messages to batch before writing to datastore.",
+		).Default("50").Int(),
+		flushInterval:    cmd.Flag("flush-interval", "Maximum interval between two flushes.").Default("5s").Duration(),
+		flushTimeout:     cmd.Flag("flush-timeout", "Maximum time for a flush to finish.").Default("20s").Duration(),
+		certPath:         cmd.Flag("cert", "Path to TLS certificate.").Required().String(),
+		keyPath:          cmd.Flag("key", "Path to TLS key.").Required().String(),
+		serviceTokenPath: cmd.Flag("service-token", "Path to service token.").Required().String(),
+	}
+	r.RegisterCommand(server)
+	return server
+}
+
+func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.Logger) error {
+	registerer := metrics.DefaultRegisterer()
+
+	p := persister.NewPersister()
+	defer p.Stop()
+
+	healthChecker := health.NewGrpcChecker(
+		health.WithTimeout(time.Second),
+		health.WithCheck("metrics", metrics.Check),
+		health.WithCheck("persister", p.Check),
+	)
+	go healthChecker.Run(ctx)
+
+	server := rpc.NewServer(healthChecker, *s.certPath, *s.keyPath,
+		rpc.WithPort(*s.port),
+		rpc.WithMetrics(registerer),
+		rpc.WithLogger(logger),
+		rpc.WithHandler("/health", healthChecker),
+	)
+	defer server.Stop(10 * time.Second)
+	go server.Run()
+
+	<-ctx.Done()
+	return nil
+}

--- a/pkg/eventpersisterops/persister/persister.go
+++ b/pkg/eventpersisterops/persister/persister.go
@@ -1,0 +1,123 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persister
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/bucketeer-io/bucketeer/pkg/health"
+	"github.com/bucketeer-io/bucketeer/pkg/metrics"
+)
+
+type persister struct {
+	ctx    context.Context
+	cancel func()
+	logger *zap.Logger
+	opts   *options
+}
+
+type options struct {
+	maxMPS        int
+	numWorkers    int
+	flushSize     int
+	flushInterval time.Duration
+	flushTimeout  time.Duration
+	metrics       metrics.Registerer
+	logger        *zap.Logger
+}
+
+type Option func(*options)
+
+func WithMaxMPS(mps int) Option {
+	return func(opts *options) {
+		opts.maxMPS = mps
+	}
+}
+
+func WithNumWorkers(n int) Option {
+	return func(opts *options) {
+		opts.numWorkers = n
+	}
+}
+
+func WithFlushSize(s int) Option {
+	return func(opts *options) {
+		opts.flushSize = s
+	}
+}
+
+func WithFlushInterval(i time.Duration) Option {
+	return func(opts *options) {
+		opts.flushInterval = i
+	}
+}
+
+func WithFlushTimeout(timeout time.Duration) Option {
+	return func(opts *options) {
+		opts.flushTimeout = timeout
+	}
+}
+
+func WithMetrics(r metrics.Registerer) Option {
+	return func(opts *options) {
+		opts.metrics = r
+	}
+}
+
+func WithLogger(l *zap.Logger) Option {
+	return func(opts *options) {
+		opts.logger = l
+	}
+}
+
+func NewPersister(
+	opts ...Option,
+) *persister {
+	dopts := &options{
+		maxMPS:        1000,
+		numWorkers:    1,
+		flushSize:     50,
+		flushInterval: 5 * time.Second,
+		flushTimeout:  20 * time.Second,
+		logger:        zap.NewNop(),
+	}
+	for _, opt := range opts {
+		opt(dopts)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &persister{
+		ctx:    ctx,
+		cancel: cancel,
+		logger: dopts.logger.Named("persister"),
+		opts:   dopts,
+	}
+}
+
+func (p *persister) Stop() {
+	p.cancel()
+}
+
+func (p *persister) Check(ctx context.Context) health.Status {
+	select {
+	case <-p.ctx.Done():
+		p.logger.Error("Unhealthy due to context Done is closed", zap.Error(p.ctx.Err()))
+		return health.Unhealthy
+	default:
+		return health.Healthy
+	}
+}

--- a/tools/build/show-image-name.sh
+++ b/tools/build/show-image-name.sh
@@ -7,6 +7,7 @@ case $APP in
     "eventcounter") echo "event-counter" ;;
     "eventpersister") echo "event-persister" ;;
     "eventpersisterdwh") echo "event-persister-dwh" ;;
+    "eventpersisterops") echo "event-persister-ops" ;;
     "metricsevent") echo "metrics-event" ;;
     "opsevent") echo "ops-event" ;;
     *) echo $APP


### PR DESCRIPTION
To keep the PR small, I'm adding the persister implementation in another PR.

#### Things done:

- Add the helm manifest
- Add event persister ops to the container images list
- Add the persister service (health check only)