### PR TITLE
chore: remove bigtable from event persister DWH

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
@@ -43,8 +43,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["server"]
           env:
+            - name: BUCKETEER_EVENT_PERSISTER_DWH_SERVICE_NAME
+              value: "{{ template "event-persister-evaluation-events-dwh.fullname" . }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_PROJECT
               value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_DWH_FEATURE_SERVICE
+              value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_EXPERIMENT_SERVICE
               value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_TOPIC

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
@@ -47,8 +47,6 @@ spec:
               value: "{{ .Values.env.project }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_EXPERIMENT_SERVICE
               value: "{{ .Values.env.experimentService }}"
-            - name: BUCKETEER_EVENT_PERSISTER_DWH_BIGTABLE_INSTANCE
-              value: "{{ .Values.env.bigtableInstance }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_TOPIC
               value: "{{ .Values.env.topic }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_SUBSCRIPTION

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/envoy-configmap.yaml
@@ -94,6 +94,38 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+        - name: feature
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: feature
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: feature.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          type: strict_dns
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -189,6 +221,18 @@ data:
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
                                 cluster: experiment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.feature.FeatureService
+                              route:
+                                cluster: feature
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
@@ -12,7 +12,6 @@ env:
   logLevel: info
   port: 9090
   metricsPort: 9002
-  bigtableInstance:
   experimentService: localhost:9001
   # option
   maxMps: "1000"

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
@@ -12,7 +12,9 @@ env:
   logLevel: info
   port: 9090
   metricsPort: 9002
+  # egress services
   experimentService: localhost:9001
+  featureService: localhost:9001
   # option
   maxMps: "1000"
   numWorkers: 5

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
@@ -43,8 +43,12 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: ["server"]
           env:
+            - name: BUCKETEER_EVENT_PERSISTER_DWH_SERVICE_NAME
+              value: "{{ template "event-persister-goal-events-dwh.fullname" . }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_PROJECT
               value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_EVENT_PERSISTER_DWH_FEATURE_SERVICE
+              value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_EXPERIMENT_SERVICE
               value: "{{ .Values.env.experimentService }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_BIGTABLE_INSTANCE

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
@@ -51,8 +51,6 @@ spec:
               value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_EXPERIMENT_SERVICE
               value: "{{ .Values.env.experimentService }}"
-            - name: BUCKETEER_EVENT_PERSISTER_DWH_BIGTABLE_INSTANCE
-              value: "{{ .Values.env.bigtableInstance }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_TOPIC
               value: "{{ .Values.env.topic }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_SUBSCRIPTION

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/envoy-configmap.yaml
@@ -94,6 +94,38 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+        - name: feature
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: feature
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: feature.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          type: strict_dns
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -189,6 +221,18 @@ data:
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
                                 cluster: experiment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.feature.FeatureService
+                              route:
+                                cluster: feature
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/values.yaml
@@ -12,8 +12,9 @@ env:
   logLevel: info
   port: 9090
   metricsPort: 9002
-  bigtableInstance:
+  # egress services
   experimentService: localhost:9001
+  featureService: localhost:9001
   # option
   maxMps: "1000"
   numWorkers: 5

