### PR TITLE
chore: add tag filtering to evaluation by evaluatedAt

### DIFF
--- a/pkg/feature/domain/evaluation.go
+++ b/pkg/feature/domain/evaluation.go
@@ -160,6 +160,8 @@ func evaluate(
 		}
 		// VariationId is used to check if prerequisite flag's result is what user expects it to be.
 		flagVariations[f.Id] = variation.Id
+		// When the tag is set in the request, it will return only the evaluations of flags that match the tag configured when the flag was created on the dashboard.
+		// When empty, it will return all the evaluations of the flags in the environment.
 		if targetTag != "" && !tagExist(f.Tags, targetTag) {
 			continue
 		}

--- a/pkg/feature/domain/evaluation.go
+++ b/pkg/feature/domain/evaluation.go
@@ -95,13 +95,14 @@ func EvaluateFeaturesByEvaluatedAt(
 	prevUEID string,
 	evaluatedAt int64,
 	isUserAttributesUpdated bool,
+	targetTag string,
 ) (*featureproto.UserEvaluations, error) {
 	if prevUEID == "" {
-		return evaluate(fs, user, mapSegmentUsers, true)
+		return evaluate(fs, user, mapSegmentUsers, true, targetTag)
 	}
 	now := time.Now()
 	if evaluatedAt < now.Unix()-secondsToReEvaluateAll {
-		return evaluate(fs, user, mapSegmentUsers, true)
+		return evaluate(fs, user, mapSegmentUsers, true, targetTag)
 	}
 	adjustedEvalAt := evaluatedAt - secondsForAdjustment
 	updatedFeatures := make([]*featureproto.Feature, 0, len(fs))
@@ -118,11 +119,11 @@ func EvaluateFeaturesByEvaluatedAt(
 	// If the UserEvaluationsID has changed, but both User Attributes and Feature Flags have not been updated,
 	// it is considered unusual and a force update should be performed.
 	if len(updatedFeatures) == 0 {
-		return evaluate(fs, user, mapSegmentUsers, true)
+		return evaluate(fs, user, mapSegmentUsers, true, targetTag)
 	}
 	featuresHavePrerequisite := getFeaturesHavePrerequisite(fs)
 	evalTargets := GetPrerequisiteUpwards(updatedFeatures, featuresHavePrerequisite)
-	return evaluate(evalTargets, user, mapSegmentUsers, false)
+	return evaluate(evalTargets, user, mapSegmentUsers, false, targetTag)
 }
 
 func evaluate(
@@ -130,6 +131,7 @@ func evaluate(
 	user *userproto.User,
 	mapSegmentUsers map[string][]*featureproto.SegmentUser,
 	forceUpdate bool,
+	targetTag string,
 ) (*featureproto.UserEvaluations, error) {
 	flagVariations := map[string]string{}
 	// fs need to be sorted in order from upstream to downstream.
@@ -158,6 +160,9 @@ func evaluate(
 		}
 		// VariationId is used to check if prerequisite flag's result is what user expects it to be.
 		flagVariations[f.Id] = variation.Id
+		if targetTag != "" && !tagExist(f.Tags, targetTag) {
+			continue
+		}
 		// FIXME: Remove the next two lines when the Variation
 		// no longer is being used
 		// For security reasons, it removes the variation name and description

--- a/pkg/feature/domain/evaluation.go
+++ b/pkg/feature/domain/evaluation.go
@@ -160,7 +160,8 @@ func evaluate(
 		}
 		// VariationId is used to check if prerequisite flag's result is what user expects it to be.
 		flagVariations[f.Id] = variation.Id
-		// When the tag is set in the request, it will return only the evaluations of flags that match the tag configured when the flag was created on the dashboard.
+		// When the tag is set in the request,
+		// it will return only the evaluations of flags that match the tag configured on the dashboard.
 		// When empty, it will return all the evaluations of the flags in the environment.
 		if targetTag != "" && !tagExist(f.Tags, targetTag) {
 			continue

--- a/pkg/feature/domain/evaluation.go
+++ b/pkg/feature/domain/evaluation.go
@@ -94,7 +94,7 @@ func EvaluateFeaturesByEvaluatedAt(
 	mapSegmentUsers map[string][]*featureproto.SegmentUser,
 	prevUEID string,
 	evaluatedAt int64,
-	isUserAttributesUpdated bool,
+	userAttributesUpdated bool,
 	targetTag string,
 ) (*featureproto.UserEvaluations, error) {
 	if prevUEID == "" {
@@ -112,7 +112,7 @@ func EvaluateFeaturesByEvaluatedAt(
 			updatedFeatures = append(updatedFeatures, f)
 			continue
 		}
-		if isUserAttributesUpdated && len(feature.Rules) != 0 {
+		if userAttributesUpdated && len(feature.Rules) != 0 {
 			updatedFeatures = append(updatedFeatures, f)
 		}
 	}

--- a/pkg/feature/domain/evaluation_test.go
+++ b/pkg/feature/domain/evaluation_test.go
@@ -223,22 +223,22 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 	segmentUser := map[string][]*featureproto.SegmentUser{}
 
 	patterns := []struct {
-		desc                    string
-		prevUEID                string
-		evaluatedAt             int64
-		isUserAttributesUpdated bool
-		tag                     string
-		createFeatures          func() []*featureproto.Feature
-		expectedEvals           *UserEvaluations
-		expectedEvalFeatureIDs  []string
-		expectedError           error
+		desc                   string
+		prevUEID               string
+		evaluatedAt            int64
+		userAttributesUpdated  bool
+		tag                    string
+		createFeatures         func() []*featureproto.Feature
+		expectedEvals          *UserEvaluations
+		expectedEvalFeatureIDs []string
+		expectedError          error
 	}{
 		{
-			desc:                    "success: evaluate all features since the previous UserEvaluationsID is empty",
-			prevUEID:                "",
-			evaluatedAt:             thirtyOneDaysAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: evaluate all features since the previous UserEvaluationsID is empty",
+			prevUEID:              "",
+			evaluatedAt:           thirtyOneDaysAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = fiveMinutesAgo.Unix()
@@ -276,11 +276,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: evaluate all features since the previous evaluation was over a month ago",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             thirtyOneDaysAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: evaluate all features since the previous evaluation was over a month ago",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           thirtyOneDaysAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = fiveMinutesAgo.Unix()
@@ -318,11 +318,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: evaluate all features since both feature flags and user attributes have not been updated (although the UEID has been updated)",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: evaluate all features since both feature flags and user attributes have not been updated (although the UEID has been updated)",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = oneHourAgo.Unix()
@@ -360,11 +360,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: evaluate only features updated since the previous evaluations",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: evaluate only features updated since the previous evaluations",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = fiveMinutesAgo.Unix()
@@ -399,11 +399,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: check the adjustment seconds",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: check the adjustment seconds",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = tenMinutesAndNineSecondsAgo.Unix()
@@ -430,11 +430,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: evaluate only features has rules when user attributes updated",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: true,
-			tag:                     "",
+			desc:                  "success: evaluate only features has rules when user attributes updated",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: true,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = thirtyOneDaysAgo.Unix()
@@ -466,11 +466,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: evaluate only the features that have been updated since the previous evaluation, or the features that have rules when user attributes are updated",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: true,
-			tag:                     "",
+			desc:                  "success: evaluate only the features that have been updated since the previous evaluation, or the features that have rules when user attributes are updated",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: true,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = fiveMinutesAgo.Unix()
@@ -514,11 +514,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: prerequisite",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: prerequisite",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.UpdatedAt = thirtyOneDaysAgo.Unix()
@@ -562,11 +562,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: When a tag is specified, it excludes the evaluations that don't have that tag. But archived features are not excluded",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "tag-1",
+			desc:                  "success: When a tag is specified, it excludes the evaluations that don't have that tag. But archived features are not excluded",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "tag-1",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.Tags = append(f1.Tags, "tag-1")
@@ -605,11 +605,11 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 			expectedError:          nil,
 		},
 		{
-			desc:                    "success: When a tag is not specified, it does not exclude evaluations that have tags.",
-			prevUEID:                "prevUEID",
-			evaluatedAt:             tenMinutesAgo.Unix(),
-			isUserAttributesUpdated: false,
-			tag:                     "",
+			desc:                  "success: When a tag is not specified, it does not exclude evaluations that have tags.",
+			prevUEID:              "prevUEID",
+			evaluatedAt:           tenMinutesAgo.Unix(),
+			userAttributesUpdated: false,
+			tag:                   "",
 			createFeatures: func() []*featureproto.Feature {
 				f1 := makeFeature("feature-1")
 				f1.Tags = append(f1.Tags, "tag-1")
@@ -675,7 +675,7 @@ func TestEvaluateFeaturesByEvaluatedAt(t *testing.T) {
 				segmentUser,
 				p.prevUEID,
 				p.evaluatedAt,
-				p.isUserAttributesUpdated,
+				p.userAttributesUpdated,
 				p.tag,
 			)
 			assert.Equal(t, p.expectedError, err)

--- a/pkg/gateway/api/api_grpc.go
+++ b/pkg/gateway/api/api_grpc.go
@@ -360,6 +360,7 @@ func (s *grpcGatewayService) GetEvaluations(
 			req.UserEvaluationsId,
 			req.EvaluatedAt,
 			req.UserAttributesUpdated,
+			req.Tag,
 		)
 		if err != nil {
 			s.logger.Error(


### PR DESCRIPTION
- Adds tag filtering to the evaluation by `evaluatedAt`.
- Renames variable `isUserAttributesUpdated` to `userAttributesUpdated`