### PR TITLE
chore: remove user metadata from user event

### DIFF
--- a/pkg/gateway/api/api.go
+++ b/pkg/gateway/api/api.go
@@ -509,7 +509,7 @@ func (s *gatewayService) publishUserEvent(
 		Tag:                  tag,
 		UserId:               user.Id,
 		LastSeen:             time.Now().Unix(),
-		Data:                 user.Data,
+		Data:                 nil, // We set nil until we decide again what to do with the user metadata.
 		EnvironmentNamespace: environmentNamespace,
 	}
 	ue, err := ptypes.MarshalAny(userEvent)

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -585,7 +585,7 @@ func (s *grpcGatewayService) publishUserEvent(
 		Tag:                  tag,
 		UserId:               user.Id,
 		LastSeen:             time.Now().Unix(),
-		Data:                 user.Data,
+		Data:                 nil, // We set nil until we decide again what to do with the user metadata.
 		EnvironmentNamespace: environmentNamespace,
 	}
 	ue, err := ptypes.MarshalAny(userEvent)


### PR DESCRIPTION
- This PR removes the user metadata from the user event.
  - We don't use the metadata now, so removes it until we decide again what to do with.