--- a/pkg/eventpersisterdwh/persister/goal_event.go
+++ b/pkg/eventpersisterdwh/persister/goal_event.go
@@ -227,6 +227,11 @@ func (w *goalEvtWriter) linkGoalEventByExperiment(
 	exps := []*exproto.Experiment{}
 	for _, exp := range experiments {
 		if w.findGoalID(event.GoalId, exp.GoalIds) {
+			// If the goal event was issued before the experiment started running,
+			// we ignore those events to avoid issues in the conversion rate
+			if exp.StartAt > event.Timestamp {
+				continue
+			}
 			exps = append(exps, exp)
 		}
 	}

--- a/pkg/eventpersisterdwh/persister/goal_event.go
+++ b/pkg/eventpersisterdwh/persister/goal_event.go
@@ -230,6 +230,7 @@ func (w *goalEvtWriter) linkGoalEventByExperiment(
 			// If the goal event was issued before the experiment started running,
 			// we ignore those events to avoid issues in the conversion rate
 			if exp.StartAt > event.Timestamp {
+				handledCounter.WithLabelValues(codeGoalEventOlderThanExperiment).Inc()
 				continue
 			}
 			exps = append(exps, exp)

--- a/pkg/eventpersisterdwh/persister/goal_event.go
+++ b/pkg/eventpersisterdwh/persister/goal_event.go
@@ -25,10 +25,8 @@ import (
 
 	"github.com/bucketeer-io/bucketeer/pkg/eventpersisterdwh/storage"
 	ec "github.com/bucketeer-io/bucketeer/pkg/experiment/client"
-	featurestorage "github.com/bucketeer-io/bucketeer/pkg/feature/storage"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/writer"
-	bigtable "github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigtable"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	epproto "github.com/bucketeer-io/bucketeer/proto/eventpersisterdwh"
 	exproto "github.com/bucketeer-io/bucketeer/proto/experiment"
@@ -38,18 +36,16 @@ import (
 const goalEventTable = "goal_event"
 
 type goalEvtWriter struct {
-	writer                storage.GoalEventWriter
-	userEvaluationStorage featurestorage.UserEvaluationsStorage
-	experimentClient      ec.Client
-	flightgroup           singleflight.Group
-	logger                *zap.Logger
+	writer           storage.GoalEventWriter
+	experimentClient ec.Client
+	flightgroup      singleflight.Group
+	logger           *zap.Logger
 }
 
 func NewGoalEventWriter(
 	ctx context.Context,
 	r metrics.Registerer,
 	l *zap.Logger,
-	userEvaluationStorage featurestorage.UserEvaluationsStorage,
 	exClient ec.Client,
 	project, ds string,
 	size int,
@@ -68,10 +64,9 @@ func NewGoalEventWriter(
 		return nil, err
 	}
 	return &goalEvtWriter{
-		writer:                storage.NewGoalEventWriter(goalWriter, size),
-		userEvaluationStorage: userEvaluationStorage,
-		experimentClient:      exClient,
-		logger:                l,
+		writer:           storage.NewGoalEventWriter(goalWriter, size),
+		experimentClient: exClient,
+		logger:           l,
 	}, nil
 }
 
@@ -308,21 +303,5 @@ func (w *goalEvtWriter) getUserEvaluation(
 	featureID string,
 	featureVersion int32,
 ) (*featureproto.Evaluation, error) {
-	evaluation, err := w.userEvaluationStorage.GetUserEvaluation(
-		ctx,
-		userID,
-		environmentNamespace,
-		tag,
-		featureID,
-		featureVersion,
-	)
-	if err != nil {
-		if err == bigtable.ErrKeyNotFound {
-			handledCounter.WithLabelValues(codeUserEvaluationNotFound).Inc()
-		} else {
-			handledCounter.WithLabelValues(codeFailedToGetUserEvaluation).Inc()
-		}
-		return nil, err
-	}
-	return evaluation, nil
+	return nil, nil
 }

--- a/pkg/eventpersisterdwh/persister/metrics.go
+++ b/pkg/eventpersisterdwh/persister/metrics.go
@@ -21,11 +21,14 @@ import (
 )
 
 const (
-	codeFailedToGetUserEvaluation      = "FailedToGetUserEvaluation"
+	codeEvaluationsAreEmpty            = "EvaluationsAreEmpty"
+	codeFailedToEvaluateFeature        = "FailedToEvaluateFeature"
+	codeFailedToGetFeature             = "FailedToGetFeature"
 	codeFailedToListExperiments        = "FailedToListExperiments"
-	codeUserEvaluationNotFound         = "UserEvaluationNotFound"
+	codeFailedToListSegmentUsers       = "FailedToListSegmentUsers"
 	codeFailedToAppendEvaluationEvents = "FailedToAppendEvaluationEvents"
 	codeFailedToAppendGoalEvents       = "FailedToAppendGoalEvents"
+	codeFeatureNotFound                = "FeatureNotFound"
 	codeLinked                         = "Linked"
 	codeNoLink                         = "NoLink"
 )

--- a/pkg/eventpersisterdwh/persister/metrics.go
+++ b/pkg/eventpersisterdwh/persister/metrics.go
@@ -23,7 +23,6 @@ import (
 const (
 	codeFailedToGetUserEvaluation      = "FailedToGetUserEvaluation"
 	codeFailedToListExperiments        = "FailedToListExperiments"
-	codeUpsertUserEvaluationFailed     = "UpsertUserEvaluationFailed"
 	codeUserEvaluationNotFound         = "UserEvaluationNotFound"
 	codeFailedToAppendEvaluationEvents = "FailedToAppendEvaluationEvents"
 	codeFailedToAppendGoalEvents       = "FailedToAppendGoalEvents"

--- a/pkg/eventpersisterdwh/persister/metrics.go
+++ b/pkg/eventpersisterdwh/persister/metrics.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	codeEvaluationsAreEmpty            = "EvaluationsAreEmpty"
+	codeGoalEventOlderThanExperiment   = "GoalEventOlderThanExperiment"
 	codeFailedToEvaluateFeature        = "FailedToEvaluateFeature"
 	codeFailedToGetFeature             = "FailedToGetFeature"
 	codeFailedToListExperiments        = "FailedToListExperiments"

--- a/pkg/eventpersisterdwh/persister/metrics.go
+++ b/pkg/eventpersisterdwh/persister/metrics.go
@@ -23,13 +23,10 @@ import (
 const (
 	codeEvaluationsAreEmpty            = "EvaluationsAreEmpty"
 	codeGoalEventOlderThanExperiment   = "GoalEventOlderThanExperiment"
-	codeFailedToEvaluateFeature        = "FailedToEvaluateFeature"
-	codeFailedToGetFeature             = "FailedToGetFeature"
+	codeFailedToEvaluateUser           = "FailedToEvaluateUser"
 	codeFailedToListExperiments        = "FailedToListExperiments"
-	codeFailedToListSegmentUsers       = "FailedToListSegmentUsers"
 	codeFailedToAppendEvaluationEvents = "FailedToAppendEvaluationEvents"
 	codeFailedToAppendGoalEvents       = "FailedToAppendGoalEvents"
-	codeFeatureNotFound                = "FeatureNotFound"
 	codeLinked                         = "Linked"
 	codeNoLink                         = "NoLink"
 )

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -36,13 +36,18 @@ const (
 )
 
 var (
-	ErrUnexpectedMessageType = errors.New("eventpersister: unexpected message type")
-	ErrAutoOpsRulesNotFound  = errors.New("eventpersister: auto ops rules not found")
-	ErrExperimentNotFound    = errors.New("eventpersister: experiment not found")
-	ErrNoAutoOpsRules        = errors.New("eventpersister: no auto ops rules")
-	ErrNoExperiments         = errors.New("eventpersister: no experiments")
-	ErrNothingToLink         = errors.New("eventpersister: nothing to link")
-	ErrInvalidEventTimestamp = errors.New("eventpersister: invalid event timestamp")
+	ErrUnexpectedMessageType    = errors.New("eventpersister: unexpected message type")
+	ErrAutoOpsRulesNotFound     = errors.New("eventpersister: auto ops rules not found")
+	ErrEvaluationsAreEmpty      = errors.New("eventpersister: evaluations are empty")
+	ErrExperimentNotFound       = errors.New("eventpersister: experiment not found")
+	ErrFailedToEvaluateFeature  = errors.New("eventpersister: failed to evaluate feature")
+	ErrFailedToGetFeature       = errors.New("eventpersister: failed to get feature")
+	ErrFailedToListSegmentUsers = errors.New("eventpersister: failed to list segment users")
+	ErrFeatureNotFound          = errors.New("eventpersister: feature not found")
+	ErrNoAutoOpsRules           = errors.New("eventpersister: no auto ops rules")
+	ErrNoExperiments            = errors.New("eventpersister: no experiments")
+	ErrNothingToLink            = errors.New("eventpersister: nothing to link")
+	ErrInvalidEventTimestamp    = errors.New("eventpersister: invalid event timestamp")
 )
 
 type PersisterDWH struct {

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -24,12 +24,10 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
-	featurestorage "github.com/bucketeer-io/bucketeer/pkg/feature/storage"
 	"github.com/bucketeer-io/bucketeer/pkg/health"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
-	bigtable "github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigtable"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 )
 
@@ -48,15 +46,14 @@ var (
 )
 
 type PersisterDWH struct {
-	puller                puller.RateLimitedPuller
-	logger                *zap.Logger
-	ctx                   context.Context
-	cancel                func()
-	group                 errgroup.Group
-	doneCh                chan struct{}
-	userEvaluationStorage featurestorage.UserEvaluationsStorage
-	writer                Writer
-	opts                  *options
+	puller puller.RateLimitedPuller
+	logger *zap.Logger
+	ctx    context.Context
+	cancel func()
+	group  errgroup.Group
+	doneCh chan struct{}
+	writer Writer
+	opts   *options
 }
 
 type eventMap map[string]proto.Message
@@ -126,7 +123,6 @@ func WithBatchSize(size int) Option {
 func NewPersisterDWH(
 	p puller.Puller,
 	r metrics.Registerer,
-	bt bigtable.Client,
 	writer Writer,
 	opts ...Option,
 ) *PersisterDWH {
@@ -147,14 +143,13 @@ func NewPersisterDWH(
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &PersisterDWH{
-		puller:                puller.NewRateLimitedPuller(p, dopts.maxMPS),
-		logger:                dopts.logger.Named("persister"),
-		ctx:                   ctx,
-		cancel:                cancel,
-		doneCh:                make(chan struct{}),
-		writer:                writer,
-		userEvaluationStorage: featurestorage.NewUserEvaluationsStorage(bt),
-		opts:                  dopts,
+		puller: puller.NewRateLimitedPuller(p, dopts.maxMPS),
+		logger: dopts.logger.Named("persister"),
+		ctx:    ctx,
+		cancel: cancel,
+		doneCh: make(chan struct{}),
+		writer: writer,
+		opts:   dopts,
 	}
 }
 

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -36,18 +36,15 @@ const (
 )
 
 var (
-	ErrUnexpectedMessageType    = errors.New("eventpersister: unexpected message type")
-	ErrAutoOpsRulesNotFound     = errors.New("eventpersister: auto ops rules not found")
-	ErrEvaluationsAreEmpty      = errors.New("eventpersister: evaluations are empty")
-	ErrExperimentNotFound       = errors.New("eventpersister: experiment not found")
-	ErrFailedToEvaluateFeature  = errors.New("eventpersister: failed to evaluate feature")
-	ErrFailedToGetFeature       = errors.New("eventpersister: failed to get feature")
-	ErrFailedToListSegmentUsers = errors.New("eventpersister: failed to list segment users")
-	ErrFeatureNotFound          = errors.New("eventpersister: feature not found")
-	ErrNoAutoOpsRules           = errors.New("eventpersister: no auto ops rules")
-	ErrNoExperiments            = errors.New("eventpersister: no experiments")
-	ErrNothingToLink            = errors.New("eventpersister: nothing to link")
-	ErrInvalidEventTimestamp    = errors.New("eventpersister: invalid event timestamp")
+	ErrUnexpectedMessageType = errors.New("eventpersister: unexpected message type")
+	ErrAutoOpsRulesNotFound  = errors.New("eventpersister: auto ops rules not found")
+	ErrEvaluationsAreEmpty   = errors.New("eventpersister: evaluations are empty")
+	ErrExperimentNotFound    = errors.New("eventpersister: experiment not found")
+	ErrFailedToEvaluateUser  = errors.New("eventpersister: failed to evaluate user")
+	ErrNoAutoOpsRules        = errors.New("eventpersister: no auto ops rules")
+	ErrNoExperiments         = errors.New("eventpersister: no experiments")
+	ErrNothingToLink         = errors.New("eventpersister: nothing to link")
+	ErrInvalidEventTimestamp = errors.New("eventpersister: invalid event timestamp")
 )
 
 type PersisterDWH struct {

--- a/pkg/eventpersisterdwh/persister/persister_test.go
+++ b/pkg/eventpersisterdwh/persister/persister_test.go
@@ -472,6 +472,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
 						},
 					},
 				}, nil)
@@ -520,6 +521,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
 						},
 					},
 				}, nil)
@@ -568,6 +570,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
 						},
 					},
 				}, nil)
