### PR TITLE
chore: batch service helm charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ local-deps:
 	if [ ! -e go.mod ]; then go mod init go-tools; fi; \
 	go install golang.org/x/tools/cmd/goimports@latest; \
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2; \
-	go install go.uber.org/mock/mockgen@v1.6.0; \
+	go install go.uber.org/mock/mockgen@v0.1.0; \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.5.2; \
 	go install github.com/nilslice/protolock/...@v0.15.0;
 	go install github.com/mikefarah/yq/v4@v4.28.2

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ local-deps:
 	if [ ! -e go.mod ]; then go mod init go-tools; fi; \
 	go install golang.org/x/tools/cmd/goimports@latest; \
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.47.2; \
-	go install go.uber.org/mock/mockgen@v0.1.0; \
+	go install go.uber.org/mock/mockgen@v1.6.0; \
 	go install github.com/golang/protobuf/protoc-gen-go@v1.5.2; \
 	go install github.com/nilslice/protolock/...@v0.15.0;
 	go install github.com/mikefarah/yq/v4@v4.28.2

--- a/manifests/bucketeer/charts/batch/Chart.yaml
+++ b/manifests/bucketeer/charts/batch/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for bucketeer-batch-server
+name: batch-server
+version: 1.0.0

--- a/manifests/bucketeer/charts/batch/templates/NOTES.txt
+++ b/manifests/bucketeer/charts/batch/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "batch-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "batch-server.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "batch-server.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "batch-server.name" . }},release={{ template "batch-server.fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:80
+{{- end }}

--- a/manifests/bucketeer/charts/batch/templates/_helpers.tpl
+++ b/manifests/bucketeer/charts/batch/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "batch-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "batch-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "batch-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "service-cert-secret" -}}
+{{- if .Values.tls.service.secret }}
+{{- printf "%s" .Values.tls.service.secret -}}
+{{- else -}}
+{{ template "batch-server.fullname" . }}-service-cert
+{{- end -}}
+{{- end -}}
+
+{{- define "service-token-secret" -}}
+{{- if .Values.serviceToken.secret }}
+{{- printf "%s" .Values.serviceToken.secret -}}
+{{- else -}}
+{{ template "batch-server.fullname" . }}-service-token
+{{- end -}}
+{{- end -}}

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -9,9 +9,14 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.cronjob.experimentStatusUpdaterSchedule }}
+  concurrencyPolicy: Forbid
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "{{ .Values.cronjob.experimentStatusUpdaterSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           volumes:
@@ -41,9 +46,16 @@ spec:
                 - -c
                 - |
                   echo "Start experiment-status-updater job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentStatusUpdater"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentStatusUpdater"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
                   echo "experiment-status-updater job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
           restartPolicy: Never
 
 ---
@@ -58,9 +70,14 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.cronjob.experimentRunningWatcherSchedule }}
+  concurrencyPolicy: Forbid
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "{{ .Values.cronjob.experimentRunningWatcherSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           volumes:
@@ -90,16 +107,23 @@ spec:
                 - -c
                 - |
                   echo "Start experiment-running-watcher job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentRunningWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentRunningWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
                   echo "experiment-running-watcher job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
           restartPolicy: Never
 
 ---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: {{ template "batch-server.fullname" . }}-feature-state-watcher
+  name: {{ template "batch-server.fullname" . }}-feature-stale-watcher
   namespace: {{ .Values.namespace }}
   labels:
     app: {{ template "batch-server.name" . }}
@@ -107,9 +131,14 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.cronjob.featureStateWatcherSchedule }}
+  concurrencyPolicy: Forbid
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "{{ .Values.cronjob.featureStaleWatcherSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           volumes:
@@ -120,7 +149,7 @@ spec:
               secret:
                 secretName: {{ template "service-token-secret" . }}
           containers:
-            - name: feature-state-watcher
+            - name: feature-stale-watcher
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
               volumeMounts:
@@ -138,10 +167,17 @@ spec:
               args:
                 - -c
                 - |
-                  echo "Start feature-state-watcher job."
+                  echo "Start feature-stale-watcher job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "FeatureStateWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
-                  echo "feature-state-watcher job result: ${RES}"
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "FeatureStaleWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "feature-stale-watcher job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
           restartPolicy: Never
 
 ---
@@ -156,10 +192,14 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
+  concurrencyPolicy: Forbid
   timeZone: {{ .Values.env.timezone }}
-  schedule: {{ .Values.cronjob.mauCountWatcherSchedule }}
+  schedule: "{{ .Values.cronjob.mauCountWatcherSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           volumes:
@@ -189,11 +229,17 @@ spec:
                 - -c
                 - |
                   echo "Start mau-count-watcher job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "MauCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "MauCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
                   echo "mau-count-watcher job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
           restartPolicy: Never
-
 
 ---
 apiVersion: batch/v1
@@ -207,9 +253,14 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.cronjob.opsDatetimeWatcherSchedule }}
+  concurrencyPolicy: Forbid
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "{{ .Values.cronjob.opsDatetimeWatcherSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           volumes:
@@ -239,11 +290,17 @@ spec:
                 - -c
                 - |
                   echo "Start ops-datetime-watcher job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "DatetimeWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "DatetimeWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
                   echo "ops-datetime-watcher job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
           restartPolicy: Never
-
 
 ---
 apiVersion: batch/v1
