### PR TITLE
chore: remove envoy health check

### DIFF
--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/deployment.yaml
@@ -100,15 +100,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -147,19 +149,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: backend
           type: strict_dns
@@ -113,17 +105,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            account-apikey-cacher:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/account-apikey-cacher/values.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/values.yaml
@@ -64,9 +64,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/api-gateway/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/deployment.yaml
@@ -107,15 +107,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service

--- a/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/envoy-configmap.yaml
@@ -25,14 +25,6 @@ data:
         - name: api-gateway
           connect_timeout: 5s
           ignore_health_on_host_removal: true
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           circuit_breakers:
             thresholds:
               - priority: DEFAULT
@@ -71,16 +63,6 @@ data:
         - name: api-gateway-rest-v1
           connect_timeout: 5s
           ignore_health_on_host_removal: true
-          health_checks:
-            - http_health_check:
-                path: /v1/gateway/health
-                codec_client_type: 1 # http2.0
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           circuit_breakers:
             thresholds:
               - priority: DEFAULT

--- a/manifests/bucketeer/charts/api-gateway/values.yaml
+++ b/manifests/bucketeer/charts/api-gateway/values.yaml
@@ -63,11 +63,11 @@ ingress:
   staticIPName:
 health:
   livenessProbe:
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 3
     failureThreshold: 5
   readinessProbe:
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 3
     failureThreshold: 2
 resources: {}

--- a/manifests/bucketeer/charts/auditlog-persister/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/auditlog-persister/templates/deployment.yaml
@@ -94,15 +94,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -141,19 +143,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/auditlog-persister/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/auditlog-persister/templates/envoy-configmap.yaml
@@ -54,14 +54,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
       listeners:
         - name: ingress
           address:
@@ -80,17 +72,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            auditlog-persister:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/auditlog-persister/values.yaml
+++ b/manifests/bucketeer/charts/auditlog-persister/values.yaml
@@ -60,9 +60,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -190,9 +190,9 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: health-check
@@ -239,21 +239,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
             initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/backend/templates/envoy-configmap.yaml
@@ -115,15 +115,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: { }
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
-          ignore_health_on_host_removal: true
         - name: auditlog
           type: strict_dns
           connect_timeout: 5s
@@ -155,14 +146,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: { }
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: autoops
           type: strict_dns
@@ -195,14 +178,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: { }
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: environment
           type: strict_dns
@@ -267,14 +242,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: experiment
           type: strict_dns
@@ -455,17 +422,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            healthcheck:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -109,9 +109,10 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
   readinessProbe:
     initialDelaySeconds: 10
     periodSeconds: 3

--- a/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/calculator/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -114,17 +106,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            calculator:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/dex/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/dex/templates/deployment.yaml
@@ -52,6 +52,25 @@ spec:
             - name: cert
               mountPath: /etc/dex/tls
               readOnly: true
