### PR TITLE
chore: adjust features and segments cache TTL

### DIFF
--- a/pkg/cache/v3/features.go
+++ b/pkg/cache/v3/features.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	featuresKind = "features"
-	featuresTTL  = 1 * time.Hour
+	featuresTTL  = time.Duration(0)
 )
 
 type FeaturesCache interface {

--- a/pkg/cache/v3/segment_users.go
+++ b/pkg/cache/v3/segment_users.go
@@ -27,7 +27,7 @@ import (
 const (
 	segmentUsersKind    = "segment_users"
 	segmentUsersMaxSize = int64(100)
-	segmentUsersTTL     = 1 * time.Hour
+	segmentUsersTTL     = time.Duration(0)
 )
 
 type SegmentUsersCache interface {


### PR DESCRIPTION
- This PR sets to 0 the TTL of the features and user-segments caches.
  - We discussed the risk of MySQL's downtime and decided to change the TTL setting so that not to clear the cache.
  - As for refreshing the cache, we plan to do it more securely.