@@ -257,9 +314,14 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.cronjob.opsEventCountWatcherSchedule }}
+  concurrencyPolicy: Forbid
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "{{ .Values.cronjob.opsEventCountWatcherSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         spec:
           volumes:
@@ -289,7 +351,14 @@ spec:
                 - -c
                 - |
                   echo "Start ops-event-count-watcher job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "EventCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "EventCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
                   echo "ops-event-count-watcher job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
           restartPolicy: Never

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "*/30 * * * *"
+  schedule: {{ .Values.cronjob.experimentStatusUpdaterSchedule }}
   jobTemplate:
     spec:
       template:
@@ -26,7 +26,7 @@ spec:
                 - "-d"
                 - '{"job": "ExperimentStatusUpdater"}'
                 - "-H"
-                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "authorization: bearer {{ template "service-token-secret" . }}"
                 - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
           restartPolicy: Never
 
@@ -42,7 +42,7 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "0 1 * * *"
+  schedule: {{ .Values.cronjob.experimentRunningWatcherSchedule }}
   jobTemplate:
     spec:
       template:
@@ -59,7 +59,7 @@ spec:
                 - "-d"
                 - '{"job": "ExperimentRunningWatcher"}'
                 - "-H"
-                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "authorization: bearer {{ template "service-token-secret" . }}"
                 - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
           restartPolicy: Never
 
@@ -75,7 +75,7 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "0 1 * * MON"
+  schedule: {{ .Values.cronjob.featureStateWatcherSchedule }}
   jobTemplate:
     spec:
       template:
@@ -92,7 +92,7 @@ spec:
                 - "-d"
                 - '{"job": "FeatureStateWatcher"}'
                 - "-H"
-                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "authorization: bearer {{ template "service-token-secret" . }}"
                 - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
           restartPolicy: Never
 
@@ -109,7 +109,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   timeZone: {{ .Values.env.timezone }}
-  schedule: "0 1 1 * *"
+  schedule: {{ .Values.cronjob.mauCountWatcherSchedule }}
   jobTemplate:
     spec:
       template:
@@ -126,7 +126,7 @@ spec:
                 - "-d"
                 - '{"job": "MauCountWatcher"}'
                 - "-H"
-                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "authorization: bearer {{ template "service-token-secret" . }}"
                 - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
           restartPolicy: Never
 
@@ -143,7 +143,7 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "* * * * *"
+  schedule: {{ .Values.cronjob.opsDatetimeWatcherSchedule }}
   jobTemplate:
     spec:
       template:
@@ -160,7 +160,7 @@ spec:
                 - "-d"
                 - '{"job": "DatetimeWatcher"}'
                 - "-H"
-                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "authorization: bearer {{ template "service-token-secret" . }}"
                 - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
           restartPolicy: Never
 
@@ -177,7 +177,7 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: "* * * * *"
+  schedule: {{ .Values.cronjob.opsEventCountWatcherSchedule }}}
   jobTemplate:
     spec:
       template:
@@ -194,6 +194,6 @@ spec:
                 - "-d"
                 - '{"job": "EventCountWatcher"}'
                 - "-H"
-                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "authorization: bearer {{ template "service-token-secret" . }}"
                 - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
           restartPolicy: Never

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ template "batch-server.name" . }}
     chart: {{ template "batch-server.chart" . }}
     release: {{ template "batch-server.fullname" . }}
-    heritage: {{ .Release.Service }} 
+    heritage: {{ .Release.Service }}
 spec:
   schedule: "*/30 * * * *"
   jobTemplate:
@@ -15,14 +15,20 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - curl
-          restartPolicy: OnFailure
+            - name: experiment-status-updater
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - "curl"
+              args:
+                - "-X"
+                - "POST"
+                - "-d"
+                - '{"job": "ExperimentStatusUpdater"}'
+                - "-H"
+                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+          restartPolicy: Never
 
 ---
 apiVersion: batch/v1
@@ -42,14 +48,20 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - date; echo Hello from the Kubernetes cluster
-          restartPolicy: OnFailure
+            - name: experiment-running-watcher
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - "curl"
+              args:
+                - "-X"
+                - "POST"
+                - "-d"
+                - '{"job": "ExperimentRunningWatcher"}'
+                - "-H"
+                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+          restartPolicy: Never
 
 ---
 apiVersion: batch/v1
@@ -69,14 +81,20 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - curl
-          restartPolicy: OnFailure
+            - name: feature-state-watcher
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - "curl"
+              args:
+                - "-X"
+                - "POST"
+                - "-d"
+                - '{"job": "FeatureStateWatcher"}'
+                - "-H"
+                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+          restartPolicy: Never
 
 ---
 apiVersion: batch/v1
@@ -97,14 +115,20 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - curl
-          restartPolicy: OnFailure
+            - name: mau-count-watcher
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - "curl"
+              args:
+                - "-X"
+                - "POST"
+                - "-d"
+                - '{"job": "MauCountWatcher"}'
+                - "-H"
+                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+          restartPolicy: Never
 
 
 ---
@@ -125,14 +149,20 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - curl
-          restartPolicy: OnFailure
+            - name: ops-datetime-watcher
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - "curl"
+              args:
+                - "-X"
+                - "POST"
+                - "-d"
+                - '{"job": "DatetimeWatcher"}'
+                - "-H"
+                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+          restartPolicy: Never
 
 
 ---