+          ports:
+            - name: admin
+              containerPort: {{ .Values.envoy.adminPort }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
+            httpGet:
+              path: /ready
+              port: admin
+              scheme: HTTP
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
         - name: {{ .Chart.Name }}
@@ -95,19 +114,23 @@ spec:
             - name: db
               mountPath: /etc/dex/db
           ports:
-            - name: https
+            - name: service
               containerPort: {{ .Values.service.internalPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
-              port: {{ .Values.service.internalPort }}
+              port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
-              port: {{ .Values.service.internalPort }}
+              port: service
               scheme: HTTPS
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/manifests/bucketeer/charts/dex/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/dex/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
             periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
+              path: /dex/healthz
               port: service
               scheme: HTTPS
           readinessProbe:
@@ -129,7 +129,7 @@ spec:
             periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
             failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
+              path: /dex/healthz
               port: service
               scheme: HTTPS
           resources:

--- a/manifests/bucketeer/charts/dex/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/dex/templates/envoy-configmap.yaml
@@ -54,16 +54,7 @@ data:
                     filename: /etc/dex/tls/tls.crt
                   private_key:
                     filename: /etc/dex/tls/tls.key
-          health_checks:
-            - http_health_check:
-                path: /dex/healthz
-                codec_client_type: HTTP2
-              healthy_threshold: 2
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
+
       listeners:
         - name: ingress
           address:
@@ -82,20 +73,9 @@ data:
                       path: /dev/stdout
                   codec_type: auto
                   http_filters:
-                  - name: envoy.filters.http.health_check
-                    typed_config:
-                      '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                      cluster_min_healthy_percentages:
-                        dex:
-                          value: 100
-                      headers:
-                        - name: :path
-                          string_match:
-                            exact: /health
-                      pass_through_mode: false
-                  - name: envoy.filters.http.router
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                    - name: envoy.filters.http.router
+                      typed_config:
+                        "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
                   route_config:
                     virtual_hosts:
                       - domains:

--- a/manifests/bucketeer/charts/dex/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/dex/templates/envoy-configmap.yaml
@@ -41,7 +41,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 5556
+                          port_value: {{ .Values.service.dexPort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:

--- a/manifests/bucketeer/charts/dex/values.yaml
+++ b/manifests/bucketeer/charts/dex/values.yaml
@@ -45,7 +45,14 @@ envoy:
       memory: 64Mi
 
 health:
-  initialDelaySeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources:
   limits:

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/deployment.yaml
@@ -102,15 +102,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -148,19 +150,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources: {{ toYaml .Values.envoy.resources | nindent 12 }}
   strategy:
     type: RollingUpdate

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -114,17 +106,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            event-persister-evaluation-events-dwh:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/values.yaml
@@ -64,9 +64,14 @@ serviceToken:
   token:
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/deployment.yaml
@@ -106,15 +106,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -153,19 +155,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress
@@ -80,17 +72,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            event-persister-evaluation-events-evaluation-count:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/values.yaml
@@ -61,9 +61,14 @@ serviceToken:
   token:
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/deployment.yaml
@@ -106,15 +106,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -152,19 +154,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources: {{ toYaml .Values.envoy.resources | nindent 12 }}
   strategy:
     type: RollingUpdate

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -113,17 +105,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            event-persister-evaluation-events-ops:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/values.yaml
@@ -68,9 +68,14 @@ serviceToken:
   token:
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/deployment.yaml
@@ -102,15 +102,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -148,19 +150,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources: {{ toYaml .Values.envoy.resources | nindent 12 }}
   strategy:
     type: RollingUpdate

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -114,17 +106,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            event-persister-goal-events-dwh:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/values.yaml
@@ -64,9 +64,14 @@ serviceToken:
   token:
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/deployment.yaml
@@ -106,15 +106,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -152,19 +154,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources: {{ toYaml .Values.envoy.resources | nindent 12 }}
   strategy:
     type: RollingUpdate

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -114,17 +106,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            event-persister-goal-events-ops:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/values.yaml
@@ -68,9 +68,14 @@ serviceToken:
   token:
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/experiment-calculator/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/experiment-calculator/templates/deployment.yaml
@@ -120,22 +120,22 @@ spec:
               containerPort: {{ .Values.env.port }}
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: service
-              scheme: HTTPS
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
           livenessProbe:
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /health
+              port: service
+              scheme: HTTPS
           resources:
 {{ toYaml .Values.resources | indent 12 }}
         - name: envoy
@@ -170,19 +170,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/experiment-calculator/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/experiment-calculator/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
         - name: backend
           type: strict_dns
@@ -113,17 +105,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            calculator:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/experiment-calculator/values.yaml
+++ b/manifests/bucketeer/charts/experiment-calculator/values.yaml
@@ -76,12 +76,17 @@ service:
   externalPort: 9000
 
 health:
-  periodSeconds: 10
-  failureThreshold: 10
   # It is necessary to wait for the model compilation to be done.
   # The duration is up to resources.
   # cf. CPU: 500m, MEM: 3Gi -> 280sec
-  initialDelaySeconds:
+  livenessProbe:
+    initialDelaySeconds: 300
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 300
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/feature-recorder/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/feature-recorder/templates/deployment.yaml
@@ -96,15 +96,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -143,19 +145,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/feature-recorder/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature-recorder/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress
@@ -80,17 +72,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature-recorder:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/feature-recorder/values.yaml
+++ b/manifests/bucketeer/charts/feature-recorder/values.yaml
@@ -65,9 +65,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/feature-segment-persister/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/feature-segment-persister/templates/deployment.yaml
@@ -104,15 +104,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -151,19 +153,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/feature-segment-persister/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/feature-segment-persister/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress
@@ -80,17 +72,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            feature-segment-persister:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/feature-segment-persister/values.yaml
+++ b/manifests/bucketeer/charts/feature-segment-persister/values.yaml
@@ -66,9 +66,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/metrics-event-persister/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/metrics-event-persister/templates/deployment.yaml
@@ -84,15 +84,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -131,19 +133,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/metrics-event-persister/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/metrics-event-persister/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress
@@ -80,17 +72,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            metrics-event-persister:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/metrics-event-persister/values.yaml
+++ b/manifests/bucketeer/charts/metrics-event-persister/values.yaml
@@ -55,9 +55,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/notification-sender/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/deployment.yaml
@@ -109,14 +109,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -155,18 +158,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/notification-sender/templates/envoy-configmap.yaml
@@ -54,14 +54,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -115,17 +107,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            notification-sender:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/notification-sender/values.yaml
+++ b/manifests/bucketeer/charts/notification-sender/values.yaml
@@ -61,9 +61,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/ops-event-batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/deployment.yaml
@@ -99,14 +99,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -145,18 +148,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -114,17 +106,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            ops-event-batch:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/ops-event-batch/values.yaml
+++ b/manifests/bucketeer/charts/ops-event-batch/values.yaml
@@ -56,8 +56,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/push-sender/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/deployment.yaml
@@ -101,14 +101,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -147,18 +150,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/push-sender/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
 
         - name: backend
@@ -114,17 +106,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            push-sender:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/push-sender/values.yaml
+++ b/manifests/bucketeer/charts/push-sender/values.yaml
@@ -58,9 +58,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/user-persister/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/user-persister/templates/deployment.yaml
@@ -100,15 +100,17 @@ spec:
             - name: metrics
               containerPort: {{ .Values.env.metricsPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /health
               port: service
@@ -147,19 +149,21 @@ spec:
             - name: admin
               containerPort: {{ .Values.envoy.adminPort }}
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
-              path: /health
-              port: envoy
-              scheme: HTTPS
+              path: /ready
+              port: admin
+              scheme: HTTP
           resources:
 {{ toYaml .Values.envoy.resources | indent 12 }}
   strategy:

--- a/manifests/bucketeer/charts/user-persister/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/user-persister/templates/envoy-configmap.yaml
@@ -53,14 +53,6 @@ data:
               '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
               explicit_http_config:
                 http2_protocol_options: {}
-          health_checks:
-            - grpc_health_check: {}
-              healthy_threshold: 1
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              timeout: 1s
-              unhealthy_threshold: 2
           ignore_health_on_host_removal: true
       listeners:
         - name: ingress
@@ -80,17 +72,6 @@ data:
                         path: /dev/stdout
                     codec_type: auto
                     http_filters:
-                      - name: envoy.filters.http.health_check
-                        typed_config:
-                          '@type': type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                          cluster_min_healthy_percentages:
-                            user-persister:
-                              value: 25
-                          headers:
-                            - name: :path
-                              string_match:
-                                exact: /health
-                          pass_through_mode: false
                       - name: envoy.filters.http.router
                         typed_config:
                           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router

--- a/manifests/bucketeer/charts/user-persister/values.yaml
+++ b/manifests/bucketeer/charts/user-persister/values.yaml
@@ -64,9 +64,14 @@ service:
   externalPort: 9000
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources: {}
 

--- a/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/envoy-configmap.yaml
@@ -53,15 +53,6 @@ data:
                     filename: /usr/local/certs/service/tls.crt
                   private_key:
                     filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
 
         - name: dex
           dns_lookup_family: V4_ONLY
@@ -94,15 +85,6 @@ data:
                     filename: /usr/local/certs/service/tls.crt
                   private_key:
                     filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
 
         - name: experiment-calculator
           dns_lookup_family: V4_ONLY
@@ -135,15 +117,6 @@ data:
                     filename: /usr/local/certs/service/tls.crt
                   private_key:
                     filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 5s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 3
 
         - name: web
           dns_lookup_family: V4_ONLY
@@ -176,15 +149,7 @@ data:
                     filename: /usr/local/certs/service/tls.crt
                   private_key:
                     filename: /usr/local/certs/service/tls.key
-          health_checks:
-            - http_health_check:
-                path: /health
-              timeout: 1s
-              interval: 10s
-              interval_jitter: 1s
-              no_traffic_interval: 2s
-              healthy_threshold: 1
-              unhealthy_threshold: 2
+
       listeners:
         - name: ingress
           address:

--- a/manifests/bucketeer/charts/web-gateway/values.yaml
+++ b/manifests/bucketeer/charts/web-gateway/values.yaml
@@ -36,11 +36,11 @@ ingress:
   staticIPName:
 health:
   livenessProbe:
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 3
     failureThreshold: 5
   readinessProbe:
-    initialDelaySeconds: 5
+    initialDelaySeconds: 10
     periodSeconds: 3
     failureThreshold: 2
 resources: {}

--- a/manifests/bucketeer/charts/web/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/web/templates/deployment.yaml
@@ -57,15 +57,17 @@ spec:
               containerPort: 443
               protocol: TCP
           livenessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
-            periodSeconds: {{ .Values.health.periodSeconds }}
-            failureThreshold: {{ .Values.health.failureThreshold }}
+            initialDelaySeconds: {{ .Values.health.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.livenessProbe.failureThreshold }}
             httpGet:
               path: /alive
               port: https
               scheme: HTTPS
           readinessProbe:
-            initialDelaySeconds: {{ .Values.health.initialDelaySeconds }}
+            initialDelaySeconds: {{ .Values.health.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.health.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.health.readinessProbe.failureThreshold }}
             httpGet:
               path: /alive
               port: https

--- a/manifests/bucketeer/charts/web/values.yaml
+++ b/manifests/bucketeer/charts/web/values.yaml
@@ -20,9 +20,14 @@ service:
   port: 443
 
 health:
-  initialDelaySeconds: 10
-  periodSeconds: 10
-  failureThreshold: 10
+  livenessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 5
+  readinessProbe:
+    initialDelaySeconds: 10
+    periodSeconds: 3
+    failureThreshold: 2
 
 resources:
   {}


### PR DESCRIPTION
Because we already check the health status using the Kubernetes Liveness and Readiness, I'm removing the health check in the envoy container because it's unnecessary.

The e2e tests have passed.

### Things done

- Remove envoy health check
- Use envoy ready api for liveness and readiness check