### PR TITLE
feat: enable Google Analytics4

### DIFF
--- a/manifests/bucketeer/charts/web/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/web/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         - name: certs
           secret:
             secretName: {{ template "cert-secret" . }}
+        - name: env-js
+          configMap:
+            name: {{ template "web.fullname" . }}-env-js
       {{- if .Values.serviceAccount.annotations }}
       serviceAccountName: {{ template "web.fullname" . }}
       {{- end }}
@@ -51,6 +54,9 @@ spec:
               readOnly: true
             - name: certs
               mountPath: /usr/local/certs
+              readOnly: true
+            - name: env-js
+              mountPath: /var/www/static/js
               readOnly: true
           ports:
             - name: https

--- a/manifests/bucketeer/charts/web/templates/env-js-configmap.yaml
+++ b/manifests/bucketeer/charts/web/templates/env-js-configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "web.fullname" . }}-env-js
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "web.name" . }}
+    chart: {{ template "web.chart" . }}
+    release: {{ template "web.fullname" . }}
+    heritage: {{ .Release.Service }}
+data:
+  env.js: |-
+    window.env = {"GOOGLE_ANALYTICS_ID":"{{ .Values.env.googleAnalyticsId }}"};

--- a/manifests/bucketeer/charts/web/values.yaml
+++ b/manifests/bucketeer/charts/web/values.yaml
@@ -9,6 +9,9 @@ namespace: default
 nginx:
   config:
 
+env:
+  googleAnalyticsId:
+
 tls:
   secret:
   cert:

--- a/ui/web-v2/apps/admin/src/config/index.ts
+++ b/ui/web-v2/apps/admin/src/config/index.ts
@@ -9,6 +9,14 @@ export const urls = {
       : `${window.location.origin}/auth/callback`,
 };
 
-export const GOOGLE_ANALYTICS_ID = process.env.NX_GOOGLE_ANALYTICS_ID;
-
 export const ENABLE_SETTINGS = true;
+
+declare global {
+  interface Window {
+    env: {
+      [key: string]: any;
+    };
+  }
+}
+
+export const GOOGLE_ANALYTICS_ID = window.env?.GOOGLE_ANALYTICS_ID || '';

--- a/ui/web-v2/apps/admin/src/index.html
+++ b/ui/web-v2/apps/admin/src/index.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
   </head>
   <body>
+    <script src="/static/js/env.js"></script>
     <div id="app"></div>
   </body>
 </html>

--- a/ui/web-v2/apps/admin/src/pages/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import { GOOGLE_ANALYTICS_ID } from '@/config';
 import React, { FC, useEffect, memo, useState, useCallback } from 'react';
-import ReactGA from 'react-ga';
+import ReactGA from 'react-ga4';
 import { useDispatch } from 'react-redux';
 import {
   Route,
@@ -70,7 +70,10 @@ export const App: FC = memo(() => {
 
   useEffect(() => {
     if (initialized) {
-      ReactGA.pageview(location.pathname + location.search);
+      ReactGA.send({
+        hitType: 'pageview',
+        page: location.pathname + location.search,
+      });
     }
   }, [initialized, location]);
 

--- a/ui/web-v2/package.json
+++ b/ui/web-v2/package.json
@@ -71,7 +71,7 @@
     "react-datetime-picker": "3.3.0",
     "react-dom": "17.0.2",
     "react-dropzone": "11.2.4",
-    "react-ga": "^3.3.1",
+    "react-ga4": "^2.1.0",
     "react-hook-form": "7.14.1",
     "react-intl": "5.20.10",
     "react-popper": "^2.2.5",

--- a/ui/web-v2/yarn.lock
+++ b/ui/web-v2/yarn.lock
@@ -13177,10 +13177,10 @@ react-fit@^1.0.3:
     detect-element-overflow "^1.2.0"
     prop-types "^15.6.0"
 
-react-ga@^3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-3.3.1.tgz#d8e1f4e05ec55ed6ff944dcb14b99011dfaf9504"
-  integrity sha512-4Vc0W5EvXAXUN/wWyxvsAKDLLgtJ3oLmhYYssx+YzphJpejtOst6cbIHCIyF50Fdxuf5DDKqRYny24yJ2y7GFQ==
+react-ga4@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-2.1.0.tgz#56601f59d95c08466ebd6edfbf8dede55c4678f9"
+  integrity sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ==
 
 react-hook-form@7.14.1:
   version "7.14.1"


### PR DESCRIPTION
- This PR enables Google Analytics 4.
  - The react project can only use environment variables at build time.
  - I prepare the window.env object so that the project reads GA4 tracking ID from that object.
  - The window.env object is created from the runtime environment variable.
- Since the `react-ga` library doesn't support GA4, I replace it with the `react-ga4` library.