### PR TITLE
chore: add audit-log, auto-ops, environment service into the backend module

### DIFF
--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
@@ -94,38 +94,7 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-        - name: environment
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: environment
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: environment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
+
       listeners:
         - name: ingress
           address:
@@ -232,7 +201,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.environment.EnvironmentService
                               route:
-                                cluster: environment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
               value: "{{ .Values.env.accountServicePort }}"
             - name: BUCKETEER_BACKEND_AUTH_SERVICE_PORT
               value: "{{ .Values.env.authServicePort }}"
+            - name: BUCKETEER_BACKEND_AUDIT_LOG_SERVICE_PORT
+              value: "{{ .Values.env.auditLogServicePort }}"
             - name: BUCKETEER_BACKEND_ACCOUNT_SERVICE
               value: "{{ .Values.env.accountService }}"
             - name: BUCKETEER_BACKEND_ENVIRONMENT_SERVICE

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
               value: "{{ .Values.env.auditLogServicePort }}"
             - name: BUCKETEER_BACKEND_AUTO_OPS_SERVICE_PORT
               value: "{{ .Values.env.autoOpsServicePort }}"
+            - name: BUCKETEER_BACKEND_ENVIRONMENT_SERVICE_PORT
+              value: "{{ .Values.env.environmentServicePort }}"
             - name: BUCKETEER_BACKEND_ACCOUNT_SERVICE
               value: "{{ .Values.env.accountService }}"
             - name: BUCKETEER_BACKEND_AUTH_SERVICE

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -75,10 +75,18 @@ spec:
               value: "{{ .Values.env.authServicePort }}"
             - name: BUCKETEER_BACKEND_AUDIT_LOG_SERVICE_PORT
               value: "{{ .Values.env.auditLogServicePort }}"
+            - name: BUCKETEER_BACKEND_AUTO_OPS_SERVICE_PORT
+              value: "{{ .Values.env.autoOpsServicePort }}"
             - name: BUCKETEER_BACKEND_ACCOUNT_SERVICE
               value: "{{ .Values.env.accountService }}"
+            - name: BUCKETEER_BACKEND_AUTH_SERVICE
+              value: "{{ .Values.env.authService }}"
             - name: BUCKETEER_BACKEND_ENVIRONMENT_SERVICE
               value: "{{ .Values.env.environmentService }}"
+            - name: BUCKETEER_BACKEND_EXPERIMENT_SERVICE
+              value: "{{ .Values.env.experimentService }}"
+            - name: BUCKETEER_BACKEND_FEATURE_SERVICE
+              value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_BACKEND_METRICS_PORT
               value: "{{ .Values.env.metricsPort }}"
             - name: BUCKETEER_BACKEND_LOG_LEVEL
@@ -105,6 +113,8 @@ spec:
               value: "{{ .Values.env.emailFilter }}"
             - name: BUCKETEER_BACKEND_OAUTH_REDIRECT_URLS
               value: {{- toYaml .Values.oauth.redirectUrls | nindent 16 }}
+            - name: BUCKETEER_BACKEND_WEBHOOK_BASE_URL
+              value: "{{ .Values.webhook.baseURL }}"
             - name: BUCKETEER_BACKEND_WEBHOOK_KMS_RESOURCE_NAME
               value: "{{ .Values.webhook.kmsResourceName }}"
           volumeMounts:

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -216,8 +216,8 @@ data:
                   - endpoint:
                       address:
                         socket_address:
-                          address: environment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
+                          address: localhost
+                          port_value: 9095
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -389,6 +389,14 @@ data:
                               route:
                                 cluster: autoops
                                 timeout: 15s
+                                retry_policy:
+                                  retry_on: 5xx
+                                  num_retries: 3
+                            - match:
+                                prefix: /bucketeer.environment.EnvironmentService
+                              route:
+                                cluster: environment
+                                timeout: 60s
                                 retry_policy:
                                   retry_on: 5xx
                                   num_retries: 3

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -124,6 +124,46 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
+        - name: auditlog
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: auditlog
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9093
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: { }
+          health_checks:
+            - grpc_health_check: {}
+              healthy_threshold: 1
+              interval: 10s
+              interval_jitter: 1s
+              no_traffic_interval: 2s
+              timeout: 1s
+              unhealthy_threshold: 2
+          ignore_health_on_host_removal: true
         - name: environment
           type: strict_dns
           connect_timeout: 5s
