### PR TITLE
chore: add httpstan container to experiment service pod

### DIFF
--- a/manifests/bucketeer/charts/experiment/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/experiment/templates/deployment.yaml
@@ -164,5 +164,26 @@ spec:
               scheme: HTTPS
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
+        - name: httpstan
+          image: "{{ .Values.httpstan.image.repository }}:{{ .Values.httpstan.image.tag }}"
+          imagePullPolicy: {{ .Values.httpstan.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.httpstan.port }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            failureThreshold: {{ .Values.health.failureThreshold }}
+            httpGet:
+              path: {{ .Values.httpstan.healthPath }}
+              port: {{ .Values.httpstan.port }}
+              scheme: HTTP
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: {{ .Values.httpstan.healthPath }}
+              port: {{ .Values.httpstan.port }}
+              scheme: HTTP
+          resources:
+{{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:
     type: RollingUpdate

--- a/manifests/bucketeer/charts/experiment/values.yaml
+++ b/manifests/bucketeer/charts/experiment/values.yaml
@@ -63,6 +63,16 @@ envoy:
   adminPort: 8001
   resources: {}
 
+httpstan:
+  image:
+    repository: ghcr.io/bucketeer-io/bucketeer-httpstan
+    tag: 4.10.1
+    pullPolicy: IfNotPresent
+  config:
+  port: 8080
+  healthPath: /v1/health
+  resources: {}
+
 service:
   type: ClusterIP
   clusterIP: None


### PR DESCRIPTION
## What I am doing?
* This pull request is part of imlementation of this [issue](https://github.com/bucketeer-io/bucketeer/issues/356).
* Implement HttpStan as a container in experiment service pod.

## Summary
This PR will add a container to the experiment service, so the architecture will look like the following:

![architecture](https://github.com/bucketeer-io/bucketeer/assets/34117229/45622ead-aeae-432e-8c39-05638f8523db)
