### PR TITLE
feat: build httpstan image

### DIFF
--- a/tools/httpstan/Dockerfile
+++ b/tools/httpstan/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.9-slim
+
+WORKDIR /httpstan
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    software-properties-common \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone https://github.com/stan-dev/httpstan.git .
+
+# Build shared libraries (Stan C++)
+RUN make
+
+# Build the httpstan wheel on your system
+RUN python3 -m pip install poetry
+RUN python3 -m poetry build
+
+# Install the wheel
+RUN python3 -m pip install dist/*.whl
+
+EXPOSE 8080
+
+CMD ["python3", "-m", "httpstan", "--host", "0.0.0.0"]

--- a/tools/httpstan/Dockerfile
+++ b/tools/httpstan/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 WORKDIR /httpstan
 

--- a/tools/httpstan/Dockerfile
+++ b/tools/httpstan/Dockerfile
@@ -1,6 +1,8 @@
-FROM python:3.9-slim
+FROM python:3.9
 
 WORKDIR /httpstan
+
+ARG TAG
 
 RUN apt-get update && apt-get install -y \
     build-essential \
@@ -9,7 +11,7 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-RUN git clone https://github.com/stan-dev/httpstan.git .
+RUN git clone --branch $TAG --depth=1 https://github.com/stan-dev/httpstan.git .
 
 # Build shared libraries (Stan C++)
 RUN make

--- a/tools/httpstan/Makefile
+++ b/tools/httpstan/Makefile
@@ -1,0 +1,14 @@
+.PHONY: docker-build
+docker-build:
+	docker build --platform linux/amd64 . -t bucketeer-httpstan:latest
+
+.PHONY: docker-push-ghcr
+docker-push-ghcr:
+	@echo $(PAT) | docker login ghcr.io -u $(GITHUB_USER_NAME) --password-stdin
+	docker tag bucketeer-httpstan:latest ghcr.io/bucketeer-io/bucketeer-dex:latest
+	docker push ghcr.io/bucketeer-io/bucketeer-httpstan:latest
+
+.PHONY: docker-push-gar
+docker-push-gar:
+	docker tag bucketeer-httpstan:latest asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:latest
+	docker push asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:latest

--- a/tools/httpstan/Makefile
+++ b/tools/httpstan/Makefile
@@ -1,6 +1,6 @@
-.PHONY: docker-build
-
 TAG := 4.10.1
+
+.PHONY: docker-build
 docker-build:
 	docker build --build-arg TAG=$(TAG) --platform linux/amd64 . -t bucketeer-httpstan:$(TAG)
 
@@ -14,3 +14,7 @@ docker-push-ghcr:
 docker-push-gar:
 	docker tag bucketeer-httpstan:$(TAG) asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:$(TAG)
 	docker push asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:$(TAG)
+
+.PHONY: run-httpstan-container
+run-httpstan-container:
+	docker run --name httpstan -p 8080:8080 -d bucketeer-httpstan:$(TAG)

--- a/tools/httpstan/Makefile
+++ b/tools/httpstan/Makefile
@@ -1,14 +1,16 @@
 .PHONY: docker-build
+
+TAG := 4.10.1
 docker-build:
-	docker build --platform linux/amd64 . -t bucketeer-httpstan:latest
+	docker build --build-arg TAG=$(TAG) --platform linux/amd64 . -t bucketeer-httpstan:$(TAG)
 
 .PHONY: docker-push-ghcr
 docker-push-ghcr:
 	@echo $(PAT) | docker login ghcr.io -u $(GITHUB_USER_NAME) --password-stdin
-	docker tag bucketeer-httpstan:latest ghcr.io/bucketeer-io/bucketeer-dex:latest
-	docker push ghcr.io/bucketeer-io/bucketeer-httpstan:latest
+	docker tag bucketeer-httpstan:$(TAG) ghcr.io/bucketeer-io/bucketeer-httpstan:$(TAG)
+	docker push ghcr.io/bucketeer-io/bucketeer-httpstan:$(TAG)
 
 .PHONY: docker-push-gar
 docker-push-gar:
-	docker tag bucketeer-httpstan:latest asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:latest
-	docker push asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:latest
+	docker tag bucketeer-httpstan:$(TAG) asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:$(TAG)
+	docker push asia-docker.pkg.dev/bucketeer-io/bucketeer/bucketeer-httpstan:$(TAG)

--- a/tools/httpstan/README.md
+++ b/tools/httpstan/README.md
@@ -15,9 +15,13 @@ make docker-build
 
 ## How to run httpstan image
 
+Use the following command to run the `HttpStan` Docker image on local machine:
+
 ```bash
-docker run -p 8080:8080 -it --rm --name httpstan bucketeer-httpstan:latest
+make run-httpstan-container
 ```
+
+Then you will see a container called `httpstan` running in the background and listening on port: `8080`.
 
 ## Test HttpStan API
 
@@ -25,6 +29,14 @@ There is a Python script that can be used to test the HttpStan API.\
 The script is `httpstan_api_test.py`, the script contains the following functions:
 
 - `compile_model` - test the `POST /v1/models` endpoint, used to compile the model
+
+Install dependencies:
+
+* `requests` - used to send HTTP requests
+
+```bash
+pip install requests
+```
 
 Just run the following command to test the HttpStan API locally:
 

--- a/tools/httpstan/README.md
+++ b/tools/httpstan/README.md
@@ -31,3 +31,22 @@ Just run the following command to test the HttpStan API locally:
 ```bash
 python httpstan_api_test.py
 ```
+
+Here are the example results:
+
+* `compile_model`:
+
+```
+compiler_output: /root/.cache/httpstan/4.10.1/models/h7wjpoel/model_h7wjpoel.cpp: ... 
+
+stanc_warnings: Warning in '/tmp/httpstan_zdtggaqa/model_h7wjpoel.stan', line 4, column 12: Declaration
+    of arrays by placing brackets after a variable name is deprecated and
+    will be removed in Stan 2.33.0. Instead use the array keyword before the
+    type. This can be changed automatically using the auto-format flag to
+    stanc...
+    
+model_name: models/h7wjpoel
+```
+
+As you can see, the `compiler_output` contains the compiler output, the `stanc_warnings` contains the warnings,
+and the `model_name` contains the compiled model name.

--- a/tools/httpstan/README.md
+++ b/tools/httpstan/README.md
@@ -1,0 +1,31 @@
+# bucketeer-httpstan
+
+Currently, the calculator service is written in Python, using Bayesian Algorithm to calculate the experiment
+probabilities.\
+Due to the following reasons, we want to rewrite the service in Go and, for Bayesian analysis, use the `HttpStan`.\
+This directory is used to build the `HttpStan` Docker image.
+
+## How to build httpstan image
+
+```bash
+make docker-build
+```
+
+## How to run httpstan image
+
+```bash
+docker run -p 8080:8080 -it --rm --name httpstan bucketeer-httpstan:latest
+```
+
+## Test HttpStan API
+
+There is a Python script that can be used to test the HttpStan API.\
+The script is `httpstan_api_test.py`, the script contains the following functions:
+
+- `compile_model` - test the `POST /v1/models` endpoint, used to compile the model
+
+Just run the following command to test the HttpStan API locally:
+
+```bash
+python httpstan_api_test.py
+```

--- a/tools/httpstan/README.md
+++ b/tools/httpstan/README.md
@@ -7,6 +7,8 @@ This directory is used to build the `HttpStan` Docker image.
 
 ## How to build httpstan image
 
+If you have compiling errors during the image build process, you might need to increase the docker VM memory.
+
 ```bash
 make docker-build
 ```

--- a/tools/httpstan/httpstan_api_test.py
+++ b/tools/httpstan/httpstan_api_test.py
@@ -1,0 +1,46 @@
+import requests
+
+
+def compile_model():
+    model_code = """
+        data {
+            int<lower=0> g;
+            int<lower=0> x[g];
+            int<lower=0> n[g];
+        }
+
+        parameters {
+            real<lower=0, upper=1> p[g];
+        }
+
+        model {
+            for(i in 1:g){
+                x[i] ~ binomial(n[i], p[i]);
+            }
+        }
+
+        generated quantities {
+            matrix[g, g] prob_upper;
+            real prob_best[g];
+
+            for(i in 1:g){
+                real others[g-1];
+                others = append_array(p[:i-1], p[i+1:]);
+                prob_best[i] = p[i] > max(others) ? 1 : 0;
+                for(j in 1:g){
+                    prob_upper[i, j] = p[i] > p[j] ? 1 : 0;
+                }
+            }
+        }
+        """
+    data = {
+        "program_code": model_code,
+    }
+    resp = requests.post("http://localhost:8080/v1/models", json=data)
+    print(f"compiler_output: {resp.json()['compiler_output']}")
+    print(f"stanc_warnings: {resp.json()['stanc_warnings']}")
+    print(f"model_name: {resp.json()['name']}")
+
+
+if __name__ == '__main__':
+    compile_model()


### PR DESCRIPTION
### What I am doing?

This pull request is part of imlementation of this [issue](https://github.com/bucketeer-io/bucketeer/issues/356), used to create the Docker image for the [HttpStan](https://github.com/stan-dev/httpstan) 

### Summary
This commit adds four new files to the tools/httpstan directory: `Dockerfile`, `Makefile`, `README.md`, and `httpstan_api_test.py` 

* The `Dockerfile` is used to build the HttpStan Docker image
* The `Makefile` includes targets for building and pushing the Docker image
* The `httpstan_api_test.py` script contains a function that tests the `POST /v1/models` endpoint, which is used to compile a model. As you can see, the stan script that used to test HttpStan compile API is the script that Python Calculator was using
* The `README.md` explains how to build and run the HttpStan Docker image and how to test the HttpStan API using the `httpstan_api_test.py` script