@@ -625,6 +628,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
 						},
 					},
 				}, nil)
@@ -691,6 +695,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
 						},
 					},
 				}, nil)
@@ -757,12 +762,23 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
 						},
 						{
 							Id:             "experiment-id-2",
 							GoalIds:        []string{"gid"},
 							FeatureId:      "fid-2",
 							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(-time.Hour).Unix(),
+						},
+						// This experiment won't be computed
+						// because the startAt is higher than the goal event timestamp
+						{
+							Id:             "experiment-id-3",
+							GoalIds:        []string{"gid"},
+							FeatureId:      "fid-2",
+							FeatureVersion: int32(1),
+							StartAt:        time.Now().Add(time.Hour).Unix(),
 						},
 					},
 				}, nil)

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -117,8 +117,10 @@ func TestGrpcExperimentGoalCount(t *testing.T) {
 		variations[v.Value] = v
 	}
 
-	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.2))
-	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
+	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.2), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3), time.Now().Add(-time.Hour).Unix())
 
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag, reason)
 
@@ -227,8 +229,10 @@ func TestExperimentGoalCount(t *testing.T) {
 		variations[v.Value] = v
 	}
 
-	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.2))
-	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
+	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.2), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3), time.Now().Add(-time.Hour).Unix())
 
 	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag, reason)
 
@@ -338,11 +342,13 @@ func TestGrpcExperimentResult(t *testing.T) {
 
 	// CVRs is 3/4
 	// Register goal variation
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1), time.Now().Add(-time.Hour).Unix())
 	// Increment experiment event count
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag, reason)
@@ -353,10 +359,12 @@ func TestGrpcExperimentResult(t *testing.T) {
 
 	// CVRs is 2/3
 	// Register goal
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15), time.Now().Add(-time.Hour).Unix())
 	// Increment experiment event count
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1), time.Now().Unix())
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag, reason)
@@ -563,11 +571,13 @@ func TestExperimentResult(t *testing.T) {
 
 	// CVRs is 3/4
 	// Register goal variation
-	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	registerGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2))
-	registerGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1))
+	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[0], userIDs[1], tag, float64(0.2), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	registerGoalEvent(t, goalIDs[0], userIDs[2], tag, float64(0.1), time.Now().Add(-time.Hour).Unix())
 	// Increment experiment event count
