### PR TITLE
chore: stop updating pip dependency group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,12 +27,3 @@ updates:
     commit-message:
       prefix: "build"
       include: "scope"
-  - package-ecosystem: "pip"
-    directory: "/python"
-    schedule:
-      interval: "monthly"
-      time: "10:00"
-      timezone: "Asia/Tokyo"
-    commit-message:
-      prefix: "build"
-      include: "scope"


### PR DESCRIPTION
We plan to remove python implementation in the feature. Thus, we don't need to update python dependencies.