### PR TITLE
chore: add proto-all command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,12 @@ proto-lock-commit:
 proto-lock-commit-force:
 	make -C proto lock-commit-force
 
+.PHONY: proto-all
+proto-all:
+	make -C proto go
+	make -C python gen
+	make -C ui/web-v2 gen_proto
+
 .PHONY: proto-go
 proto-go:
 	make -C proto go


### PR DESCRIPTION
Currently, generated proto files are checked in CI. If we update proto files, we must run all proto commands in each directory. Thus, it would be useful if we update all generated proto files in one command. I introduced proto-all command in this PR.