### PR TITLE
revert: "fix: wrong starting time in GetEvaluationTimeseriesCount (#326)"

### DIFF
--- a/pkg/eventcounter/api/api.go
+++ b/pkg/eventcounter/api/api.go
@@ -277,10 +277,7 @@ func (s *eventCounterService) GetEvaluationTimeseriesCount(
 		return nil, dt.Err()
 	}
 	endAt := time.Now()
-	startAt := truncateDate(
-		jpLocation,
-		getStartTime(jpLocation, endAt, 30),
-	)
+	startAt := getStartTime(jpLocation, endAt, 30)
 	if err != nil {
 		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),

--- a/pkg/eventcounter/api/api_test.go
+++ b/pkg/eventcounter/api/api_test.go
@@ -1141,10 +1141,7 @@ func TestGetEvaluationTimeseriesCount(t *testing.T) {
 					}, nil)
 				vIDs := []string{vID0, vID1, defaultVariationID}
 				endAt := time.Now()
-				startAt := truncateDate(
-					jpLocation,
-					getStartTime(jpLocation, endAt, 30),
-				)
+				startAt := getStartTime(jpLocation, endAt, 30)
 				timeStamps := getDailyTimestamps(startAt, 30)
 				for idx, vID := range vIDs {
 					ec := getEventCountKeys(vID, fID, environmentNamespace, timeStamps)


### PR DESCRIPTION
This reverts commit c848584cd9dbe65985cba3e3b866f1adf2b75e0d.