@@ -153,11 +183,17 @@ spec:
       template:
         spec:
           containers:
-          - name: hello
-            image: busybox:1.28
-            imagePullPolicy: IfNotPresent
-            command:
-            - /bin/sh
-            - -c
-            - curl
-          restartPolicy: OnFailure
+            - name: ops-event-count-watcher
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              command:
+                - "curl"
+              args:
+                - "-X"
+                - "POST"
+                - "-d"
+                - '{"job": "EventCountWatcher"}'
+                - "-H"
+                - "authorization: bearer {{ .Values.cronjob.token }}"
+                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+          restartPolicy: Never

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -362,3 +362,64 @@ spec:
                     exit 1
                   fi
           restartPolicy: Never
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-domain-event-informer
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  concurrencyPolicy: Forbid
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "{{ .Values.cronjob.domainEventInformerSchedule }}"
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
+          containers:
+            - name: ops-event-count-watcher
+              image: curlimages/curl:8.1.2
+              imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
+              command:
+                - /bin/sh
+              args:
+                - -c
+                - |
+                  echo "Start domain-event-informer job."
+                  ENDPOINT="${WEB_GATEWAY_ADDRESS}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "DomainEventInformer"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "ops-event-count-watcher job result: ${RES}"
+                  if [ "$RES" == 200 ]
+                  then
+                    exit 0
+                  else
+                    exit 1
+                  fi
+          restartPolicy: Never

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -14,20 +14,34 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
           containers:
             - name: experiment-status-updater
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
               command:
-                - "curl"
+                - /bin/sh
               args:
-                - "-X"
-                - "POST"
-                - "-d"
-                - '{"job": "ExperimentStatusUpdater"}'
-                - "-H"
-                - "authorization: bearer {{ template "service-token-secret" . }}"
-                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                - -c
+                - |
+                  echo "Start experiment-status-updater job."
+                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentStatusUpdater"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "experiment-status-updater job result: ${RES}"
           restartPolicy: Never
 
 ---
@@ -47,20 +61,34 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
           containers:
             - name: experiment-running-watcher
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
               command:
-                - "curl"
+                - /bin/sh
               args:
-                - "-X"
-                - "POST"
-                - "-d"
-                - '{"job": "ExperimentRunningWatcher"}'
-                - "-H"
-                - "authorization: bearer {{ template "service-token-secret" . }}"
-                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                - -c
+                - |
+                  echo "Start experiment-running-watcher job."
+                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentRunningWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "experiment-running-watcher job result: ${RES}"
           restartPolicy: Never
 
 ---
@@ -80,20 +108,34 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
           containers:
             - name: feature-state-watcher
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
               command:
-                - "curl"
+                - /bin/sh
               args:
-                - "-X"
-                - "POST"
-                - "-d"
-                - '{"job": "FeatureStateWatcher"}'
-                - "-H"
-                - "authorization: bearer {{ template "service-token-secret" . }}"
-                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                - -c
+                - |
+                  echo "Start feature-state-watcher job."
+                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "FeatureStateWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "feature-state-watcher job result: ${RES}"
           restartPolicy: Never
 
 ---
@@ -114,20 +156,34 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
           containers:
             - name: mau-count-watcher
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
               command:
-                - "curl"
+                - /bin/sh
               args:
-                - "-X"
-                - "POST"
-                - "-d"
-                - '{"job": "MauCountWatcher"}'
-                - "-H"
-                - "authorization: bearer {{ template "service-token-secret" . }}"
-                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                - -c
+                - |
+                  echo "Start mau-count-watcher job."
+                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "MauCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "mau-count-watcher job result: ${RES}"
           restartPolicy: Never
 
 
@@ -148,20 +204,34 @@ spec:
     spec:
       template:
         spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
           containers:
             - name: ops-datetime-watcher
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
               command:
-                - "curl"
+                - /bin/sh
               args:
-                - "-X"
-                - "POST"
-                - "-d"
-                - '{"job": "DatetimeWatcher"}'
-                - "-H"
-                - "authorization: bearer {{ template "service-token-secret" . }}"
-                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                - -c
+                - |
+                  echo "Start ops-datetime-watcher job."
+                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "DatetimeWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "ops-datetime-watcher job result: ${RES}"
           restartPolicy: Never
 
 
@@ -177,23 +247,37 @@ metadata:
     release: {{ template "batch-server.fullname" . }}
     heritage: {{ .Release.Service }}
 spec:
-  schedule: {{ .Values.cronjob.opsEventCountWatcherSchedule }}}
+  schedule: {{ .Values.cronjob.opsEventCountWatcherSchedule }}
   jobTemplate:
     spec:
       template:
         spec:
+          volumes:
+            - name: service-cert-secret
+              secret:
+                secretName: {{ template "service-cert-secret" . }}
+            - name: service-token-secret
+              secret:
+                secretName: {{ template "service-token-secret" . }}
           containers:
             - name: ops-event-count-watcher
               image: curlimages/curl:8.1.2
               imagePullPolicy: IfNotPresent
+              volumeMounts:
+                - name: service-cert-secret
+                  mountPath: /usr/local/certs/service
+                  readOnly: true
+                - name: service-token-secret
+                  mountPath: /usr/local/service-token
+                  readOnly: true
               command:
-                - "curl"
+                - /bin/sh
               args:
