### PR TITLE
chore: migrate v1 environment api to v2 in batch and calculator

### DIFF
--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -424,12 +424,12 @@ func TestDomainEventInformer(t *testing.T) {
 		domainMockEventPuller *domainEventPullerMock,
 		mysqlMockClient *mysqlmock.MockClient) {
 		environmentMockClient.EXPECT().
-			GetEnvironmentByNamespace(gomock.Any(), gomock.Any()).
+			GetEnvironmentV2(gomock.Any(), gomock.Any()).
 			MinTimes(3).
 			MaxTimes(5).
 			Return(
-				&environmentproto.GetEnvironmentByNamespaceResponse{
-					Environment: &environmentproto.Environment{
+				&environmentproto.GetEnvironmentV2Response{
+					Environment: &environmentproto.EnvironmentV2{
 						Id: "eid0",
 					}},
 				nil,

--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -109,9 +109,9 @@ func TestExperimentStatusUpdater(t *testing.T) {
 		domainMockEventPuller *domainEventPullerMock,
 		mysqlMockClient *mysqlmock.MockClient) {
 		environmentMockClient.EXPECT().
-			ListEnvironments(gomock.Any(), gomock.Any()).
+			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
 			Return(
-				&environmentproto.ListEnvironmentsResponse{
+				&environmentproto.ListEnvironmentsV2Response{
 					Environments: getEnvironments(t),
 				},
 				nil,
@@ -157,10 +157,10 @@ func TestExperimentRunningWatcher(t *testing.T) {
 		domainMockEventPuller *domainEventPullerMock,
 		mysqlMockClient *mysqlmock.MockClient) {
 		environmentMockClient.EXPECT().
-			ListEnvironments(gomock.Any(), gomock.Any()).
+			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
 			Times(1).
 			Return(
-				&environmentproto.ListEnvironmentsResponse{
+				&environmentproto.ListEnvironmentsV2Response{
 					Environments: getEnvironments(t),
 				}, nil,
 			)
@@ -195,10 +195,10 @@ func TestFeatureStaleWatcher(t *testing.T) {
 		domainMockEventPuller *domainEventPullerMock,
 		mysqlMockClient *mysqlmock.MockClient) {
 		environmentMockClient.EXPECT().
-			ListEnvironments(gomock.Any(), gomock.Any()).
+			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
 			Times(1).
 			Return(
-				&environmentproto.ListEnvironmentsResponse{
+				&environmentproto.ListEnvironmentsV2Response{
 					Environments: getEnvironments(t),
 				}, nil,
 			)
@@ -242,10 +242,10 @@ func TestMAUCountWatcher(t *testing.T) {
 				nil,
 			)
 		environmentMockClient.EXPECT().
-			ListEnvironments(gomock.Any(), gomock.Any()).
+			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
 			Times(1).
 			Return(
-				&environmentproto.ListEnvironmentsResponse{
+				&environmentproto.ListEnvironmentsV2Response{
 					Environments: getEnvironments(t),
 				},
 				nil,
@@ -542,11 +542,11 @@ func newBatchService(t *testing.T,
 	return service
 }
 
-func getEnvironments(t *testing.T) []*environmentproto.Environment {
+func getEnvironments(t *testing.T) []*environmentproto.EnvironmentV2 {
 	t.Helper()
-	return []*environmentproto.Environment{
-		{Id: "ns0", Namespace: "ns0", ProjectId: "pj0"},
-		{Id: "ns1", Namespace: "ns1", ProjectId: "pj0"},
+	return []*environmentproto.EnvironmentV2{
+		{Id: "ns0", Name: "ns0", ProjectId: "pj0"},
+		{Id: "ns1", Name: "ns1", ProjectId: "pj0"},
 	}
 }
 

--- a/pkg/batch/jobs/experiment/experiment_status_updater.go
+++ b/pkg/batch/jobs/experiment/experiment_status_updater.go
@@ -76,10 +76,10 @@ func (u *experimentStatusUpdater) Run(ctx context.Context) (lastErr error) {
 			experimentproto.Experiment_RUNNING,
 		}
 		for _, status := range statuses {
-			exps, err := u.listExperiments(ctx, env.Namespace, status)
+			exps, err := u.listExperiments(ctx, env.Id, status)
 			if err != nil {
 				u.logger.Error("Failed to list experiments", zap.Error(err),
-					zap.String("environmentNamespace", env.Namespace),
+					zap.String("environmentNamespace", env.Id),
 					zap.Int32("status", int32(status)),
 				)
 				lastErr = err
@@ -88,7 +88,7 @@ func (u *experimentStatusUpdater) Run(ctx context.Context) (lastErr error) {
 			experiments = append(experiments, exps...)
 		}
 		for _, e := range experiments {
-			if err = u.updateStatus(ctx, env.Namespace, e); err != nil {
+			if err = u.updateStatus(ctx, env.Id, e); err != nil {
 				lastErr = err
 			}
 		}
@@ -199,13 +199,14 @@ func (u *experimentStatusUpdater) listExperiments(
 	}
 }
 
-func (u *experimentStatusUpdater) listEnvironments(ctx context.Context) ([]*environmentproto.Environment, error) {
-	var environments []*environmentproto.Environment
+func (u *experimentStatusUpdater) listEnvironments(ctx context.Context) ([]*environmentproto.EnvironmentV2, error) {
+	var environments []*environmentproto.EnvironmentV2
 	cursor := ""
 	for {
-		resp, err := u.environmentClient.ListEnvironments(ctx, &environmentproto.ListEnvironmentsRequest{
+		resp, err := u.environmentClient.ListEnvironmentsV2(ctx, &environmentproto.ListEnvironmentsV2Request{
 			PageSize: listRequestSize,
 			Cursor:   cursor,
+			Archived: &wrappersproto.BoolValue{Value: false},
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/batch/jobs/notification/domain_event_informer.go
+++ b/pkg/batch/jobs/notification/domain_event_informer.go
@@ -217,16 +217,16 @@ func (i *domainEventInformer) createNotificationEvent(
 
 func (i *domainEventInformer) getEnvironment(
 	ctx context.Context,
-	environmentNamespace string,
-) (*environmentproto.Environment, error) {
-	resp, err := i.environmentClient.GetEnvironmentByNamespace(ctx, &environmentproto.GetEnvironmentByNamespaceRequest{
-		Namespace: environmentNamespace,
+	environmentId string,
+) (*environmentproto.EnvironmentV2, error) {
+	resp, err := i.environmentClient.GetEnvironmentV2(ctx, &environmentproto.GetEnvironmentV2Request{
+		Id: environmentId,
 	})
 	if err != nil {
 		i.logger.Error(
 			"Failed to get environment",
 			zap.Error(err),
-			zap.String("environmentNamespace", environmentNamespace),
+			zap.String("environmentId", environmentId),
 		)
 		return nil, err
 	}

--- a/pkg/batch/jobs/notification/experiment_running_watcher_test.go
+++ b/pkg/batch/jobs/notification/experiment_running_watcher_test.go
@@ -44,10 +44,10 @@ func TestCreateExperimentRunningNotification(t *testing.T) {
 		{
 			desc: "no experiment",
 			setup: func(t *testing.T, w *experimentRunningWatcher) {
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "ns0", Namespace: "ns0"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "ns0", Name: "ns0"}},
 						Cursor:       "",
 					}, nil)
 				w.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(
@@ -60,10 +60,10 @@ func TestCreateExperimentRunningNotification(t *testing.T) {
 		{
 			desc: "experiments exist",
 			setup: func(t *testing.T, w *experimentRunningWatcher) {
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "ns0", Namespace: "ns0"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "ns0", Name: "ns0"}},
 						Cursor:       "",
 					}, nil)
 				w.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(

--- a/pkg/batch/jobs/notification/feature_stale_watcher_test.go
+++ b/pkg/batch/jobs/notification/feature_stale_watcher_test.go
@@ -44,10 +44,10 @@ func TestCreateNotification(t *testing.T) {
 		{
 			desc: "no featres",
 			setup: func(t *testing.T, w *featureStaleWatcher) {
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "ns0", Namespace: "ns0"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "ns0", Name: "ns0"}},
 						Cursor:       "",
 					}, nil)
 				w.featureClient.(*featureclientmock.MockClient).EXPECT().ListFeatures(
@@ -60,10 +60,10 @@ func TestCreateNotification(t *testing.T) {
 		{
 			desc: "no stale featres",
 			setup: func(t *testing.T, w *featureStaleWatcher) {
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "ns0", Namespace: "ns0"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "ns0", Name: "ns0"}},
 						Cursor:       "",
 					}, nil)
 				w.featureClient.(*featureclientmock.MockClient).EXPECT().ListFeatures(
@@ -83,10 +83,10 @@ func TestCreateNotification(t *testing.T) {
 		{
 			desc: "stale exists",
 			setup: func(t *testing.T, w *featureStaleWatcher) {
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "ns0", Namespace: "ns0"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "ns0", Name: "ns0"}},
 						Cursor:       "",
 					}, nil)
 				w.featureClient.(*featureclientmock.MockClient).EXPECT().ListFeatures(

--- a/pkg/batch/jobs/notification/mau_count_watcher_test.go
+++ b/pkg/batch/jobs/notification/mau_count_watcher_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
@@ -73,7 +74,7 @@ func TestCreateMAUNotification(t *testing.T) {
 						Projects: []*environmentproto.Project{{Id: "pj0"}},
 						Cursor:   "cursor",
 					}, nil)
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
 					nil, errInternal)
 			},
@@ -88,9 +89,9 @@ func TestCreateMAUNotification(t *testing.T) {
 						Projects: []*environmentproto.Project{{Id: "pj0"}},
 						Cursor:   "cursor",
 					}, nil)
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{}, nil)
+					&environmentproto.ListEnvironmentsV2Response{}, nil)
 			},
 			expectedErr: nil,
 		},
@@ -103,10 +104,10 @@ func TestCreateMAUNotification(t *testing.T) {
 						Projects: []*environmentproto.Project{{Id: "pj0"}},
 						Cursor:   "cursor",
 					}, nil)
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "eID", Namespace: "eNamespace"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "eID", Name: "eID"}},
 						Cursor:       "",
 					}, nil)
 				w.eventCounterClient.(*ecclientmock.MockClient).EXPECT().GetMAUCount(
@@ -125,10 +126,10 @@ func TestCreateMAUNotification(t *testing.T) {
 						Projects: []*environmentproto.Project{{Id: "pj0"}},
 						Cursor:   "cursor",
 					}, nil)
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any()).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "eID", Namespace: "eNamespace"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "eID", Name: "eID"}},
 						Cursor:       "",
 					}, nil)
 				w.eventCounterClient.(*ecclientmock.MockClient).EXPECT().GetMAUCount(
@@ -157,16 +158,17 @@ func TestCreateMAUNotification(t *testing.T) {
 						Cursor:   "cursor",
 					}, nil)
 				// list environments
-				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironments(
+				w.environmentClient.(*environmentclientmock.MockClient).EXPECT().ListEnvironmentsV2(
 					gomock.Any(),
-					&environmentproto.ListEnvironmentsRequest{
+					&environmentproto.ListEnvironmentsV2Request{
 						PageSize:  listRequestSize,
 						Cursor:    "",
 						ProjectId: "pj0",
+						Archived:  &wrappers.BoolValue{Value: false},
 					},
 				).Return(
-					&environmentproto.ListEnvironmentsResponse{
-						Environments: []*environmentproto.Environment{{Id: "eID", Namespace: "eNamespace"}},
+					&environmentproto.ListEnvironmentsV2Response{
+						Environments: []*environmentproto.EnvironmentV2{{Id: "eID", Name: "eID"}},
 						Cursor:       "",
 					}, nil)
 				// get user count
@@ -174,7 +176,7 @@ func TestCreateMAUNotification(t *testing.T) {
 				w.eventCounterClient.(*ecclientmock.MockClient).EXPECT().GetMAUCount(
 					gomock.Any(),
 					&ecproto.GetMAUCountRequest{
-						EnvironmentNamespace: "eNamespace",
+						EnvironmentNamespace: "eID",
 						YearMonth:            w.newYearMonth(year, month),
 					},
 				).Return(


### PR DESCRIPTION
- This PR replaces v1 environment API (GetEnvironmentByNamespace, ListEnvironments) in the batch and calculator to v2.