### PR TITLE
chore: add function to get prerequisites

### DIFF
--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -350,14 +350,14 @@ func (s *grpcGatewayService) validateGetEvaluationsRequest(req *gwproto.GetEvalu
 }
 
 /*
-getPrerequisiteDownwards recursively gets the features specified as prerequisite by the targetFeatures.
+getPrerequisiteDownwards gets the features specified as prerequisite by the targetFeatures.
 */
 func (s *grpcGatewayService) getPrerequisiteDownwards(
 	targetFeatures, allFeatures map[string]*featureproto.Feature,
 ) (map[string]*featureproto.Feature, error) {
 	prerequisites := make(map[string]*featureproto.Feature, 0)
 	// depth first search
-	queue := []*featureproto.Feature{}
+	queue := make([]*featureproto.Feature, 0)
 	for _, f := range targetFeatures {
 		queue = append(queue, f)
 	}
@@ -377,30 +377,6 @@ func (s *grpcGatewayService) getPrerequisiteDownwards(
 		return targetFeatures, nil
 	}
 	return s.mapMerge(targetFeatures, prerequisites), nil
-}
-	targetFeatures, allFeatures map[string]*featureproto.Feature,
-) (map[string]*featureproto.Feature, error) {
-	prerequisites := make(map[string]*featureproto.Feature, 0)
-	for _, f := range targetFeatures {
-		for _, pre := range f.Prerequisites {
-			if _, ok := targetFeatures[pre.FeatureId]; ok {
-				continue
-			}
-			preFeature, ok := allFeatures[pre.FeatureId]
-			if !ok {
-				return nil, ErrFeatureNotFound
-			}
-			prerequisites[preFeature.Id] = preFeature
-		}
-	}
-	if len(prerequisites) == 0 {
-		return targetFeatures, nil
-	}
-	newTargets, err := s.getPrerequisiteDownwards(prerequisites, allFeatures)
-	if err != nil {
-		return nil, err
-	}
-	return s.mapMerge(targetFeatures, newTargets), nil
 }
 
 /*

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -374,7 +374,7 @@ func (s *grpcGatewayService) getPrerequisiteDownwards(
 		}
 		queue = queue[1:]
 	}
-	return s.getaPrerequisiteResult(targetFeatures, prerequisites), nil
+	return s.getPrerequisiteResult(targetFeatures, prerequisites), nil
 }
 
 /*
@@ -401,10 +401,10 @@ func (s *grpcGatewayService) getPrerequisiteUpwards( // nolint:unused
 		}
 		queue = queue[1:]
 	}
-	return s.getaPrerequisiteResult(targetFeatures, upwardsFeatures), nil
+	return s.getPrerequisiteResult(targetFeatures, upwardsFeatures), nil
 }
 
-func (s *grpcGatewayService) getaPrerequisiteResult(
+func (s *grpcGatewayService) getPrerequisiteResult(
 	targetFeatures []*featureproto.Feature,
 	featuresDepenencies map[string]*featureproto.Feature,
 ) []*featureproto.Feature {
@@ -422,7 +422,6 @@ func (s *grpcGatewayService) getaPrerequisiteResult(
 	}
 	return result
 }
-
 
 func (s *grpcGatewayService) getFeaturesHavePrerequisite( // nolint:unused
 	fs []*featureproto.Feature,

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -350,7 +350,7 @@ func (s *grpcGatewayService) validateGetEvaluationsRequest(req *gwproto.GetEvalu
 }
 
 /*
-getPrerequisiteUpwards recursively gets the features specified by the targetFeatures as prerequisite.
+getPrerequisiteDownwards recursively gets the features specified as prerequisite by the targetFeatures.
 */
 func (s *grpcGatewayService) getPrerequisiteDownwards(
 	targetFeatures, allFeatures map[string]*featureproto.Feature,
@@ -381,7 +381,7 @@ func (s *grpcGatewayService) getPrerequisiteDownwards(
 /*
 getPrerequisiteUpwards recursively gets the features that have the specified targetFeatures as the prerequisite.
 */
-func (s *grpcGatewayService) getPrerequisiteUpwards(
+func (s *grpcGatewayService) getPrerequisiteUpwards( // nolint:unused
 	targetFeatures, featuresHavePrerequisite map[string]*featureproto.Feature,
 ) (map[string]*featureproto.Feature, error) {
 	upwardsFeatures := make(map[string]*featureproto.Feature, 0)
@@ -407,7 +407,7 @@ func (s *grpcGatewayService) getPrerequisiteUpwards(
 	return s.mapMerge(targetFeatures, newTargets), nil
 }
 
-func (s *grpcGatewayService) getFeaturesHavePrerequisite(
+func (s *grpcGatewayService) getFeaturesHavePrerequisite( // nolint:unused
 	fs map[string]*featureproto.Feature,
 ) (map[string]*featureproto.Feature, error) {
 	featuresHavePrerequisite := make(map[string]*featureproto.Feature, 0)

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -363,12 +363,9 @@ func (s *grpcGatewayService) getPrerequisiteDownwards(
 	for _, f := range allFeatures {
 		allFeaturesMap[f.Id] = f
 	}
-	prerequisites := make(map[string]*featureproto.Feature, 0)
+	prerequisites := make(map[string]*featureproto.Feature)
 	// depth first search
-	queue := make([]*featureproto.Feature, 0)
-	for _, f := range targetFeatures {
-		queue = append(queue, f)
-	}
+	queue := append([]*featureproto.Feature{}, targetFeatures...)
 	for len(queue) > 0 {
 		f := queue[0]
 		for _, p := range f.Prerequisites {
@@ -402,12 +399,9 @@ func (s *grpcGatewayService) getPrerequisiteUpwards( // nolint:unused
 	for _, f := range targetFeatures {
 		targetFeaturesMap[f.Id] = f
 	}
-	upwardsFeatures := make(map[string]*featureproto.Feature, 0)
+	upwardsFeatures := make(map[string]*featureproto.Feature)
 	// depth first search
-	queue := make([]*featureproto.Feature, 0)
-	for _, f := range targetFeatures {
-		queue = append(queue, f)
-	}
+	queue := append([]*featureproto.Feature{}, targetFeatures...)
 	for len(queue) > 0 {
 		f := queue[0]
 		for _, newTarget := range featuresHavePrerequisite {
@@ -437,7 +431,7 @@ func (s *grpcGatewayService) getPrerequisiteUpwards( // nolint:unused
 func (s *grpcGatewayService) getFeaturesHavePrerequisite( // nolint:unused
 	fs []*featureproto.Feature,
 ) []*featureproto.Feature {
-	featuresHavePrerequisite := make(map[string]*featureproto.Feature, 0)
+	featuresHavePrerequisite := make(map[string]*featureproto.Feature)
 	for _, f := range fs {
 		if len(f.Prerequisites) == 0 {
 			continue
@@ -955,7 +949,7 @@ func (s *grpcGatewayService) containsInvalidTimestampError(errs map[string]*gwpr
 func (*grpcGatewayService) mergeMaps(
 	maps ...map[string]*gwproto.RegisterEventsResponse_Error,
 ) map[string]*gwproto.RegisterEventsResponse_Error {
-	result := make(map[string]*gwproto.RegisterEventsResponse_Error, 0)
+	result := make(map[string]*gwproto.RegisterEventsResponse_Error)
 	for _, m := range maps {
 		for k, v := range m {
 			result[k] = v

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -352,7 +352,9 @@ func (s *grpcGatewayService) validateGetEvaluationsRequest(req *gwproto.GetEvalu
 /*
 getPrerequisiteUpwards recursively gets the features specified by the targetFeatures as prerequisite.
 */
-func (s *grpcGatewayService) getPrerequisiteDownwards(targetFeatures, allFeatures map[string]*featureproto.Feature) (map[string]*featureproto.Feature, error) {
+func (s *grpcGatewayService) getPrerequisiteDownwards(
+	targetFeatures, allFeatures map[string]*featureproto.Feature,
+) (map[string]*featureproto.Feature, error) {
 	prerequisites := make(map[string]*featureproto.Feature, 0)
 	for _, f := range targetFeatures {
 		for _, pre := range f.Prerequisites {
@@ -379,7 +381,9 @@ func (s *grpcGatewayService) getPrerequisiteDownwards(targetFeatures, allFeature
 /*
 getPrerequisiteUpwards recursively gets the features that have the specified targetFeatures as the prerequisite.
 */
-func (s *grpcGatewayService) getPrerequisiteUpwards(targetFeatures, featuresHavePrerequisite map[string]*featureproto.Feature) (map[string]*featureproto.Feature, error) {
+func (s *grpcGatewayService) getPrerequisiteUpwards(
+	targetFeatures, featuresHavePrerequisite map[string]*featureproto.Feature,
+) (map[string]*featureproto.Feature, error) {
 	upwardsFeatures := make(map[string]*featureproto.Feature, 0)
 	for _, target := range targetFeatures {
 		for _, newTarget := range featuresHavePrerequisite {
@@ -403,7 +407,9 @@ func (s *grpcGatewayService) getPrerequisiteUpwards(targetFeatures, featuresHave
 	return s.mapMerge(targetFeatures, newTargets), nil
 }
 
-func (s *grpcGatewayService) getFeaturesHavePrerequisite(fs map[string]*featureproto.Feature) (map[string]*featureproto.Feature, error) {
+func (s *grpcGatewayService) getFeaturesHavePrerequisite(
+	fs map[string]*featureproto.Feature,
+) (map[string]*featureproto.Feature, error) {
 	featuresHavePrerequisite := make(map[string]*featureproto.Feature, 0)
 	for _, f := range fs {
 		if len(f.Prerequisites) == 0 {

--- a/pkg/gateway/api/api_grpc_test.go
+++ b/pkg/gateway/api/api_grpc_test.go
@@ -2223,9 +2223,9 @@ func TestGetTargetFeatures(t *testing.T) {
 			id:   "fid",
 			fs:   multiplePreFs,
 			expected: []*featureproto.Feature{
-				multiplePreFs[3],
 				multiplePreFs[0],
 				multiplePreFs[2],
+				multiplePreFs[3],
 			},
 			expectedErr: nil,
 		},
@@ -2234,7 +2234,7 @@ func TestGetTargetFeatures(t *testing.T) {
 		t.Run(p.desc, func(t *testing.T) {
 			gs := newGrpcGatewayServiceWithMock(t, mockController)
 			actual, err := gs.getTargetFeatures(p.fs, p.id)
-			assert.Equal(t, p.expected, actual)
+			assert.ElementsMatch(t, p.expected, actual)
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}
@@ -2350,76 +2350,79 @@ func TestGetPrerequisiteDownwards(t *testing.T) {
 
 	patterns := []struct {
 		desc        string
-		target      map[string]*featureproto.Feature
-		expected    map[string]*featureproto.Feature
+		target      []*featureproto.Feature
+		expected    []*featureproto.Feature
 		expectedErr error
 	}{
 		{
 			desc: "success: No prerequisites",
-			target: map[string]*featureproto.Feature{
-				"featureB": allFeaturesForPrerequisiteTest["featureB"],
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureB"],
+				allFeaturesForPrerequisiteTest["featureD"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureB": allFeaturesForPrerequisiteTest["featureB"],
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureB"],
+				allFeaturesForPrerequisiteTest["featureD"],
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "success: Get prerequisites pattern1",
-			target: map[string]*featureproto.Feature{
-				"featureA": allFeaturesForPrerequisiteTest["featureA"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureA"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureA": allFeaturesForPrerequisiteTest["featureA"],
-				"featureE": allFeaturesForPrerequisiteTest["featureE"],
-				"featureF": allFeaturesForPrerequisiteTest["featureF"],
-				"featureG": allFeaturesForPrerequisiteTest["featureG"],
-				"featureH": allFeaturesForPrerequisiteTest["featureH"],
-				"featureI": allFeaturesForPrerequisiteTest["featureI"],
-				"featureJ": allFeaturesForPrerequisiteTest["featureJ"],
-				"featureK": allFeaturesForPrerequisiteTest["featureK"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureA"],
+				allFeaturesForPrerequisiteTest["featureE"],
+				allFeaturesForPrerequisiteTest["featureF"],
+				allFeaturesForPrerequisiteTest["featureG"],
+				allFeaturesForPrerequisiteTest["featureH"],
+				allFeaturesForPrerequisiteTest["featureI"],
+				allFeaturesForPrerequisiteTest["featureJ"],
+				allFeaturesForPrerequisiteTest["featureK"],
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "success: Get prerequisites pattern2",
-			target: map[string]*featureproto.Feature{
-				"featureC": allFeaturesForPrerequisiteTest["featureC"],
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureC"],
+				allFeaturesForPrerequisiteTest["featureD"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureC": allFeaturesForPrerequisiteTest["featureC"],
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
-				"featureL": allFeaturesForPrerequisiteTest["featureL"],
-				"featureM": allFeaturesForPrerequisiteTest["featureM"],
-				"featureN": allFeaturesForPrerequisiteTest["featureN"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureC"],
+				allFeaturesForPrerequisiteTest["featureD"],
+				allFeaturesForPrerequisiteTest["featureL"],
+				allFeaturesForPrerequisiteTest["featureM"],
+				allFeaturesForPrerequisiteTest["featureN"],
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "success: Get prerequisites pattern3",
-			target: map[string]*featureproto.Feature{
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
-				"featureH": allFeaturesForPrerequisiteTest["featureH"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureD"],
+				allFeaturesForPrerequisiteTest["featureH"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
-				"featureH": allFeaturesForPrerequisiteTest["featureH"],
-				"featureI": allFeaturesForPrerequisiteTest["featureI"],
-				"featureJ": allFeaturesForPrerequisiteTest["featureJ"],
-				"featureK": allFeaturesForPrerequisiteTest["featureK"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureD"],
+				allFeaturesForPrerequisiteTest["featureH"],
+				allFeaturesForPrerequisiteTest["featureI"],
+				allFeaturesForPrerequisiteTest["featureJ"],
+				allFeaturesForPrerequisiteTest["featureK"],
 			},
 			expectedErr: nil,
 		},
 	}
-
+	allFeatures := make([]*featureproto.Feature, 0, len(allFeaturesForPrerequisiteTest))
+	for _, v := range allFeaturesForPrerequisiteTest {
+		allFeatures = append(allFeatures, v)
+	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			gs := newGrpcGatewayServiceWithMock(t, mockController)
-			actual, err := gs.getPrerequisiteDownwards(p.target, allFeaturesForPrerequisiteTest)
-			assert.Equal(t, p.expected, actual)
+			actual, err := gs.getPrerequisiteDownwards(p.target, allFeatures)
+			assert.ElementsMatch(t, p.expected, actual)
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}
@@ -2432,75 +2435,78 @@ func TestGetPrerequisiteUpwards(t *testing.T) {
 
 	patterns := []struct {
 		desc        string
-		target      map[string]*featureproto.Feature
-		expected    map[string]*featureproto.Feature
+		target      []*featureproto.Feature
+		expected    []*featureproto.Feature
 		expectedErr error
 	}{
 		{
 			desc: "success: No prerequisites",
-			target: map[string]*featureproto.Feature{
-				"featureA": allFeaturesForPrerequisiteTest["featureA"],
-				"featureB": allFeaturesForPrerequisiteTest["featureB"],
-				"featureC": allFeaturesForPrerequisiteTest["featureC"],
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureA"],
+				allFeaturesForPrerequisiteTest["featureB"],
+				allFeaturesForPrerequisiteTest["featureC"],
+				allFeaturesForPrerequisiteTest["featureD"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureA": allFeaturesForPrerequisiteTest["featureA"],
-				"featureB": allFeaturesForPrerequisiteTest["featureB"],
-				"featureC": allFeaturesForPrerequisiteTest["featureC"],
-				"featureD": allFeaturesForPrerequisiteTest["featureD"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureA"],
+				allFeaturesForPrerequisiteTest["featureB"],
+				allFeaturesForPrerequisiteTest["featureC"],
+				allFeaturesForPrerequisiteTest["featureD"],
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "success: Get prerequisites pattern1",
-			target: map[string]*featureproto.Feature{
-				"featureF": allFeaturesForPrerequisiteTest["featureF"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureF"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureA": allFeaturesForPrerequisiteTest["featureA"],
-				"featureF": allFeaturesForPrerequisiteTest["featureF"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureA"],
+				allFeaturesForPrerequisiteTest["featureF"],
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "success: Get prerequisites pattern2",
-			target: map[string]*featureproto.Feature{
-				"featureK": allFeaturesForPrerequisiteTest["featureK"],
-				"featureE": allFeaturesForPrerequisiteTest["featureE"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureK"],
+				allFeaturesForPrerequisiteTest["featureE"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureA": allFeaturesForPrerequisiteTest["featureA"],
-				"featureE": allFeaturesForPrerequisiteTest["featureE"],
-				"featureG": allFeaturesForPrerequisiteTest["featureG"],
-				"featureH": allFeaturesForPrerequisiteTest["featureH"],
-				"featureI": allFeaturesForPrerequisiteTest["featureI"],
-				"featureK": allFeaturesForPrerequisiteTest["featureK"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureA"],
+				allFeaturesForPrerequisiteTest["featureE"],
+				allFeaturesForPrerequisiteTest["featureG"],
+				allFeaturesForPrerequisiteTest["featureH"],
+				allFeaturesForPrerequisiteTest["featureI"],
+				allFeaturesForPrerequisiteTest["featureK"],
 			},
 			expectedErr: nil,
 		},
 		{
 			desc: "success: Get prerequisites pattern3",
-			target: map[string]*featureproto.Feature{
-				"featureM": allFeaturesForPrerequisiteTest["featureM"],
-				"featureN": allFeaturesForPrerequisiteTest["featureN"],
+			target: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureM"],
+				allFeaturesForPrerequisiteTest["featureN"],
 			},
-			expected: map[string]*featureproto.Feature{
-				"featureC": allFeaturesForPrerequisiteTest["featureC"],
-				"featureL": allFeaturesForPrerequisiteTest["featureL"],
-				"featureM": allFeaturesForPrerequisiteTest["featureM"],
-				"featureN": allFeaturesForPrerequisiteTest["featureN"],
+			expected: []*featureproto.Feature{
+				allFeaturesForPrerequisiteTest["featureC"],
+				allFeaturesForPrerequisiteTest["featureL"],
+				allFeaturesForPrerequisiteTest["featureM"],
+				allFeaturesForPrerequisiteTest["featureN"],
 			},
 			expectedErr: nil,
 		},
 	}
+	allFeatures := make([]*featureproto.Feature, 0, len(allFeaturesForPrerequisiteTest))
+	for _, v := range allFeaturesForPrerequisiteTest {
+		allFeatures = append(allFeatures, v)
+	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			gs := newGrpcGatewayServiceWithMock(t, mockController)
-			featuresHavePrerequisite, err := gs.getFeaturesHavePrerequisite(allFeaturesForPrerequisiteTest)
-			assert.NoError(t, err)
+			featuresHavePrerequisite := gs.getFeaturesHavePrerequisite(allFeatures)
 			actual, err := gs.getPrerequisiteUpwards(p.target, featuresHavePrerequisite)
-			assert.Equal(t, p.expected, actual)
+			assert.ElementsMatch(t, p.expected, actual)
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}

--- a/pkg/gateway/api/api_grpc_test.go
+++ b/pkg/gateway/api/api_grpc_test.go
@@ -2219,10 +2219,14 @@ func TestGetTargetFeatures(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc:        "success: configure prerequisite",
-			id:          "fid",
-			fs:          multiplePreFs,
-			expected:    multiplePreFs,
+			desc: "success: configure prerequisite",
+			id:   "fid",
+			fs:   multiplePreFs,
+			expected: []*featureproto.Feature{
+				multiplePreFs[3],
+				multiplePreFs[0],
+				multiplePreFs[2],
+			},
 			expectedErr: nil,
 		},
 	}


### PR DESCRIPTION
- This PR adds functions to get the prerequisites of features recursively.
  - `getPrerequisiteDownwards` gets the features specified as prerequisite by the targetFeatures.
  - `getPrerequisiteUpwards gets the features that have the specified targetFeatures as the prerequisite.
- This PR modifies the behavior of GetEvaluation to evaluation only features with prerequisites instead of all features. 