-                - "-X"
-                - "POST"
-                - "-d"
-                - '{"job": "EventCountWatcher"}'
-                - "-H"
-                - "authorization: bearer {{ template "service-token-secret" . }}"
-                - "https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                - -c
+                - |
+                  echo "Start ops-event-count-watcher job."
+                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
+                  TOKEN=`cat /usr/local/service-token/token`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "EventCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  echo "ops-event-count-watcher job result: ${RES}"
           restartPolicy: Never

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -32,15 +32,17 @@ spec:
                 - name: service-token-secret
                   mountPath: /usr/local/service-token
                   readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
               command:
                 - /bin/sh
               args:
                 - -c
                 - |
                   echo "Start experiment-status-updater job."
-                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentStatusUpdater"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentStatusUpdater"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
                   echo "experiment-status-updater job result: ${RES}"
           restartPolicy: Never
 
@@ -79,15 +81,17 @@ spec:
                 - name: service-token-secret
                   mountPath: /usr/local/service-token
                   readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
               command:
                 - /bin/sh
               args:
                 - -c
                 - |
                   echo "Start experiment-running-watcher job."
-                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentRunningWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "ExperimentRunningWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
                   echo "experiment-running-watcher job result: ${RES}"
           restartPolicy: Never
 
@@ -126,15 +130,17 @@ spec:
                 - name: service-token-secret
                   mountPath: /usr/local/service-token
                   readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
               command:
                 - /bin/sh
               args:
                 - -c
                 - |
                   echo "Start feature-state-watcher job."
-                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "FeatureStateWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "FeatureStateWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
                   echo "feature-state-watcher job result: ${RES}"
           restartPolicy: Never
 
@@ -174,15 +180,17 @@ spec:
                 - name: service-token-secret
                   mountPath: /usr/local/service-token
                   readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
               command:
                 - /bin/sh
               args:
                 - -c
                 - |
                   echo "Start mau-count-watcher job."
-                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "MauCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "MauCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
                   echo "mau-count-watcher job result: ${RES}"
           restartPolicy: Never
 
@@ -222,15 +230,17 @@ spec:
                 - name: service-token-secret
                   mountPath: /usr/local/service-token
                   readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
               command:
                 - /bin/sh
               args:
                 - -c
                 - |
                   echo "Start ops-datetime-watcher job."
-                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "DatetimeWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "DatetimeWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
                   echo "ops-datetime-watcher job result: ${RES}"
           restartPolicy: Never
 
@@ -270,14 +280,16 @@ spec:
                 - name: service-token-secret
                   mountPath: /usr/local/service-token
                   readOnly: true
+              env:
+                - name: WEB_GATEWAY_ADDRESS
+                  value: "{{ .Values.cronjob.webGatewayAddress }}"
               command:
                 - /bin/sh
               args:
                 - -c
                 - |
                   echo "Start ops-event-count-watcher job."
-                  ENDPOINT="https://web-gateway.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.cronjob.webGatewayPort }}/bucketeer.batch.BatchService/ExecuteBatchJob"
                   TOKEN=`cat /usr/local/service-token/token`
-                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "EventCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
+                  RES=`curl -X POST --cacert /usr/local/certs/service/tls.crt -d '{"job": "EventCountWatcher"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${WEB_GATEWAY_ADDRESS}`
                   echo "ops-event-count-watcher job result: ${RES}"
           restartPolicy: Never

--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -1,0 +1,163 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-experiment-status-updater
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }} 
+spec:
+  schedule: "*/30 * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - curl
+          restartPolicy: OnFailure
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-experiment-running-watcher
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "0 1 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - date; echo Hello from the Kubernetes cluster
+          restartPolicy: OnFailure
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-feature-state-watcher
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "0 1 * * MON"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - curl
+          restartPolicy: OnFailure
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-mau-count-watcher
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  timeZone: {{ .Values.env.timezone }}
+  schedule: "0 1 1 * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - curl
+          restartPolicy: OnFailure
+
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-ops-datetime-watcher
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - curl
+          restartPolicy: OnFailure
+
+
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ template "batch-server.fullname" . }}-ops-event-count-watcher
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: hello
+            image: busybox:1.28
+            imagePullPolicy: IfNotPresent
+            command:
+            - /bin/sh
+            - -c
+            - curl
+          restartPolicy: OnFailure

--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
               value: "{{ .Values.env.pullerMaxOutstandingMessages }}"
             - name: BUCKETEER_BATCH_PULLER_MAX_OUTSTANDING_BYTES
               value: "{{ .Values.env.pullerMaxOutstandingBytes }}"
+            - name: BUCKETEER_BATCH_RUNNING_DURATION_PER_BATCH
+              value: "{{ .Values.env.runningDurationPerBatch }}"
             - name: BUCKETEER_BATCH_MYSQL_USER
               value: "{{ .Values.env.mysqlUser }}"
             - name: BUCKETEER_BATCH_MYSQL_PASS