-	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
+	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
@@ -578,10 +588,12 @@ func TestExperimentResult(t *testing.T) {
 
 	// CVRs is 2/3
 	// Register goal
-	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
-	registerGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15))
+	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	registerGoalEvent(t, goalIDs[0], userIDs[4], tag, float64(0.15), time.Now().Add(-time.Hour).Unix())
 	// Increment experiment event count
-	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
+	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1), time.Now().Unix())
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag, reason)
@@ -792,10 +804,12 @@ func TestGrpcMultiGoalsEventCounter(t *testing.T) {
 		variations[v.Value] = v
 	}
 
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
-	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2), time.Now().Unix())
+	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2), time.Now().Add(-time.Hour).Unix())
 
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
 	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[1].Id, tag, reason)
@@ -973,10 +987,12 @@ func TestMultiGoalsEventCounter(t *testing.T) {
 		variations[v.Value] = v
 	}
 
-	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
-	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
-	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
+	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2), time.Now().Unix())
+	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2), time.Now().Unix())
+	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
+	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2), time.Now().Add(-time.Hour).Unix())
 
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
 	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[1].Id, tag, reason)
@@ -1581,6 +1597,7 @@ func grpcRegisterGoalEvent(
 	t *testing.T,
 	goalID, userID, tag string,
 	value float64,
+	timestamp int64,
 ) {
 	t.Helper()
 	c := newGatewayClient(t)
@@ -1588,7 +1605,7 @@ func grpcRegisterGoalEvent(
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	goal, err := ptypes.MarshalAny(&eventproto.GoalEvent{
-		Timestamp: time.Now().Unix(),
+		Timestamp: timestamp,
 		GoalId:    goalID,
 		UserId:    userID,
 		Value:     value,
@@ -1621,12 +1638,13 @@ func registerGoalEvent(
 	t *testing.T,
 	goalID, userID, tag string,
 	value float64,
+	timestamp int64,
 ) {
 	t.Helper()
 	c := newGatewayClient(t)
 	defer c.Close()
 	goal, err := protojson.Marshal(&eventproto.GoalEvent{
-		Timestamp: time.Now().Unix(),
+		Timestamp: timestamp,
 		GoalId:    goalID,
 		UserId:    userID,
 		Value:     value,

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -106,7 +106,7 @@ func TestGrpcExperimentGoalCount(t *testing.T) {
 	f = getFeature(t, featureClient, featureID)
 
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
+	startAt := time.Now().Local()
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
 		ctx, t, experimentClient, "TestGrpcExperimentGoalCount", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
@@ -218,7 +218,7 @@ func TestExperimentGoalCount(t *testing.T) {
 	f = getFeature(t, featureClient, featureID)
 
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
+	startAt := time.Now().Local()
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
 		ctx, t, experimentClient, "TestExperimentGoalCount", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
@@ -335,7 +335,7 @@ func TestGrpcExperimentResult(t *testing.T) {
 	f = getFeature(t, featureClient, featureID)
 
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
+	startAt := time.Now().Local()
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
 		ctx, t, experimentClient, "TestGrpcExperimentResult", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
@@ -564,7 +564,7 @@ func TestExperimentResult(t *testing.T) {
 	f = getFeature(t, featureClient, featureID)
 
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
+	startAt := time.Now().Local()
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
 		ctx, t, experimentClient, "TestExperimentResult", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
@@ -792,7 +792,7 @@ func TestGrpcMultiGoalsEventCounter(t *testing.T) {
 	f = getFeature(t, featureClient, featureID)
 
 	goalIDs := createGoals(ctx, t, experimentClient, 3)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
+	startAt := time.Now().Local()
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
 		ctx, t, experimentClient, "TestGrpcMultiGoalsEventCounter", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
@@ -975,7 +975,7 @@ func TestMultiGoalsEventCounter(t *testing.T) {
 	f = getFeature(t, featureClient, featureID)
 
 	goalIDs := createGoals(ctx, t, experimentClient, 3)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
+	startAt := time.Now().Local()
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
 		ctx, t, experimentClient, "TestMultiGoalsEventCounter", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	ecclient "github.com/bucketeer-io/bucketeer/pkg/eventcounter/client"
@@ -49,7 +50,7 @@ import (
 const (
 	prefixTestName = "e2e-test"
 	timeout        = 20 * time.Second
-	retryTimes     = 360
+	retryTimes     = 30
 )
 
 const defaultVariationID = "default"
@@ -92,6 +93,18 @@ func TestGrpcExperimentGoalCount(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userID, f.Variations[0].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
@@ -107,7 +120,7 @@ func TestGrpcExperimentGoalCount(t *testing.T) {
 	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.2))
 	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
 
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -190,6 +203,18 @@ func TestExperimentGoalCount(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userID, f.Variations[0].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
@@ -205,7 +230,7 @@ func TestExperimentGoalCount(t *testing.T) {
 	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.2))
 	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3))
 
-	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -264,207 +289,6 @@ func TestExperimentGoalCount(t *testing.T) {
 	}
 }
 
-// Test for old SDK client. Tag is not set in the EvaluationEvent and GoalEvent
-// Evaluation field in the GoalEvent is deprecated.
-func TestExperimentResultWithoutTag(t *testing.T) {
-	t.Parallel()
-	featureClient := newFeatureClient(t)
-	defer featureClient.Close()
-	experimentClient := newExperimentClient(t)
-	defer experimentClient.Close()
-	ecClient := newEventCounterClient(t)
-	defer ecClient.Close()
-	uuid := newUUID(t)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
-	defer cancel()
-
-	tag := fmt.Sprintf("%s-tag-%s", prefixTestName, uuid)
-	userIDs := []string{}
-	for i := 0; i < 5; i++ {
-		userIDs = append(userIDs, fmt.Sprintf("%s-%d", createUserID(t, uuid), i))
-	}
-	featureID := createFeatureID(t, uuid)
-
-	cmd := newCreateFeatureCommand(featureID, []string{"a", "b"})
-	createFeature(t, featureClient, cmd)
-	addTag(t, tag, featureID, featureClient)
-	enableFeature(t, featureID, featureClient)
-	f := getFeature(t, featureClient, featureID)
-	goalIDs := createGoals(ctx, t, experimentClient, 1)
-	startAt := time.Now().Local().Add(-1 * time.Hour)
-	stopAt := startAt.Local().Add(time.Hour * 2)
-	experiment := createExperimentWithMultiGoals(
-		ctx, t, experimentClient, "TestExperimentResultWithoutTag", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
-
-	// CVRs is 3/4
-	// Register goal variation
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[0], experiment.Variations[0].Id, float64(0.3))
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[1], experiment.Variations[0].Id, float64(0.2))
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[2], experiment.Variations[0].Id, float64(0.1))
-	// Register 3 events and 2 user counts for user 1, 2 and 3
-	// Register variation a
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, "")
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[1], experiment.Variations[0].Id, "")
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, "")
-	// Increment evaluation event count
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, "")
-
-	// CVRs is 2/3
-	// Register goal
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[3], experiment.Variations[1].Id, float64(0.1))
-	registerGoalEventWithEvaluations(t, featureID, f.Version, goalIDs[0], userIDs[4], experiment.Variations[1].Id, float64(0.15))
-	// Register 3 events and 2 user counts for user 4 and 5
-	// Register variation
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, "")
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, "")
-	// Increment evaluation event count
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, "")
-
-	for i := 0; i < retryTimes; i++ {
-		resp := getExperimentResult(t, ecClient, experiment.Id)
-		if resp != nil {
-			er := resp.ExperimentResult
-			if er.Id != experiment.Id {
-				t.Fatalf("experiment ID is not correct: %s", er.Id)
-			}
-			if len(er.GoalResults) == 0 {
-				continue
-			}
-			if len(er.GoalResults) != 1 {
-				t.Fatalf("the number of goal results is not correct: %d", len(er.GoalResults))
-			}
-			gr := er.GoalResults[0]
-			if gr.GoalId != goalIDs[0] {
-				t.Fatalf("goal ID is not correct: %s", gr.GoalId)
-			}
-			if len(gr.VariationResults) != 2 {
-				t.Fatalf("the number of variation results is not correct: %d", len(gr.VariationResults))
-			}
-			if gr.VariationResults[0].EvaluationCount.EventCount == 0 && // variation A
-				gr.VariationResults[0].EvaluationCount.UserCount == 0 &&
-				gr.VariationResults[1].EvaluationCount.EventCount == 0 && // variation B
-				gr.VariationResults[1].EvaluationCount.UserCount == 0 {
-				continue
-			}
-			if gr.VariationResults[0].ExperimentCount.EventCount == 0 && // variation A
-				gr.VariationResults[0].ExperimentCount.UserCount == 0 &&
-				gr.VariationResults[1].ExperimentCount.EventCount == 0 && // variation B
-				gr.VariationResults[1].ExperimentCount.UserCount == 0 {
-				continue
-			}
-			for _, vr := range gr.VariationResults {
-				// variation a
-				if vr.VariationId == experiment.Variations[0].Id {
-					vv := experiment.Variations[0].Value
-					// Evaluation
-					if vr.EvaluationCount.EventCount != 4 {
-						t.Fatalf("variation: %s: evaluation event count is not correct: %d", vv, vr.EvaluationCount.EventCount)
-					}
-					if vr.EvaluationCount.UserCount != 3 {
-						t.Fatalf("variation: %s: evaluation user count is not correct: %d", vv, vr.EvaluationCount.UserCount)
-					}
-					// Experiment
-					if vr.ExperimentCount.EventCount != 3 {
-						t.Fatalf("variation: %s: experiment event count is not correct: %d", vv, vr.ExperimentCount.EventCount)
-					}
-					if vr.ExperimentCount.UserCount != 3 {
-						t.Fatalf("variation: %s: experiment user count is not correct: %d", vv, vr.ExperimentCount.UserCount)
-					}
-					if diff := cmp.Diff(vr.ExperimentCount.ValueSum, 0.6, compareFloatOpt); diff != "" {
-						t.Fatalf("variation: %s: experiment value sum is not correct: %f", vv, vr.ExperimentCount.ValueSum)
-					}
-					// cvr prob best
-					if vr.CvrProbBest.Mean <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob best mean is not correct: %f", vv, vr.CvrProbBest.Mean)
-					}
-					if vr.CvrProbBest.Sd <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob best sd is not correct: %f", vv, vr.CvrProbBest.Sd)
-					}
-					if vr.CvrProbBest.Rhat <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob best rhat is not correct: %f", vv, vr.CvrProbBest.Rhat)
-					}
-					// cvr prob beat baseline
-					if diff := cmp.Diff(vr.CvrProbBeatBaseline.Mean, 0.0, compareFloatOpt); diff != "" {
-						t.Fatalf("variation: %s: cvr prob beat baseline mean is not correct: %f", vv, vr.CvrProbBeatBaseline.Mean)
-					}
-					if diff := cmp.Diff(vr.CvrProbBeatBaseline.Sd, 0.0, compareFloatOpt); diff != "" {
-						t.Fatalf("variation: %s: cvr prob beat baseline best sd is not correct: %f", vv, vr.CvrProbBeatBaseline.Sd)
-					}
-					if diff := cmp.Diff(vr.CvrProbBeatBaseline.Rhat, 0.0, compareFloatOpt); diff != "" {
-						t.Fatalf("variation: %s: cvr prob beat baseline best rhat is not correct: %f", vv, vr.CvrProbBeatBaseline.Rhat)
-					}
-					// value sum per user prob best
-					if vr.GoalValueSumPerUserProbBest.Mean <= float64(0.0) {
-						t.Fatalf("variation: %s: value sum per user prob best mean is not correct: %f", vv, vr.GoalValueSumPerUserProbBest.Mean)
-					}
-					// value sum per user prob beat baseline
-					if diff := cmp.Diff(vr.GoalValueSumPerUserProbBeatBaseline.Mean, 0.0, compareFloatOpt); diff != "" {
-						t.Fatalf("variation: %s: value sum per user prob beat baseline mean is not correct: %f", vv, vr.GoalValueSumPerUserProbBeatBaseline.Mean)
-					}
-					continue
-				}
-				// variation b
-				if vr.VariationId == experiment.Variations[1].Id {
-					vv := experiment.Variations[1].Value
-					// Evaluation
-					if vr.EvaluationCount.EventCount != 3 {
-						t.Fatalf("variation: %s: evaluation event count is not correct: %d", vv, vr.EvaluationCount.EventCount)
-					}
-					if vr.EvaluationCount.UserCount != 2 {
-						t.Fatalf("variation: %s: evaluation user count is not correct: %d", vv, vr.EvaluationCount.UserCount)
-					}
-					// Experiment
-					if vr.ExperimentCount.EventCount != 2 {
-						t.Fatalf("variation: %s: experiment event count is not correct: %d", vv, vr.ExperimentCount.EventCount)
-					}
-					if vr.ExperimentCount.UserCount != 2 {
-						t.Fatalf("variation: %s: experiment user count is not correct: %d", vv, vr.ExperimentCount.UserCount)
-					}
-					if diff := cmp.Diff(vr.ExperimentCount.ValueSum, 0.25, compareFloatOpt); diff != "" {
-						t.Fatalf("variation: %s: experiment value sum is not correct: %f", vv, vr.ExperimentCount.ValueSum)
-					}
-					// cvr prob best
-					if vr.CvrProbBest.Mean <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob best mean is not correct: %f", vv, vr.CvrProbBest.Mean)
-					}
-					if vr.CvrProbBest.Sd <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob best sd is not correct: %f", vv, vr.CvrProbBest.Sd)
-					}
-					if vr.CvrProbBest.Rhat <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob best rhat is not correct: %f", vv, vr.CvrProbBest.Rhat)
-					}
-					// cvr prob beat baseline
-					if vr.CvrProbBeatBaseline.Mean <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob beat baseline mean is not correct: %f", vv, vr.CvrProbBeatBaseline.Mean)
-					}
-					if vr.CvrProbBeatBaseline.Sd <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob beat baseline best sd is not correct: %f", vv, vr.CvrProbBeatBaseline.Sd)
-					}
-					if vr.CvrProbBeatBaseline.Rhat <= float64(0.0) {
-						t.Fatalf("variation: %s: cvr prob beat baseline best rhat is not correct: %f", vv, vr.CvrProbBeatBaseline.Rhat)
-					}
-					// value sum per user prob best
-					if vr.GoalValueSumPerUserProbBest.Mean <= float64(0.0) {
-						t.Fatalf("variation: %s: value sum per user prob best mean is not correct: %f", vv, vr.GoalValueSumPerUserProbBest.Mean)
-					}
-					// value sum per user prob beat baseline
-					if vr.GoalValueSumPerUserProbBeatBaseline.Mean <= float64(0.0) {
-						t.Fatalf("variation: %s: value sum per user prob beat baseline mean is not correct: %f", vv, vr.GoalValueSumPerUserProbBeatBaseline.Mean)
-					}
-					continue
-				}
-				t.Fatalf("unknown variation results: %s", vr.VariationId)
-			}
-			break
-		}
-		if i == retryTimes-1 {
-			t.Fatalf("retry timeout")
-		}
-		time.Sleep(10 * time.Second)
-	}
-}
-
 func TestGrpcExperimentResult(t *testing.T) {
 	t.Parallel()
 	featureClient := newFeatureClient(t)
@@ -490,6 +314,22 @@ func TestGrpcExperimentResult(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userIDs[0], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[1], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[2], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[3], f.Variations[1].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[4], f.Variations[1].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
@@ -505,11 +345,11 @@ func TestGrpcExperimentResult(t *testing.T) {
 	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[1], experiment.Variations[0].Id, tag)
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag, reason)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[1], experiment.Variations[0].Id, tag, reason)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, tag, reason)
 	// Increment evaluation event count
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag, reason)
 
 	// CVRs is 2/3
 	// Register goal
