### PR TITLE
chore: fix mockgen version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ local-deps:
 	if [ ! -e go.mod ]; then go mod init go-tools; fi; \
 	go install golang.org/x/tools/cmd/goimports@latest; \
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2; \
-	go install go.uber.org/mock/mockgen@v1.6.0; \
+	go install go.uber.org/mock/mockgen@v0.1.0; \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.5.2; \
 	go install github.com/nilslice/protolock/...@v0.15.0;
 	go install github.com/mikefarah/yq/v4@v4.28.2


### PR DESCRIPTION
- We must uninstall `github.com/golang/mock/mockgen@v1.6.0` and install `go.uber.org/mock/mockgen@0.1.0` before running the command `make mockgen` since [this PR](https://github.com/bucketeer-io/bucketeer/pull/435) was merged. 