--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -115,14 +115,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -161,18 +164,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "batch-server.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "batch-server.name" . }}
+      release: {{ template "batch-server.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "batch-server.name" . }}
+        release: {{ template "batch-server.fullname" . }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/envoy-configmap.yaml") . | sha256sum }}
+    spec:
+      {{- with .Values.global.image.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      volumes:
+        - name: envoy-config
+          configMap:
+            name: {{ template "batch-server.fullname" . }}-envoy-config
+        - name: service-cert-secret
+          secret:
+            secretName: {{ template "service-cert-secret" . }}
+        - name: service-token-secret
+          secret:
+            secretName: {{ template "service-token-secret" . }} 
+      {{- if .Values.serviceAccount.annotations }}
+      serviceAccountName: {{ template "batch-server.fullname" . }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args: ["server"]
+          env:
+            - name: BUCKETEER_BATCH_PROJECT
+              value: "{{ .Values.env.project }}"
+            - name: BUCKETEER_BATCH_NOTIFICATION_SERVICE
+              value: "{{ .Values.env.notificationService }}"
+            - name: BUCKETEER_BATCH_ENVIRONMENT_SERVICE
+              value: "{{ .Values.env.environmentService }}"
+            - name: BUCKETEER_BATCH_AUTO_OPS_SERVICE
+              value: "{{ .Values.env.autoOpsService }}"
+            - name: BUCKETEER_BATCH_EXPERIMENT_SERVICE
+              value: "{{ .Values.env.experimentService }}"
+            - name: BUCKETEER_BATCH_EVENT_COUNTER_SERVICE
+              value: "{{ .Values.env.eventCounterService }}"
+            - name: BUCKETEER_BATCH_FEATURE_SERVICE
+              value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_BATCH_MYSQL_USER
+              value: "{{ .Values.env.mysqlUser }}"
+            - name: BUCKETEER_BATCH_MYSQL_PASS
+              value: "{{ .Values.env.mysqlPass }}"
+            - name: BUCKETEER_BATCH_MYSQL_HOST
+              value: "{{ .Values.env.mysqlHost }}"
+            - name: BUCKETEER_BATCH_MYSQL_PORT
+              value: "{{ .Values.env.mysqlPort }}"
+            - name: BUCKETEER_BATCH_MYSQL_DB_NAME
+              value: "{{ .Values.env.mysqlDbName }}"
+            - name: BUCKETEER_BATCH_WEB_URL
+              value: "{{ .Values.env.webURL }}"
+            - name: BUCKETEER_BATCH_LOG_LEVEL
+              value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_BATCH_REFRESH_INTERVAL
+              value: "{{ .Values.env.refreshInterval }}"
+            - name: BUCKETEER_BATCH_PORT
+              value: "{{ .Values.env.port }}"
+            - name: BUCKETEER_BATCH_METRICS_PORT
+              value: "{{ .Values.env.metricsPort }}"
+            - name: BUCKETEER_BATCH_SERVICE_TOKEN
+              value: /usr/local/service-token/token
+            - name: BUCKETEER_BATCH_CERT
+              value: /usr/local/certs/service/tls.crt
+            - name: BUCKETEER_BATCH_KEY
+              value: /usr/local/certs/service/tls.key
+            - name: BUCKETEER_BATCH_TIMEZONE
+              value: "{{ .Values.env.timezone }}"
+          volumeMounts:
+            - name: service-cert-secret
+              mountPath: /usr/local/certs/service
+              readOnly: true
+            - name: service-token-secret
+              mountPath: /usr/local/service-token
+              readOnly: true
+          ports:
+            - name: service
+              containerPort: {{ .Values.env.port }}
+            - name: metrics
+              containerPort: {{ .Values.env.metricsPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: envoy
+          image: "{{ .Values.envoy.image.repository }}:{{ .Values.envoy.image.tag }}"
+          imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "/bin/sh"
+                  - "-c"
+                  - "while [ $(netstat -plunt | grep tcp | grep -v envoy | wc -l) -ne 0 ]; do sleep 1; done;"
+          command: ["envoy"]
+          args:
+            - "-c"
+            - "/usr/local/conf/config.yaml"
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          volumeMounts:
+            - name: envoy-config
+              mountPath: /usr/local/conf/
+              readOnly: true
+            - name: service-cert-secret
+              mountPath: /usr/local/certs/service
+              readOnly: true
+          ports:
+            - name: envoy
+              containerPort: {{ .Values.envoy.port }}
+            - name: admin
+              containerPort: {{ .Values.envoy.adminPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.periodSeconds }}
+            httpGet:
+              path: /health
+              port: envoy
+              scheme: HTTPS
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            httpGet:
+              path: /health
+              port: envoy
+              scheme: HTTPS
+          resources:
+{{ toYaml .Values.envoy.resources | indent 12 }}
+  strategy:
+    type: RollingUpdate

--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -62,6 +62,16 @@ spec:
               value: "{{ .Values.env.eventCounterService }}"
             - name: BUCKETEER_BATCH_FEATURE_SERVICE
               value: "{{ .Values.env.featureService }}"
+            - name: BUCKETEER_BATCH_DOMAIN_TOPIC
+              value: "{{ .Values.env.domainTopic }}"
+            - name: BUCKETEER_BATCH_DOMAIN_SUBSCRIPTION
+              value: "{{ .Values.env.domainSubscription }}"
+            - name: BUCKETEER_BATCH_PULLER_NUM_GOROUTINES
+              value: "{{ .Values.env.pullerNumGoroutines }}"
+            - name: BUCKETEER_BATCH_PULLER_MAX_OUTSTANDING_MESSAGES
+              value: "{{ .Values.env.pullerMaxOutstandingMessages }}"
+            - name: BUCKETEER_BATCH_PULLER_MAX_OUTSTANDING_BYTES
+              value: "{{ .Values.env.pullerMaxOutstandingBytes }}"
             - name: BUCKETEER_BATCH_MYSQL_USER
               value: "{{ .Values.env.mysqlUser }}"
             - name: BUCKETEER_BATCH_MYSQL_PASS

--- a/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
@@ -126,6 +126,8 @@ data:
                                 exact: /health
                           pass_through_mode: false
                       - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     route_config:
                       virtual_hosts:
                         - domains:
@@ -178,6 +180,8 @@ data:
                     codec_type: auto
                     http_filters:
                       - name: envoy.filters.http.router
+                        typed_config:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     route_config:
                       virtual_hosts:
                         - domains:

--- a/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
@@ -130,22 +130,22 @@ data:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     route_config:
                       virtual_hosts:
-                        - domains:
+                        - name: ingress_services
+                          domains:
                             - '*'
-                          name: ingress_services
                           routes:
                             - match:
                                 headers:
                                   - name: content-type
                                     string_match:
                                       exact: application/grpc
-                                prefix: /bucketeer.batch.BatchService
+                                prefix: /
                               route:
                                 cluster: batch
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx
-                                timeout: 15s
+                                timeout: 3600s
                     stat_prefix: ingress_http
                     stream_idle_timeout: 3600s
               transport_socket:
@@ -184,10 +184,22 @@ data:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                     route_config:
                       virtual_hosts:
-                        - domains:
+                        - name: egress_services
+                          domains:
                             - '*'
-                          name: egress_services
                           routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.autoops.AutoOpsService
+                              route:
+                                cluster: backend
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
                             - match:
                                 headers:
                                   - name: content-type
@@ -248,18 +260,6 @@ data:
                                   num_retries: 3
                                   retry_on: 5xx
                                 timeout: 15s
-                            - match:
-                                prefix: /bucketeer.autoops.AutoOpsService
-                                headers:
-                                  - name: content-type
-                                    string_match:
-                                      exact: application/grpc
-                                route:
-                                  cluster: backend
-                                  retry_policy:
-                                    num_retries: 3
-                                    retry_on: 5xx
-                                  timeout: 15s
                     stat_prefix: egress_http
                     stream_idle_timeout: 3600s
               transport_socket:

--- a/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
@@ -1,0 +1,273 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "batch-server.fullname" . }}-envoy-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+data:
+  config.yaml: |-
+    admin:
+      access_log:
+        name: envoy.access_loggers.file
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+          path: /dev/stdout
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8001
+    static_resources:
+      clusters:
+        - name: batch-server
+          type: strict_dns
+          lb_policy: round_robin
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          load_assignment:
+            cluster_name: batch-server
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: localhost
+                          port_value: 9090
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          health_checks:
+            - grpc_health_check: {}
+              healthy_threshold: 1
+              interval: 10s
+              interval_jitter: 1s
+              no_traffic_interval: 2s
+              timeout: 1s
+              unhealthy_threshold: 2
+          ignore_health_on_host_removal: true
+
+        - name: backend
+          type: strict_dns
+          lb_policy: round_robin
+          connect_timeout: 5s
+          dns_lookup_family: V4_ONLY
+          load_assignment:
+            cluster_name: backend
+            endpoints:
+              - lb_endpoints:
+                  - endpoint:
+                      address:
+                        socket_address:
+                          address: backend.{{ .Values.namespace }}.svc.cluster.local
+                          port_value: 9000
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols:
+                  - h2
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          ignore_health_on_host_removal: true
+
+      listeners:
+        - name: ingress
+          address:
+            socket_address:
+              address: 0.0.0.0
+              port_value: 9000
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    access_log:
+                      name: envoy.access_loggers.file
+                      typed_config:
+                        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                    codec_type: auto
+                    http_filters:
+                      - name: envoy.filters.http.health_check
+                        typed_config:
+                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                          cluster_min_healthy_percentages:
+                            batch-server:
+                              value: 25
+                          headers:
+                            - name: :path
+                              string_match:
+                                exact: /health
+                          pass_through_mode: false
+                      - name: envoy.filters.http.router
+                    route_config:
+                      virtual_hosts:
+                        - domains:
+                            - '*'
+                          name: ingress_services
+                          routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /
+                              route:
+                                cluster: batch-server
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                    stat_prefix: ingress_http
+                    stream_idle_timeout: 3600s
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    alpn_protocols:
+                      - h2
+                    tls_certificates:
+                      - certificate_chain:
+                          filename: /usr/local/certs/service/tls.crt
+                        private_key:
+                          filename: /usr/local/certs/service/tls.key
+                  require_client_certificate: true
+
+        - name: egress
+          address:
+            socket_address:
+              address: 127.0.0.1
+              port_value: 9001
+          filter_chains:
+            - filters:
+                - name: envoy.filters.network.http_connection_manager
+                  typed_config:
+                    '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                    access_log:
+                      name: envoy.access_loggers.file
+                      typed_config:
+                        '@type': type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                        path: /dev/stdout
+                    codec_type: auto
+                    http_filters:
+                      - name: envoy.filters.http.router
+                    route_config:
+                      virtual_hosts:
+                        - domains:
+                            - '*'
+                          name: egress_services
+                          routes:
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.notification.NotificationService
+                              route:
+                                cluster: backend
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.environment.EnvironmentService
+                              route:
+                                cluster: backend
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.experiment.ExperimentService
+                              route:
+                                cluster: backend
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.eventcounter.EventCounterService
+                              route:
+                                cluster: backend
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 3600s
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                prefix: /bucketeer.feature.FeatureService
+                              route:
+                                cluster: backend
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                                timeout: 15s
+                            - match:
+                                prefix: /bucketeer.autoops.AutoOpsService
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
+                                route:
+                                  cluster: backend
+                                  retry_policy:
+                                    num_retries: 3
+                                    retry_on: 5xx
+                                  timeout: 15s
+                    stat_prefix: egress_http
+                    stream_idle_timeout: 3600s
+              transport_socket:
+                name: envoy.transport_sockets.tls
+                typed_config:
+                  '@type': type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+                  common_tls_context:
+                    alpn_protocols:
+                      - h2
+                    tls_certificates:
+                      - certificate_chain:
+                          filename: /usr/local/certs/service/tls.crt
+                        private_key:
+                          filename: /usr/local/certs/service/tls.key
+                  require_client_certificate: true

--- a/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
@@ -22,13 +22,13 @@ data:
           port_value: 8001
     static_resources:
       clusters:
-        - name: batch-server
+        - name: batch
           type: strict_dns
           lb_policy: round_robin
           connect_timeout: 5s
           dns_lookup_family: V4_ONLY
           load_assignment:
-            cluster_name: batch-server
+            cluster_name: batch
             endpoints:
               - lb_endpoints:
                   - endpoint:
@@ -118,7 +118,7 @@ data:
                         typed_config:
                           '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
                           cluster_min_healthy_percentages:
-                            batch-server:
+                            batch:
                               value: 25
                           headers:
                             - name: :path
@@ -137,9 +137,9 @@ data:
                                   - name: content-type
                                     string_match:
                                       exact: application/grpc
-                                prefix: /
+                                prefix: /bucketeer.batch.BatchService
                               route:
-                                cluster: batch-server
+                                cluster: batch
                                 retry_policy:
                                   num_retries: 3
                                   retry_on: 5xx

--- a/manifests/bucketeer/charts/batch/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/batch/templates/pdb.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "batch-server.fullname" . }}
+  namespace: {{ .Values.namespace }}
+spec:
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      app: {{ template "batch-server.name" . }}
+{{ end }}

--- a/manifests/bucketeer/charts/batch/templates/service-account.yaml
+++ b/manifests/bucketeer/charts/batch/templates/service-account.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.annotations }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+    namespace: {{ .Values.namespace }}
+    name: {{ template "batch-server.fullname" . }}
+    annotations: {{ toYaml .Values.serviceAccount.annotations | nindent 8 }}
+{{- end }}

--- a/manifests/bucketeer/charts/batch/templates/service-cert-secret.yaml
+++ b/manifests/bucketeer/charts/batch/templates/service-cert-secret.yaml
@@ -1,0 +1,16 @@
+{{- if not .Values.tls.service.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "batch-server.fullname" . }}-service-cert
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  tls.crt: {{ required "Service TLS certificate is required" .Values.tls.service.cert | b64enc | quote }}
+  tls.key: {{ required "Service TLS key is required" .Values.tls.service.key | b64enc | quote }}
+{{- end }}

--- a/manifests/bucketeer/charts/batch/templates/service-token-secret.yaml
+++ b/manifests/bucketeer/charts/batch/templates/service-token-secret.yaml
@@ -1,0 +1,15 @@
+{{- if not .Values.serviceToken.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "batch-server.fullname" . }}-service-token
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  token: {{ required "Service token is required" .Values.serviceToken.token | b64enc | quote }}
+{{- end }}

--- a/manifests/bucketeer/charts/batch/templates/service.yaml
+++ b/manifests/bucketeer/charts/batch/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "batch-server.fullname" . }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "batch-server.name" . }}
+    chart: {{ template "batch-server.chart" . }}
+    release: {{ template "batch-server.fullname" . }}
+    heritage: {{ .Release.Service }}
+    envoy: "true"
+    metrics: "true"
+spec:
+  type: {{ .Values.service.type }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  ports:
+    - name: service
+      port: {{ .Values.service.externalPort }}
+      targetPort: envoy
+      protocol: TCP
+    - name: metrics
+      port: {{ .Values.env.metricsPort }}
+      protocol: TCP
+    - name: admin
+      port: {{ .Values.envoy.adminPort }}
+      protocol: TCP
+  selector:
+    app: {{ template "batch-server.name" . }}
+    release: {{ template "batch-server.fullname" . }}

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -34,8 +34,8 @@ replicaCount: 1
 
 envoy:
   image:
-    repository: envoyproxy/envoy-alpine
-    tag: v1.21.1
+    repository: ghcr.io/bucketeer-io/bucketeer-envoy
+    tag: v1.26.2
     pullPolicy: IfNotPresent
   config:
   port: 9000
@@ -68,5 +68,10 @@ serviceAccount:
   annotations: {}
 
 cronjob:
-  token:
+  experimentStatusUpdaterSchedule: "*/30 * * * *"
+  experimentRunningWatcherSchedule: "0 1 * * *"
+  featureStateWatcherSchedule: "0 1 * * MON"
+  mauCountWatcherSchedule: "0 1 1 * *"
+  opsDatetimeWatcherSchedule: "* * * * *"
+  opsEventCountWatcherSchedule: "* * * * *"
   webGatewayPort: 9000

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -68,10 +68,10 @@ serviceAccount:
   annotations: {}
 
 cronjob:
+  webGatewayAddress: https://web-gateway.default.svc.cluster.local:9000
   experimentStatusUpdaterSchedule: "*/30 * * * *"
   experimentRunningWatcherSchedule: "0 1 * * *"
   featureStateWatcherSchedule: "0 1 * * MON"
   mauCountWatcherSchedule: "0 1 1 * *"
   opsDatetimeWatcherSchedule: "* * * * *"
   opsEventCountWatcherSchedule: "* * * * *"
-  webGatewayPort: 9000

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -24,7 +24,7 @@ env:
   port: 9090
   metricsPort: 9002
   timezone: UTC
-  refreshInterval:
+  refreshInterval: 10m
 
 affinity: {}
 
@@ -68,10 +68,12 @@ serviceAccount:
   annotations: {}
 
 cronjob:
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
   webGatewayAddress: https://web-gateway.default.svc.cluster.local:9000
   experimentStatusUpdaterSchedule: "*/30 * * * *"
   experimentRunningWatcherSchedule: "0 1 * * *"
-  featureStateWatcherSchedule: "0 1 * * MON"
+  featureStaleWatcherSchedule: "0 1 * * MON"
   mauCountWatcherSchedule: "0 1 1 * *"
   opsDatetimeWatcherSchedule: "* * * * *"
   opsEventCountWatcherSchedule: "* * * * *"

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -30,6 +30,7 @@ env:
   pullerNumGoroutines: 5
   pullerMaxOutstandingMessages: "1000"
   pullerMaxOutstandingBytes: "1000000000"
+  runningDurationPerBatch: 30s
 
 affinity: {}
 
@@ -82,3 +83,4 @@ cronjob:
   mauCountWatcherSchedule: "0 1 1 * *"
   opsDatetimeWatcherSchedule: "* * * * *"
   opsEventCountWatcherSchedule: "* * * * *"
+  domainEventInformerSchedule: "* * * * *"

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -25,6 +25,11 @@ env:
   metricsPort: 9002
   timezone: UTC
   refreshInterval: 10m
+  domainTopic:
+  domainSubscription:
+  pullerNumGoroutines: 5
+  pullerMaxOutstandingMessages: "1000"
+  pullerMaxOutstandingBytes: "1000000000"
 
 affinity: {}
 

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -30,7 +30,7 @@ env:
   pullerNumGoroutines: 5
   pullerMaxOutstandingMessages: "1000"
   pullerMaxOutstandingBytes: "1000000000"
-  runningDurationPerBatch: 30s
+  runningDurationPerBatch: 15s
 
 affinity: {}
 
@@ -64,9 +64,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -66,3 +66,7 @@ resources: {}
 
 serviceAccount:
   annotations: {}
+
+cronjob:
+  token:
+  webGatewayPort: 9000

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -1,0 +1,68 @@
+image:
+  repository: ghcr.io/bucketeer-io/bucketeer-batch
+  pullPolicy: IfNotPresent
+
+fullnameOverride: "batch-server"
+
+namespace: default
+
+env:
+  project:
+  mysqlUser:
+  mysqlPass:
+  mysqlHost:
+  mysqlPort:
+  mysqlDBName:
+  notificationService: localhost:9001
+  environmentService: localhost:9001
+  autoOpsService: localhost:9001
+  experimentService: localhost:9001
+  eventCounterService: localhost:9001
+  featureService: localhost:9001
+  webURL:
+  logLevel: info
+  port: 9090
+  metricsPort: 9002
+  timezone: UTC
+  refreshInterval:
+
+affinity: {}
+
+nodeSelector: {}
+
+replicaCount: 1
+
+envoy:
+  image:
+    repository: envoyproxy/envoy-alpine
+    tag: v1.21.1
+    pullPolicy: IfNotPresent
+  config:
+  port: 9000
+  adminPort: 8001
+  resources: {}
+
+tls:
+  service:
+    secret:
+    cert:
+    key:
+
+serviceToken:
+  secret:
+  token:
+
+service:
+  type: ClusterIP
+  clusterIP: None
+  externalPort: 9000
+
+health:
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  failureThreshold: 10
+
+resources: {}
+
+serviceAccount:
+  annotations: {}


### PR DESCRIPTION
## Summary
* This PR will create the new batch service helm charts
* Aside the batch service deployment, there is also contain the cronjob of batch service API call

### Batch service API call
Currently we have Envoy gRPCJsonTranscoder, so I am using `Curl` Docker image to make requests against the `web-gateway`.

The batch job gRPC service [proto file](https://github.com/bucketeer-io/bucketeer/pull/450/files#diff-4a0ee597c9cb3813733ef8488a35bb75aa660c13f9a251b08f2412f9a6c4c741). 


## Other
The cronjob in `pkg/opsevent/cmd/batch/batch.go` was executed every 10 second. 
Reference: https://github.com/bucketeer-io/bucketeer/issues/428#issuecomment-1614321392

But the cronjob in kubernetes can't schedule job in second level, so currently we are executing these jobs every minute.
Reference: https://github.com/bucketeer-io/bucketeer/issues/428#issuecomment-1617417630