@@ -519,12 +359,16 @@ func TestGrpcExperimentResult(t *testing.T) {
 	grpcRegisterGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag, reason)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, tag, reason)
 	// Increment evaluation event count
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
+		if i == retryTimes-1 {
+			t.Fatalf("retry timeout")
+		}
+		time.Sleep(10 * time.Second)
 		resp := getExperimentResult(t, ecClient, experiment.Id)
 		if resp != nil {
 			er := resp.ExperimentResult
@@ -544,15 +388,15 @@ func TestGrpcExperimentResult(t *testing.T) {
 			if len(gr.VariationResults) != 2 {
 				t.Fatalf("the number of variation results is not correct: %d", len(gr.VariationResults))
 			}
-			if gr.VariationResults[0].EvaluationCount.EventCount == 0 && // variation A
-				gr.VariationResults[0].EvaluationCount.UserCount == 0 &&
-				gr.VariationResults[1].EvaluationCount.EventCount == 0 && // variation B
+			if gr.VariationResults[0].EvaluationCount.EventCount == 0 || // variation A
+				gr.VariationResults[0].EvaluationCount.UserCount == 0 ||
+				gr.VariationResults[1].EvaluationCount.EventCount == 0 || // variation B
 				gr.VariationResults[1].EvaluationCount.UserCount == 0 {
 				continue
 			}
-			if gr.VariationResults[0].ExperimentCount.EventCount == 0 && // variation A
-				gr.VariationResults[0].ExperimentCount.UserCount == 0 &&
-				gr.VariationResults[1].ExperimentCount.EventCount == 0 && // variation B
+			if gr.VariationResults[0].ExperimentCount.EventCount == 0 || // variation A
+				gr.VariationResults[0].ExperimentCount.UserCount == 0 ||
+				gr.VariationResults[1].ExperimentCount.EventCount == 0 || // variation B
 				gr.VariationResults[1].ExperimentCount.UserCount == 0 {
 				continue
 			}
@@ -661,10 +505,6 @@ func TestGrpcExperimentResult(t *testing.T) {
 			}
 			break
 		}
-		if i == retryTimes-1 {
-			t.Fatalf("retry timeout")
-		}
-		time.Sleep(10 * time.Second)
 	}
 	res := getExperiment(t, experimentClient, experiment.Id)
 	if res.Experiment.Status != experimentproto.Experiment_RUNNING {
@@ -699,6 +539,22 @@ func TestExperimentResult(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userIDs[0], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[1], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[2], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[3], f.Variations[1].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[4], f.Variations[1].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
@@ -714,11 +570,11 @@ func TestExperimentResult(t *testing.T) {
 	registerGoalEvent(t, goalIDs[0], userIDs[0], tag, float64(0.3))
 	// Register 3 events and 2 user counts for user 1, 2 and 3
 	// Register variation a
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], experiment.Variations[0].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[2], experiment.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[0].Id, tag, reason)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[2], f.Variations[0].Id, tag, reason)
 	// Increment evaluation event count
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
 
 	// CVRs is 2/3
 	// Register goal
