### PR TITLE
chore: add routing to migration-mysql, notification, push in the backend module

### DIFF
--- a/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
@@ -116,44 +116,6 @@ data:
                     private_key:
                       filename: /usr/local/certs/service/tls.key
           type: strict_dns
-        - name: feature
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          circuit_breakers:
-            thresholds:
-              - priority: DEFAULT
-                max_retries: 3
-                # we don't want to break a circuit by number of request, so set a large number.
-                max_pending_requests: 100000000
-                max_requests: 100000000
-          load_assignment:
-            cluster_name: feature
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: feature.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          dns_lookup_family: V4_ONLY
-          lb_policy: least_request
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          type: strict_dns
         - name: backend
           connect_timeout: 5s
           ignore_health_on_host_removal: true
@@ -313,7 +275,7 @@ data:
                                     exact: application/grpc
                               prefix: /bucketeer.feature.FeatureService
                             route:
-                              cluster: feature
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx

--- a/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
@@ -62,51 +62,20 @@ data:
               timeout: 1s
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
-        - connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          ignore_health_on_host_removal: true
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: environment
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: environment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          name: environment
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          type: strict_dns
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-        - name: feature
+
+        - name: backend
           type: strict_dns
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           lb_policy: round_robin
           load_assignment:
-            cluster_name: feature
+            cluster_name: backend
             endpoints:
               - lb_endpoints:
                   - endpoint:
                       address:
                         socket_address:
-                          address: feature.{{ .Values.namespace }}.svc.cluster.local
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
                           port_value: 9000
           transport_socket:
             name: envoy.transport_sockets.tls
@@ -126,70 +95,7 @@ data:
               explicit_http_config:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
-        - name: experiment
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: experiment
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: experiment.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-        - name: event-counter-server
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: event-counter-server
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: event-counter.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
+
       listeners:
         - name: ingress
           address:
@@ -284,7 +190,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.environment.EnvironmentService
                               route:
-                                cluster: environment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -296,7 +202,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
-                                cluster: feature
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -308,7 +214,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.experiment.ExperimentService
                               route:
-                                cluster: experiment
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
@@ -320,7 +226,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.eventcounter.EventCounterService
                               route:
-                                cluster: event-counter-server
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
@@ -64,39 +64,6 @@ data:
               unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
-        - name: notification
-          connect_timeout: 5s
-          type: strict_dns
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: notification
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: notification.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
-
         - name: backend
           type: strict_dns
           lb_policy: round_robin
@@ -225,7 +192,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.notification.NotificationService
                               route:
-                                cluster: notification
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
@@ -96,38 +96,6 @@ data:
                 http2_protocol_options: {}
           ignore_health_on_host_removal: true
 
-        - name: push
-          type: strict_dns
-          connect_timeout: 5s
-          dns_lookup_family: V4_ONLY
-          lb_policy: round_robin
-          load_assignment:
-            cluster_name: push
-            endpoints:
-              - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: push.{{ .Values.namespace }}.svc.cluster.local
-                          port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols:
-                  - h2
-                tls_certificates:
-                  - certificate_chain:
-                      filename: /usr/local/certs/service/tls.crt
-                    private_key:
-                      filename: /usr/local/certs/service/tls.key
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          ignore_health_on_host_removal: true
       listeners:
         - name: ingress
           address:
@@ -235,7 +203,7 @@ data:
                                       exact: application/grpc
                                 prefix: /bucketeer.push.PushService
                               route:
-                                cluster: push
+                                cluster: backend
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
@@ -63,129 +63,6 @@ data:
               healthy_threshold: 1
               unhealthy_threshold: 2
 
-        - name: push
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: push
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: push.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: notification
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: notification
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: notification.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
-        - name: migration-mysql
-          dns_lookup_family: V4_ONLY
-          connect_timeout: 5s
-          ignore_health_on_host_removal: true
-          type: strict_dns
-          lb_policy: round_robin
-          typed_extension_protocol_options:
-            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
-              explicit_http_config:
-                http2_protocol_options: {}
-          load_assignment:
-            cluster_name: migration-mysql
-            endpoints:
-              - lb_endpoints:
-                - endpoint:
-                    address:
-                      socket_address:
-                        address: migration-mysql.{{ .Values.namespace }}.svc.cluster.local
-                        port_value: 9000
-          transport_socket:
-            name: envoy.transport_sockets.tls
-            typed_config:
-              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
-              common_tls_context:
-                alpn_protocols: ["h2"]
-                tls_certificates:
-                - certificate_chain:
-                    filename: /usr/local/certs/service/tls.crt
-                  private_key:
-                    filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
-
         - name: dex
           dns_lookup_family: V4_ONLY
           connect_timeout: 5s
@@ -480,7 +357,7 @@ data:
                           - match:
                               prefix: /bucketeer.notification.NotificationService
                             route:
-                              cluster: notification
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -488,7 +365,7 @@ data:
                           - match:
                               prefix: /bucketeer.push.PushService
                             route:
-                              cluster: push
+                              cluster: backend
                               timeout: 15s
                               retry_policy:
                                 retry_on: 5xx
@@ -496,7 +373,7 @@ data:
                           - match:
                               prefix: /bucketeer.migration.MigrationMySQLService
                             route:
-                              cluster: migration-mysql
+                              cluster: backend
                               timeout: 600s
                               retry_policy:
                                 retry_on: 5xx


### PR DESCRIPTION
- This PR adds the route to the migration-mysql, notification, and push services in the backend module.
- Once this PR is merged, requests to the migration-mysql, notification, and push module will no longer be sent. 