### PR TITLE
chore: move function saving metrics event to gateway

### DIFF
--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -134,7 +134,6 @@ type grpcGatewayService struct {
 	goalPublisher          publisher.Publisher
 	evaluationPublisher    publisher.Publisher
 	userPublisher          publisher.Publisher
-	metricsPublisher       publisher.Publisher
 	featuresCache          cachev3.FeaturesCache
 	segmentUsersCache      cachev3.SegmentUsersCache
 	environmentAPIKeyCache cachev3.EnvironmentAPIKeyCache
@@ -149,7 +148,6 @@ func NewGrpcGatewayService(
 	gp publisher.Publisher,
 	ep publisher.Publisher,
 	up publisher.Publisher,
-	mp publisher.Publisher,
 	v3Cache cache.MultiGetCache,
 	opts ...Option,
 ) rpc.Service {
@@ -166,7 +164,6 @@ func NewGrpcGatewayService(
 		goalPublisher:          gp,
 		evaluationPublisher:    ep,
 		userPublisher:          up,
-		metricsPublisher:       mp,
 		featuresCache:          cachev3.NewFeaturesCache(v3Cache),
 		segmentUsersCache:      cachev3.NewSegmentUsersCache(v3Cache),
 		environmentAPIKeyCache: cachev3.NewEnvironmentAPIKeyCache(v3Cache),
@@ -691,8 +688,13 @@ func (s *grpcGatewayService) RegisterEvents(
 	errs := make(map[string]*gwproto.RegisterEventsResponse_Error)
 	goalMessages := make([]publisher.Message, 0)
 	evaluationMessages := make([]publisher.Message, 0)
-	metricsMessages := make([]publisher.Message, 0)
-	publish := func(p publisher.Publisher, messages []publisher.Message, typ string) {
+	metricsEvents := make([]*eventproto.MetricsEvent, 0)
+	publish := func(
+		p publisher.Publisher,
+		messages []publisher.Message,
+		typ string,
+	) map[string]*gwproto.RegisterEventsResponse_Error {
+		errs := make(map[string]*gwproto.RegisterEventsResponse_Error)
 		errors := p.PublishMulti(ctx, messages)
 		var repeatableErrors, nonRepeateableErrors float64
 		for id, err := range errors {
@@ -707,6 +709,7 @@ func (s *grpcGatewayService) RegisterEvents(
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.Error(err),
 					zap.String("environmentNamespace", envAPIKey.EnvironmentNamespace),
+					zap.String("eventType", typ),
 					zap.String("id", id),
 				)...,
 			)
@@ -718,8 +721,9 @@ func (s *grpcGatewayService) RegisterEvents(
 		eventCounter.WithLabelValues(callerGatewayService, typ, codeNonRepeatableError).Add(nonRepeateableErrors)
 		eventCounter.WithLabelValues(callerGatewayService, typ, codeRepeatableError).Add(repeatableErrors)
 		eventCounter.WithLabelValues(callerGatewayService, typ, codeOK).Add(float64(len(messages) - len(errors)))
+		return errs
 	}
-	for _, event := range req.Events {
+	for i, event := range req.Events {
 		event.EnvironmentNamespace = envAPIKey.EnvironmentNamespace
 		if event.Id == "" {
 			return nil, ErrMissingEventID
@@ -769,12 +773,23 @@ func (s *grpcGatewayService) RegisterEvents(
 				}
 				continue
 			}
-			metricsMessages = append(metricsMessages, event)
+			m := &eventproto.MetricsEvent{}
+			if err := ptypes.UnmarshalAny(req.Events[i].Event, m); err != nil {
+				eventCounter.WithLabelValues(callerGatewayService, typeMetrics, codeUnmarshalFailed).Inc()
+				errs[event.Id] = &gwproto.RegisterEventsResponse_Error{
+					Retriable: false,
+					Message:   err.Error(),
+				}
+				continue
+			}
+			metricsEvents = append(metricsEvents, m)
 		}
 	}
-	publish(s.goalPublisher, goalMessages, typeGoal)
-	publish(s.evaluationPublisher, evaluationMessages, typeEvaluation)
-	publish(s.metricsPublisher, metricsMessages, typeMetrics)
+	// MetricsEvents are saved asynchronously for performance, since there is no user impact even if they are lost.
+	s.saveMetricsEventsAsync(metricsEvents, envAPIKey.EnvironmentNamespace)
+	goalErrors := publish(s.goalPublisher, goalMessages, typeGoal)
+	evalErrors := publish(s.evaluationPublisher, evaluationMessages, typeEvaluation)
+	errs = s.mergeMaps(errs, goalErrors, evalErrors)
 	if len(errs) > 0 {
 		if s.containsInvalidTimestampError(errs) {
 			eventCounter.WithLabelValues(callerGatewayService, typeRegisterEvent, codeInvalidTimestampRequest).Inc()
@@ -792,6 +807,16 @@ func (s *grpcGatewayService) containsInvalidTimestampError(errs map[string]*gwpr
 		}
 	}
 	return false
+}
+
+func (s *grpcGatewayService) mergeMaps(maps ...map[string]*gwproto.RegisterEventsResponse_Error) map[string]*gwproto.RegisterEventsResponse_Error {
+	result := make(map[string]*gwproto.RegisterEventsResponse_Error, 0)
+	for _, m := range maps {
+		for k, v := range m {
+			result[k] = v
+		}
+	}
+	return result
 }
 
 func (s *grpcGatewayService) checkTrackRequest(

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -809,7 +809,9 @@ func (s *grpcGatewayService) containsInvalidTimestampError(errs map[string]*gwpr
 	return false
 }
 
-func (s *grpcGatewayService) mergeMaps(maps ...map[string]*gwproto.RegisterEventsResponse_Error) map[string]*gwproto.RegisterEventsResponse_Error {
+func (s *grpcGatewayService) mergeMaps(
+	maps ...map[string]*gwproto.RegisterEventsResponse_Error,
+) map[string]*gwproto.RegisterEventsResponse_Error {
 	result := make(map[string]*gwproto.RegisterEventsResponse_Error, 0)
 	for _, m := range maps {
 		for k, v := range m {

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -809,7 +809,7 @@ func (s *grpcGatewayService) containsInvalidTimestampError(errs map[string]*gwpr
 	return false
 }
 
-func (s *grpcGatewayService) mergeMaps(
+func (*grpcGatewayService) mergeMaps(
 	maps ...map[string]*gwproto.RegisterEventsResponse_Error,
 ) map[string]*gwproto.RegisterEventsResponse_Error {
 	result := make(map[string]*gwproto.RegisterEventsResponse_Error, 0)

--- a/pkg/gateway/api/api_grpc_test.go
+++ b/pkg/gateway/api/api_grpc_test.go
@@ -89,7 +89,7 @@ func TestWithLogger(t *testing.T) {
 
 func TestNewGrpcGatewayService(t *testing.T) {
 	t.Parallel()
-	g := NewGrpcGatewayService(nil, nil, nil, nil, nil, nil, nil)
+	g := NewGrpcGatewayService(nil, nil, nil, nil, nil, nil)
 	assert.IsType(t, &grpcGatewayService{}, g)
 }
 
@@ -2014,8 +2014,6 @@ func TestGrcpRegisterEvents(t *testing.T) {
 					nil).MaxTimes(1)
 				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
-					nil).MaxTimes(1)
 			},
 			input: &gwproto.RegisterEventsRequest{
 				Events: []*eventproto.Event{
@@ -2053,8 +2051,6 @@ func TestGrcpRegisterEvents(t *testing.T) {
 				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
-					nil).MaxTimes(1)
-				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.RegisterEventsRequest{
@@ -2148,7 +2144,6 @@ func newGrpcGatewayServiceWithMock(t *testing.T, mockController *gomock.Controll
 		accountClient:          accountclientmock.NewMockClient(mockController),
 		goalPublisher:          publishermock.NewMockPublisher(mockController),
 		userPublisher:          publishermock.NewMockPublisher(mockController),
-		metricsPublisher:       publishermock.NewMockPublisher(mockController),
 		evaluationPublisher:    publishermock.NewMockPublisher(mockController),
 		featuresCache:          cachev3mock.NewMockFeaturesCache(mockController),
 		segmentUsersCache:      cachev3mock.NewMockSegmentUsersCache(mockController),

--- a/pkg/gateway/api/metrics.go
+++ b/pkg/gateway/api/metrics.go
@@ -54,16 +54,6 @@ const (
 
 var (
 	registerOnce sync.Once
-
-	/* TODO: After deleting "gateway" service, we need to do the following things:
-	1. Rename cacheCounter to grpccacheCounter
-	2. Rename api_cache_requests_total to api_grpc_cache_requests_total
-	3. Rename api_register_events_total to api_grpc_register_events_total
-	4. Rename restCacheCounter to cacheCounter
-	5. Rename api_rest_cache_requests_total to api_cache_requests_total
-	6. Rename api_rest_register_events_total to api_register_events_total
-	*/
-
 	cacheCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -71,7 +61,6 @@ var (
 			Name:      "api_cache_requests_total",
 			Help:      "Total number of cache requests",
 		}, []string{"caller", "type", "layer", "code"})
-
 	eventCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -79,7 +68,7 @@ var (
 			Name:      "api_register_events_total",
 			Help:      "Total number of registered events",
 		}, []string{"caller", "type", "code"})
-
+	// TODO: Remove after deleting api-gateway REST server
 	restCacheCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -87,7 +76,7 @@ var (
 			Name:      "api_rest_cache_requests_total",
 			Help:      "Total number of cache requests",
 		}, []string{"caller", "type", "layer", "code"})
-
+	// TODO: Remove after deleting api-gateway REST server
 	restEventCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -95,7 +84,7 @@ var (
 			Name:      "api_rest_register_events_total",
 			Help:      "Total number of registered events",
 		}, []string{"caller", "type", "code"})
-	// TODO: Remove this event after grpc server is removed.
+	// TODO: Remove after deleting api-gateway REST server
 	sdkGetEvaluationsLatencyHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "bucketeer",
@@ -104,8 +93,7 @@ var (
 			Help:      "Histogram of get evaluations response latency (seconds).",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"environment_namespace", "tag", "state"})
-
-	// TODO: Remove this event after grpc server is removed.
+	// TODO: Remove after deleting api-gateway REST server
 	sdkGetEvaluationsSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "bucketeer",
@@ -114,8 +102,7 @@ var (
 			Help:      "Histogram of get evaluations response size (byte).",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"environment_namespace", "tag", "state"})
-
-	// TODO: Remove this event after grpc server is removed.
+	// TODO: Remove after deleting api-gateway REST server
 	sdkTimeoutErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -123,8 +110,7 @@ var (
 			Name:      "sdk_timeout_error_total",
 			Help:      "Total number of sdk timeout errors",
 		}, []string{"environment_namespace", "tag"})
-
-	// TODO: Remove this event after grpc server is removed.
+	// TODO: Remove after deleting api-gateway REST server
 	sdkInternalErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -132,7 +118,6 @@ var (
 			Name:      "sdk_internal_error_total",
 			Help:      "Total number of sdk internal errors",
 		}, []string{"environment_namespace", "tag"})
-
 	sdkLatencyHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "bucketeer",
@@ -141,7 +126,6 @@ var (
 			Help:      "Histogram of get evaluations response latency (seconds).",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"environment_namespace", "tag", "api", "sdk_version", "source_id"})
-
 	sdkSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: "bucketeer",
@@ -150,7 +134,6 @@ var (
 			Help:      "Histogram of get evaluations response size (byte).",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"environment_namespace", "tag", "api", "sdk_version", "source_id"})
-
 	sdkErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",

--- a/pkg/gateway/api/metrics.go
+++ b/pkg/gateway/api/metrics.go
@@ -140,7 +140,7 @@ var (
 			Name:      "sdk_api_handling_seconds",
 			Help:      "Histogram of get evaluations response latency (seconds).",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"environment_namespace", "tag", "state", "api", "sdk_version", "source_id"})
+		}, []string{"environment_namespace", "tag", "api", "sdk_version", "source_id"})
 
 	sdkSizeHistogram = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -149,7 +149,7 @@ var (
 			Name:      "sdk_api_response_size",
 			Help:      "Histogram of get evaluations response size (byte).",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"environment_namespace", "tag", "state", "api", "sdk_version", "source_id"})
+		}, []string{"environment_namespace", "tag", "api", "sdk_version", "source_id"})
 
 	sdkErrorCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/gateway/api/metrics.go
+++ b/pkg/gateway/api/metrics.go
@@ -95,10 +95,83 @@ var (
 			Name:      "api_rest_register_events_total",
 			Help:      "Total number of registered events",
 		}, []string{"caller", "type", "code"})
+	// TODO: Remove this event after grpc server is removed.
+	sdkGetEvaluationsLatencyHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_get_evaluations_handling_seconds",
+			Help:      "Histogram of get evaluations response latency (seconds).",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"environment_namespace", "tag", "state"})
+
+	// TODO: Remove this event after grpc server is removed.
+	sdkGetEvaluationsSizeHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_get_evaluations_size",
+			Help:      "Histogram of get evaluations response size (byte).",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"environment_namespace", "tag", "state"})
+
+	// TODO: Remove this event after grpc server is removed.
+	sdkTimeoutErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_timeout_error_total",
+			Help:      "Total number of sdk timeout errors",
+		}, []string{"environment_namespace", "tag"})
+
+	// TODO: Remove this event after grpc server is removed.
+	sdkInternalErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_internal_error_total",
+			Help:      "Total number of sdk internal errors",
+		}, []string{"environment_namespace", "tag"})
+
+	sdkLatencyHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_api_handling_seconds",
+			Help:      "Histogram of get evaluations response latency (seconds).",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"environment_namespace", "tag", "state", "api", "sdk_version", "source_id"})
+
+	sdkSizeHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_api_response_size",
+			Help:      "Histogram of get evaluations response size (byte).",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"environment_namespace", "tag", "state", "api", "sdk_version", "source_id"})
+
+	sdkErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "metrics_event",
+			Name:      "sdk_api_error_total",
+			Help:      "Total number of sdk errors",
+		}, []string{"environment_namespace", "tag", "error_type", "api", "sdk_version", "source_id"})
 )
 
 func registerMetrics(r metrics.Registerer) {
 	registerOnce.Do(func() {
-		r.MustRegister(cacheCounter, eventCounter)
+		r.MustRegister(
+			cacheCounter,
+			eventCounter,
+			sdkGetEvaluationsLatencyHistogram,
+			sdkGetEvaluationsSizeHistogram,
+			sdkTimeoutErrorCounter,
+			sdkInternalErrorCounter,
+			sdkLatencyHistogram,
+			sdkSizeHistogram,
+			sdkErrorCounter,
+		)
 	})
 }

