### PR TITLE
chore: precompile stan model

### DIFF
--- a/tools/httpstan/Dockerfile
+++ b/tools/httpstan/Dockerfile
@@ -24,7 +24,7 @@ RUN python3 -m poetry build
 RUN python3 -m pip install dist/*.whl
 
 # Pre Compile the model
-copy ./model.stan ./model.stan
+COPY ./model.stan ./model.stan
 COPY ./stan_model_compile.py ./stan_model_compile.py
 RUN python3 stan_model_compile.py
 

--- a/tools/httpstan/Dockerfile
+++ b/tools/httpstan/Dockerfile
@@ -23,6 +23,11 @@ RUN python3 -m poetry build
 # Install the wheel
 RUN python3 -m pip install dist/*.whl
 
+# Pre Compile the model
+copy ./model.stan ./model.stan
+COPY ./stan_model_compile.py ./stan_model_compile.py
+RUN python3 stan_model_compile.py
+
 EXPOSE 8080
 
 CMD ["python3", "-m", "httpstan", "--host", "0.0.0.0"]

--- a/tools/httpstan/httpstan_api_test.py
+++ b/tools/httpstan/httpstan_api_test.py
@@ -2,37 +2,9 @@ import requests
 
 
 def compile_model():
-    model_code = """
-        data {
-            int<lower=0> g;
-            int<lower=0> x[g];
-            int<lower=0> n[g];
-        }
+    with open("model.stan", "r") as f:
+        model_code = f.read()
 
-        parameters {
-            real<lower=0, upper=1> p[g];
-        }
-
-        model {
-            for(i in 1:g){
-                x[i] ~ binomial(n[i], p[i]);
-            }
-        }
-
-        generated quantities {
-            matrix[g, g] prob_upper;
-            real prob_best[g];
-
-            for(i in 1:g){
-                real others[g-1];
-                others = append_array(p[:i-1], p[i+1:]);
-                prob_best[i] = p[i] > max(others) ? 1 : 0;
-                for(j in 1:g){
-                    prob_upper[i, j] = p[i] > p[j] ? 1 : 0;
-                }
-            }
-        }
-        """
     data = {
         "program_code": model_code,
     }

--- a/tools/httpstan/model.stan
+++ b/tools/httpstan/model.stan
@@ -1,0 +1,29 @@
+data {
+    int<lower=0> g;
+    int<lower=0> x[g];
+    int<lower=0> n[g];
+}
+
+parameters {
+    real<lower=0, upper=1> p[g];
+}
+
+model {
+    for(i in 1:g){
+        x[i] ~ binomial(n[i], p[i]);
+    }
+}
+
+generated quantities {
+    matrix[g, g] prob_upper;
+    real prob_best[g];
+
+    for(i in 1:g){
+        real others[g-1];
+        others = append_array(p[:i-1], p[i+1:]);
+        prob_best[i] = p[i] > max(others) ? 1 : 0;
+        for(j in 1:g){
+            prob_upper[i, j] = p[i] > p[j] ? 1 : 0;
+        }
+    }
+}

--- a/tools/httpstan/stan_model_compile.py
+++ b/tools/httpstan/stan_model_compile.py
@@ -1,0 +1,48 @@
+#  Copyright 2023 The Bucketeer Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+import asyncio
+import typing
+
+import aiohttp.web
+import httpstan.app
+
+with open("model.stan", "r") as f:
+    model_code = f.read()
+
+data = {
+    "program_code": model_code,
+}
+
+
+async def server_start():
+    app = httpstan.app.make_app()
+    runner = aiohttp.web.AppRunner(app)
+    await runner.setup()
+    site = aiohttp.web.TCPSite(runner, "0.0.0.0", 8080)
+    await site.start()
+
+
+async def main():
+    await server_start()
+    async with aiohttp.ClientSession() as session:
+        async with session.post("http://localhost:8080/v1/models", json=data) as resp:
+            assert resp.status == 201
+            response_payload = await resp.json()
+    model_name = typing.cast(str, response_payload["name"])
+    print(f"model_name: {model_name}")
+
+
+if __name__ == '__main__':
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
Golang calculator service(https://github.com/bucketeer-io/bucketeer/pull/395) need to call httpstan to compile the stan model code first. And it could take long time to finish compile progress.

So this PR will precompile the stan model that we use in Golang calculator service and save the precompiled model files in the HttpStan Docker image directly. Then we can skip compile model in the Golang calculator service pod to speed up service start.

### How to make it
* Implement a precompile model python script, the script will start a httpstan server "locally" then call the httpstan's compile model http endpoint.
* After httpstan finished to compile model, it will save the compiled model in the following directory:
 `/root/.cache/httpstan/${httpstan_version}/models/${model_id}`.
  NOTE: the `model_id` was calculated by using the stan model code string hash automaticly.
* Copy the script into the Docker builder then execute it, then we can get an image that contains compiled model.
