### PR TITLE
chore: add stop function to be called when the app gets the sigterm signal

### DIFF
--- a/pkg/account/cmd/apikeycacher/apikeycacher.go
+++ b/pkg/account/cmd/apikeycacher/apikeycacher.go
@@ -175,6 +175,11 @@ func (c *apiKeyCacher) Run(ctx context.Context, metrics metrics.Metrics, logger 
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/auditlog/cmd/persister/persister.go
+++ b/pkg/auditlog/cmd/persister/persister.go
@@ -136,6 +136,11 @@ func (p *persister) Run(ctx context.Context, metrics metrics.Metrics, logger *za
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/eventpersister/cmd/server/server.go
+++ b/pkg/eventpersister/cmd/server/server.go
@@ -172,6 +172,11 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/eventpersisterdwh/cmd/server/eventpersisterdwh.go
+++ b/pkg/eventpersisterdwh/cmd/server/eventpersisterdwh.go
@@ -203,6 +203,11 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/eventpersisterops/cmd/server/eventpersisterops.go
+++ b/pkg/eventpersisterops/cmd/server/eventpersisterops.go
@@ -219,6 +219,11 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/experimentcalculator/cmd/server/server.go
+++ b/pkg/experimentcalculator/cmd/server/server.go
@@ -174,6 +174,11 @@ func (s server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.Lo
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/feature/cmd/recorder/recorder.go
+++ b/pkg/feature/cmd/recorder/recorder.go
@@ -145,6 +145,11 @@ func (r *recorder) Run(ctx context.Context, metrics metrics.Metrics, logger *zap
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/feature/cmd/segmentpersister/persister.go
+++ b/pkg/feature/cmd/segmentpersister/persister.go
@@ -191,6 +191,11 @@ func (p *persister) Run(ctx context.Context, metrics metrics.Metrics, logger *za
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/gateway/cmd/server.go
+++ b/pkg/gateway/cmd/server.go
@@ -299,6 +299,12 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer httpServer.Stop(10 * time.Second)
 	go httpServer.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+	defer restHealthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -136,3 +136,7 @@ func (hc *checker) getStatus() Status {
 func (hc *checker) setStatus(s Status) {
 	atomic.StoreUint32(&hc.status, uint32(s))
 }
+
+func (hc *checker) Stop() {
+	hc.setStatus(Unhealthy)
+}

--- a/pkg/metricsevent/cmd/persister/persister.go
+++ b/pkg/metricsevent/cmd/persister/persister.go
@@ -119,6 +119,11 @@ func (p *persister) Run(ctx context.Context, metrics metrics.Metrics, logger *za
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/notification/cmd/sender/sender.go
+++ b/pkg/notification/cmd/sender/sender.go
@@ -272,6 +272,11 @@ func (s *sender) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/opsevent/cmd/batch/batch.go
+++ b/pkg/opsevent/cmd/batch/batch.go
@@ -210,6 +210,11 @@ func (b *batch) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.Lo
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/push/cmd/sender/sender.go
+++ b/pkg/push/cmd/sender/sender.go
@@ -194,6 +194,11 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }

--- a/pkg/user/cmd/persister/persister.go
+++ b/pkg/user/cmd/persister/persister.go
@@ -151,6 +151,11 @@ func (p *persister) Run(ctx context.Context, metrics metrics.Metrics, logger *za
 	defer server.Stop(10 * time.Second)
 	go server.Run()
 
+	// Ensure to stop the health check before stopping the application
+	// so the Kubernetes Readiness can detect it faster and remove the pod
+	// from the service load balancer.
+	defer healthChecker.Stop()
+
 	<-ctx.Done()
 	return nil
 }


### PR DESCRIPTION
Ensure to stop the health check before stopping the application so the Kubernetes Readiness can detect it faster and remove the pod from the service load balancer.