--- a/pkg/gateway/api/metrics_event.go
+++ b/pkg/gateway/api/metrics_event.go
@@ -184,10 +184,9 @@ func (s *grpcGatewayService) saveLatencyMetricsEvent(event *eventproto.MetricsEv
 	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
 		return MetricsSaveErrUnknownApiId
 	}
-	var tag, status string
+	var tag string
 	if ev.Labels != nil {
 		tag = ev.Labels["tag"]
-		status = ev.Labels["state"]
 	}
 	dur, err := ptypes.Duration(ev.Duration)
 	if err != nil {
@@ -196,7 +195,6 @@ func (s *grpcGatewayService) saveLatencyMetricsEvent(event *eventproto.MetricsEv
 	sdkLatencyHistogram.WithLabelValues(
 		env,
 		tag,
-		status,
 		ev.ApiId.String(),
 		event.SdkVersion,
 		event.SourceId.String(),
@@ -212,15 +210,13 @@ func (s *grpcGatewayService) saveSizeMetricsEvent(event *eventproto.MetricsEvent
 	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
 		return MetricsSaveErrUnknownApiId
 	}
-	var tag, status string
+	var tag string
 	if ev.Labels != nil {
 		tag = ev.Labels["tag"]
-		status = ev.Labels["state"]
 	}
 	sdkSizeHistogram.WithLabelValues(
 		env,
 		tag,
-		status,
 		ev.ApiId.String(),
 		event.SdkVersion,
 		event.SourceId.String(),

--- a/pkg/gateway/api/metrics_event.go
+++ b/pkg/gateway/api/metrics_event.go
@@ -49,7 +49,9 @@ var (
 	unknownErrorMetricsEventP             = &eventproto.UnknownErrorMetricsEvent{}
 )
 
-func (s *grpcGatewayService) saveMetricsEventsAsync(metricsEvents []*eventproto.MetricsEvent, environmentNamespace string) {
+func (s *grpcGatewayService) saveMetricsEventsAsync(
+	metricsEvents []*eventproto.MetricsEvent, environmentNamespace string,
+) {
 	// TODO: using buffered channel to reduce the number of go routines
 	go func() {
 		for i := range metricsEvents {

--- a/pkg/gateway/api/metrics_event.go
+++ b/pkg/gateway/api/metrics_event.go
@@ -1,0 +1,515 @@
+package api
+
+import (
+	"errors"
+
+	"github.com/golang/protobuf/ptypes"
+	"go.uber.org/zap"
+
+	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
+)
+
+const (
+	ErrorTypeBadRequest          = "BadRequest"
+	ErrorTypeUnauthenticated     = "Unauthenticated"
+	ErrorTypeForbidden           = "Forbidden"
+	ErrorTypeNotFound            = "NotFound"
+	ErrorTypeClientClosedRequest = "ClientClosedRequest"
+	ErrorTypeInternalServerError = "InternalServerError"
+	ErrorTypeServiceUnavailable  = "ServiceUnavailable"
+	ErrorTypeTimeout             = "Timeout"
+	ErrorTypeInternal            = "Internal"
+	ErrorTypeNetwork             = "Network"
+	ErrorTypeSDKInternal         = "SDKInternal"
+	ErrorTypeUnknown             = "Unknown"
+)
+
+var (
+	MetricsSaveErrUnknownEvent    = errors.New("gateway: unknown metrics event")
+	MetricsSaveErrInvalidDuration = errors.New("gateway: metrics event has invalid duration")
+	MetricsSaveErrUnknownApiId    = errors.New("gateway: metrics event has unknown api id")
+
+	getEvaluationLatencyMetricsEventP     = &eventproto.GetEvaluationLatencyMetricsEvent{}
+	getEvaluationSizeMetricsEventP        = &eventproto.GetEvaluationSizeMetricsEvent{}
+	timeoutErrorCountMetricsEventP        = &eventproto.TimeoutErrorCountMetricsEvent{}
+	internalErrorCountMetricsEventP       = &eventproto.InternalErrorCountMetricsEvent{}
+	latencyMetricsEventP                  = &eventproto.LatencyMetricsEvent{}
+	sizeMetricsEventP                     = &eventproto.SizeMetricsEvent{}
+	badRequestErrorMetricsEventP          = &eventproto.BadRequestErrorMetricsEvent{}
+	unauthorizedErrorMetricsEventP        = &eventproto.UnauthorizedErrorMetricsEvent{}
+	forbiddenErrorMetricsEventP           = &eventproto.ForbiddenErrorMetricsEvent{}
+	notFoundErrorMetricsEventP            = &eventproto.NotFoundErrorMetricsEvent{}
+	clientClosedRequestErrorMetricsEventP = &eventproto.ClientClosedRequestErrorMetricsEvent{}
+	internalServerErrorMetricsEventP      = &eventproto.InternalServerErrorMetricsEvent{}
+	serviceUnavailableErrorMetricsEventP  = &eventproto.ServiceUnavailableErrorMetricsEvent{}
+	timeoutErrorMetricsEventP             = &eventproto.TimeoutErrorMetricsEvent{}
+	internalErrorMetricsEventP            = &eventproto.InternalErrorMetricsEvent{}
+	networkErrorMetricsEventP             = &eventproto.NetworkErrorMetricsEvent{}
+	internalSdkErrorMetricsEventP         = &eventproto.InternalSdkErrorMetricsEvent{}
+	unknownErrorMetricsEventP             = &eventproto.UnknownErrorMetricsEvent{}
+)
+
+func (s *grpcGatewayService) saveMetricsEventsAsync(metricsEvents []*eventproto.MetricsEvent, environmentNamespace string) {
+	// TODO: using buffered channel to reduce the number of go routines
+	go func() {
+		for i := range metricsEvents {
+			if err := s.saveMetrics(metricsEvents[i], environmentNamespace); err != nil {
+				s.logger.Error("Failed to store metrics event to prometheus client", zap.Error(err))
+			}
+		}
+	}()
+}
+
+func (s *grpcGatewayService) saveMetrics(event *eventproto.MetricsEvent, environmentNamespace string) error {
+	if ptypes.Is(event.Event, getEvaluationLatencyMetricsEventP) {
+		return s.saveGetEvaluationLatencyMetricsEvent(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, getEvaluationSizeMetricsEventP) {
+		return s.saveGetEvaluationSizeMetricsEvent(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, timeoutErrorCountMetricsEventP) {
+		return s.saveTimeoutErrorCountMetricsEvent(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, internalErrorCountMetricsEventP) {
+		return s.saveInternalErrorCountMetricsEvent(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, latencyMetricsEventP) {
+		return s.saveLatencyMetricsEvent(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, sizeMetricsEventP) {
+		return s.saveSizeMetricsEvent(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, badRequestErrorMetricsEventP) {
+		return s.saveBadRequestError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, unauthorizedErrorMetricsEventP) {
+		return s.saveUnauthorizedError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, forbiddenErrorMetricsEventP) {
+		return s.saveForbiddenError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, notFoundErrorMetricsEventP) {
+		return s.saveNotFoundError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, clientClosedRequestErrorMetricsEventP) {
+		return s.saveClientClosedRequestError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, internalServerErrorMetricsEventP) {
+		return s.saveInternalServerError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, serviceUnavailableErrorMetricsEventP) {
+		return s.saveServiceUnavailableError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, timeoutErrorMetricsEventP) {
+		return s.saveTimeoutError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, internalErrorMetricsEventP) {
+		return s.saveInternalError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, networkErrorMetricsEventP) {
+		return s.saveNetworkError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, internalSdkErrorMetricsEventP) {
+		return s.saveInternalSdkError(event, environmentNamespace)
+	}
+	if ptypes.Is(event.Event, unknownErrorMetricsEventP) {
+		return s.saveUnknownError(event, environmentNamespace)
+	}
+	return MetricsSaveErrUnknownEvent
+}
+
+func (s *grpcGatewayService) saveGetEvaluationLatencyMetricsEvent(event *eventproto.MetricsEvent, env string) error {
+	ev := &eventproto.GetEvaluationLatencyMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.Duration == nil {
+		return MetricsSaveErrInvalidDuration
+	}
+	var tag, status string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+		status = ev.Labels["state"]
+	}
+	dur, err := ptypes.Duration(ev.Duration)
+	if err != nil {
+		return MetricsSaveErrInvalidDuration
+	}
+	sdkGetEvaluationsLatencyHistogram.WithLabelValues(env, tag, status).Observe(dur.Seconds())
+	return nil
+}
+
+func (s *grpcGatewayService) saveGetEvaluationSizeMetricsEvent(event *eventproto.MetricsEvent, env string) error {
+	ev := &eventproto.GetEvaluationSizeMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	var tag, status string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+		status = ev.Labels["state"]
+	}
+	sdkGetEvaluationsSizeHistogram.WithLabelValues(env, tag, status).Observe(float64(ev.SizeByte))
+	return nil
+}
+
+func (s *grpcGatewayService) saveTimeoutErrorCountMetricsEvent(event *eventproto.MetricsEvent, env string) error {
+	ev := &eventproto.TimeoutErrorCountMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	sdkTimeoutErrorCounter.WithLabelValues(env, ev.Tag).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveInternalErrorCountMetricsEvent(event *eventproto.MetricsEvent, env string) error {
+	ev := &eventproto.InternalErrorCountMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	sdkInternalErrorCounter.WithLabelValues(env, ev.Tag).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveLatencyMetricsEvent(event *eventproto.MetricsEvent, env string) error {
+	ev := &eventproto.LatencyMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.Duration == nil {
+		return MetricsSaveErrInvalidDuration
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag, status string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+		status = ev.Labels["state"]
+	}
+	dur, err := ptypes.Duration(ev.Duration)
+	if err != nil {
+		return MetricsSaveErrInvalidDuration
+	}
+	sdkLatencyHistogram.WithLabelValues(
+		env,
+		tag,
+		status,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Observe(dur.Seconds())
+	return nil
+}
+
+func (s *grpcGatewayService) saveSizeMetricsEvent(event *eventproto.MetricsEvent, env string) error {
+	ev := &eventproto.SizeMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag, status string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+		status = ev.Labels["state"]
+	}
+	sdkSizeHistogram.WithLabelValues(
+		env,
+		tag,
+		status,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Observe(float64(ev.SizeByte))
+	return nil
+}
+
+func (s *grpcGatewayService) saveBadRequestError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeBadRequest
+	ev := &eventproto.BadRequestErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveUnauthorizedError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeUnauthenticated
+	ev := &eventproto.UnauthorizedErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveForbiddenError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeForbidden
+	ev := &eventproto.ForbiddenErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveNotFoundError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeNotFound
+	ev := &eventproto.NotFoundErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveClientClosedRequestError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeClientClosedRequest
+	ev := &eventproto.ClientClosedRequestErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveInternalServerError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeInternalServerError
+	ev := &eventproto.InternalServerErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveServiceUnavailableError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeServiceUnavailable
+	ev := &eventproto.ServiceUnavailableErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveTimeoutError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeTimeout
+	ev := &eventproto.TimeoutErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveInternalError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeInternal
+	ev := &eventproto.InternalErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveNetworkError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeNetwork
+	ev := &eventproto.NetworkErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveInternalSdkError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeSDKInternal
+	ev := &eventproto.InternalSdkErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}
+
+func (s *grpcGatewayService) saveUnknownError(event *eventproto.MetricsEvent, env string) error {
+	errorType := ErrorTypeUnknown
+	ev := &eventproto.UnknownErrorMetricsEvent{}
+	if err := ptypes.UnmarshalAny(event.Event, ev); err != nil {
+		return err
+	}
+	if ev.ApiId == eventproto.ApiId_UNKNOWN_API {
+		return MetricsSaveErrUnknownApiId
+	}
+	var tag string
+	if ev.Labels != nil {
+		tag = ev.Labels["tag"]
+	}
+	sdkErrorCounter.WithLabelValues(
+		env,
+		tag,
+		errorType,
+		ev.ApiId.String(),
+		event.SdkVersion,
+		event.SourceId.String(),
+	).Inc()
+	return nil
+}

--- a/pkg/gateway/api/metrics_event_test.go
+++ b/pkg/gateway/api/metrics_event_test.go
@@ -1,0 +1,157 @@
+// Copyright 2022 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
+)
+
+func TestSaveMetrics(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	ns := "ns0"
+	patterns := []struct {
+		desc        string
+		inputEvent  func() *eventproto.MetricsEvent
+		expectedErr error
+	}{
+		{
+			desc: "error: SizeMetricsEvent MetricsSaveErrUnknownApiId",
+			inputEvent: func() *eventproto.MetricsEvent {
+				size, err := ptypes.MarshalAny(&eventproto.SizeMetricsEvent{
+					ApiId:    eventproto.ApiId_UNKNOWN_API,
+					Labels:   map[string]string{"tag": "iOS"},
+					SizeByte: 100,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &eventproto.MetricsEvent{
+					Timestamp:  time.Now().Unix(),
+					Event:      size,
+					SdkVersion: "v0.0.1-unit-test",
+					SourceId:   eventproto.SourceId_IOS,
+				}
+			},
+			expectedErr: MetricsSaveErrUnknownApiId,
+		},
+		{
+			desc: "success: SizeMetricsEvent",
+			inputEvent: func() *eventproto.MetricsEvent {
+				size, err := ptypes.MarshalAny(&eventproto.SizeMetricsEvent{
+					ApiId:    eventproto.ApiId_GET_EVALUATIONS,
+					Labels:   map[string]string{"tag": "iOS"},
+					SizeByte: 100,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &eventproto.MetricsEvent{
+					Timestamp:  time.Now().Unix(),
+					Event:      size,
+					SdkVersion: "v0.0.1-unit-test",
+					SourceId:   eventproto.SourceId_IOS,
+				}
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error: LatencyMetricsEvent MetricsSaveErrInvalidDuration",
+			inputEvent: func() *eventproto.MetricsEvent {
+				latency, err := ptypes.MarshalAny(&eventproto.LatencyMetricsEvent{
+					ApiId:  eventproto.ApiId_GET_EVALUATIONS,
+					Labels: map[string]string{"tag": "iOS"},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &eventproto.MetricsEvent{
+					Timestamp:  time.Now().Unix(),
+					Event:      latency,
+					SdkVersion: "v0.0.1-unit-test",
+					SourceId:   eventproto.SourceId_IOS,
+				}
+			},
+			expectedErr: MetricsSaveErrInvalidDuration,
+		},
+		{
+			desc: "success: LatencyMetricsEvent",
+			inputEvent: func() *eventproto.MetricsEvent {
+				latency, err := ptypes.MarshalAny(&eventproto.LatencyMetricsEvent{
+					ApiId:    eventproto.ApiId_GET_EVALUATIONS,
+					Labels:   map[string]string{"tag": "iOS"},
+					Duration: durationpb.New(time.Duration(5)),
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &eventproto.MetricsEvent{
+					Timestamp:  time.Now().Unix(),
+					Event:      latency,
+					SdkVersion: "v0.0.1-unit-test",
+					SourceId:   eventproto.SourceId_IOS,
+				}
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error: UnknownEvent",
+			inputEvent: func() *eventproto.MetricsEvent {
+				return &eventproto.MetricsEvent{
+					Timestamp:  time.Now().Unix(),
+					SdkVersion: "v0.0.1-unit-test",
+					SourceId:   eventproto.SourceId_UNKNOWN,
+				}
+			},
+			expectedErr: MetricsSaveErrUnknownEvent,
+		},
+
+		{
+			desc: "success: ErrorMetricsEvent",
+			inputEvent: func() *eventproto.MetricsEvent {
+				internalSDKErr, err := ptypes.MarshalAny(&eventproto.InternalSdkErrorMetricsEvent{
+					ApiId:  eventproto.ApiId_GET_EVALUATIONS,
+					Labels: map[string]string{"tag": "iOS"},
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				return &eventproto.MetricsEvent{
+					Timestamp:  time.Now().Unix(),
+					Event:      internalSDKErr,
+					SdkVersion: "v0.0.1-unit-test",
+					SourceId:   eventproto.SourceId_IOS,
+				}
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			gs := newGrpcGatewayServiceWithMock(t, mockController)
+			err := gs.saveMetrics(p.inputEvent(), ns)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}

--- a/pkg/gateway/cmd/server.go
+++ b/pkg/gateway/cmd/server.go
@@ -244,7 +244,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		goalPublisher,
 		evaluationPublisher,
 		userPublisher,
-		metricsPublisher,
 		redisV3Cache,
 		api.WithOldestEventTimestamp(*s.oldestEventTimestamp),
 		api.WithFurthestEventTimestamp(*s.furthestEventTimestamp),

--- a/test/e2e/gateway/api_grpc_test.go
+++ b/test/e2e/gateway/api_grpc_test.go
@@ -21,12 +21,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
 	gatewayclient "github.com/bucketeer-io/bucketeer/pkg/gateway/client"
@@ -217,6 +217,7 @@ func TestGrpcRegisterEvents(t *testing.T) {
 	defer c.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	// Evaluation Event
 	evaluation, err := ptypes.MarshalAny(&eventproto.EvaluationEvent{
 		Timestamp:      time.Now().Unix(),
 		FeatureId:      "feature-id",
@@ -232,6 +233,7 @@ func TestGrpcRegisterEvents(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// GoalEvent
 	goal, err := ptypes.MarshalAny(&eventproto.GoalEvent{
 		Timestamp: time.Now().Unix(),
 		GoalId:    "goal-id",
@@ -241,6 +243,76 @@ func TestGrpcRegisterEvents(t *testing.T) {
 			Id: "user-id",
 		},
 		Tag: "tag",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// InternalSDKErrorMetricsEvent
+	internalSDKErr, err := ptypes.MarshalAny(&eventproto.InternalSdkErrorMetricsEvent{
+		ApiId:  eventproto.ApiId_GET_EVALUATIONS,
+		Labels: map[string]string{"tag": "iOS"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricsInternalSDK, err := ptypes.MarshalAny(&eventproto.MetricsEvent{
+		Timestamp:  time.Now().Unix(),
+		Event:      internalSDKErr,
+		SdkVersion: "v0.0.1-e2e",
+		SourceId:   eventproto.SourceId_IOS,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// BadRequestErrorMetricsEvent
+	badRequestErr, err := ptypes.MarshalAny(&eventproto.BadRequestErrorMetricsEvent{
+		ApiId:  eventproto.ApiId_REGISTER_EVENTS,
+		Labels: map[string]string{"tag": "Android"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricsBadRequest, err := ptypes.MarshalAny(&eventproto.MetricsEvent{
+		Timestamp:  time.Now().Unix(),
+		Event:      badRequestErr,
+		SdkVersion: "v0.0.1-e2e",
+		SourceId:   eventproto.SourceId_ANDROID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// SizeMetricsEvent
+	size, err := ptypes.MarshalAny(&eventproto.SizeMetricsEvent{
+		ApiId:    eventproto.ApiId_REGISTER_EVENTS,
+		Labels:   map[string]string{"tag": "web"},
+		SizeByte: 99,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricsSize, err := ptypes.MarshalAny(&eventproto.MetricsEvent{
+		Timestamp:  time.Now().Unix(),
+		Event:      size,
+		SdkVersion: "v0.0.1-e2e",
+		SourceId:   eventproto.SourceId_WEB,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// LatencyMetricsEvent
+	latency, err := ptypes.MarshalAny(&eventproto.LatencyMetricsEvent{
+		ApiId:    eventproto.ApiId_REGISTER_EVENTS,
+		Labels:   map[string]string{"tag": "go-server-sdk"},
+		Duration: durationpb.New(time.Duration(99)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	metricsLatency, err := ptypes.MarshalAny(&eventproto.MetricsEvent{
+		Timestamp:  time.Now().Unix(),
+		Event:      latency,
+		SdkVersion: "v0.0.1-e2e",
+		SourceId:   eventproto.SourceId_GO_SERVER,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -255,6 +327,26 @@ func TestGrpcRegisterEvents(t *testing.T) {
 			{
 				Id:                   newUUID(t),
 				Event:                goal,
+				EnvironmentNamespace: "",
+			},
+			{
+				Id:                   newUUID(t),
+				Event:                metricsInternalSDK,
+				EnvironmentNamespace: "",
+			},
+			{
+				Id:                   newUUID(t),
+				Event:                metricsBadRequest,
+				EnvironmentNamespace: "",
+			},
+			{
+				Id:                   newUUID(t),
+				Event:                metricsSize,
+				EnvironmentNamespace: "",
+			},
+			{
+				Id:                   newUUID(t),
+				Event:                metricsLatency,
 				EnvironmentNamespace: "",
 			},
 		},

--- a/test/e2e/gateway/api_grpc_test.go
+++ b/test/e2e/gateway/api_grpc_test.go
@@ -320,34 +320,28 @@ func TestGrpcRegisterEvents(t *testing.T) {
 	req := &gatewayproto.RegisterEventsRequest{
 		Events: []*eventproto.Event{
 			{
-				Id:                   newUUID(t),
-				Event:                evaluation,
-				EnvironmentNamespace: "",
+				Id:    newUUID(t),
+				Event: evaluation,
 			},
 			{
-				Id:                   newUUID(t),
-				Event:                goal,
-				EnvironmentNamespace: "",
+				Id:    newUUID(t),
+				Event: goal,
 			},
 			{
-				Id:                   newUUID(t),
-				Event:                metricsInternalSDK,
-				EnvironmentNamespace: "",
+				Id:    newUUID(t),
+				Event: metricsInternalSDK,
 			},
 			{
-				Id:                   newUUID(t),
-				Event:                metricsBadRequest,
-				EnvironmentNamespace: "",
+				Id:    newUUID(t),
+				Event: metricsBadRequest,
 			},
 			{
-				Id:                   newUUID(t),
-				Event:                metricsSize,
-				EnvironmentNamespace: "",
+				Id:    newUUID(t),
+				Event: metricsSize,
 			},
 			{
-				Id:                   newUUID(t),
-				Event:                metricsLatency,
-				EnvironmentNamespace: "",
+				Id:    newUUID(t),
+				Event: metricsLatency,
 			},
 		},
 	}


### PR DESCRIPTION
- move function saving metrics event to the api-gateway
- add new metrics event according to HTTP status code
- add e2e test for metrics event saving