### PR TITLE
chore: change service-accounts name

### DIFF
--- a/manifests/bucketeer/charts/api-gateway/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "api-gateway.name" . }}
+    name: {{ template "api-gateway.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/auditlog-persister/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/auditlog-persister/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "auditlog-persister.name" . }}
+    name: {{ template "auditlog-persister.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/auditlog/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/auditlog/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "auditlog.name" . }}
+    name: {{ template "auditlog.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/auth/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/auth/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "auth.name" . }}
+    name: {{ template "auth.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/auto-ops/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/auto-ops/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "auto-ops.name" . }}
+    name: {{ template "auto-ops.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/calculator/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/calculator/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "calculator.name" . }}
+    name: {{ template "calculator.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/dex/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/dex/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "dex.name" . }}
+    name: {{ template "dex.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/environment/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/environment/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "environment.name" . }}
+    name: {{ template "environment.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/event-counter/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-counter/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "event-counter.name" . }}
+    name: {{ template "event-counter.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "event-persister-evaluation-events-dwh.name" . }}
+    name: {{ template "event-persister-evaluation-events-dwh.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "event-persister-evaluation-events-evaluation-count.name" . }}
+    name: {{ template "event-persister-evaluation-events-evaluation-count.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "event-persister-evaluation-events-ops.name" . }}
+    name: {{ template "event-persister-evaluation-events-ops.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "event-persister-goal-events-dwh.name" . }}
+    name: {{ template "event-persister-goal-events-dwh.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "event-persister-goal-events-ops.name" . }}
+    name: {{ template "event-persister-goal-events-ops.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/experiment/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/experiment/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "experiment.name" . }}
+    name: {{ template "experiment.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/feature-recorder/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/feature-recorder/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "feature-recorder.name" . }}
+    name: {{ template "feature-recorder.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/feature-segment-persister/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/feature-segment-persister/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "feature-segment-persister.name" . }}
+    name: {{ template "feature-segment-persister.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/feature/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/feature/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "feature.name" . }}
+    name: {{ template "feature.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/metrics-event-persister/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/metrics-event-persister/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "metrics-event-persister.name" . }}
+    name: {{ template "metrics-event-persister.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/migration-mysql/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/migration-mysql/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "migration-mysql.name" . }}
+    name: {{ template "migration-mysql.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/notification-sender/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "notification-sender.name" . }}
+    name: {{ template "notification-sender.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/notification/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/notification/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "notification.name" . }}
+    name: {{ template "notification.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/ops-event-batch/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "ops-event-batch.name" . }}
+    name: {{ template "ops-event-batch.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/push-sender/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "push-sender.name" . }}
+    name: {{ template "push-sender.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/push/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/push/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "push.name" . }}
+    name: {{ template "push.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/user-persister/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/user-persister/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "user-persister.name" . }}
+    name: {{ template "user-persister.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/web-gateway/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "web-gateway.name" . }}
+    name: {{ template "web-gateway.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}

--- a/manifests/bucketeer/charts/web/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/web/templates/service-account.yaml
@@ -3,6 +3,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
     namespace: {{ .Values.namespace }}
-    name: {{ template "web.name" . }}
+    name: {{ template "web.fullname" . }}
     annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
 {{- end }}


### PR DESCRIPTION
- This PR changes the service-account name because they have conflicts. 
  - e.g., There is a name conflict between `event-persister-evaluation-events-dwh` and `event-persister-goal-events-dwh`.