### PR TITLE
fix: mysql error alerts when the auto ops rule is already triggered

### DIFF
--- a/pkg/autoops/api/operation.go
+++ b/pkg/autoops/api/operation.go
@@ -60,17 +60,29 @@ func enableFeature(
 		EnvironmentNamespace: environmentNamespace,
 	}
 	_, err := featureClient.EnableFeature(ctx, req)
-	if code := status.Code(err); code == codes.FailedPrecondition {
-		logger.Warn(
-			"Failed to enable feature",
+	if err != nil {
+		if code := status.Code(err); code == codes.FailedPrecondition {
+			logger.Warn(
+				"Feature flag is already enabled",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.Error(err),
+					zap.String("featureId", req.Id),
+					zap.String("environmentNamespace", req.EnvironmentNamespace),
+				)...,
+			)
+			return nil
+		}
+		logger.Error(
+			"Failed to enable feature flag",
 			log.FieldsFromImcomingContext(ctx).AddFields(
 				zap.Error(err),
+				zap.String("featureId", req.Id),
 				zap.String("environmentNamespace", req.EnvironmentNamespace),
 			)...,
 		)
-		return nil
+		return err
 	}
-	return err
+	return nil
 }
 
 func disableFeature(
@@ -86,15 +98,27 @@ func disableFeature(
 		EnvironmentNamespace: environmentNamespace,
 	}
 	_, err := featureClient.DisableFeature(ctx, req)
-	if code := status.Code(err); code == codes.FailedPrecondition {
-		logger.Warn(
-			"Failed to disable feature",
+	if err != nil {
+		if code := status.Code(err); code == codes.FailedPrecondition {
+			logger.Warn(
+				"Feature flag is already disabled",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.Error(err),
+					zap.String("featureId", req.Id),
+					zap.String("environmentNamespace", req.EnvironmentNamespace),
+				)...,
+			)
+			return nil
+		}
+		logger.Error(
+			"Failed to disable feature flag",
 			log.FieldsFromImcomingContext(ctx).AddFields(
 				zap.Error(err),
+				zap.String("featureId", req.Id),
 				zap.String("environmentNamespace", req.EnvironmentNamespace),
 			)...,
 		)
-		return nil
+		return err
 	}
-	return err
+	return nil
 }


### PR DESCRIPTION
If the user schedule to turn on a flag, and before the auto ops run, he enables the flag, it will treat it as an error, so I'm changing the ExecuteOperation to return nil if the operation is already done.

#### Things done

- Changed to check if the ops have been triggered outside of the transaction
- Changed not to treat as an error if no rows were affected
- Split the logs in the operation to make debugging easier