### PR TITLE
revert: update dependency numpy to v1.22.0 [security]

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -23,7 +23,7 @@ httplib2==0.20.4; python_version >= "3.6" and python_full_version < "3.0.0" or p
 idna==3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 marshmallow==3.15.0; python_version >= "3.7"
 multidict==6.0.2; python_version >= "3.7"
-numpy==1.22.0
+numpy==1.21.6
 packaging==21.3; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 pandas==1.3.5; python_full_version >= "3.7.1"
 prometheus-async==19.2.0; (python_version >= "2.7" and python_version < "3.0") or (python_version > "3.0" and python_version < "3.1") or (python_version > "3.1" and python_version < "3.2") or (python_version > "3.2" and python_version < "3.3") or (python_version > "3.3" and python_version < "3.4") or (python_version > "3.4")


### PR DESCRIPTION
Reverts bucketeer-io/bucketeer#222

numpy 1.22 requires python >= 3.8.