@@ -728,12 +584,16 @@ func TestExperimentResult(t *testing.T) {
 	registerGoalEvent(t, goalIDs[0], userIDs[3], tag, float64(0.1))
 	// Register 3 events and 2 user counts for user 4 and 5
 	// Register variation
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[4], experiment.Variations[1].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag, reason)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[4], f.Variations[1].Id, tag, reason)
 	// Increment evaluation event count
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], experiment.Variations[1].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
+		if i == retryTimes-1 {
+			t.Fatalf("retry timeout")
+		}
+		time.Sleep(10 * time.Second)
 		resp := getExperimentResult(t, ecClient, experiment.Id)
 		if resp != nil {
 			er := resp.ExperimentResult
@@ -753,15 +613,15 @@ func TestExperimentResult(t *testing.T) {
 			if len(gr.VariationResults) != 2 {
 				t.Fatalf("the number of variation results is not correct: %d", len(gr.VariationResults))
 			}
-			if gr.VariationResults[0].EvaluationCount.EventCount == 0 && // variation A
-				gr.VariationResults[0].EvaluationCount.UserCount == 0 &&
-				gr.VariationResults[1].EvaluationCount.EventCount == 0 && // variation B
+			if gr.VariationResults[0].EvaluationCount.EventCount == 0 || // variation A
+				gr.VariationResults[0].EvaluationCount.UserCount == 0 ||
+				gr.VariationResults[1].EvaluationCount.EventCount == 0 || // variation B
 				gr.VariationResults[1].EvaluationCount.UserCount == 0 {
 				continue
 			}
-			if gr.VariationResults[0].ExperimentCount.EventCount == 0 && // variation A
-				gr.VariationResults[0].ExperimentCount.UserCount == 0 &&
-				gr.VariationResults[1].ExperimentCount.EventCount == 0 && // variation B
+			if gr.VariationResults[0].ExperimentCount.EventCount == 0 || // variation A
+				gr.VariationResults[0].ExperimentCount.UserCount == 0 ||
+				gr.VariationResults[1].ExperimentCount.EventCount == 0 || // variation B
 				gr.VariationResults[1].ExperimentCount.UserCount == 0 {
 				continue
 			}
@@ -870,10 +730,6 @@ func TestExperimentResult(t *testing.T) {
 			}
 			break
 		}
-		if i == retryTimes-1 {
-			t.Fatalf("retry timeout")
-		}
-		time.Sleep(10 * time.Second)
 	}
 	res := getExperiment(t, experimentClient, experiment.Id)
 	if res.Experiment.Status != experimentproto.Experiment_RUNNING {
@@ -883,7 +739,7 @@ func TestExperimentResult(t *testing.T) {
 	}
 }
 
