### PR TITLE
chore: update BigQuery query files

### DIFF
--- a/pkg/eventcounter/storage/v2/sql/evaluation_count.sql
+++ b/pkg/eventcounter/storage/v2/sql/evaluation_count.sql
@@ -5,7 +5,7 @@ SELECT
 FROM
     `%s`
 WHERE
-    _PARTITIONTIME BETWEEN TIMESTAMP(@startAt) AND TIMESTAMP(@endAt)
+    timestamp BETWEEN TIMESTAMP(@startAt) AND TIMESTAMP(@endAt)
     AND environment_namespace = @environmentNamespace
     AND feature_id = @featureID
     AND feature_version = @featureVersion

--- a/pkg/eventcounter/storage/v2/sql/goal_count.sql
+++ b/pkg/eventcounter/storage/v2/sql/goal_count.sql
@@ -7,7 +7,7 @@ WITH grouped_by_user_evaluation AS (
     FROM
         `%s`
     WHERE
-        _PARTITIONTIME BETWEEN TIMESTAMP(@startAt) AND TIMESTAMP(@endAt)
+        timestamp BETWEEN TIMESTAMP(@startAt) AND TIMESTAMP(@endAt)
     AND environment_namespace = @environmentNamespace
     AND feature_id = @featureID
     AND feature_version = @featureVersion


### PR DESCRIPTION
- We chose the time-unit column partitioning instead of the ingestion time partitioning.
  - https://cloud.google.com/bigquery/docs/partitioned-tables
  - A pseudo column named `_PARTITIONTIME` doesn't exist when you use the time-unit column partitioning.