### PR TITLE
ci: compress build time 

### DIFF
--- a/.github/workflows/pr-ui-web.yaml
+++ b/.github/workflows/pr-ui-web.yaml
@@ -96,13 +96,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate proto files
-        run: make gen_proto
       - name: Build
         run: make build
 

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - main
-      - improve-image-push
     tags:
         - "v*"
     paths-ignore:

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -36,6 +36,7 @@ env:
   GO_VERSION: 1.20.4
   NODE_VERSION: 16
   WEB_PATH: ./ui/web-v2
+  GO_BUILD_CONCURRENCY: 15
 
 jobs:
   setup:
@@ -70,7 +71,7 @@ jobs:
       - name: Install go dependencies
         run: make vendor
       - name: Build go applications
-        run: make build-go
+        run: make build-go -j ${{ env.GO_BUILD_CONCURRENCY }}
       - name: Add executable permission to go binary files
         run: chmod +x bin/*
       - name: Set up docker

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -35,7 +35,7 @@ env:
   GO_VERSION: 1.20.4
   NODE_VERSION: 16
   WEB_PATH: ./ui/web-v2
-  GO_BUILD_CONCURRENCY: 15
+  GO_BUILD_CONCURRENCY: 15 # Set the same number of apps to build.
 
 jobs:
   setup:

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - main
+      - improve-image-push
     tags:
         - "v*"
     paths-ignore:
@@ -32,8 +33,6 @@ on:
 env:
   GHCR_REGISTRY: ghcr.io/bucketeer-io
   GAR_REGISTRY: asia-docker.pkg.dev
-  PROTOC_VERSION: 23.4
-  PROTOC_GEN_GO_VERSION: v1.5.2
   GO_VERSION: 1.20.4
   NODE_VERSION: 16
   WEB_PATH: ./ui/web-v2
@@ -68,15 +67,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install protoc-gen-go
-        run: go install github.com/golang/protobuf/protoc-gen-go@${{ env.PROTOC_GEN_GO_VERSION }}
-      - name: Generate proto go files
-        run: make proto-go
       - name: Install go dependencies
         run: make vendor
       - name: Build go applications
@@ -197,13 +187,6 @@ jobs:
             ${{ runner.os }}-yarn-
       - name: Install dependencies
         run: make install
-      - name: Install Protoc
-        uses: arduino/setup-protoc@9b1ee5b22b0a3f1feb8c2ff99b32c89b3c3191e9 # v2.0.0
-        with:
-          version: ${{ env.PROTOC_VERSION }}
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Generate proto files
-        run: make gen_proto
       - name: Build web
         env:
           RELEASE_CHANNEL: prod


### PR DESCRIPTION
- removes needless proto-compile processes.
- modifies go build process so that it works concurrently.
  - [Concurrent go build process took 1m4s](https://github.com/bucketeer-io/bucketeer/actions/runs/5620512977/job/15229596827). (Sequential build process takes about 2min.)