### PR TITLE
feat: batch service graceful shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/tkuchiki/go-timezone v0.2.2
 	go.opencensus.io v0.24.0
+	go.uber.org/atomic v1.9.0
 	go.uber.org/mock v0.2.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/oauth2 v0.10.0
@@ -107,7 +108,6 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/prometheus/prometheus v0.35.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.11.0 // indirect
 	golang.org/x/exp v0.0.0-20230315142452-642cacee5cc0 // indirect

--- a/pkg/batch/api/api.go
+++ b/pkg/batch/api/api.go
@@ -36,6 +36,7 @@ var (
 )
 
 type batchService struct {
+	runningJobManager        *RunningJobManager
 	experimentStatusUpdater  jobs.Job
 	experimentRunningWatcher jobs.Job
 	featureStaleWatcher      jobs.Job
@@ -50,6 +51,7 @@ type batchService struct {
 }
 
 func NewBatchService(
+	runningJobManager *RunningJobManager,
 	experimentStatusUpdater, experimentRunningWatcher,
 	featureStaleWatcher, mauCountWatcher, datetimeWatcher,
 	eventCountWatcher jobs.Job,
@@ -60,6 +62,7 @@ func NewBatchService(
 	options ...notification.Option,
 ) *batchService {
 	return &batchService{
+		runningJobManager:        runningJobManager,
 		experimentStatusUpdater:  experimentStatusUpdater,
 		experimentRunningWatcher: experimentRunningWatcher,
 		featureStaleWatcher:      featureStaleWatcher,
@@ -77,6 +80,8 @@ func NewBatchService(
 func (s *batchService) ExecuteBatchJob(
 	ctx context.Context, req *batch.BatchJobRequest) (*batch.BatchJobResponse, error) {
 	var err error
+	s.runningJobManager.AddRunningJob()
+	defer s.runningJobManager.RemoveRunningJob()
 	switch req.Job {
 	case batch.BatchJob_ExperimentStatusUpdater:
 		err = s.experimentStatusUpdater.Run(ctx)

--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -443,6 +443,7 @@ func newBatchService(t *testing.T,
 	)
 
 	service := NewBatchService(
+		NewRunningJobManager(),
 		experiment.NewExperimentStatusUpdater(
 			environmentMockClient,
 			experimentMockClient,

--- a/pkg/batch/api/running_job_manager.go
+++ b/pkg/batch/api/running_job_manager.go
@@ -1,0 +1,40 @@
+// Copyright 2023 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import "go.uber.org/atomic"
+
+type RunningJobManager struct {
+	runningJobs *atomic.Int32
+}
+
+func NewRunningJobManager() *RunningJobManager {
+	return &RunningJobManager{
+		runningJobs: atomic.NewInt32(0),
+	}
+}
+
+func (m RunningJobManager) AddRunningJob() {
+	m.runningJobs.Inc()
+}
+
+func (m RunningJobManager) RemoveRunningJob() {
+	m.runningJobs.Dec()
+}
+
+func (m RunningJobManager) GetCurrentRunningJobs() int32 {
+	return m.runningJobs.Load()
+}


### PR DESCRIPTION
## Summary
Currently, there are always failures for some jobs when the batch service pod restarts. This PR aims to add a running job manager to implement graceful shutdown in the batch service.

## Implementation
Use `go.uber.org/atomic` to implement a running jobs counter. When the `NewBatchService` method of the batch service is called, it should first increase the counter. After the job is finished, it should then decrease the counter.

When the batch service receives an exit signal, it will check the running job counter to see if it is equal to zero. If it's not zero, it will sleep for one second and then recheck the counter until it reaches zero.

