### PR TITLE
chore: stop upserting daily evaluation count keys

### DIFF
--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -304,14 +304,6 @@ func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamesp
 		}
 		// To avoid duplication when the request fails, we increment the event count in the end
 		// because the user count is an unique count, and there is no problem adding the same event more than once
-		uck := p.newEvaluationCountkey(userCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
-		if err := p.countUser(uck, e.UserId); err != nil {
-			return err
-		}
-		eck := p.newEvaluationCountkey(eventCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
-		if err := p.countEvent(eck); err != nil {
-			return err
-		}
 		uckv2 := p.newEvaluationCountkeyV2(userCountKey, e.FeatureId, vID, environmentNamespace, e.Timestamp)
 		if err := p.countUser(uckv2, e.UserId); err != nil {
 			return err
@@ -322,20 +314,6 @@ func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamesp
 		}
 	}
 	return nil
-}
-
-// TODO: Remove this method
-func (p *Persister) newEvaluationCountkey(
-	kind, featureID, variationID, environmentNamespace string,
-	timestamp int64,
-) string {
-	t := time.Unix(timestamp, 0)
-	date := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, jpLocation)
-	return cache.MakeKey(
-		kind,
-		fmt.Sprintf("%d:%s:%s", date.Unix(), featureID, variationID),
-		environmentNamespace,
-	)
 }
 
 func (p *Persister) newEvaluationCountkeyV2(

--- a/pkg/eventpersister/persister/persister_test.go
+++ b/pkg/eventpersister/persister/persister_test.go
@@ -32,53 +32,6 @@ var defaultOptions = options{
 	logger: zap.NewNop(),
 }
 
-func TestEvaluationCountkey(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	featureID := "feature_id"
-	variationID := "variation_id"
-	unix := time.Now().Unix()
-	environmentNamespace := "en-1"
-	now := time.Unix(unix, 0)
-	date := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, jpLocation)
-	patterns := []struct {
-		desc                 string
-		kind                 string
-		featureID            string
-		variationID          string
-		environmentNamespace string
-		timestamp            int64
-		expected             string
-	}{
-		{
-			desc:                 "userCount",
-			kind:                 userCountKey,
-			featureID:            featureID,
-			variationID:          variationID,
-			environmentNamespace: environmentNamespace,
-			timestamp:            unix,
-			expected:             fmt.Sprintf("%s:%s:%d:%s:%s", environmentNamespace, userCountKey, date.Unix(), featureID, variationID),
-		},
-		{
-			desc:                 "eventCount",
-			kind:                 eventCountKey,
-			featureID:            featureID,
-			variationID:          variationID,
-			environmentNamespace: environmentNamespace,
-			timestamp:            unix,
-			expected:             fmt.Sprintf("%s:%s:%d:%s:%s", environmentNamespace, eventCountKey, date.Unix(), featureID, variationID),
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			persister := newPersister(mockController)
-			actual := persister.newEvaluationCountkey(p.kind, p.featureID, p.variationID, p.environmentNamespace, p.timestamp)
-			assert.Equal(t, p.expected, actual)
-		})
-	}
-}
-
 func TestEvaluationCountkeyV2(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)


### PR DESCRIPTION
We don't need to store daily evaluation count keys since we started using hourly evaluation count keys in https://github.com/bucketeer-io/bucketeer/pull/307.