@@ -212,6 +252,18 @@ data:
                                       exact: application/grpc
                               route:
                                 cluster: auth
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                prefix: /bucketeer.auditlog.AuditLogService
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                              route:
+                                cluster: auditlog
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -164,6 +164,46 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
+        - name: autoops
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: autoops
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9094
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: { }
+          health_checks:
+            - grpc_health_check: {}
+              healthy_threshold: 1
+              interval: 10s
+              interval_jitter: 1s
+              no_traffic_interval: 2s
+              timeout: 1s
+              unhealthy_threshold: 2
+          ignore_health_on_host_removal: true
         - name: environment
           type: strict_dns
           connect_timeout: 5s
@@ -177,6 +217,70 @@ data:
                       address:
                         socket_address:
                           address: environment.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+        - name: experiment
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: experiment
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+        - name: feature
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: feature
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: feature.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -269,6 +373,26 @@ data:
                                   retry_on: 5xx
                                 timeout: 15s
                             - match:
+                                prefix: /bucketeer.autoops.AutoOpsService
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                              route:
+                                cluster: autoops
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                prefix: /hook
+                              route:
+                                cluster: autoops
+                                timeout: 15s
+                                retry_policy:
+                                  retry_on: 5xx
+                                  num_retries: 3
+                            - match:
                                 prefix: /
                                 headers:
                                   - name: content-type
@@ -352,6 +476,30 @@ data:
                                 prefix: /bucketeer.environment.EnvironmentService
                               route:
                                 cluster: environment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.experiment.ExperimentService
+                              route:
+                                cluster: experiment
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.feature.FeatureService
+                              route:
+                                cluster: feature
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -19,6 +19,7 @@ env:
   healthCheckServicePort: 8000
   accountServicePort: 9091
   authServicePort: 9092
+  auditLogServicePort: 9093
   metricsPort: 9002
   emailFilter:
   logLevel: info

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -24,6 +24,7 @@ env:
   authServicePort: 9092
   auditLogServicePort: 9093
   autoOpsServicePort: 9094
+  environmentServicePort: 9095
   metricsPort: 9002
   emailFilter:
   logLevel: info

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -15,11 +15,15 @@ env:
   mysqlDbName:
   domainTopic:
   accountService: localhost:9001
+  authService: localhost:9001
   environmentService: localhost:9001
+  experimentService: localhost:9001
+  featureService: localhost:9001
   healthCheckServicePort: 8000
   accountServicePort: 9091
   authServicePort: 9092
   auditLogServicePort: 9093
+  autoOpsServicePort: 9094
   metricsPort: 9002
   emailFilter:
   logLevel: info
@@ -63,6 +67,7 @@ oauth:
   issuer:
 
 webhook:
+  baseURL:
   kmsResourceName:
 
 envoy:

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
@@ -94,19 +94,19 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: auto-ops
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: auto-ops
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -232,7 +232,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.autoops.AutoOpsService
                               route:
-                                cluster: auto-ops
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
@@ -94,19 +94,19 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: auto-ops
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: auto-ops
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -232,7 +232,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.autoops.AutoOpsService
                               route:
-                                cluster: auto-ops
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
@@ -97,19 +97,19 @@ data:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
 
-        - name: environment
+        - name: backend
           type: strict_dns
           lb_policy: round_robin
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           load_assignment:
-            cluster_name: environment
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: environment.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -336,7 +336,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.environment.EnvironmentService
                               route:
-                                cluster: environment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
@@ -63,52 +63,19 @@ data:
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
-        - name: environment
+        - name: backend
           type: strict_dns
           lb_policy: round_robin
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           load_assignment:
-            cluster_name: environment
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: environment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
-        - name: auto-ops
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: auto-ops
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -289,7 +256,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.environment.EnvironmentService
                               route:
