### PR TITLE
fix: getEnvironmentV2 fails to get env with empty ID

### DIFF
--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -350,6 +350,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		),
 		logger,
 		notification.WithRunningDurationPerBatch(*s.runningDurationPerBatch),
+		notification.WithLogger(logger),
 	)
 
 	healthChecker := health.NewGrpcChecker(

--- a/pkg/environment/api/environment_v2.go
+++ b/pkg/environment/api/environment_v2.go
@@ -79,16 +79,7 @@ func validateGetEnvironmentV2Request(
 	req *environmentproto.GetEnvironmentV2Request,
 	localizer locale.Localizer,
 ) error {
-	if req.Id == "" {
-		dt, err := statusEnvironmentIDRequired.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
+	// Essentially, the id field is required, but no validation is performed because some older services do not have ID.
 	return nil
 }
 
@@ -441,20 +432,11 @@ func getUpdateEnvironmentV2Commands(req *environmentproto.UpdateEnvironmentV2Req
 }
 
 func validateUpdateEnvironmentV2Request(id string, commands []command.Command, localizer locale.Localizer) error {
+	// Essentially, the id field is required, but no validation is performed because some older services do not have ID.
 	if len(commands) == 0 {
 		dt, err := statusNoCommand.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "command"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if id == "" {
-		dt, err := statusEnvironmentIDRequired.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
 		})
 		if err != nil {
 			return statusInternal.Err()
@@ -551,20 +533,11 @@ func validateArchiveEnvironmentV2Request(
 	req *environmentproto.ArchiveEnvironmentV2Request,
 	localizer locale.Localizer,
 ) error {
+	// Essentially, the id field is required, but no validation is performed because some older services do not have ID.
 	if req.Command == nil {
 		dt, err := statusNoCommand.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "command"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if req.Id == "" {
-		dt, err := statusEnvironmentIDRequired.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
 		})
 		if err != nil {
 			return statusInternal.Err()
@@ -646,20 +619,11 @@ func validateUnarchiveEnvironmentV2Request(
 	req *environmentproto.UnarchiveEnvironmentV2Request,
 	localizer locale.Localizer,
 ) error {
+	// Essentially, the id field is required, but no validation is performed because some older services do not have ID.
 	if req.Command == nil {
 		dt, err := statusNoCommand.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "command"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if req.Id == "" {
-		dt, err := statusEnvironmentIDRequired.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
 		})
 		if err != nil {
 			return statusInternal.Err()

--- a/pkg/environment/api/environment_v2_test.go
+++ b/pkg/environment/api/environment_v2_test.go
@@ -60,15 +60,6 @@ func TestGetEnvironmentV2(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc:  "err: ErrEnvironmentIDRequired",
-			setup: nil,
-			id:    "",
-			expectedErr: createError(
-				statusEnvironmentIDRequired,
-				localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
-			),
-		},
-		{
 			desc: "err: ErrEnvironmentNotFound",
 			setup: func(s *EnvironmentService) {
 				row := mysqlmock.NewMockRow(mockController)
@@ -441,17 +432,6 @@ func TestUpdateEnvironmentV2(t *testing.T) {
 			),
 		},
 		{
-			desc:  "err: ErrEnvironmentIDRequired",
-			setup: nil,
-			req: &proto.UpdateEnvironmentV2Request{
-				RenameCommand: &proto.RenameEnvironmentV2Command{Name: "name 01"},
-			},
-			expectedErr: createError(
-				statusEnvironmentIDRequired,
-				localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
-			),
-		},
-		{
 			desc:  "err: ErrInvalidEnvironmentName: only space",
 			setup: nil,
 			req: &proto.UpdateEnvironmentV2Request{
@@ -560,15 +540,6 @@ func TestArchiveEnvironmentV2(t *testing.T) {
 		expectedErr error
 	}{
 		{
-			desc:  "err: ErrEnvironmentIDRequired",
-			setup: nil,
-			req:   &proto.ArchiveEnvironmentV2Request{Command: &proto.ArchiveEnvironmentV2Command{}},
-			expectedErr: createError(
-				statusEnvironmentIDRequired,
-				localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
-			),
-		},
-		{
 			desc: "err: ErrEnvironmentNotFound",
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
@@ -643,15 +614,6 @@ func TestUnarchiveEnvironmentV2(t *testing.T) {
 		req         *proto.UnarchiveEnvironmentV2Request
 		expectedErr error
 	}{
-		{
-			desc:  "err: ErrEnvironmentIDRequired",
-			setup: nil,
-			req:   &proto.UnarchiveEnvironmentV2Request{Command: &proto.UnarchiveEnvironmentV2Command{}},
-			expectedErr: createError(
-				statusEnvironmentIDRequired,
-				localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
-			),
-		},
 		{
 			desc: "err: ErrEnvironmentNotFound",
 			setup: func(s *EnvironmentService) {


### PR DESCRIPTION
- This PR modifies the GetEnvironmentV2 API to retrieve the environment even with an empty ID.
- This PR fixes the batch server doesn't emit logs.