### PR TITLE
chore: change list experiments condition in the event persister

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: "{{ .Values.env.port }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_METRICS_PORT
               value: "{{ .Values.env.metricsPort }}"
+            - name: BUCKETEER_EVENT_PERSISTER_DWH_TIMEZONE
+              value: "{{ .Values.env.timezone }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_LOG_LEVEL
               value: "{{ .Values.env.logLevel }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_MAX_MPS

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
@@ -12,6 +12,7 @@ env:
   logLevel: info
   port: 9090
   metricsPort: 9002
+  timezone: UTC
   # egress services
   experimentService: localhost:9001
   featureService: localhost:9001

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
@@ -61,6 +61,8 @@ spec:
               value: "{{ .Values.env.port }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_METRICS_PORT
               value: "{{ .Values.env.metricsPort }}"
+            - name: BUCKETEER_EVENT_PERSISTER_DWH_TIMEZONE
+              value: "{{ .Values.env.timezone }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_LOG_LEVEL
               value: "{{ .Values.env.logLevel }}"
             - name: BUCKETEER_EVENT_PERSISTER_DWH_MAX_MPS

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/values.yaml
@@ -12,6 +12,7 @@ env:
   logLevel: info
   port: 9090
   metricsPort: 9002
+  timezone: UTC
   # egress services
   experimentService: localhost:9001
   featureService: localhost:9001

--- a/pkg/eventpersisterdwh/persister/evaluation_event.go
+++ b/pkg/eventpersisterdwh/persister/evaluation_event.go
@@ -38,6 +38,7 @@ type evalEvtWriter struct {
 	writer           storage.EvalEventWriter
 	experimentClient ec.Client
 	flightgroup      singleflight.Group
+	location         *time.Location
 	logger           *zap.Logger
 }
 
@@ -48,6 +49,7 @@ func NewEvalEventWriter(
 	exClient ec.Client,
 	project, ds string,
 	size int,
+	location *time.Location,
 ) (Writer, error) {
 	evt := epproto.EvaluationEvent{}
 	evalQuery, err := writer.NewWriter(
@@ -65,6 +67,7 @@ func NewEvalEventWriter(
 	return &evalEvtWriter{
 		writer:           storage.NewEvalEventWriter(evalQuery, size),
 		experimentClient: exClient,
+		location:         location,
 		logger:           l,
 	}, nil
 }
@@ -202,6 +205,7 @@ func (w *evalEvtWriter) listExperiments(
 					EnvironmentNamespace: environmentNamespace,
 					Statuses: []exproto.Experiment_Status{
 						exproto.Experiment_RUNNING,
+						exproto.Experiment_STOPPED,
 					},
 				})
 				if err != nil {
@@ -220,5 +224,16 @@ func (w *evalEvtWriter) listExperiments(
 		handledCounter.WithLabelValues(codeFailedToListExperiments).Inc()
 		return nil, err
 	}
-	return exp.([]*exproto.Experiment), nil
+	// Filter the stopped experiments
+	// Because the evaluation and goal events may be sent with a delay for many reasons from the client side,
+	// we still calculate the results for two days after it stopped.
+	now := time.Now().In(w.location)
+	experiments := make([]*exproto.Experiment, 0, len(exp.([]*exproto.Experiment)))
+	for _, e := range exp.([]*exproto.Experiment) {
+		if e.Status == exproto.Experiment_STOPPED && now.Unix()-e.StopAt > 2*day {
+			continue
+		}
+		experiments = append(experiments, e)
+	}
+	return experiments, nil
 }

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	listRequestSize = 500
+	day             = 24 * 60 * 60
 )
 
 var (


### PR DESCRIPTION
Because the evaluation and goal events may be sent with a delay for many reasons from the client side,
We should still calculate the results after the experiment stops.

E2E tests have passed.