### PR TITLE
chore: modify environment APIs to write v1 and v2 temporarily

### DIFF
--- a/pkg/environment/api/environment.go
+++ b/pkg/environment/api/environment.go
@@ -266,6 +266,27 @@ func (s *EnvironmentService) CreateEnvironment(
 	if err := s.createEnvironment(ctx, req.Command, newEnvironment, editor, localizer); err != nil {
 		return nil, err
 	}
+	// TODO: We create environments with v1 and v2 APIs for now.
+	// We should remove v1 API once we migrate all environments to v2.
+	createEnvCmdV2 := &environmentproto.CreateEnvironmentV2Command{
+		Name:        newEnvironment.Id,
+		UrlCode:     newEnvironment.Id,
+		ProjectId:   newEnvironment.ProjectId,
+		Description: newEnvironment.Description,
+	}
+	newEnvironmentV2, err := domain.NewEnvironmentV2(
+		createEnvCmdV2.Name,
+		createEnvCmdV2.UrlCode,
+		createEnvCmdV2.Description,
+		createEnvCmdV2.ProjectId,
+		s.logger,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.createEnvironmentV2(ctx, createEnvCmdV2, newEnvironmentV2, editor, localizer); err != nil {
+		return nil, err
+	}
 	return &environmentproto.CreateEnvironmentResponse{}, nil
 }
 

--- a/pkg/environment/api/environment.go
+++ b/pkg/environment/api/environment.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -425,7 +426,8 @@ func (s *EnvironmentService) UpdateEnvironment(
 	// We should remove v1 once we migrate all environments to v2.
 	v2Commands := createV2UpdateEnvironmentCommands(req)
 	if len(v2Commands) != 0 {
-		if err := s.updateEnvironmentV2(ctx, req.Id, v2Commands, editor, localizer); err != nil {
+		envId := strings.ReplaceAll(req.Id, "-", "")
+		if err := s.updateEnvironmentV2(ctx, envId, v2Commands, editor, localizer); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/environment/api/environment.go
+++ b/pkg/environment/api/environment.go
@@ -274,16 +274,12 @@ func (s *EnvironmentService) CreateEnvironment(
 		ProjectId:   newEnvironment.ProjectId,
 		Description: newEnvironment.Description,
 	}
-	newEnvironmentV2, err := domain.NewEnvironmentV2(
+	newEnvironmentV2 := domain.TmpNewEnvironmentV2(
 		createEnvCmdV2.Name,
 		createEnvCmdV2.UrlCode,
 		createEnvCmdV2.Description,
 		createEnvCmdV2.ProjectId,
-		s.logger,
 	)
-	if err != nil {
-		return nil, err
-	}
 	if err := s.createEnvironmentV2(ctx, createEnvCmdV2, newEnvironmentV2, editor, localizer); err != nil {
 		return nil, err
 	}

--- a/pkg/environment/api/environment_test.go
+++ b/pkg/environment/api/environment_test.go
@@ -489,10 +489,10 @@ func TestUpdateEnvironmentMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *EnvironmentService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil).Times(2)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil)
+				).Return(nil).Times(2)
 			},
 			req: &proto.UpdateEnvironmentRequest{
 				Id:                       "ns1",

--- a/pkg/environment/api/environment_test.go
+++ b/pkg/environment/api/environment_test.go
@@ -393,10 +393,10 @@ func TestCreateEnvironmentMySQL(t *testing.T) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil).Times(2)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil)
+				).Return(nil).Times(2)
 			},
 			req: &proto.CreateEnvironmentRequest{
 				Command: &proto.CreateEnvironmentCommand{Id: "ns-2", ProjectId: "project-id-0"},

--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -542,10 +542,7 @@ func (s *EnvironmentService) createTrialEnvironmentsAndAccounts(
 			ProjectId:   project.Id,
 			Description: "",
 		}
-		envV2, err := domain.NewEnvironmentV2(envID, envID, "", project.Id, s.logger)
-		if err != nil {
-			return err
-		}
+		envV2 := domain.TmpNewEnvironmentV2(envID, envID, "", project.Id)
 		if err := s.createEnvironmentV2(ctx, createEnvCmdV2, envV2, editor, localizer); err != nil {
 			return err
 		}

--- a/pkg/environment/domain/environment.go
+++ b/pkg/environment/domain/environment.go
@@ -81,6 +81,23 @@ func NewEnvironmentV2(name, urlCode, description, projectID string, logger *zap.
 	}}, nil
 }
 
+// TmpNewEnvironmentV2 sets the id field to the same value as the namespace field in v1.
+// TODO: remove this function after migration
+func TmpNewEnvironmentV2(name, urlCode, description, projectID string) *EnvironmentV2 {
+	now := time.Now().Unix()
+	id := strings.ReplaceAll(name, "-", "")
+	return &EnvironmentV2{&proto.EnvironmentV2{
+		Id:          id,
+		Name:        name,
+		UrlCode:     urlCode,
+		Description: description,
+		ProjectId:   projectID,
+		Archived:    false,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}}
+}
+
 func (e *EnvironmentV2) Rename(name string) {
 	e.EnvironmentV2.Name = name
 	e.EnvironmentV2.UpdatedAt = time.Now().Unix()


### PR DESCRIPTION
- Temporarily, the environment API V1 persists objects to V1 and V2 tables until all V1 API will be replaced.  