### PR TITLE
chore: include the current hour in GetEvaluationTimeseriesCount

### DIFF
--- a/pkg/eventcounter/api/api.go
+++ b/pkg/eventcounter/api/api.go
@@ -651,7 +651,7 @@ func (s *eventCounterService) getTimestamps(
 	switch timeRange {
 	case ecproto.GetEvaluationTimeseriesCountRequest_TWENTY_FOUR_HOURS:
 		startAt := getStartTime(s.location, endAt, 1)
-		truncated := truncateHour(s.location, startAt)
+		truncated := truncateHour(s.location, startAt).Add(time.Hour * 1)
 		return getOneDayTimestamps(truncated), ecproto.Timeseries_HOUR, nil
 	case ecproto.GetEvaluationTimeseriesCountRequest_SEVEN_DAYS:
 		startAt := getStartTime(s.location, endAt, 6)


### PR DESCRIPTION


## Before
<img width="470" alt="Screen Shot 2023-06-21 at 11 02 01" src="https://github.com/bucketeer-io/bucketeer/assets/59436572/895bd5e7-e088-4566-9447-96ed6a142cf2">


## After
<img width="470" alt="Screen Shot 2023-06-21 at 11 02 16" src="https://github.com/bucketeer-io/bucketeer/assets/59436572/21abd815-f11d-4ee8-9823-ae92548c4ccd">
