### PR TITLE
chore: add routing to event-counter, experiment, feature in the backend module

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/envoy-configmap.yaml
@@ -62,19 +62,20 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: experiment
+
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: experiment
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -94,38 +95,7 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: feature
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          type: strict_dns
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
+
       listeners:
         - name: ingress
           address:
@@ -220,7 +190,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
-                                cluster: experiment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -232,7 +202,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
@@ -62,38 +62,7 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: feature
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
+
         - name: backend
           type: strict_dns
           connect_timeout: 5s
@@ -220,7 +189,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/envoy-configmap.yaml
@@ -62,19 +62,20 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: experiment
+
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: experiment
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -94,38 +95,7 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: feature
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          type: strict_dns
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
+    
       listeners:
         - name: ingress
           address:
@@ -220,7 +190,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
-                                cluster: experiment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -232,7 +202,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
@@ -62,38 +62,7 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - name: feature
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
+
         - name: backend
           type: strict_dns
           connect_timeout: 5s
@@ -126,6 +95,7 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+
       listeners:
         - name: ingress
           address:
@@ -220,7 +190,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
@@ -130,105 +130,6 @@ data:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
 
-        - name: experiment
-          type: strict_dns
-          lb_policy: round_robin
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          load_assignment:
-            cluster_name: experiment
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
-        - name: event-counter-server
-          type: strict_dns
-          lb_policy: round_robin
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          load_assignment:
-            cluster_name: event-counter-server
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: event-counter.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
-        - name: feature
-          type: strict_dns
-          lb_policy: round_robin
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
       listeners:
         - name: ingress
           address:
@@ -348,7 +249,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
-                                cluster: experiment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -360,7 +261,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.eventcounter.EventCounterService
                               route:
-                                cluster: event-counter-server
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -372,7 +273,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
@@ -96,72 +96,6 @@ data:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
 
-        - name: event-counter-server
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: event-counter-server
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: event-counter.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          type: strict_dns
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
-        - name: feature
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
       listeners:
         - name: ingress
           address:
@@ -280,7 +214,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.eventcounter.EventCounterService
                               route:
-                                cluster: event-counter-server
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -292,7 +226,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
@@ -63,19 +63,19 @@ data:
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
-        - name: feature
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: feature
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -223,7 +223,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push/templates/envoy-configmap.yaml
@@ -96,71 +96,6 @@ data:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
 
-        - name: experiment
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: experiment
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
-        - name: feature
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -268,7 +203,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
-                                cluster: experiment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -280,7 +215,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
@@ -22,129 +22,6 @@ data:
           port_value: 8001
     static_resources:
       clusters:
-        - name: feature
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: feature.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: experiment
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: experiment
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: experiment.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: event-counter
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: event-counter
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: event-counter.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
         - name: backend
           dns_lookup_family: V4_ONLY
           connect_timeout: 5s
@@ -579,7 +456,7 @@ data:
                           - match:
                               prefix: /bucketeer.eventcounter.EventCounterService
                             route:
-                              cluster: event-counter
+                              cluster: backend
                               timeout: 10800s
                               retry_policy:
                                 retry_on: 5xx
@@ -587,7 +464,7 @@ data:
                           - match:
                               prefix: /bucketeer.experiment.ExperimentService
                             route:
-                              cluster: experiment
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -595,7 +472,7 @@ data:
                           - match:
                               prefix: /bucketeer.feature.FeatureService
                             route:
-                              cluster: feature
+                              cluster: backend
                               timeout: 60s
                               retry_policy:
                                 retry_on: 5xx


### PR DESCRIPTION
- This PR adds the route to the event-counter, experiment, and feature services in the backend module.
- Once this PR is merged, requests to the event-counter, experiment, and feature module will no longer be sent. 