### PR TITLE
fix: time location in unit test

### DIFF
--- a/pkg/batch/jobs/notification/mau_count_watcher_test.go
+++ b/pkg/batch/jobs/notification/mau_count_watcher_test.go
@@ -172,7 +172,7 @@ func TestCreateMAUNotification(t *testing.T) {
 						Cursor:       "",
 					}, nil)
 				// get user count
-				year, month := w.getLastYearMonth(time.Now())
+				year, month := w.getLastYearMonth(time.Now().In(w.location))
 				w.eventCounterClient.(*ecclientmock.MockClient).EXPECT().GetMAUCount(
 					gomock.Any(),
 					&ecproto.GetMAUCountRequest{


### PR DESCRIPTION
I noticed an error while executing the Github Action `pr-go`. This [line](https://github.com/bucketeer-io/bucketeer/blob/main/pkg/batch/jobs/notification/mau_count_watcher_test.go#L175)  has not been set to the same timzone as the [line](https://github.com/bucketeer-io/bucketeer/blob/main/pkg/batch/jobs/notification/mau_count_watcher.go#L75) in `mauCountWatcher.Run` function. 

Due to the timezone used in `mauCountWatcher` being `Japan`, when I ran this unit test in the `Beijing` timezone on August 31, 2023, at 11:56 PM, I encountered the following error:
<img width="1960" alt="image" src="https://github.com/bucketeer-io/bucketeer/assets/34117229/ec2327e6-caf9-4f18-bd30-16a0dc32353d">

So, we should set the same time zone in the unit test. :)