### PR TITLE
chore: add archived feature flags to the cache

### DIFF
--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -2240,7 +2240,7 @@ func (s *FeatureService) refreshFeaturesCache(ctx context.Context, environmentNa
 			continue
 		}
 		// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
-		if ff.IsArchivedLongAgo() {
+		if ff.IsArchivedBeforeLastThirtyDays() {
 			continue
 		}
 		filtered = append(filtered, f)

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	experimentdomain "github.com/bucketeer-io/bucketeer/pkg/experiment/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/feature/command"
@@ -2224,7 +2223,7 @@ func (s *FeatureService) refreshFeaturesCache(ctx context.Context, environmentNa
 		nil,
 		"",
 		nil,
-		wrapperspb.Bool(false),
+		nil,
 		nil,
 		"",
 		featureproto.ListFeaturesRequest_DEFAULT,

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -759,10 +759,10 @@ func (f *Feature) IsDisabledAndOffVariationEmpty() bool {
 }
 
 /*
-IsArchivedLongAgo returns a bool value
-indicating whether the feature flag was archived more than a certain period of time ago.
+IsArchivedBeforeLastThirtyDays returns a bool value
+indicating whether the feature flag was archived within the last thirty days.
 */
-func (f *Feature) IsArchivedLongAgo() bool {
+func (f *Feature) IsArchivedBeforeLastThirtyDays() bool {
 	if !f.Archived {
 		return false
 	}

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -26,7 +26,8 @@ import (
 )
 
 const (
-	SecondsToStale = 90 * 24 * 60 * 60 // 90 days
+	SecondsToStale         = 90 * 24 * 60 * 60 // 90 days
+	SecondsToReEvaluateAll = 30 * 24 * time.Hour
 )
 
 var (
@@ -748,6 +749,24 @@ func (f *Feature) IsStale(t time.Time) bool {
 		return false
 	}
 	return true
+}
+
+func (f *Feature) IsDisabledAndOffVariationEmpty() bool {
+	if f.Enabled {
+		return false
+	}
+	return f.OffVariation == ""
+}
+
+/*
+IsArchivedLongAgo returns a bool value indicating whether the feature flag was archived more than a certain period of time ago.
+*/
+func (f *Feature) IsArchivedLongAgo() bool {
+	if !f.Archived {
+		return false
+	}
+	now := time.Now()
+	return f.UpdatedAt < now.Add(-1*SecondsToReEvaluateAll).Unix()
 }
 
 func (f *Feature) findTarget(id string) (int, error) {

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -759,7 +759,8 @@ func (f *Feature) IsDisabledAndOffVariationEmpty() bool {
 }
 
 /*
-IsArchivedLongAgo returns a bool value indicating whether the feature flag was archived more than a certain period of time ago.
+IsArchivedLongAgo returns a bool value
+indicating whether the feature flag was archived more than a certain period of time ago.
 */
 func (f *Feature) IsArchivedLongAgo() bool {
 	if !f.Archived {

--- a/pkg/gateway/api/api.go
+++ b/pkg/gateway/api/api.go
@@ -817,7 +817,12 @@ func (s *gatewayService) listFeatures(
 			return nil, err
 		}
 		for _, f := range resp.Features {
-			if !f.Enabled && f.OffVariation == "" {
+			ff := featuredomain.Feature{Feature: f}
+			if ff.IsDisabledAndOffVariationEmpty() {
+				continue
+			}
+			// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
+			if ff.IsArchivedLongAgo() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/gateway/api/api.go
+++ b/pkg/gateway/api/api.go
@@ -822,7 +822,7 @@ func (s *gatewayService) listFeatures(
 				continue
 			}
 			// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
-			if ff.IsArchivedLongAgo() {
+			if ff.IsArchivedBeforeLastThirtyDays() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -653,7 +653,12 @@ func (s *grpcGatewayService) listFeatures(
 			return nil, err
 		}
 		for _, f := range resp.Features {
-			if !f.Enabled && f.OffVariation == "" {
+			ff := featuredomain.Feature{Feature: f}
+			if ff.IsDisabledAndOffVariationEmpty() {
+				continue
+			}
+			// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
+			if ff.IsArchivedLongAgo() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -658,7 +658,7 @@ func (s *grpcGatewayService) listFeatures(
 				continue
 			}
 			// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
-			if ff.IsArchivedLongAgo() {
+			if ff.IsArchivedBeforeLastThirtyDays() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/gateway/api/api_grpc_test.go
+++ b/pkg/gateway/api/api_grpc_test.go
@@ -526,6 +526,10 @@ func TestGrpcGetFeatures(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
+	now := time.Now()
+	twentyNineDaysAgo := now.Add(-29 * 24 * time.Hour)
+	thirtyOneDaysAgo := now.Add(-31 * 24 * time.Hour)
+
 	patterns := []struct {
 		desc                 string
 		setup                func(*grpcGatewayService)
@@ -580,14 +584,106 @@ func TestGrpcGetFeatures(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
-		// TODO: add test for off-variation features
+		{
+			desc: "success: including off-variation features",
+			setup: func(gs *grpcGatewayService) {
+				gs.featuresCache.(*cachev3mock.MockFeaturesCache).EXPECT().Get(gomock.Any()).Return(
+					nil, cache.ErrNotFound)
+				gs.featureClient.(*featureclientmock.MockClient).EXPECT().ListFeatures(gomock.Any(), gomock.Any()).Return(
+					&featureproto.ListFeaturesResponse{Features: []*featureproto.Feature{
+						{
+							Id:      "id-0",
+							Enabled: true,
+						},
+						{
+							Id:           "id-1",
+							Enabled:      true,
+							OffVariation: "",
+						},
+						{
+							Id:           "id-2",
+							Enabled:      false,
+							OffVariation: "var-2",
+						},
+						{
+							Id:           "id-3",
+							Enabled:      false,
+							OffVariation: "",
+						},
+					}}, nil)
+				gs.featuresCache.(*cachev3mock.MockFeaturesCache).EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			environmentNamespace: "ns0",
+			expected: []*featureproto.Feature{
+				{
+					Id:      "id-0",
+					Enabled: true,
+				},
+				{
+					Id:           "id-1",
+					Enabled:      true,
+					OffVariation: "",
+				},
+				{
+					Id:           "id-2",
+					Enabled:      false,
+					OffVariation: "var-2",
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "success: including archived features",
+			setup: func(gs *grpcGatewayService) {
+				gs.featuresCache.(*cachev3mock.MockFeaturesCache).EXPECT().Get(gomock.Any()).Return(
+					nil, cache.ErrNotFound)
+				gs.featureClient.(*featureclientmock.MockClient).EXPECT().ListFeatures(gomock.Any(), gomock.Any()).Return(
+					&featureproto.ListFeaturesResponse{Features: []*featureproto.Feature{
+						{
+							Id:       "id-0",
+							Enabled:  true,
+							Archived: false,
+						},
+						{
+							Id:        "id-1",
+							Enabled:   true,
+							Archived:  true,
+							UpdatedAt: twentyNineDaysAgo.Unix(),
+						},
+						{
+							Id:        "id-2",
+							Enabled:   true,
+							Archived:  true,
+							UpdatedAt: thirtyOneDaysAgo.Unix(),
+						},
+					}}, nil)
+				gs.featuresCache.(*cachev3mock.MockFeaturesCache).EXPECT().Put(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			environmentNamespace: "ns0",
+			expected: []*featureproto.Feature{
+				{
+					Id:       "id-0",
+					Enabled:  true,
+					Archived: false,
+				},
+				{
+					Id:        "id-1",
+					Enabled:   true,
+					Archived:  true,
+					UpdatedAt: twentyNineDaysAgo.Unix(),
+				},
+			},
+			expectedErr: nil,
+		},
 	}
 	for _, p := range patterns {
-		gs := newGrpcGatewayServiceWithMock(t, mockController)
-		p.setup(gs)
-		actual, err := gs.getFeatures(context.Background(), p.environmentNamespace)
-		assert.Equal(t, p.expected, actual, "%s", p.desc)
-		assert.Equal(t, p.expectedErr, err, "%s", p.desc)
+		t.Run(p.desc, func(t *testing.T) {
+			gs := newGrpcGatewayServiceWithMock(t, mockController)
+			p.setup(gs)
+			actual, err := gs.getFeatures(context.Background(), p.environmentNamespace)
+			assert.Equal(t, p.expected, actual, "%s", p.desc)
+			assert.Equal(t, p.expectedErr, err, "%s", p.desc)
+		})
 	}
 }
 

--- a/pkg/gateway/api/api_test.go
+++ b/pkg/gateway/api/api_test.go
@@ -1194,7 +1194,7 @@ func testGetEvaluationsNoSegmentList(t *testing.T) {
 	}
 }
 
-func TestGetEvaluationsEvaluteFeatures(t *testing.T) {
+func TestGetEvaluationsEvaluateFeatures(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
@@ -1542,27 +1542,115 @@ func TestGetEvaluationsEvaluteFeatures(t *testing.T) {
 			},
 			expectedErr: nil,
 		},
+		{
+			desc: "success: the cache includes archived features but the evaluation doesn't target them",
+			setup: func(gs *gatewayService) {
+				gs.environmentAPIKeyCache.(*cachev3mock.MockEnvironmentAPIKeyCache).EXPECT().Get(gomock.Any()).Return(
+					&accountproto.EnvironmentAPIKey{
+						EnvironmentNamespace: "ns0",
+						ApiKey: &accountproto.APIKey{
+							Id:       "id-0",
+							Role:     accountproto.APIKey_SDK,
+							Disabled: false,
+						},
+					}, nil)
+				gs.featuresCache.(*cachev3mock.MockFeaturesCache).EXPECT().Get(gomock.Any()).Return(
+					&featureproto.Features{
+						Features: []*featureproto.Feature{
+							{
+								Id: "feature-1",
+								Variations: []*featureproto.Variation{
+									{
+										Id:    "variation-a",
+										Value: "true",
+									},
+									{
+										Id:    "variation-b",
+										Value: "false",
+									},
+								},
+								DefaultStrategy: &featureproto.Strategy{
+									Type: featureproto.Strategy_FIXED,
+									FixedStrategy: &featureproto.FixedStrategy{
+										Variation: "variation-b",
+									},
+								},
+								Tags: []string{"test"},
+							},
+							{
+								Id:       "feature-2",
+								Archived: true,
+								Variations: []*featureproto.Variation{
+									{
+										Id:    "variation-c",
+										Value: "true",
+									},
+									{
+										Id:    "variation-d",
+										Value: "false",
+									},
+								},
+								DefaultStrategy: &featureproto.Strategy{
+									Type: featureproto.Strategy_FIXED,
+									FixedStrategy: &featureproto.FixedStrategy{
+										Variation: "variation-d",
+									},
+								},
+								Tags: []string{"test"},
+							},
+						},
+					}, nil)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+					nil).MaxTimes(1)
+			},
+			input: httptest.NewRequest(
+				"POST",
+				dummyURL,
+				renderBody(
+					t,
+					getEvaluationsRequest{
+						Tag:  "test",
+						User: &userproto.User{Id: "id-0"},
+					},
+				),
+			),
+			expected: &getEvaluationsResponse{
+				Evaluations: &featureproto.UserEvaluations{
+					Evaluations: []*featureproto.Evaluation{
+						{
+							VariationId: "variation-b",
+							Reason: &featureproto.Reason{
+								Type: featureproto.Reason_DEFAULT,
+							},
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
 	}
 	for _, p := range patterns {
-		gs := newGatewayServiceWithMock(t, mockController)
-		if p.setup != nil {
-			p.setup(gs)
-		}
-		actual := httptest.NewRecorder()
-		p.input.Header.Add(authorizationKey, "test-key")
-		gs.getEvaluations(actual, p.input)
-		if actual.Code != http.StatusOK {
-			assert.Equal(t, newErrResponse(t, p.expectedErr), actual.Body.String(), "%s", p.desc)
-			continue
-		}
-		var respBody getEvaluationsResponse
-		decoded := decodeSuccessResponse(t, actual.Body)
-		err := json.Unmarshal(decoded, &respBody)
-		assert.NoError(t, err)
-		assert.Equal(t, len(p.expected.Evaluations.Evaluations), 1, "%s", p.desc)
-		assert.Equal(t, p.expected.Evaluations.Evaluations[0].VariationId, "variation-b", "%s", p.desc)
-		assert.Equal(t, p.expected.Evaluations.Evaluations[0].Reason, respBody.Evaluations.Evaluations[0].Reason, p.desc)
-		assert.NotEmpty(t, respBody.UserEvaluationsID, "%s", p.desc)
+		t.Run(p.desc, func(t *testing.T) {
+			gs := newGatewayServiceWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(gs)
+			}
+			actual := httptest.NewRecorder()
+			p.input.Header.Add(authorizationKey, "test-key")
+			gs.getEvaluations(actual, p.input)
+			if actual.Code != http.StatusOK {
+				assert.Equal(t, newErrResponse(t, p.expectedErr), actual.Body.String(), "%s", p.desc)
+			} else {
+				var respBody getEvaluationsResponse
+				decoded := decodeSuccessResponse(t, actual.Body)
+				err := json.Unmarshal(decoded, &respBody)
+				assert.NoError(t, err)
+				assert.Equal(t, len(respBody.Evaluations.Evaluations), 1, "%s", p.desc)
+				assert.Equal(t, p.expected.Evaluations.Evaluations[0].VariationId, "variation-b", "%s", p.desc)
+				assert.Equal(t, p.expected.Evaluations.Evaluations[0].Reason, respBody.Evaluations.Evaluations[0].Reason, p.desc)
+				assert.NotEmpty(t, respBody.UserEvaluationsID, "%s", p.desc)
+			}
+		})
 	}
 }
 

--- a/pkg/notification/sender/informer/batch/job/feature_watcher.go
+++ b/pkg/notification/sender/informer/batch/job/feature_watcher.go
@@ -161,7 +161,8 @@ func (w *featureWatcher) listFeatures(
 			return nil, err
 		}
 		for _, f := range resp.Features {
-			if !f.Enabled && f.OffVariation == "" {
+			ff := featuredomain.Feature{Feature: f}
+			if ff.IsDisabledAndOffVariationEmpty() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/push/sender/sender.go
+++ b/pkg/push/sender/sender.go
@@ -29,6 +29,7 @@ import (
 	cachev3 "github.com/bucketeer-io/bucketeer/pkg/cache/v3"
 	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
 	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
+	featuredomain "github.com/bucketeer-io/bucketeer/pkg/feature/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/health"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
@@ -420,7 +421,12 @@ func (s *sender) listFeatures(ctx context.Context, environmentNamespace string) 
 			return nil, err
 		}
 		for _, f := range resp.Features {
-			if !f.Enabled && f.OffVariation == "" {
+			ff := featuredomain.Feature{Feature: f}
+			if ff.IsDisabledAndOffVariationEmpty() {
+				continue
+			}
+			// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
+			if ff.IsArchivedLongAgo() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/push/sender/sender.go
+++ b/pkg/push/sender/sender.go
@@ -426,7 +426,7 @@ func (s *sender) listFeatures(ctx context.Context, environmentNamespace string) 
 				continue
 			}
 			// To keep the cache size small, we exclude feature flags archived more than thirty days ago.
-			if ff.IsArchivedLongAgo() {
+			if ff.IsArchivedBeforeLastThirtyDays() {
 				continue
 			}
 			features = append(features, f)

--- a/pkg/push/sender/sender.go
+++ b/pkg/push/sender/sender.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto" // nolint:staticcheck
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"go.uber.org/zap"
 
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
@@ -416,7 +415,6 @@ func (s *sender) listFeatures(ctx context.Context, environmentNamespace string) 
 			PageSize:             listRequestSize,
 			Cursor:               cursor,
 			EnvironmentNamespace: environmentNamespace,
-			Archived:             &wrappers.BoolValue{Value: false},
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- This PR changes the caching behavior to add archived feature flags to the Redis.
  - To keep the cache size small, feature flags archived more than thirty days ago are excluded.
  - To follow the existing behavior of the api-gateway, I added a function to filter out archived features before the response. (This function was temporarily added. I will remove it when I implement a differential evaluation feature.)