### PR TITLE
chore: add event persister service for auto ops

### DIFF
--- a/pkg/cache/v3/eventcounter.go
+++ b/pkg/cache/v3/eventcounter.go
@@ -28,6 +28,7 @@ type EventCounterCache interface {
 	GetEventCounts(keys []string) ([]float64, error)
 	GetUserCount(key string) (int64, error)
 	GetUserCounts(keys []string) ([]float64, error)
+	UpdateUserCount(key, userID string) error
 }
 
 type eventCounterCache struct {
@@ -94,4 +95,12 @@ func getUserValues(cmds []*goredis.IntCmd) ([]float64, error) {
 		userVals = append(userVals, float64(val))
 	}
 	return userVals, nil
+}
+
+func (c *eventCounterCache) UpdateUserCount(key, userID string) error {
+	_, err := c.cache.PFAdd(key, userID)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/cache/v3/mock/eventcounter.go
+++ b/pkg/cache/v3/mock/eventcounter.go
@@ -77,3 +77,17 @@ func (mr *MockEventCounterCacheMockRecorder) GetUserCounts(keys interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserCounts", reflect.TypeOf((*MockEventCounterCache)(nil).GetUserCounts), keys)
 }
+
+// UpdateUserCount mocks base method.
+func (m *MockEventCounterCache) UpdateUserCount(key, userID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateUserCount", key, userID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateUserCount indicates an expected call of UpdateUserCount.
+func (mr *MockEventCounterCacheMockRecorder) UpdateUserCount(key, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserCount", reflect.TypeOf((*MockEventCounterCache)(nil).UpdateUserCount), key, userID)
+}

--- a/pkg/eventpersisterops/cmd/server/eventpersisterops.go
+++ b/pkg/eventpersisterops/cmd/server/eventpersisterops.go
@@ -16,53 +16,110 @@ package server
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.uber.org/zap"
 	kingpin "gopkg.in/alecthomas/kingpin.v2"
 
+	aoclient "github.com/bucketeer-io/bucketeer/pkg/autoops/client"
+	"github.com/bucketeer-io/bucketeer/pkg/cache"
+	cachev3 "github.com/bucketeer-io/bucketeer/pkg/cache/v3"
 	"github.com/bucketeer-io/bucketeer/pkg/cli"
 	"github.com/bucketeer-io/bucketeer/pkg/eventpersisterops/persister"
+	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
 	"github.com/bucketeer-io/bucketeer/pkg/health"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
+	redisv3 "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
+	"github.com/bucketeer-io/bucketeer/pkg/rpc/client"
 )
 
 const (
-	command = "server"
+	command         = "server"
+	evalEvtSvcName  = "event-persister-evaluation-events-ops"
+	evalGoalSvcName = "event-persister-goal-events-ops"
 )
+
+var errUnknownSvcName = errors.New("persister: unknown service name")
 
 type server struct {
 	*kingpin.CmdClause
-	port *int
-	// option
+	serviceName *string
+	// egress services
+	featureService *string
+	autoOpsService *string
+	// rpc
+	port             *int
+	serviceTokenPath *string
+	certPath         *string
+	keyPath          *string
+	// pubsub
+	project                      *string
+	subscription                 *string
+	topic                        *string
+	pullerNumGoroutines          *int
+	pullerMaxOutstandingMessages *int
+	pullerMaxOutstandingBytes    *int
+	// redis
+	redisServerName    *string
+	redisAddr          *string
+	redisPoolMaxIdle   *int
+	redisPoolMaxActive *int
+	// batch options
 	maxMPS        *int
 	numWorkers    *int
 	flushSize     *int
 	flushInterval *time.Duration
 	flushTimeout  *time.Duration
-	// rpc
-	serviceTokenPath *string
-	certPath         *string
-	keyPath          *string
 }
 
 func RegisterServerCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 	cmd := p.Command(command, "Start the server")
 	server := &server{
-		CmdClause:  cmd,
-		port:       cmd.Flag("port", "Port to bind to.").Default("9090").Int(),
-		maxMPS:     cmd.Flag("max-mps", "Maximum messages should be handled in a second.").Default("1000").Int(),
-		numWorkers: cmd.Flag("num-workers", "Number of workers.").Default("2").Int(),
-		flushSize: cmd.Flag(
-			"flush-size",
-			"Maximum number of messages to batch before writing to datastore.",
-		).Default("50").Int(),
-		flushInterval:    cmd.Flag("flush-interval", "Maximum interval between two flushes.").Default("5s").Duration(),
-		flushTimeout:     cmd.Flag("flush-timeout", "Maximum time for a flush to finish.").Default("20s").Duration(),
+		CmdClause:        cmd,
+		serviceName:      cmd.Flag("service-name", "Service name.").Required().String(),
+		project:          cmd.Flag("project", "Google Cloud project name.").Required().String(),
+		port:             cmd.Flag("port", "Port to bind to.").Required().Int(),
+		featureService:   cmd.Flag("feature-service", "bucketeer-feature-service address.").Required().String(),
+		autoOpsService:   cmd.Flag("auto-ops-service", "bucketeer-auto-ops-service address.").Required().String(),
 		certPath:         cmd.Flag("cert", "Path to TLS certificate.").Required().String(),
 		keyPath:          cmd.Flag("key", "Path to TLS key.").Required().String(),
 		serviceTokenPath: cmd.Flag("service-token", "Path to service token.").Required().String(),
+		subscription:     cmd.Flag("subscription", "Google PubSub subscription name.").Required().String(),
+		topic:            cmd.Flag("topic", "Google PubSub topic name.").Required().String(),
+		pullerNumGoroutines: cmd.Flag(
+			"puller-num-goroutines",
+			"Number of goroutines will be spawned to pull messages.",
+		).Required().Int(),
+		pullerMaxOutstandingMessages: cmd.Flag(
+			"puller-max-outstanding-messages",
+			"Maximum number of unprocessed messages.",
+		).Required().Int(),
+		pullerMaxOutstandingBytes: cmd.Flag(
+			"puller-max-outstanding-bytes",
+			"Maximum size of unprocessed messages.",
+		).Required().Int(),
+		redisServerName: cmd.Flag("redis-server-name", "Name of the redis.").Required().String(),
+		redisAddr:       cmd.Flag("redis-addr", "Address of the redis.").Required().String(),
+		redisPoolMaxIdle: cmd.Flag(
+			"redis-pool-max-idle",
+			"Maximum number of idle connections in the pool.",
+		).Required().Int(),
+		redisPoolMaxActive: cmd.Flag(
+			"redis-pool-max-active",
+			"Maximum number of connections allocated by the pool at a given time.",
+		).Required().Int(),
+		maxMPS:     cmd.Flag("max-mps", "Maximum messages should be handled in a second.").Required().Int(),
+		numWorkers: cmd.Flag("num-workers", "Number of workers.").Required().Int(),
+		flushSize: cmd.Flag(
+			"flush-size",
+			"Maximum number of messages to batch before writing to datastore.",
+		).Required().Int(),
+		flushInterval: cmd.Flag("flush-interval", "Maximum interval between two flushes.").Required().Duration(),
+		flushTimeout:  cmd.Flag("flush-timeout", "Maximum time for a flush to finish.").Required().Duration(),
 	}
 	r.RegisterCommand(server)
 	return server
@@ -71,8 +128,79 @@ func RegisterServerCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Comma
 func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.Logger) error {
 	registerer := metrics.DefaultRegisterer()
 
-	p := persister.NewPersister()
+	puller, err := s.createPuller(ctx, logger)
+	if err != nil {
+		return err
+	}
+
+	creds, err := client.NewPerRPCCredentials(*s.serviceTokenPath)
+	if err != nil {
+		return err
+	}
+
+	featureClient, err := featureclient.NewClient(*s.featureService, *s.certPath,
+		client.WithPerRPCCredentials(creds),
+		client.WithDialTimeout(30*time.Second),
+		client.WithBlock(),
+		client.WithMetrics(registerer),
+		client.WithLogger(logger),
+	)
+	if err != nil {
+		return err
+	}
+	defer featureClient.Close()
+
+	autoOpsClient, err := aoclient.NewClient(*s.autoOpsService, *s.certPath,
+		client.WithPerRPCCredentials(creds),
+		client.WithDialTimeout(30*time.Second),
+		client.WithBlock(),
+		client.WithMetrics(registerer),
+		client.WithLogger(logger),
+	)
+	if err != nil {
+		return err
+	}
+	defer autoOpsClient.Close()
+
+	redisV3Client, err := redisv3.NewClient(
+		*s.redisAddr,
+		redisv3.WithPoolSize(*s.redisPoolMaxActive),
+		redisv3.WithMinIdleConns(*s.redisPoolMaxIdle),
+		redisv3.WithServerName(*s.redisServerName),
+		redisv3.WithMetrics(registerer),
+		redisv3.WithLogger(logger),
+	)
+	if err != nil {
+		return err
+	}
+	defer redisV3Client.Close()
+	redisV3Cache := cachev3.NewRedisCache(redisV3Client)
+
+	updater, err := s.newUserCountUpdater(
+		ctx,
+		featureClient,
+		autoOpsClient,
+		redisV3Cache,
+		registerer,
+		logger,
+	)
+	if err != nil {
+		return err
+	}
+
+	p := persister.NewPersister(
+		updater,
+		puller,
+		persister.WithMaxMPS(*s.maxMPS),
+		persister.WithNumWorkers(*s.numWorkers),
+		persister.WithFlushSize(*s.flushSize),
+		persister.WithFlushInterval(*s.flushInterval),
+		persister.WithFlushTimeout(*s.flushTimeout),
+		persister.WithMetrics(registerer),
+		persister.WithLogger(logger),
+	)
 	defer p.Stop()
+	go p.Run() // nolint:errcheck
 
 	healthChecker := health.NewGrpcChecker(
 		health.WithTimeout(time.Second),
@@ -92,4 +220,52 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 
 	<-ctx.Done()
 	return nil
+}
+
+func (s *server) createPuller(ctx context.Context, logger *zap.Logger) (puller.Puller, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	client, err := pubsub.NewClient(ctx, *s.project, pubsub.WithLogger(logger))
+	if err != nil {
+		logger.Error("Failed to create PubSub client", zap.Error(err))
+		return nil, err
+	}
+	return client.CreatePuller(*s.subscription, *s.topic,
+		pubsub.WithNumGoroutines(*s.pullerNumGoroutines),
+		pubsub.WithMaxOutstandingMessages(*s.pullerMaxOutstandingMessages),
+		pubsub.WithMaxOutstandingBytes(*s.pullerMaxOutstandingBytes),
+	)
+}
+
+func (s *server) newUserCountUpdater(
+	ctx context.Context,
+	featureClient featureclient.Client,
+	autoOpsClient aoclient.Client,
+	redis cache.MultiGetDeleteCountCache,
+	registerer metrics.Registerer,
+	logger *zap.Logger,
+) (persister.Updater, error) {
+	var updater persister.Updater
+	var err error
+	switch *s.serviceName {
+	case evalEvtSvcName:
+		updater = persister.NewEvalUserCountUpdater(
+			ctx,
+			featureClient,
+			autoOpsClient,
+			cachev3.NewEventCountCache(redis),
+			logger,
+		)
+	case evalGoalSvcName:
+		updater = persister.NewGoalUserCountUpdater(
+			ctx,
+			featureClient,
+			autoOpsClient,
+			cachev3.NewEventCountCache(redis),
+			logger,
+		)
+	default:
+		return nil, errUnknownSvcName
+	}
+	return updater, err
 }

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -199,7 +199,7 @@ func (u *evalEvtUpdater) linkOpsRulesByFeatureID(
 
 func (u *evalEvtUpdater) linkOpsEventRateByVariationID(
 	rule *aoproto.AutoOpsRule,
-	targetVariationID string,
+	variationID string,
 ) ([]string, error) {
 	r := &aodomain.AutoOpsRule{AutoOpsRule: rule}
 	clauses, err := r.ExtractOpsEventRateClauses()
@@ -209,8 +209,8 @@ func (u *evalEvtUpdater) linkOpsEventRateByVariationID(
 	}
 	ids := make([]string, 0, len(clauses))
 	for id, clause := range clauses {
-		// The variation must match
-		if clause.VariationId == targetVariationID {
+		// The variation must match to link
+		if clause.VariationId == variationID {
 			ids = append(ids, id)
 		}
 	}

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -1,0 +1,270 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persister
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
+	aoclient "github.com/bucketeer-io/bucketeer/pkg/autoops/client"
+	aodomain "github.com/bucketeer-io/bucketeer/pkg/autoops/domain"
+	"github.com/bucketeer-io/bucketeer/pkg/cache"
+	cachev3 "github.com/bucketeer-io/bucketeer/pkg/cache/v3"
+	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
+	aoproto "github.com/bucketeer-io/bucketeer/proto/autoops"
+	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
+)
+
+const opsEvalKeyPrefix = "autoops:evaluation"
+
+type evalTargetRule struct {
+	id        string
+	clauseIDs []string
+}
+
+type evalEvtUpdater struct {
+	ctx               context.Context
+	featureClient     featureclient.Client
+	autoOpsClient     aoclient.Client
+	eventCounterCache cachev3.EventCounterCache
+	flightgroup       singleflight.Group
+	logger            *zap.Logger
+}
+
+func NewEvalUserCountUpdater(
+	ctx context.Context,
+	featureClient featureclient.Client,
+	autoOpsClient aoclient.Client,
+	eventCounterCache cachev3.EventCounterCache,
+	logger *zap.Logger,
+) Updater {
+	return &evalEvtUpdater{
+		ctx:               ctx,
+		featureClient:     featureClient,
+		autoOpsClient:     autoOpsClient,
+		eventCounterCache: eventCounterCache,
+		logger:            logger,
+	}
+}
+
+func (u *evalEvtUpdater) UpdateUserCounts(ctx context.Context, evt environmentEventMap) map[string]bool {
+	fails := map[string]bool{}
+	for environmentNamespace, events := range evt {
+		for id, event := range events {
+			switch evt := event.(type) {
+			case *eventproto.EvaluationEvent:
+				retriable, err := u.updateUserCount(ctx, environmentNamespace, evt)
+				if err != nil {
+					if err == ErrNoAutoOpsRules || err == ErrAutoOpsRulesNotFound {
+						handledCounter.WithLabelValues(codeNoLink).Inc()
+						u.logger.Debug(
+							"There is no auto ops rules to link the evaluation event",
+							zap.Error(err),
+							zap.String("eventId", id),
+							zap.String("environmentNamespace", environmentNamespace),
+						)
+						continue
+					}
+					if !retriable {
+						u.logger.Error(
+							"Failed to persister evaluation event for auto ops",
+							zap.Error(err),
+							zap.String("eventId", id),
+							zap.String("environmentNamespace", environmentNamespace),
+						)
+					}
+					fails[id] = retriable
+					continue
+				}
+				handledCounter.WithLabelValues(codeLinked).Inc()
+			default:
+				u.logger.Error(
+					"Unexpected message type while trying to persister an evaluation event",
+					zap.String("eventId", id),
+					zap.String("environmentNamespace", environmentNamespace),
+				)
+				fails[id] = false
+			}
+		}
+	}
+	return fails
+}
+
+func (u *evalEvtUpdater) updateUserCount(
+	ctx context.Context,
+	environmentNamespace string,
+	event *eventproto.EvaluationEvent,
+) (bool, error) {
+	// List all the auto ops rules
+	list, err := u.listAutoOpsRules(ctx, environmentNamespace)
+	if err != nil {
+		handledCounter.WithLabelValues(codeFailedToListAutoOpsRules).Inc()
+		return true, err
+	}
+	if len(list) == 0 {
+		return false, ErrNoAutoOpsRules
+	}
+	// Find the rules
+	rules := u.findOpsRules(event.FeatureId, list)
+	if len(rules) == 0 {
+		return false, ErrAutoOpsRulesNotFound
+	}
+	// Find the event rate clauses by variation ID
+	targetRules := []*evalTargetRule{}
+	for _, rule := range rules {
+		targetRule, err := u.findEventRateClauseIDs(rule, event.VariationId)
+		if err != nil {
+			return false, err
+		}
+		targetRules = append(targetRules, targetRule)
+	}
+	// Update the user count by rule
+	for _, tr := range targetRules {
+		err := u.updateUserCountByRule(
+			environmentNamespace,
+			event.FeatureId,
+			event.FeatureVersion,
+			event.VariationId,
+			event.UserId,
+			tr,
+		)
+		if err != nil {
+			return true, err
+		}
+	}
+	return false, nil
+}
+
+func (u *evalEvtUpdater) listAutoOpsRules(
+	ctx context.Context,
+	environmentNamespace string,
+) ([]*aoproto.AutoOpsRule, error) {
+	exp, err, _ := u.flightgroup.Do(
+		fmt.Sprintf("%s:%s", environmentNamespace, "listAutoOpsRules"),
+		func() (interface{}, error) {
+			aor := []*aoproto.AutoOpsRule{}
+			cursor := ""
+			for {
+				resp, err := u.autoOpsClient.ListAutoOpsRules(ctx, &aoproto.ListAutoOpsRulesRequest{
+					EnvironmentNamespace: environmentNamespace,
+					PageSize:             listRequestSize,
+					Cursor:               cursor,
+				})
+				if err != nil {
+					return nil, err
+				}
+				aor = append(aor, resp.AutoOpsRules...)
+				aorSize := len(resp.AutoOpsRules)
+				if aorSize == 0 || aorSize < listRequestSize {
+					return aor, nil
+				}
+				cursor = resp.Cursor
+			}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return exp.([]*aoproto.AutoOpsRule), nil
+}
+
+func (u *evalEvtUpdater) findOpsRules(
+	featureID string,
+	listAutoOpsRules []*aoproto.AutoOpsRule,
+) []*aoproto.AutoOpsRule {
+	rules := []*aoproto.AutoOpsRule{}
+	for _, aor := range listAutoOpsRules {
+		// Ignore already triggered ops rules
+		if aor.FeatureId == featureID && aor.TriggeredAt == 0 {
+			rules = append(rules, aor)
+		}
+	}
+	return rules
+}
+
+func (u *evalEvtUpdater) findEventRateClauseIDs(
+	rule *aoproto.AutoOpsRule,
+	targetVariationID string,
+) (*evalTargetRule, error) {
+	r := &aodomain.AutoOpsRule{AutoOpsRule: rule}
+	clauses, err := r.ExtractOpsEventRateClauses()
+	if err != nil {
+		handledCounter.WithLabelValues(codeFailedToExtractOpsEventRateClauses).Inc()
+		return nil, err
+	}
+	ids := make([]string, 0, len(clauses))
+	for id, clause := range clauses {
+		// The variation must match
+		if clause.VariationId == targetVariationID {
+			ids = append(ids, id)
+		}
+	}
+	return &evalTargetRule{
+		id:        r.Id,
+		clauseIDs: ids,
+	}, nil
+}
+
+func (u *evalEvtUpdater) updateUserCountByRule(
+	environmentNamespace,
+	featureID string,
+	featureVersion int32,
+	variationID,
+	userID string,
+	targetRule *evalTargetRule,
+) error {
+	for _, clauseID := range targetRule.clauseIDs {
+		key := u.newUserCountKey(
+			environmentNamespace,
+			targetRule.id,
+			clauseID,
+			featureID,
+			variationID,
+			featureVersion,
+		)
+		if err := u.eventCounterCache.UpdateUserCount(key, userID); err != nil {
+			handledCounter.WithLabelValues(codeFailedToUpdateUserCount).Inc()
+			return err
+		}
+		u.logger.Debug(
+			"User count updated successfully",
+			zap.String("pfcountKey", key),
+			zap.String("environmentNamespace", environmentNamespace),
+		)
+	}
+	return nil
+}
+
+func (u *evalEvtUpdater) newUserCountKey(
+	environmentNamespace,
+	ruleID, clauseID, featureID, variationID string,
+	featureVersion int32,
+) string {
+	key := fmt.Sprintf("%s:%s:%s:%d:%s",
+		ruleID,
+		clauseID,
+		featureID,
+		featureVersion,
+		variationID,
+	)
+	return cache.MakeKey(
+		opsEvalKeyPrefix,
+		key,
+		environmentNamespace,
+	)
+}

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -131,7 +131,7 @@ func (u *evalEvtUpdater) updateUserCount(
 	}
 	// Update the user count per rule
 	for ruleID, clauseIDs := range linkedOpsRules {
-		err := u.updateUserCountPerRule(
+		err := u.updateUserCountPerClause(
 			environmentNamespace,
 			event.FeatureId,
 			event.FeatureVersion,
@@ -217,7 +217,7 @@ func (u *evalEvtUpdater) linkOpsEventRateByVariationID(
 	return ids, nil
 }
 
-func (u *evalEvtUpdater) updateUserCountPerRule(
+func (u *evalEvtUpdater) updateUserCountPerClause(
 	environmentNamespace,
 	featureID string,
 	featureVersion int32,

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -156,6 +156,9 @@ func (u *evalEvtUpdater) listAutoOpsRules(
 			aor := []*aoproto.AutoOpsRule{}
 			cursor := ""
 			for {
+				// We don't use the feature ID to filter the results in the request
+				// because it will increase access to the DB, which also will increase the costs.
+				// So we list all rules and use the singleflight implementation to share the response
 				resp, err := u.autoOpsClient.ListAutoOpsRules(ctx, &aoproto.ListAutoOpsRulesRequest{
 					EnvironmentNamespace: environmentNamespace,
 					PageSize:             listRequestSize,

--- a/pkg/eventpersisterops/persister/event.go
+++ b/pkg/eventpersisterops/persister/event.go
@@ -1,0 +1,23 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persister
+
+import (
+	"context"
+)
+
+type Updater interface {
+	UpdateUserCounts(ctx context.Context, events environmentEventMap) map[string]bool
+}

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -142,8 +142,8 @@ func (u *evalGoalUpdater) updateUserCount(
 	}
 	for _, tr := range targetRules {
 		// Find the latest feature version
-		fVersion := u.findFeatureVersion(tr.featureID, resp.Features)
-		if fVersion == 0 {
+		fVersion, err := u.findFeatureVersion(tr.featureID, resp.Features)
+		if err != nil {
 			u.logger.Error(
 				"Failed to find the feature version",
 				zap.Error(ErrFailedToFindFeatureVersion),
@@ -151,10 +151,10 @@ func (u *evalGoalUpdater) updateUserCount(
 				zap.String("environmentNamespace", environmentNamespace),
 			)
 			handledCounter.WithLabelValues(codeFailedToFindFeatureVersion).Inc()
-			return false, ErrFailedToFindFeatureVersion
+			return false, err
 		}
 		// Update the user count by rule
-		err := u.updateUserCountByRule(
+		err = u.updateUserCountByRule(
 			environmentNamespace,
 			tr.featureID,
 			fVersion,
@@ -249,13 +249,13 @@ func (u *evalGoalUpdater) findOpsRules(
 func (u *evalGoalUpdater) findFeatureVersion(
 	featureID string,
 	features []*featureproto.Feature,
-) int32 {
+) (int32, error) {
 	for _, f := range features {
 		if f.Id == featureID {
-			return f.Version
+			return f.Version, nil
 		}
 	}
-	return 0
+	return 0, ErrFailedToFindFeatureVersion
 }
 
 func (u *evalGoalUpdater) updateUserCountByRule(

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -1,0 +1,307 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persister
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
+
+	aoclient "github.com/bucketeer-io/bucketeer/pkg/autoops/client"
+	aodomain "github.com/bucketeer-io/bucketeer/pkg/autoops/domain"
+	"github.com/bucketeer-io/bucketeer/pkg/cache"
+	cachev3 "github.com/bucketeer-io/bucketeer/pkg/cache/v3"
+	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
+	aoproto "github.com/bucketeer-io/bucketeer/proto/autoops"
+	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
+	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
+)
+
+const opsGoalKeyPrefix = "autoops:goal"
+
+type goalTargetRule struct {
+	id        string
+	featureID string
+	clauses   map[string]*aoproto.OpsEventRateClause
+}
+
+type evalGoalUpdater struct {
+	ctx               context.Context
+	featureClient     featureclient.Client
+	autoOpsClient     aoclient.Client
+	eventCounterCache cachev3.EventCounterCache
+	flightgroup       singleflight.Group
+	logger            *zap.Logger
+}
+
+func NewGoalUserCountUpdater(
+	ctx context.Context,
+	featureClient featureclient.Client,
+	autoOpsClient aoclient.Client,
+	eventCounterCache cachev3.EventCounterCache,
+	logger *zap.Logger,
+) Updater {
+	return &evalGoalUpdater{
+		ctx:               ctx,
+		featureClient:     featureClient,
+		autoOpsClient:     autoOpsClient,
+		eventCounterCache: eventCounterCache,
+		logger:            logger,
+	}
+}
+
+func (u *evalGoalUpdater) UpdateUserCounts(ctx context.Context, evt environmentEventMap) map[string]bool {
+	fails := map[string]bool{}
+	for environmentNamespace, events := range evt {
+		for id, event := range events {
+			switch evt := event.(type) {
+			case *eventproto.GoalEvent:
+				retriable, err := u.updateUserCount(ctx, environmentNamespace, evt)
+				if err != nil {
+					if err == ErrNoAutoOpsRules || err == ErrAutoOpsRulesNotFound {
+						handledCounter.WithLabelValues(codeNoLink).Inc()
+						u.logger.Debug(
+							"There is no auto ops rules to link the goal event",
+							zap.Error(err),
+							zap.String("eventId", id),
+							zap.String("environmentNamespace", environmentNamespace),
+						)
+						continue
+					}
+					if !retriable {
+						u.logger.Error(
+							"Failed to persister goal event for auto ops",
+							zap.Error(err),
+							zap.String("eventId", id),
+							zap.String("environmentNamespace", environmentNamespace),
+						)
+					}
+					fails[id] = retriable
+					continue
+				}
+				handledCounter.WithLabelValues(codeLinked).Inc()
+			default:
+				u.logger.Error(
+					"Unexpected message type while trying to persister a goal event",
+					zap.String("eventId", id),
+					zap.String("environmentNamespace", environmentNamespace),
+				)
+				fails[id] = false
+			}
+		}
+	}
+	return fails
+}
+
+func (u *evalGoalUpdater) updateUserCount(
+	ctx context.Context,
+	environmentNamespace string,
+	event *eventproto.GoalEvent,
+) (bool, error) {
+	// List all the auto ops rules
+	list, err := u.listAutoOpsRules(ctx, environmentNamespace)
+	if err != nil {
+		handledCounter.WithLabelValues(codeFailedToListAutoOpsRules).Inc()
+		return true, err
+	}
+	if len(list) == 0 {
+		return false, ErrNoAutoOpsRules
+	}
+	// Find the rules
+	featureIDs, targetRules := u.findOpsRules(event.GoalId, list)
+	if len(featureIDs) == 0 {
+		return false, ErrAutoOpsRulesNotFound
+	}
+	// Get the latest feature version
+	resp, err := u.featureClient.GetFeatures(ctx, &featureproto.GetFeaturesRequest{
+		EnvironmentNamespace: environmentNamespace,
+		Ids:                  featureIDs,
+	})
+	if err != nil {
+		handledCounter.WithLabelValues(codeFailedToGetFeatures).Inc()
+		return true, err
+	}
+	// At this point get features can't be empty
+	if len(resp.Features) == 0 {
+		handledCounter.WithLabelValues(codeGetFeaturesReturnedEmpty).Inc()
+		return true, ErrFeatureEmptyList
+	}
+	for _, tr := range targetRules {
+		// Find the latest feature version
+		fVersion := u.findFeatureVersion(tr.featureID, resp.Features)
+		if fVersion == 0 {
+			u.logger.Error(
+				"Failed to find the feature version",
+				zap.Error(ErrFailedToFindFeatureVersion),
+				zap.String("featureId", tr.featureID),
+				zap.String("environmentNamespace", environmentNamespace),
+			)
+			handledCounter.WithLabelValues(codeFailedToFindFeatureVersion).Inc()
+			return false, ErrFailedToFindFeatureVersion
+		}
+		// Update the user count by rule
+		err := u.updateUserCountByRule(
+			environmentNamespace,
+			tr.featureID,
+			fVersion,
+			event.UserId,
+			tr,
+		)
+		if err != nil {
+			return true, err
+		}
+	}
+	return false, nil
+}
+
+func (u *evalGoalUpdater) listAutoOpsRules(
+	ctx context.Context,
+	environmentNamespace string,
+) ([]*aoproto.AutoOpsRule, error) {
+	exp, err, _ := u.flightgroup.Do(
+		fmt.Sprintf("%s:%s", environmentNamespace, "listAutoOpsRules"),
+		func() (interface{}, error) {
+			aor := []*aoproto.AutoOpsRule{}
+			cursor := ""
+			for {
+				resp, err := u.autoOpsClient.ListAutoOpsRules(ctx, &aoproto.ListAutoOpsRulesRequest{
+					EnvironmentNamespace: environmentNamespace,
+					PageSize:             listRequestSize,
+					Cursor:               cursor,
+				})
+				if err != nil {
+					return nil, err
+				}
+				aor = append(aor, resp.AutoOpsRules...)
+				aorSize := len(resp.AutoOpsRules)
+				if aorSize == 0 || aorSize < listRequestSize {
+					return aor, nil
+				}
+				cursor = resp.Cursor
+			}
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return exp.([]*aoproto.AutoOpsRule), nil
+}
+
+func (u *evalGoalUpdater) findOpsRules(
+	goalID string,
+	listAutoOpsRules []*aoproto.AutoOpsRule,
+) ([]string, []*goalTargetRule) {
+	featureIDsMap := make(map[string]struct{})
+	targetRules := []*goalTargetRule{}
+	for _, aor := range listAutoOpsRules {
+		autoOpsRule := &aodomain.AutoOpsRule{AutoOpsRule: aor}
+		// We ignore the rules that are already triggered
+		if autoOpsRule.AlreadyTriggered() {
+			continue
+		}
+		clauses, err := autoOpsRule.ExtractOpsEventRateClauses()
+		if err != nil {
+			handledCounter.WithLabelValues(codeFailedToExtractOpsEventRateClauses).Inc()
+			continue
+		}
+		if len(clauses) == 0 {
+			continue
+		}
+		// Find the clauses that contain the goal ID from the the goal event
+		targetClauses := make(map[string]*aoproto.OpsEventRateClause)
+		for id, clause := range clauses {
+			if clause.GoalId == goalID {
+				featureIDsMap[autoOpsRule.FeatureId] = struct{}{}
+				targetClauses[id] = clause
+			}
+		}
+		if len(targetClauses) == 0 {
+			continue
+		}
+		targetRules = append(targetRules, &goalTargetRule{
+			id:        autoOpsRule.Id,
+			featureID: autoOpsRule.FeatureId,
+			clauses:   targetClauses,
+		})
+	}
+	// Convert map to slice
+	featureIDs := make([]string, 0, len(featureIDsMap))
+	for id := range featureIDsMap {
+		featureIDs = append(featureIDs, id)
+	}
+	return featureIDs, targetRules
+}
+
+func (u *evalGoalUpdater) findFeatureVersion(
+	featureID string,
+	features []*featureproto.Feature,
+) int32 {
+	for _, f := range features {
+		if f.Id == featureID {
+			return f.Version
+		}
+	}
+	return 0
+}
+
+func (u *evalGoalUpdater) updateUserCountByRule(
+	environmentNamespace,
+	featureID string,
+	featureVersion int32,
+	userID string,
+	targetRule *goalTargetRule,
+) error {
+	for id, clause := range targetRule.clauses {
+		key := u.newUserCountKey(
+			environmentNamespace,
+			targetRule.id,
+			id,
+			featureID,
+			clause.VariationId,
+			featureVersion,
+		)
+		if err := u.eventCounterCache.UpdateUserCount(key, userID); err != nil {
+			handledCounter.WithLabelValues(codeFailedToUpdateUserCount).Inc()
+			return err
+		}
+		u.logger.Debug(
+			"User count updated successfully",
+			zap.String("pfcountKey", key),
+			zap.String("environmentNamespace", environmentNamespace),
+		)
+	}
+	return nil
+}
+
+func (u *evalGoalUpdater) newUserCountKey(
+	environmentNamespace,
+	ruleID, clauseID, featureID, variationID string,
+	featureVersion int32,
+) string {
+	key := fmt.Sprintf("%s:%s:%s:%d:%s",
+		ruleID,
+		clauseID,
+		featureID,
+		featureVersion,
+		variationID,
+	)
+	return cache.MakeKey(
+		opsGoalKeyPrefix,
+		key,
+		environmentNamespace,
+	)
+}

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -141,26 +141,26 @@ func (u *evalGoalUpdater) updateUserCount(
 		handledCounter.WithLabelValues(codeGetFeaturesReturnedEmpty).Inc()
 		return true, ErrFeatureEmptyList
 	}
-	for _, tr := range rules {
+	for _, r := range rules {
 		// Get the latest feature version
-		fVersion, err := u.getFeatureVersion(tr.featureID, resp.Features)
+		fVersion, err := u.getFeatureVersion(r.featureID, resp.Features)
 		if err != nil {
 			u.logger.Error(
 				"Failed to find the feature version",
 				zap.Error(ErrFailedToFindFeatureVersion),
-				zap.String("featureId", tr.featureID),
+				zap.String("featureId", r.featureID),
 				zap.String("environmentNamespace", environmentNamespace),
 			)
 			handledCounter.WithLabelValues(codeFailedToFindFeatureVersion).Inc()
 			return false, err
 		}
-		// Update the user count by rule
-		err = u.updateUserCountPerRule(
+		// Update the user count per clause
+		err = u.updateUserCountPerClause(
 			environmentNamespace,
-			tr.featureID,
+			r.featureID,
 			fVersion,
 			event.UserId,
-			tr,
+			r,
 		)
 		if err != nil {
 			return true, err
@@ -262,7 +262,7 @@ func (u *evalGoalUpdater) getFeatureVersion(
 	return 0, ErrFailedToFindFeatureVersion
 }
 
-func (u *evalGoalUpdater) updateUserCountPerRule(
+func (u *evalGoalUpdater) updateUserCountPerClause(
 	environmentNamespace,
 	featureID string,
 	featureVersion int32,

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -147,7 +147,7 @@ func (u *evalGoalUpdater) updateUserCount(
 		if err != nil {
 			u.logger.Error(
 				"Failed to find the feature version",
-				zap.Error(ErrFailedToFindFeatureVersion),
+				zap.Error(ErrFeatureVersionNotFound),
 				zap.String("featureId", r.featureID),
 				zap.String("environmentNamespace", environmentNamespace),
 			)
@@ -259,7 +259,7 @@ func (u *evalGoalUpdater) getFeatureVersion(
 			return f.Version, nil
 		}
 	}
-	return 0, ErrFailedToFindFeatureVersion
+	return 0, ErrFeatureVersionNotFound
 }
 
 func (u *evalGoalUpdater) updateUserCountPerClause(

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -178,6 +178,9 @@ func (u *evalGoalUpdater) listAutoOpsRules(
 			aor := []*aoproto.AutoOpsRule{}
 			cursor := ""
 			for {
+				// We don't use the feature ID to filter the results in the request
+				// because it will increase access to the DB, which also will increase the costs.
+				// So we list all rules and use the singleflight implementation to share the response
 				resp, err := u.autoOpsClient.ListAutoOpsRules(ctx, &aoproto.ListAutoOpsRulesRequest{
 					EnvironmentNamespace: environmentNamespace,
 					PageSize:             listRequestSize,

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -34,7 +34,7 @@ import (
 const opsGoalKeyPrefix = "autoops:goal"
 
 type linkGoalOpsRule struct {
-	id        string
+	ruleID    string
 	featureID string
 	clauses   map[string]*aoproto.OpsEventRateClause
 }
@@ -236,7 +236,7 @@ func (u *evalGoalUpdater) linkOpsRulesByGoalID(
 			continue
 		}
 		linkedRules = append(linkedRules, &linkGoalOpsRule{
-			id:        autoOpsRule.Id,
+			ruleID:    autoOpsRule.Id,
 			featureID: autoOpsRule.FeatureId,
 			clauses:   linkedClauses,
 		})
@@ -274,7 +274,7 @@ func (u *evalGoalUpdater) updateUserCountPerClause(
 	for id, clause := range rule.clauses {
 		key := u.newUserCountKey(
 			environmentNamespace,
-			rule.id,
+			rule.ruleID,
 			id,
 			featureID,
 			clause.VariationId,

--- a/pkg/eventpersisterops/persister/metrics.go
+++ b/pkg/eventpersisterops/persister/metrics.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package persister
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/bucketeer-io/bucketeer/pkg/metrics"
+)
+
+const (
+	codeFailedToExtractOpsEventRateClauses = "FailedToExtractOpsEventRateClauses"
+	codeFailedToGetFeatures                = "FailedToGetFeatures"
+	codeFailedToFindFeatureVersion         = "FailedToFindFeatureVersion"
+	codeFailedToListAutoOpsRules           = "FailedToListAutoOpsRules"
+	codeFailedToUpdateUserCount            = "FailedToUpdateUserCount"
+	codeGetFeaturesReturnedEmpty           = "GetFeaturesReturnedEmpty"
+	codeLinked                             = "Linked"
+	codeNoLink                             = "NoLink"
+)
+
+var (
+	receivedCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "event_persister_ops",
+			Name:      "received_total",
+			Help:      "Total number of received messages",
+		})
+
+	handledCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "event_persister_ops",
+			Name:      "handled_total",
+			Help:      "Total number of handled messages",
+		}, []string{"code"})
+
+	cacheCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "event_persister_ops",
+			Name:      "cache_requests_total",
+			Help:      "Total number of cache requests",
+		}, []string{"type", "code"})
+)
+
+func registerMetrics(r metrics.Registerer) {
+	r.MustRegister(receivedCounter, handledCounter, cacheCounter)
+}

--- a/pkg/eventpersisterops/persister/metrics.go
+++ b/pkg/eventpersisterops/persister/metrics.go
@@ -47,16 +47,8 @@ var (
 			Name:      "handled_total",
 			Help:      "Total number of handled messages",
 		}, []string{"code"})
-
-	cacheCounter = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "bucketeer",
-			Subsystem: "event_persister_ops",
-			Name:      "cache_requests_total",
-			Help:      "Total number of cache requests",
-		}, []string{"type", "code"})
 )
 
 func registerMetrics(r metrics.Registerer) {
-	r.MustRegister(receivedCounter, handledCounter, cacheCounter)
+	r.MustRegister(receivedCounter, handledCounter)
 }

--- a/pkg/eventpersisterops/persister/persister.go
+++ b/pkg/eventpersisterops/persister/persister.go
@@ -34,13 +34,13 @@ import (
 const listRequestSize = 500
 
 var (
-	ErrAutoOpsRulesNotFound       = errors.New("eventpersister: auto ops rules not found")
-	ErrFailedToFindFeatureVersion = errors.New("eventpersister: failed to find the feature version")
-	ErrFeatureEmptyList           = errors.New("eventpersister: list feature returned empty")
-	ErrNoAutoOpsRules             = errors.New("eventpersister: no auto ops rules")
-	ErrNoExperiments              = errors.New("eventpersister: no experiments")
-	ErrNothingToLink              = errors.New("eventpersister: nothing to link")
-	ErrUnexpectedMessageType      = errors.New("eventpersister: unexpected message type")
+	ErrAutoOpsRulesNotFound   = errors.New("eventpersister: auto ops rules not found")
+	ErrFeatureEmptyList       = errors.New("eventpersister: list feature returned empty")
+	ErrFeatureVersionNotFound = errors.New("eventpersister: feature version not found")
+	ErrNoAutoOpsRules         = errors.New("eventpersister: no auto ops rules")
+	ErrNoExperiments          = errors.New("eventpersister: no experiments")
+	ErrNothingToLink          = errors.New("eventpersister: nothing to link")
+	ErrUnexpectedMessageType  = errors.New("eventpersister: unexpected message type")
 )
 
 type eventMap map[string]proto.Message

--- a/pkg/eventpersisterops/persister/persister.go
+++ b/pkg/eventpersisterops/persister/persister.go
@@ -16,19 +16,45 @@ package persister
 
 import (
 	"context"
+	"errors"
 	"time"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"go.uber.org/zap"
 
+	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
 	"github.com/bucketeer-io/bucketeer/pkg/health"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
+	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 )
 
+const listRequestSize = 500
+
+var (
+	ErrAutoOpsRulesNotFound       = errors.New("eventpersister: auto ops rules not found")
+	ErrFailedToFindFeatureVersion = errors.New("eventpersister: failed to find the feature version")
+	ErrFeatureEmptyList           = errors.New("eventpersister: list feature returned empty")
+	ErrNoAutoOpsRules             = errors.New("eventpersister: no auto ops rules")
+	ErrNoExperiments              = errors.New("eventpersister: no experiments")
+	ErrNothingToLink              = errors.New("eventpersister: nothing to link")
+	ErrUnexpectedMessageType      = errors.New("eventpersister: unexpected message type")
+)
+
+type eventMap map[string]proto.Message
+type environmentEventMap map[string]eventMap
+
 type persister struct {
-	ctx    context.Context
-	cancel func()
-	logger *zap.Logger
-	opts   *options
+	ctx     context.Context
+	cancel  func()
+	updater Updater
+	puller  puller.RateLimitedPuller
+	group   errgroup.Group
+	doneCh  chan struct{}
+	logger  *zap.Logger
+	opts    *options
 }
 
 type options struct {
@@ -86,30 +112,50 @@ func WithLogger(l *zap.Logger) Option {
 }
 
 func NewPersister(
+	updater Updater,
+	p puller.Puller,
 	opts ...Option,
 ) *persister {
 	dopts := &options{
 		maxMPS:        1000,
 		numWorkers:    1,
-		flushSize:     50,
-		flushInterval: 5 * time.Second,
-		flushTimeout:  20 * time.Second,
+		flushSize:     100,
+		flushInterval: 2 * time.Second,
+		flushTimeout:  600 * time.Second,
 		logger:        zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)
 	}
+	if dopts.metrics != nil {
+		registerMetrics(dopts.metrics)
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &persister{
-		ctx:    ctx,
-		cancel: cancel,
-		logger: dopts.logger.Named("persister"),
-		opts:   dopts,
+		ctx:     ctx,
+		cancel:  cancel,
+		updater: updater,
+		puller:  puller.NewRateLimitedPuller(p, dopts.maxMPS),
+		doneCh:  make(chan struct{}),
+		logger:  dopts.logger.Named("persister"),
+		opts:    dopts,
 	}
+}
+
+func (p *persister) Run() error {
+	defer close(p.doneCh)
+	p.group.Go(func() error {
+		return p.puller.Run(p.ctx)
+	})
+	for i := 0; i < p.opts.numWorkers; i++ {
+		p.group.Go(p.batch)
+	}
+	return p.group.Wait()
 }
 
 func (p *persister) Stop() {
 	p.cancel()
+	<-p.doneCh
 }
 
 func (p *persister) Check(ctx context.Context) health.Status {
@@ -118,6 +164,110 @@ func (p *persister) Check(ctx context.Context) health.Status {
 		p.logger.Error("Unhealthy due to context Done is closed", zap.Error(p.ctx.Err()))
 		return health.Unhealthy
 	default:
+		if p.group.FinishedCount() > 0 {
+			p.logger.Error("Unhealthy", zap.Int32("FinishedCount", p.group.FinishedCount()))
+			return health.Unhealthy
+		}
 		return health.Healthy
 	}
+}
+
+func (p *persister) batch() error {
+	batch := make(map[string]*puller.Message)
+	timer := time.NewTimer(p.opts.flushInterval)
+	defer timer.Stop()
+	for {
+		select {
+		case msg, ok := <-p.puller.MessageCh():
+			if !ok {
+				return nil
+			}
+			receivedCounter.Inc()
+			id := msg.Attributes["id"]
+			if id == "" {
+				msg.Ack()
+				// TODO: better log format for msg data
+				handledCounter.WithLabelValues(codes.MissingID.String()).Inc()
+				continue
+			}
+			if previous, ok := batch[id]; ok {
+				previous.Ack()
+				p.logger.Warn("Message with duplicate id", zap.String("id", id))
+				handledCounter.WithLabelValues(codes.DuplicateID.String()).Inc()
+			}
+			batch[id] = msg
+			if len(batch) < p.opts.flushSize {
+				continue
+			}
+			p.send(batch)
+			batch = make(map[string]*puller.Message)
+			timer.Reset(p.opts.flushInterval)
+		case <-timer.C:
+			if len(batch) > 0 {
+				p.send(batch)
+				batch = make(map[string]*puller.Message)
+			}
+			timer.Reset(p.opts.flushInterval)
+		case <-p.ctx.Done():
+			batchSize := len(batch)
+			p.logger.Info("Context is done", zap.Int("batchSize", batchSize))
+			if len(batch) > 0 {
+				p.send(batch)
+				p.logger.Info("All the left messages are processed successfully", zap.Int("batchSize", batchSize))
+			}
+			return nil
+		}
+	}
+}
+
+func (p *persister) send(messages map[string]*puller.Message) {
+	ctx, cancel := context.WithTimeout(context.Background(), p.opts.flushTimeout)
+	defer cancel()
+	envEvents := p.extractEvents(messages)
+	if len(envEvents) == 0 {
+		p.logger.Error("All messages were bad")
+		return
+	}
+	fails := p.updater.UpdateUserCounts(ctx, envEvents)
+	for id, m := range messages {
+		if repeatable, ok := fails[id]; ok {
+			if repeatable {
+				m.Nack()
+				handledCounter.WithLabelValues(codes.RepeatableError.String()).Inc()
+			} else {
+				m.Ack()
+				handledCounter.WithLabelValues(codes.NonRepeatableError.String()).Inc()
+			}
+			continue
+		}
+		m.Ack()
+		handledCounter.WithLabelValues(codes.OK.String()).Inc()
+	}
+}
+
+func (p *persister) extractEvents(messages map[string]*puller.Message) environmentEventMap {
+	envEvents := environmentEventMap{}
+	handleBadMessage := func(m *puller.Message, err error) {
+		m.Ack()
+		p.logger.Error("Bad message", zap.Error(err), zap.Any("msg", m))
+		handledCounter.WithLabelValues(codes.BadMessage.String()).Inc()
+	}
+	for _, m := range messages {
+		event := &eventproto.Event{}
+		if err := proto.Unmarshal(m.Data, event); err != nil {
+			handleBadMessage(m, err)
+			continue
+		}
+		var innerEvent ptypes.DynamicAny
+		if err := ptypes.UnmarshalAny(event.Event, &innerEvent); err != nil {
+			handleBadMessage(m, err)
+			continue
+		}
+		if innerEvents, ok := envEvents[event.EnvironmentNamespace]; ok {
+			innerEvents[event.Id] = innerEvent.Message
+			continue
+		}
+		envEvents[event.EnvironmentNamespace] = eventMap{event.Id: innerEvent.Message}
+	}
+	return envEvents
 }


### PR DESCRIPTION
As part of BigQuery migration, I'm changing the Auto Ops to write/read the ops event count from Redis to reduce costs.
I will write the unit tests in another PR, but I have already tested it on the dev environment, and the e2e tests have passed.

#### Things done

- Added event persister service for auto ops
- Change the ops event count watcher to get the ops event count from Redis