-func TestGrpcMultiGoalsEventCounterRealtime(t *testing.T) {
+func TestGrpcMultiGoalsEventCounter(t *testing.T) {
 	t.Parallel()
 	featureClient := newFeatureClient(t)
 	defer featureClient.Close()
@@ -910,11 +766,24 @@ func TestGrpcMultiGoalsEventCounterRealtime(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userIDs[0], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[1], f.Variations[1].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 3)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
-		ctx, t, experimentClient, "GrpcMultiGoalsEventCounterRealtime", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
+		ctx, t, experimentClient, "TestGrpcMultiGoalsEventCounter", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
 
 	variations := make(map[string]*featureproto.Variation)
 	variationIDs := []string{}
@@ -928,8 +797,8 @@ func TestGrpcMultiGoalsEventCounterRealtime(t *testing.T) {
 	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
 	grpcRegisterGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
 
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], experiment.Variations[0].Id, tag)
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[1], experiment.Variations[1].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[1].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -1051,7 +920,7 @@ func TestGrpcMultiGoalsEventCounterRealtime(t *testing.T) {
 	}
 }
 
-func TestMultiGoalsEventCounterRealtime(t *testing.T) {
+func TestMultiGoalsEventCounter(t *testing.T) {
 	t.Parallel()
 	featureClient := newFeatureClient(t)
 	defer featureClient.Close()
@@ -1078,11 +947,24 @@ func TestMultiGoalsEventCounterRealtime(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userIDs[0], f.Variations[0].Id, featureClient)
+	addFeatureIndividualTargeting(t, featureID, userIDs[1], f.Variations[1].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 3)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
 	experiment := createExperimentWithMultiGoals(
-		ctx, t, experimentClient, "GrpcMultiGoalsEventCounterRealtime", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
+		ctx, t, experimentClient, "TestMultiGoalsEventCounter", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
 
 	variations := make(map[string]*featureproto.Variation)
 	variationIDs := []string{}
@@ -1096,8 +978,8 @@ func TestMultiGoalsEventCounterRealtime(t *testing.T) {
 	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
 	registerGoalEvent(t, goalIDs[1], userIDs[1], tag, float64(0.2))
 
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[1].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, reason)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[1].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -1244,6 +1126,18 @@ func TestHTTPTrack(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userID, f.Variations[0].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	goalIDs := createGoals(ctx, t, experimentClient, 1)
 	startAt := time.Now().Local().Add(-1 * time.Hour)
 	stopAt := startAt.Local().Add(time.Hour * 2)
@@ -1259,7 +1153,7 @@ func TestHTTPTrack(t *testing.T) {
 
 	// Send track events.
 	sendHTTPTrack(t, userID, goalIDs[0], tag, value)
-	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userID, f.Variations[0].Id, tag, reason)
 
 	// Check the count
 	for i := 0; i < retryTimes; i++ {
@@ -1331,6 +1225,18 @@ func TestGrpcExperimentEvaluationEventCount(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userID, f.Variations[0].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	variations := make(map[string]*featureproto.Variation)
 	variationIDs := []string{}
 	for _, v := range f.Variations {
@@ -1352,7 +1258,7 @@ func TestGrpcExperimentEvaluationEventCount(t *testing.T) {
 		startAt, stopAt,
 	)
 
-	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, variations[variationVarA].Id, tag)
+	grpcRegisterEvaluationEvent(t, featureID, f.Version, userID, variations[variationVarA].Id, tag, reason)
 
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
@@ -1426,6 +1332,18 @@ func TestExperimentEvaluationEventCount(t *testing.T) {
 	addTag(t, tag, featureID, featureClient)
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
+
+	// Because we set the user to the individual targeting,
+	// We must ensure to set the correct reason. Otherwise, it will fail when the event persister
+	// evaluates the user
+	reason := &featureproto.Reason{
+		Type: featureproto.Reason_TARGET,
+	}
+	addFeatureIndividualTargeting(t, featureID, userID, f.Variations[0].Id, featureClient)
+
+	// Get the latest version after all changes in the feature flag
+	f = getFeature(t, featureClient, featureID)
+
 	variations := make(map[string]*featureproto.Variation)
 	variationIDs := []string{}
 	for _, v := range f.Variations {
@@ -1446,8 +1364,7 @@ func TestExperimentEvaluationEventCount(t *testing.T) {
 		startAt, stopAt,
 	)
 
-	registerEvaluationEvent(t, featureID, f.Version, userID, variations[variationVarA].Id, tag)
-
+	registerEvaluationEvent(t, featureID, f.Version, userID, variations[variationVarA].Id, tag, reason)
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
 			t.Fatalf("retry timeout")
@@ -1516,20 +1433,20 @@ func TestGetEvaluationTimeseriesCount(t *testing.T) {
 	enableFeature(t, featureID, featureClient)
 	f := getFeature(t, featureClient, featureID)
 	// Register variation
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[0].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[2], f.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, nil)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[1], f.Variations[0].Id, tag, nil)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[2], f.Variations[0].Id, tag, nil)
 	// Increment evaluation event count
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[0], f.Variations[0].Id, tag, nil)
 	// Register variation
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[4], f.Variations[1].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag, nil)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[4], f.Variations[1].Id, tag, nil)
 	// Increment evaluation event count
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[3], f.Variations[1].Id, tag, nil)
 	// Register variation
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[5], defaultVariationID, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[6], defaultVariationID, tag)
-	registerEvaluationEvent(t, featureID, f.Version, userIDs[7], defaultVariationID, tag)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[5], defaultVariationID, tag, nil)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[6], defaultVariationID, tag, nil)
+	registerEvaluationEvent(t, featureID, f.Version, userIDs[7], defaultVariationID, tag, nil)
 	expectedUserVal := []float64{3, 2, 3}
 	expectedEventVal := []float64{4, 3, 3}
 	i := 0
