### PR TITLE
chore: change the wait-interval field in lewagon/wait-on-check-action

### DIFF
--- a/.github/workflows/auto_merge.yaml
+++ b/.github/workflows/auto_merge.yaml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           running-workflow-name: 'dependabot'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
+          wait-interval: 120
           allowed-conclusions: success
       - name: Dependabot metadata
         id: metadata


### PR DESCRIPTION
API rate limit error such as https://github.com/bucketeer-io/bucketeer/actions/runs/5129569875/jobs/9227333942#step:2:287 occurs when CI for Dependabot runs.

Thus, the waiting interval should be longer. This PR fixes it.