### PR TITLE
chore: allow calculator image tag to be set individually

### DIFF
--- a/manifests/bucketeer/charts/calculator/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/calculator/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.global.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: BUCKETEER_CALCULATOR_PROJECT

--- a/manifests/bucketeer/charts/calculator/values.yaml
+++ b/manifests/bucketeer/charts/calculator/values.yaml
@@ -2,6 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/bucketeer-io/bucketeer-calculator
+  tag:
   pullPolicy: IfNotPresent
 
 fullnameOverride: "calculator"


### PR DESCRIPTION
- This PR allows calculator image tag to be set individually.
  - The calculator(Python) will be replaced by the experiment-calculator(Go) in the future, so we decided to stop new calculator image builds from now on.