### PR TITLE
chore: add routing from other microservices to backend service

### DIFF
--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
@@ -62,20 +62,20 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: account
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           ignore_health_on_host_removal: true
           lb_policy: round_robin
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -220,7 +220,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
@@ -154,7 +154,7 @@ data:
                   private_key:
                     filename: /usr/local/certs/service/tls.key
           type: strict_dns
-        - name: account
+        - name: backend
           connect_timeout: 5s
           ignore_health_on_host_removal: true
           circuit_breakers:
@@ -165,13 +165,13 @@ data:
                 max_pending_requests: 100000000
                 max_requests: 100000000
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                 - endpoint:
                     address:
                       socket_address:
-                        address: account.{{ .Values.namespace }}.svc.cluster.local
+                        address: backend.{{ .Values.namespace }}.svc.cluster.local
                         port_value: 9000
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
@@ -325,7 +325,7 @@ data:
                                     exact: application/grpc
                               prefix: /bucketeer.account.AccountService
                             route:
-                              cluster: account
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx

--- a/manifests/bucketeer/charts/auditlog/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auditlog/templates/envoy-configmap.yaml
@@ -62,20 +62,20 @@ data:
               no_traffic_interval: 2s
               timeout: 1s
               unhealthy_threshold: 2
-        - name: account
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           ignore_health_on_host_removal: true
           lb_policy: round_robin
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -188,7 +188,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -208,4 +208,3 @@ data:
                         private_key:
                           filename: /usr/local/certs/service/tls.key
                   require_client_certificate: true
-

--- a/manifests/bucketeer/charts/auto-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auto-ops/templates/envoy-configmap.yaml
@@ -62,51 +62,19 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: account
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-        - name: auth
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: auth
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: auth.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -286,7 +254,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -298,7 +266,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.auth.AuthService
                               route:
-                                cluster: auth
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -205,7 +205,7 @@ data:
                                   retry_on: 5xx
                                 timeout: 15s
                             - match:
-                                prefix: /bucketeer.account.AuthService
+                                prefix: /bucketeer.auth.AuthService
                                 headers:
                                   - name: content-type
                                     string_match:

--- a/manifests/bucketeer/charts/environment/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/environment/templates/envoy-configmap.yaml
@@ -62,19 +62,19 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: account
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -188,7 +188,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-counter/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-counter/templates/envoy-configmap.yaml
@@ -126,19 +126,19 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: account
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -276,7 +276,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/experiment/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/experiment/templates/envoy-configmap.yaml
@@ -94,19 +94,19 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: account
+        - name: backend
           type: strict_dns
           lb_policy: round_robin
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -232,7 +232,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/feature/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature/templates/envoy-configmap.yaml
@@ -62,19 +62,19 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: account
+        - name: backend
           type: strict_dns
           lb_policy: round_robin
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -220,7 +220,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/notification/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification/templates/envoy-configmap.yaml
@@ -63,19 +63,19 @@ data:
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
-        - name: account
+        - name: backend
           type: strict_dns
           lb_policy: round_robin
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -191,7 +191,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
@@ -63,19 +63,19 @@ data:
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
-        - name: account
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: account.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -256,7 +256,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.account.AccountService
                               route:
-                                cluster: account
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
@@ -186,7 +186,7 @@ data:
               healthy_threshold: 1
               unhealthy_threshold: 2
 
-        - name: account
+        - name: backend
           dns_lookup_family: V4_ONLY
           connect_timeout: 5s
           ignore_health_on_host_removal: true
@@ -198,54 +198,13 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           load_assignment:
-            cluster_name: account
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                 - endpoint:
                     address:
                       socket_address:
-                        address: account.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: auth
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: auth
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: auth.{{ .Values.namespace }}.svc.cluster.local
+                        address: backend.{{ .Values.namespace }}.svc.cluster.local
                         port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -695,7 +654,7 @@ data:
                           - match:
                               prefix: /bucketeer.account.AccountService
                             route:
-                              cluster: account
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -711,7 +670,7 @@ data:
                           - match:
                               prefix: /bucketeer.auth.AuthService
                             route:
-                              cluster: auth
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx


### PR DESCRIPTION
- This PR adds routing settings to the backend service from other microservices.
- After this PR is merged, requests will no longer be sent to the `auth` and `account` services.