### PR TITLE
chore: add migration-mysql, notification, push  service into the backend  module

### DIFF
--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -114,6 +114,8 @@ spec:
               value: "{{ .Values.env.migrateMysqlServicePort }}"
             - name: BUCKETEER_BACKEND_NOTIFICATION_SERVICE_PORT
               value: "{{ .Values.env.notificationServicePort }}"
+            - name: BUCKETEER_BACKEND_PUSH_SERVICE_PORT
+              value: "{{ .Values.env.pushServicePort }}"
             - name: BUCKETEER_BACKEND_ACCOUNT_SERVICE
               value: "{{ .Values.env.accountService }}"
             - name: BUCKETEER_BACKEND_AUTH_SERVICE

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -112,6 +112,8 @@ spec:
               value: "{{ .Values.env.featureServicePort }}"
             - name: BUCKETEER_BACKEND_MIGRATE_MYSQL_SERVICE_PORT
               value: "{{ .Values.env.migrateMysqlServicePort }}"
+            - name: BUCKETEER_BACKEND_NOTIFICATION_SERVICE_PORT
+              value: "{{ .Values.env.notificationServicePort }}"
             - name: BUCKETEER_BACKEND_ACCOUNT_SERVICE
               value: "{{ .Values.env.accountService }}"
             - name: BUCKETEER_BACKEND_AUTH_SERVICE

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - name: oauth-key-secret
           secret:
             secretName: {{ template "oauth-key-secret" . }}
+        - name: github-access-token-secret
+          secret:
+            secretName: github-token
       {{- if .Values.serviceAccount.annotations }}
       serviceAccountName: {{ template "backend.fullname" . }}
       {{- end }}
@@ -107,6 +110,8 @@ spec:
               value: "{{ .Values.env.experimentServicePort }}"
             - name: BUCKETEER_BACKEND_FEATURE_SERVICE_PORT
               value: "{{ .Values.env.featureServicePort }}"
+            - name: BUCKETEER_BACKEND_MIGRATE_MYSQL_SERVICE_PORT
+              value: "{{ .Values.env.migrateMysqlServicePort }}"
             - name: BUCKETEER_BACKEND_ACCOUNT_SERVICE
               value: "{{ .Values.env.accountService }}"
             - name: BUCKETEER_BACKEND_AUTH_SERVICE
@@ -149,6 +154,12 @@ spec:
               value: "{{ .Values.webhook.baseURL }}"
             - name: BUCKETEER_BACKEND_WEBHOOK_KMS_RESOURCE_NAME
               value: "{{ .Values.webhook.kmsResourceName }}"
+            - name: BUCKETEER_BACKEND_GITHUB_USER
+              value: "{{ .Values.env.githubUser }}"
+            - name: BUCKETEER_BACKEND_GITHUB_ACCESS_TOKEN_PATH
+              value: /usr/local/github-access-token/bucketeer-bot-access-token
+            - name: BUCKETEER_BACKEND_GITHUB_MIGRATION_SOURCE_PATH
+              value: "{{ .Values.env.githubMigrationSourcePath }}"
           volumeMounts:
             - name: issuer-cert-secret
               mountPath: /usr/local/certs/issuer
@@ -161,6 +172,9 @@ spec:
               readOnly: true
             - name: oauth-key-secret
               mountPath: /usr/local/oauth-key
+              readOnly: true
+            - name: github-access-token-secret
+              mountPath: /usr/local/github-access-token
               readOnly: true
           ports:
             - name: health-check

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -340,7 +340,7 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: mygrationmysql
+        - name: migrationmysql
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -340,6 +340,103 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
+        - name: mygrationmysql
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: mygrationmysql
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9099
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+        - name: notification
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: notification
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9100
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+        - name: push
+          type: strict_dns
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          lb_policy: round_robin
+          load_assignment:
+            cluster_name: push
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9101
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+
       listeners:
         - name: ingress
           address:
@@ -461,6 +558,30 @@ data:
                               route:
                                 cluster: feature
                                 timeout: 60s
+                                retry_policy:
+                                  retry_on: 5xx
+                                  num_retries: 3
+                            - match:
+                                prefix: /bucketeer.migration.MigrationMySQLService
+                              route:
+                                cluster: migrationmysql
+                                timeout: 600s
+                                retry_policy:
+                                  retry_on: 5xx
+                                  num_retries: 3
+                            - match:
+                                prefix: /bucketeer.notification.NotificationService
+                              route:
+                                cluster: notification
+                                timeout: 15s
+                                retry_policy:
+                                  retry_on: 5xx
+                                  num_retries: 3
+                            - match:
+                                prefix: /bucketeer.push.PushService
+                              route:
+                                cluster: push
+                                timeout: 15s
                                 retry_policy:
                                   retry_on: 5xx
                                   num_retries: 3

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -43,6 +43,7 @@ env:
   featureServicePort: 9098
   migrateMysqlServicePort: 9099
   notificationServicePort: 9100
