### PR TITLE
chore: change auto ops count key format

### DIFF
--- a/pkg/eventcounter/api/api.go
+++ b/pkg/eventcounter/api/api.go
@@ -849,7 +849,7 @@ func newOpsEvaluationUserCountKey(
 ) string {
 	return cache.MakeKey(
 		kind,
-		fmt.Sprintf("%s:%s:%s:%d:%s", opsRuleID, clauseID, featureID, featureVersion, variationID),
+		fmt.Sprintf("%s:%d:%s:%s:%s", featureID, featureVersion, opsRuleID, clauseID, variationID),
 		environmentNamespace,
 	)
 }
@@ -969,7 +969,7 @@ func newOpsGoalUserCountKey(
 ) string {
 	return cache.MakeKey(
 		kind,
-		fmt.Sprintf("%s:%s:%s:%d:%s", opsRuleID, clauseID, featureID, featureVersion, variationID),
+		fmt.Sprintf("%s:%d:%s:%s:%s", featureID, featureVersion, opsRuleID, clauseID, variationID),
 		environmentNamespace,
 	)
 }

--- a/pkg/eventcounter/api/api_test.go
+++ b/pkg/eventcounter/api/api_test.go
@@ -1070,8 +1070,8 @@ func TestGetOpsEvaluationUserCount(t *testing.T) {
 	fID := "fid0"
 	fVersion := 2
 	vID0 := "vid0"
-	cacheKey := "ns0:autoops:evaluation:rule0:clause0:fid0:2:vid0"
-	cacheKeyWithoutNS := "autoops:evaluation:rule0:clause0:fid0:2:vid0"
+	cacheKey := "ns0:autoops:evaluation:fid0:2:rule0:clause0:vid0"
+	cacheKeyWithoutNS := "autoops:evaluation:fid0:2:rule0:clause0:vid0"
 	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -1209,8 +1209,8 @@ func TestGetOpsGoalUserCount(t *testing.T) {
 	fID := "fid0"
 	fVersion := 2
 	vID0 := "vid0"
-	cacheKey := "ns0:autoops:goal:rule0:clause0:fid0:2:vid0"
-	cacheKeyWithoutNS := "autoops:goal:rule0:clause0:fid0:2:vid0"
+	cacheKey := "ns0:autoops:goal:fid0:2:rule0:clause0:vid0"
+	cacheKeyWithoutNS := "autoops:goal:fid0:2:rule0:clause0:vid0"
 	localizer := locale.NewLocalizer(locale.NewLocale(locale.JaJP))
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -253,11 +253,11 @@ func (u *evalEvtUpdater) newUserCountKey(
 	ruleID, clauseID, featureID, variationID string,
 	featureVersion int32,
 ) string {
-	key := fmt.Sprintf("%s:%s:%s:%d:%s",
-		ruleID,
-		clauseID,
+	key := fmt.Sprintf("%s:%d:%s:%s:%s",
 		featureID,
 		featureVersion,
+		ruleID,
+		clauseID,
 		variationID,
 	)
 	return cache.MakeKey(

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -298,11 +298,11 @@ func (u *evalGoalUpdater) newUserCountKey(
 	ruleID, clauseID, featureID, variationID string,
 	featureVersion int32,
 ) string {
-	key := fmt.Sprintf("%s:%s:%s:%d:%s",
-		ruleID,
-		clauseID,
+	key := fmt.Sprintf("%s:%d:%s:%s:%s",
 		featureID,
 		featureVersion,
+		ruleID,
+		clauseID,
 		variationID,
 	)
 	return cache.MakeKey(


### PR DESCRIPTION
I'm changing the auto ops key format so that we can easily scan the keys by feature id.