-                                cluster: environment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -301,7 +268,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.autoops.AutoOpsService
                               route:
-                                cluster: auto-ops
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
@@ -145,47 +145,6 @@ data:
               healthy_threshold: 1
               unhealthy_threshold: 2
 
-        - name: auditlog
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: auditlog
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: auditlog.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
         - name: backend
           dns_lookup_family: V4_ONLY
           connect_timeout: 5s
@@ -205,88 +164,6 @@ data:
                     address:
                       socket_address:
                         address: backend.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: environment
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: environment
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: environment.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: auto-ops
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: auto-ops
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: auto-ops.{{ .Values.namespace }}.svc.cluster.local
                         port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -662,7 +539,7 @@ data:
                           - match:
                               prefix: /bucketeer.auditlog.AuditLogService
                             route:
-                              cluster: auditlog
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -678,7 +555,7 @@ data:
                           - match:
                               prefix: /bucketeer.autoops.AutoOpsService
                             route:
-                              cluster: auto-ops
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -686,7 +563,7 @@ data:
                           - match:
                               prefix: /hook
                             route:
-                              cluster: auto-ops
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -694,7 +571,7 @@ data:
                           - match:
                               prefix: /bucketeer.environment.EnvironmentService
                             route:
-                              cluster: environment
+                              cluster: backend
                               timeout: 60s
                               retry_policy:
                                 retry_on: 5xx

--- a/pkg/backend/cmd/server/server.go
+++ b/pkg/backend/cmd/server/server.go
@@ -99,10 +99,6 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 		certPath:         cmd.Flag("cert", "Path to TLS certificate.").Required().String(),
 		keyPath:          cmd.Flag("key", "Path to TLS key.").Required().String(),
 		serviceTokenPath: cmd.Flag("service-token", "Path to service token.").Required().String(),
-		oauthPrivateKeyPath: cmd.Flag(
-			"oauth-private-key",
-			"Path to private key for signing oauth token.",
-		).Required().String(),
 		oauthPublicKeyPath: cmd.Flag(
 			"oauth-public-key",
 			"Path to public key used to verify oauth token.",
@@ -111,14 +107,19 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"oauth-client-id",
 			"The oauth clientID registered at dex.",
 		).Required().String(),
+		oauthIssuer: cmd.Flag("oauth-issuer", "The url of dex issuer.").Required().String(),
+		// auth
+		oauthIssuerCertPath: cmd.Flag("oauth-issuer-cert", "Path to TLS certificate of issuer.").Required().String(),
+		emailFilter:         cmd.Flag("email-filter", "Regexp pattern for filtering email.").String(),
+		oauthRedirectURLs:   cmd.Flag("oauth-redirect-urls", "The redirect urls registered at Dex.").Required().Strings(),
 		oauthClientSecret: cmd.Flag(
 			"oauth-client-secret",
 			"The oauth client secret registered at Dex.",
 		).Required().String(),
-		oauthRedirectURLs:   cmd.Flag("oauth-redirect-urls", "The redirect urls registered at Dex.").Required().Strings(),
-		oauthIssuer:         cmd.Flag("oauth-issuer", "The url of dex issuer.").Required().String(),
-		oauthIssuerCertPath: cmd.Flag("oauth-issuer-cert", "Path to TLS certificate of issuer.").Required().String(),
-		emailFilter:         cmd.Flag("email-filter", "Regexp pattern for filtering email.").String(),
+		oauthPrivateKeyPath: cmd.Flag(
+			"oauth-private-key",
+			"Path to private key for signing oauth token.",
+		).Required().String(),
 	}
 	r.RegisterCommand(server)
 	return server


### PR DESCRIPTION
- This PR integrates the audit-log, the auto-ops, and the environment service into the backend module.
- This PR adds routing settings to the backend service from other microservices.
- After this PR is merged, requests will no longer be sent to the audit-log, auto-ops, and environment services.