+  pushServicePort: 9101
   metricsPort: 9002
   timezone: UTC
   emailFilter:

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -42,6 +42,7 @@ env:
   experimentServicePort: 9097
   featureServicePort: 9098
   migrateMysqlServicePort: 9099
+  notificationServicePort: 9100
   metricsPort: 9002
   timezone: UTC
   emailFilter:

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -41,9 +41,12 @@ env:
   eventCounterServicePort: 9096
   experimentServicePort: 9097
   featureServicePort: 9098
+  migrateMysqlServicePort: 9099
   metricsPort: 9002
   timezone: UTC
   emailFilter:
+  githubUser:
+  githubMigrationSourcePath:
   logLevel: info
 
 affinity: {}

--- a/pkg/backend/cmd/server/server.go
+++ b/pkg/backend/cmd/server/server.go
@@ -47,6 +47,8 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/health"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
+	migratemysqlapi "github.com/bucketeer-io/bucketeer/pkg/migration/mysql/api"
+	"github.com/bucketeer-io/bucketeer/pkg/migration/mysql/migrate"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher"
 	redisv3 "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
@@ -107,6 +109,7 @@ type server struct {
 	eventCounterServicePort *int
 	experimentServicePort   *int
 	featureServicePort      *int
+	migrateMySQLServicePort *int
 	// Service
 	accountService     *string
 	authService        *string
@@ -123,6 +126,10 @@ type server struct {
 	webhookBaseURL         *string
 	webhookKMSResourceName *string
 	cloudService           *string
+	// migration-mysql
+	githubUser                *string
+	githubAccessTokenPath     *string
+	githubMigrationSourcePath *string
 }
 
 func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
@@ -209,6 +216,10 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"feature-service-port",
 			"Port to bind to feature service.",
 		).Default("9098").Int(),
+		migrateMySQLServicePort: cmd.Flag(
+			"migrate-mysql-service-port",
+			"Port to bind to migrate mysql service.",
+		).Default("9099").Int(),
 		accountService: cmd.Flag(
 			"account-service",
 			"bucketeer-account-service address.",
@@ -261,6 +272,13 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"Cloud KMS resource name to encrypt and decrypt webhook credentials.",
 		).Required().String(),
 		cloudService: cmd.Flag("cloud-service", "Cloud Service info").Default(gcp).String(),
+		// migration-mysql
+		githubUser:            cmd.Flag("github-user", "GitHub user.").Required().String(),
+		githubAccessTokenPath: cmd.Flag("github-access-token-path", "Path to GitHub access token.").Required().String(),
+		githubMigrationSourcePath: cmd.Flag(
+			"github-migration-source-path",
+			"Path to migration file in GitHub. (e.g. owner/repo/path#ref)",
+		).Required().String(),
 	}
 	r.RegisterCommand(server)
 	return server
@@ -553,6 +571,26 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	)
 	defer featureServer.Stop(10 * time.Second)
 	go featureServer.Run()
+	// migrateMySQLService
+	migrateClientFactory, err := migrate.NewClientFactory(
+		*s.githubUser, *s.githubAccessTokenPath, *s.githubMigrationSourcePath,
+		*s.mysqlUser, *s.mysqlPass, *s.mysqlHost, *s.mysqlPort, *s.mysqlDBName,
+	)
+	if err != nil {
+		return err
+	}
+	migrateMySQLService := migratemysqlapi.NewMySQLService(
+		migrateClientFactory,
+		migratemysqlapi.WithLogger(logger),
+	)
+	migrateMySQLServer := rpc.NewServer(migrateMySQLService, *s.certPath, *s.keyPath,
+		rpc.WithPort(*s.migrateMySQLServicePort),
+		rpc.WithVerifier(verifier),
+		rpc.WithMetrics(registerer),
+		rpc.WithLogger(logger),
+	)
+	defer migrateMySQLServer.Stop(10 * time.Second)
+	go migrateMySQLServer.Run()
 	// other services...
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
- This PR integrates the migration-mysql, notification and push service into the backend module.
- Even if this PR is merged, requests will be sent to the migration-mysql, notification and push services from the web-gateway.