@@ -1675,8 +1592,10 @@ func grpcRegisterGoalEvent(
 		GoalId:    goalID,
 		UserId:    userID,
 		Value:     value,
-		User:      &userproto.User{},
-		Tag:       tag,
+		User: &userproto.User{
+			Id:   userID,
+			Data: map[string]string{"appVersion": "0.1.0"}},
+		Tag: tag,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1711,8 +1630,10 @@ func registerGoalEvent(
 		GoalId:    goalID,
 		UserId:    userID,
 		Value:     value,
-		User:      &userproto.User{},
-		Tag:       tag,
+		User: &userproto.User{
+			Id:   userID,
+			Data: map[string]string{"appVersion": "0.1.0"}},
+		Tag: tag,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1810,21 +1731,27 @@ func grpcRegisterEvaluationEvent(
 	featureID string,
 	featureVersion int32,
 	userID, variationID, tag string,
+	reason *featureproto.Reason,
 ) {
 	t.Helper()
 	c := newGatewayClient(t)
 	defer c.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	if reason == nil {
+		reason = &featureproto.Reason{}
+	}
 	evaluation, err := ptypes.MarshalAny(&eventproto.EvaluationEvent{
 		Timestamp:      time.Now().Unix(),
 		FeatureId:      featureID,
 		FeatureVersion: featureVersion,
 		UserId:         userID,
 		VariationId:    variationID,
-		User:           &userproto.User{Data: map[string]string{"appVersion": "0.1.0"}},
-		Reason:         &featureproto.Reason{},
-		Tag:            tag,
+		User: &userproto.User{
+			Id:   userID,
+			Data: map[string]string{"appVersion": "0.1.0"}},
+		Reason: reason,
+		Tag:    tag,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1851,17 +1778,23 @@ func registerEvaluationEvent(
 	featureID string,
 	featureVersion int32,
 	userID, variationID, tag string,
+	reason *featureproto.Reason,
 ) {
 	t.Helper()
+	if reason == nil {
+		reason = &featureproto.Reason{}
+	}
 	evaluation, err := protojson.Marshal(&eventproto.EvaluationEvent{
 		Timestamp:      time.Now().Unix(),
 		FeatureId:      featureID,
 		FeatureVersion: featureVersion,
 		UserId:         userID,
 		VariationId:    variationID,
-		User:           &userproto.User{},
-		Reason:         &featureproto.Reason{},
-		Tag:            tag,
+		User: &userproto.User{
+			Id:   userID,
+			Data: map[string]string{"appVersion": "0.1.0"}},
+		Reason: reason,
+		Tag:    tag,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -2009,6 +1942,30 @@ func enableFeature(t *testing.T, featureID string, client featureclient.Client) 
 	defer cancel()
 	if _, err := client.EnableFeature(ctx, enableReq); err != nil {
 		t.Fatalf("Failed to enable feature id: %s. Error: %v", featureID, err)
+	}
+}
+
+func addFeatureIndividualTargeting(t *testing.T, featureID, userID, variationID string, client featureclient.Client) {
+	t.Helper()
+	c := &featureproto.AddUserToVariationCommand{
+		Id:   variationID,
+		User: userID,
+	}
+	cmd, err := ptypes.MarshalAny(c)
+	assert.NoError(t, err)
+	req := &featureproto.UpdateFeatureTargetingRequest{
+		Id: featureID,
+		Commands: []*featureproto.Command{
+			{
+				Command: cmd,
+			},
+		},
+		EnvironmentNamespace: *environmentNamespace,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if _, err := client.UpdateFeatureTargeting(ctx, req); err != nil {
+		t.Fatalf("Failed add user to individual targeting: %s. Error: %v", featureID, err)
 	}
 }
 


### PR DESCRIPTION
Instead of using Bigtable to save the user evaluations, I changed it to evaluate the user to get the needed data to save the goal event.
Doing this, will simplify the data pipeline when supporting a multi-cloud platform and reduce costs.

I will remove the Bigtable client in another PR.