### PR TITLE
ci: add build step to workflow for validating pull request for python

### DIFF
--- a/.github/workflows/pr-python.yaml
+++ b/.github/workflows/pr-python.yaml
@@ -45,4 +45,7 @@ jobs:
           source .venv/bin/activate
           make gen
           make test
-
+      - name: Build python
+        run: |
+          source .venv/bin/activate
+          make gen


### PR DESCRIPTION
I addressed to a [PR](https://github.com/bucketeer-io/bucketeer/pull/222/checks) that passed test but did not pass build.