### PR TITLE
chore: update console to use environment v2 object

### DIFF
--- a/ui/web-v2/apps/admin/src/components/EnvironmentSelect/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/EnvironmentSelect/index.tsx
@@ -20,7 +20,7 @@ import {
   useCurrentEnvironment,
   useEnvironments,
 } from '../../modules/me';
-import { Environment } from '../../proto/environment/environment_pb';
+import { EnvironmentV2 } from '../../proto/environment/environment_pb';
 import { AppDispatch } from '../../store';
 import { classNames } from '../../utils/css';
 
@@ -31,10 +31,10 @@ export const EnvironmentSelect: FC = memo(() => {
   const currenEnvironment = useCurrentEnvironment();
   const environments = useEnvironments();
   const initialEnvironment = unwrapUndefinable(
-    environments.find((env) => env.namespace == currenEnvironment.namespace)
+    environments.find((env) => env.id == currenEnvironment.id)
   );
   const [selected, setSelected] =
-    useState<Environment.AsObject>(initialEnvironment);
+    useState<EnvironmentV2.AsObject>(initialEnvironment);
 
   const handleChange = useCallback(
     (value: string) => {
@@ -75,7 +75,7 @@ export const EnvironmentSelect: FC = memo(() => {
           >
             <span className="block truncate">
               {' '}
-              {`(${selected.projectId}) ${selected.id}`}
+              {`(${selected.projectId}) ${selected.name}`}
             </span>
             <span
               className={classNames(
@@ -126,7 +126,7 @@ export const EnvironmentSelect: FC = memo(() => {
                         </span>
                       ) : null}
                       <span className="block text-sm">
-                        {`(${env.projectId}) ${env.id}`}
+                        {`(${env.projectId}) ${env.name}`}
                       </span>
                     </>
                   )}

--- a/ui/web-v2/apps/admin/src/components/ExperimentAddForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/ExperimentAddForm/index.tsx
@@ -95,7 +95,7 @@ export const ExperimentAddForm: FC<ExperimentAddFormProps> = memo(
     useEffect(() => {
       dispatch(
         listGoals({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: 99999,
           cursor: '',
           searchKeyword: null,
@@ -106,7 +106,7 @@ export const ExperimentAddForm: FC<ExperimentAddFormProps> = memo(
       );
       dispatch(
         listFeatures({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: 99999,
           cursor: '',
           tags: [],

--- a/ui/web-v2/apps/admin/src/components/ExperimentList/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/ExperimentList/index.tsx
@@ -187,7 +187,7 @@ export const ExperimentList: FC<ExperimentListProps> = memo(
                           disabled={false}
                           onClick={() =>
                             history.push(
-                              `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${experiment.featureId}${PAGE_PATH_EXPERIMENTS}?experimentId=${experiment.id}`
+                              `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${experiment.featureId}${PAGE_PATH_EXPERIMENTS}?experimentId=${experiment.id}`
                             )
                           }
                         >

--- a/ui/web-v2/apps/admin/src/components/ExperimentResultDetail/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/ExperimentResultDetail/index.tsx
@@ -77,7 +77,7 @@ export const ExperimentResultDetail: FC<ExperimentResultDetailProps> = ({
     if (experimentId && experiment.startAt < Number(Date.now() / 1000)) {
       dispatch(
         getExperimentResult({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           experimentId: experimentId,
         })
       );

--- a/ui/web-v2/apps/admin/src/components/FeatureCloneForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureCloneForm/index.tsx
@@ -89,10 +89,10 @@ export const FeatureCloneForm: FC<FeatureCloneFormProps> = memo(
                   <div className="mt-1">
                     <input
                       type="text"
-                      name="originEnvironmentId"
-                      id="originEnvironmentId"
+                      name="originEnvironmentName"
+                      id="originEnvironmentName"
                       className="input-text w-full"
-                      defaultValue={currenEnvironment.id}
+                      defaultValue={currenEnvironment.name}
                       disabled={true}
                     />
                   </div>

--- a/ui/web-v2/apps/admin/src/components/FeatureCloneForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureCloneForm/index.tsx
@@ -29,7 +29,7 @@ export const FeatureCloneForm: FC<FeatureCloneFormProps> = memo(
     const environmentOptions = filteredOptions.map((environment) => {
       return {
         value: environment.id,
-        label: environment.id,
+        label: environment.name,
       };
     });
     return (

--- a/ui/web-v2/apps/admin/src/components/FeatureConfirmDialog/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureConfirmDialog/index.tsx
@@ -65,7 +65,7 @@ export const FeatureConfirmDialog: FC<FeatureConfirmDialogProps> = ({
   useEffect(() => {
     if (isArchive && open) {
       listFeatures({
-        environmentNamespace: currentEnvironment.namespace,
+        environmentNamespace: currentEnvironment.id,
         pageSize: 0,
         cursor: '',
         tags: [],

--- a/ui/web-v2/apps/admin/src/components/FeatureConfirmDialog/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureConfirmDialog/index.tsx
@@ -141,7 +141,7 @@ export const FeatureConfirmDialog: FC<FeatureConfirmDialogProps> = ({
                     <li key={flag.id}>
                       <Link
                         className="link text-left"
-                        to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${flag.id}`}
+                        to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${flag.id}`}
                       >
                         <p className="truncate w-60">{flag.name}</p>
                       </Link>

--- a/ui/web-v2/apps/admin/src/components/FeatureEvaluation/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureEvaluation/index.tsx
@@ -128,7 +128,7 @@ export const FeatureEvaluation: FC<FeatureEvaluationProps> = memo(
       dispatch(
         getEvaluationTimeseriesCount({
           featureId: featureId,
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           timeRange: o.value,
         })
       );

--- a/ui/web-v2/apps/admin/src/components/FeatureHeader/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureHeader/index.tsx
@@ -72,7 +72,7 @@ export const FeatureHeader: FC<FeatureHeaderProps> = memo(({ featureId }) => {
     <div>
       <div className="mb-4">
         <Breadcrumbs
-          pages={createPages(currentEnvironment.id, featureId, detailPath)}
+          pages={createPages(currentEnvironment.urlCode, featureId, detailPath)}
         />
       </div>
       <div className="flex">
@@ -99,16 +99,16 @@ export const FeatureHeader: FC<FeatureHeaderProps> = memo(({ featureId }) => {
   );
 });
 
-const createPages = (envId, featureId, detailPath: string) => {
+const createPages = (envUrlCode, featureId, detailPath: string) => {
   return [
     {
       name: intl.formatMessage(messages.sideMenu.featureFlags),
-      path: `${PAGE_PATH_ROOT}${envId}${PAGE_PATH_FEATURES}`,
+      path: `${PAGE_PATH_ROOT}${envUrlCode}${PAGE_PATH_FEATURES}`,
       current: false,
     },
     {
       name: featureId,
-      path: `${PAGE_PATH_ROOT}${envId}${PAGE_PATH_FEATURES}/${featureId}/${detailPath}`,
+      path: `${PAGE_PATH_ROOT}${envUrlCode}${PAGE_PATH_FEATURES}/${featureId}/${detailPath}`,
       current: true,
     },
   ];

--- a/ui/web-v2/apps/admin/src/components/FeatureList/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureList/index.tsx
@@ -354,7 +354,7 @@ export const FeatureList: FC<FeatureListProps> = memo(
                     <td className="px-5 py-3 border-b">
                       <div className="flex mb-2">
                         <Link
-                          to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${feature.id}${PAGE_PATH_FEATURE_TARGETING}`}
+                          to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${feature.id}${PAGE_PATH_FEATURE_TARGETING}`}
                           className="link text-left"
                         >
                           {feature.name}

--- a/ui/web-v2/apps/admin/src/components/FeatureTargetingForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureTargetingForm/index.tsx
@@ -398,7 +398,7 @@ const FlagIsPrerequisite: FC<FlagIsPrerequisiteProps> = ({ featureId }) => {
 
   useEffect(() => {
     listFeatures({
-      environmentNamespace: currentEnvironment.namespace,
+      environmentNamespace: currentEnvironment.id,
       pageSize: 0,
       cursor: '',
       tags: [],
@@ -551,7 +551,7 @@ export const PrerequisiteInput: FC<PrerequisiteInputProps> = memo(
     const dispatchListFeatures = () => {
       return dispatch(
         listFeatures({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: 99999,
           cursor: '',
           tags: [],
@@ -951,7 +951,7 @@ export const ClausesInput: FC<ClausesInputProps> = memo(({ ruleIdx }) => {
           });
           dispatch(
             listSegments({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               cursor: '',
             })
           );

--- a/ui/web-v2/apps/admin/src/components/FeatureTargetingForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/FeatureTargetingForm/index.tsx
@@ -472,7 +472,7 @@ const FlagIsPrerequisite: FC<FlagIsPrerequisiteProps> = ({ featureId }) => {
                   <li key={flag.id}>
                     <Link
                       className="link text-left"
-                      to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${flag.id}`}
+                      to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${flag.id}`}
                     >
                       <p className="truncate w-96">{flag.name}</p>
                     </Link>

--- a/ui/web-v2/apps/admin/src/components/SegmentDeleteDialog/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/SegmentDeleteDialog/index.tsx
@@ -60,7 +60,7 @@ export const SegmentDeleteDialog: FC<SegmentDeleteDialogProps> = ({
                       <li key={feature.id}>
                         <Link
                           className="link text-left"
-                          to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${feature.id}`}
+                          to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${feature.id}`}
                         >
                           <p className="truncate w-60">{feature.name}</p>
                         </Link>

--- a/ui/web-v2/apps/admin/src/components/SegmentUpdateForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/SegmentUpdateForm/index.tsx
@@ -155,7 +155,7 @@ export const SegmentUpdateForm: FC<SegmentUpdateFormProps> = memo(
                               <li key={feature.id}>
                                 <Link
                                   className="link text-left"
-                                  to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${feature.id}`}
+                                  to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${feature.id}`}
                                 >
                                   <p className="truncate w-60">
                                     {feature.name}

--- a/ui/web-v2/apps/admin/src/components/SideMenu/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/SideMenu/index.tsx
@@ -52,14 +52,14 @@ interface Divider {
 
 const createMenuItems = (
   isAdmin: boolean,
-  environmentId: string
+  environmentUrlCode: string
 ): Array<MenuItem | Divider> => {
   const items: Array<MenuItem | Divider> = [];
   items.push({
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.featureFlags)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_FEATURES}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_FEATURES}`,
     external: null,
     target: null,
     iconElement: <MUToggleOnIcon />,
@@ -68,7 +68,7 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.goals)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_GOALS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_GOALS}`,
     external: null,
     target: null,
     iconElement: <MUFlagIcon />,
@@ -77,7 +77,7 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.experiments)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_EXPERIMENTS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_EXPERIMENTS}`,
     external: null,
     target: null,
     iconElement: <MUBarChart />,
@@ -86,14 +86,14 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.userSegments)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_USER_SEGMENTS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_USER_SEGMENTS}`,
     external: null,
     target: null,
     iconElement: <MUPeopleIcon />,
   });
   // items.push({ TODO: User implementation
   //   messageComponent: <span>{intl.formatMessage(messages.sideMenu.user)}</span>,
-  //   path: `/${environmentId}${PAGE_PATH_USERS}`,
+  //   path: `/${environmentUrlCode}${PAGE_PATH_USERS}`,
   //   external: null,
   //   target: null,
   //   iconElement: <MUPermIdentityIcon />,
@@ -102,7 +102,7 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.auditLog)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_AUDIT_LOGS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_AUDIT_LOGS}`,
     external: null,
     target: null,
     iconElement: <MUNotificationsIcon />,
@@ -112,7 +112,7 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.accounts)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_ACCOUNTS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_ACCOUNTS}`,
     external: null,
     target: null,
     iconElement: <MUAccountCircleIcon />,
@@ -121,7 +121,7 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.apiKeys)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_APIKEYS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_APIKEYS}`,
     external: null,
     target: null,
     iconElement: <MUVpnKeyIcon />,
@@ -142,7 +142,7 @@ const createMenuItems = (
     messageComponent: (
       <span>{intl.formatMessage(messages.sideMenu.settings)}</span>
     ),
-    path: `/${environmentId}${PAGE_PATH_SETTINGS}`,
+    path: `/${environmentUrlCode}${PAGE_PATH_SETTINGS}`,
     external: null,
     target: null,
     iconElement: <MUSettingsIcon />,
@@ -196,7 +196,7 @@ export const SideMenu: FC<Props> = memo(({ onClickNavLink }) => {
         <EnvironmentSelect />
       </div>
       <div className="flex-grow">
-        {createMenuItems(me.isAdmin, currentEnvironment.id).map((item, i) =>
+        {createMenuItems(me.isAdmin, currentEnvironment.urlCode).map((item, i) =>
           isMenuItem(item) ? (
             <div key={i} className="py-1">
               <SideMenuItem item={item} onClick={onClickNavLink} />

--- a/ui/web-v2/apps/admin/src/components/WebhookUpdateForm/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/WebhookUpdateForm/index.tsx
@@ -41,7 +41,7 @@ export const WebhookUpdateForm: FC<WebhookUpdateFormProps> = memo(
     useEffect(() => {
       dispatch(
         getWebhook({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: webhookId,
         })
       );

--- a/ui/web-v2/apps/admin/src/grpc/account.ts
+++ b/ui/web-v2/apps/admin/src/grpc/account.ts
@@ -16,6 +16,8 @@ import {
   GetAccountResponse,
   GetMeRequest,
   GetMeResponse,
+  GetMeV2Request,
+  GetMeV2Response,
   ListAccountsRequest,
   ListAccountsResponse,
 } from '../proto/account/service_pb';
@@ -37,6 +39,25 @@ export interface GetMeResult {
 export function getMe(request: GetMeRequest): Promise<GetMeResult> {
   return new Promise((resolve: (result: GetMeResult) => void, reject): void => {
     client.getMe(request, getMetaData(), (error, response): void => {
+      if (isNotNull(error) || isNull(response)) {
+        reject(
+          new AccountServiceError(extractErrorMessage(error), request, error)
+        );
+      } else {
+        resolve({ request, response });
+      }
+    });
+  });
+}
+
+export interface GetMeV2Result {
+  request: GetMeV2Request;
+  response: GetMeV2Response;
+}
+
+export function getMeV2(request: GetMeV2Request): Promise<GetMeV2Result> {
+  return new Promise((resolve: (result: GetMeV2Result) => void, reject): void => {
+    client.getMeV2(request, getMetaData(), (error, response): void => {
       if (isNotNull(error) || isNull(response)) {
         reject(
           new AccountServiceError(extractErrorMessage(error), request, error)

--- a/ui/web-v2/apps/admin/src/modules/me.ts
+++ b/ui/web-v2/apps/admin/src/modules/me.ts
@@ -46,7 +46,7 @@ export const meSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchMe.fulfilled, (_, action) => {
-        const curEnvId = getCurrentEnvironmentId()
+        const curEnvId = (getCurrentEnvironmentId() != (null || undefined))
           ? getCurrentEnvironmentId()
           : action.payload.environmentRoles[0].environment.id;
         setCurrentEnvironmentId(curEnvId);
@@ -63,7 +63,7 @@ export const useMe = (): MeState =>
 
 const currentEnvironmentRole = (state: AppState): EnvironmentRoleV2.AsObject => {
   if ('environmentRoles' in state.me) {
-    const curEnvId = getCurrentEnvironmentId()
+    const curEnvId = (getCurrentEnvironmentId() != (null || undefined))
       ? getCurrentEnvironmentId()
       : state.me.environmentRoles[0].environment.id;
     const envRole = state.me.environmentRoles.find(

--- a/ui/web-v2/apps/admin/src/modules/me.ts
+++ b/ui/web-v2/apps/admin/src/modules/me.ts
@@ -1,9 +1,9 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { shallowEqual, useSelector } from 'react-redux';
 
-import { getMe } from '../grpc/account';
-import { Account, EnvironmentRole } from '../proto/account/account_pb';
-import { GetMeRequest } from '../proto/account/service_pb';
+import { getMeV2 } from '../grpc/account';
+import { Account, EnvironmentRoleV2 } from '../proto/account/account_pb';
+import { GetMeV2Request } from '../proto/account/service_pb';
 import { Environment } from '../proto/environment/environment_pb';
 import {
   getCurrentEnvironmentId,
@@ -16,14 +16,14 @@ const MODULE_NAME = 'me';
 
 export interface Me {
   isAdmin: boolean;
-  environmentRoles: Array<EnvironmentRole.AsObject>;
+  environmentRoles: Array<EnvironmentRoleV2.AsObject>;
   isLogin: boolean;
 }
 
 export type MeState = Me;
 
 export const fetchMe = createAsyncThunk<Me>('me/fetch', async () => {
-  const res = await getMe(new GetMeRequest());
+  const res = await getMeV2(new GetMeV2Request());
   return {
     isAdmin: res.response.getIsAdmin(),
     environmentRoles: res.response.toObject().environmentRolesList,

--- a/ui/web-v2/apps/admin/src/modules/me.ts
+++ b/ui/web-v2/apps/admin/src/modules/me.ts
@@ -4,7 +4,7 @@ import { shallowEqual, useSelector } from 'react-redux';
 import { getMeV2 } from '../grpc/account';
 import { Account, EnvironmentRoleV2 } from '../proto/account/account_pb';
 import { GetMeV2Request } from '../proto/account/service_pb';
-import { Environment } from '../proto/environment/environment_pb';
+import { EnvironmentV2 } from '../proto/environment/environment_pb';
 import {
   getCurrentEnvironmentId,
   setCurrentEnvironmentId,
@@ -61,7 +61,7 @@ export const meSlice = createSlice({
 export const useMe = (): MeState =>
   useSelector<AppState, MeState>((state) => state.me);
 
-const currentEnvironmentRole = (state: AppState): EnvironmentRole.AsObject => {
+const currentEnvironmentRole = (state: AppState): EnvironmentRoleV2.AsObject => {
   if ('environmentRoles' in state.me) {
     const curEnvId = getCurrentEnvironmentId()
       ? getCurrentEnvironmentId()
@@ -71,24 +71,24 @@ const currentEnvironmentRole = (state: AppState): EnvironmentRole.AsObject => {
     );
     return envRole;
   }
-  return new EnvironmentRole().toObject();
+  return new EnvironmentRoleV2().toObject();
 };
 
-export const useCurrentEnvironmentRole = (): EnvironmentRole.AsObject => {
-  return useSelector<AppState, EnvironmentRole.AsObject>(
+export const useCurrentEnvironmentRole = (): EnvironmentRoleV2.AsObject => {
+  return useSelector<AppState, EnvironmentRoleV2.AsObject>(
     currentEnvironmentRole,
     shallowEqual
   );
 };
 
-export const useCurrentEnvironment = (): Environment.AsObject => {
-  return useSelector<AppState, Environment.AsObject>((state: AppState) => {
+export const useCurrentEnvironment = (): EnvironmentV2.AsObject => {
+  return useSelector<AppState, EnvironmentV2.AsObject>((state: AppState) => {
     return currentEnvironmentRole(state).environment;
   }, shallowEqual);
 };
 
-export const useEnvironments = (): Array<Environment.AsObject> => {
-  return useSelector<AppState, Array<Environment.AsObject>>((state) => {
+export const useEnvironments = (): Array<EnvironmentV2.AsObject> => {
+  return useSelector<AppState, Array<EnvironmentV2.AsObject>>((state) => {
     if ('environmentRoles' in state.me) {
       return state.me.environmentRoles.map(
         (environmentRole) => environmentRole.environment

--- a/ui/web-v2/apps/admin/src/modules/me.ts
+++ b/ui/web-v2/apps/admin/src/modules/me.ts
@@ -46,6 +46,7 @@ export const meSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchMe.fulfilled, (_, action) => {
+        // Since some old environments have empty id, so accept empty and reject only null or undefined
         const curEnvId = (getCurrentEnvironmentId() != (null || undefined))
           ? getCurrentEnvironmentId()
           : action.payload.environmentRoles[0].environment.id;
@@ -63,6 +64,7 @@ export const useMe = (): MeState =>
 
 const currentEnvironmentRole = (state: AppState): EnvironmentRoleV2.AsObject => {
   if ('environmentRoles' in state.me) {
+    // Since some old environments have empty id, so accept empty and reject only null or undefined
     const curEnvId = (getCurrentEnvironmentId() != (null || undefined))
       ? getCurrentEnvironmentId()
       : state.me.environmentRoles[0].environment.id;

--- a/ui/web-v2/apps/admin/src/pages/account/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/account/index.tsx
@@ -132,7 +132,7 @@ export const AccountIndexPage: FC = memo(() => {
         options && options.enabled ? options.enabled === 'false' : null;
       dispatch(
         listAccounts({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: ACCOUNT_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -176,12 +176,12 @@ export const AccountIndexPage: FC = memo(() => {
         (() => {
           if (data.enabled) {
             return enableAccount({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.accountId,
             });
           }
           return disableAccount({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: data.accountId,
           });
         })()
@@ -189,7 +189,7 @@ export const AccountIndexPage: FC = memo(() => {
         setIsConfirmDialogOpen(false);
         dispatch(
           getAccount({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             email: data.accountId,
           })
         );
@@ -267,7 +267,7 @@ export const AccountIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createAccount({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           email: data.email,
           role: data.role,
         })
@@ -287,14 +287,14 @@ export const AccountIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         updateAccount({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: accountId,
           role: data.role,
         })
       ).then(() => {
         dispatch(
           getAccount({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             email: accountId,
           })
         );

--- a/ui/web-v2/apps/admin/src/pages/account/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/account/index.tsx
@@ -217,7 +217,7 @@ export const AccountIndexPage: FC = memo(() => {
   const handleOpenAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_ACCOUNTS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_ACCOUNTS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -230,7 +230,7 @@ export const AccountIndexPage: FC = memo(() => {
         role: a.role.toString(),
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_ACCOUNTS}/${a.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_ACCOUNTS}/${a.id}`,
         search: location.search,
       });
     },
@@ -258,7 +258,7 @@ export const AccountIndexPage: FC = memo(() => {
     resetUpdate();
     setOpen(false);
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_ACCOUNTS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_ACCOUNTS}`,
       search: location.search,
     });
   }, [setOpen, history, location, resetAdd, resetUpdate]);
@@ -275,7 +275,7 @@ export const AccountIndexPage: FC = memo(() => {
         resetAdd();
         setOpen(false);
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_ACCOUNTS}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_ACCOUNTS}`
         );
         updateAccountList(null, 1);
       });

--- a/ui/web-v2/apps/admin/src/pages/apiKey/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/apiKey/index.tsx
@@ -236,7 +236,7 @@ export const APIKeyIndexPage: FC = memo(() => {
   const handleOpenAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_APIKEYS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_APIKEYS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -248,7 +248,7 @@ export const APIKeyIndexPage: FC = memo(() => {
         name: a.name,
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_APIKEYS}/${a.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_APIKEYS}/${a.id}`,
         search: location.search,
       });
     },
@@ -260,7 +260,7 @@ export const APIKeyIndexPage: FC = memo(() => {
     resetAdd();
     resetUpdate();
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_APIKEYS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_APIKEYS}`,
       search: location.search,
     });
   }, [setOpen, history, location, resetAdd, resetUpdate]);
@@ -276,7 +276,7 @@ export const APIKeyIndexPage: FC = memo(() => {
         setOpen(false);
         resetAdd();
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_APIKEYS}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_APIKEYS}`
         );
         updateAPIKeyList(null, 1);
       });

--- a/ui/web-v2/apps/admin/src/pages/apiKey/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/apiKey/index.tsx
@@ -135,7 +135,7 @@ export const APIKeyIndexPage: FC = memo(() => {
         options && options.enabled ? options.enabled === 'false' : null;
       dispatch(
         listAPIKeys({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: APIKEY_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -180,12 +180,12 @@ export const APIKeyIndexPage: FC = memo(() => {
         (() => {
           if (data.enabled) {
             return enableAPIKey({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.apiKeyId,
             });
           }
           return disableAPIKey({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: data.apiKeyId,
           });
         })()
@@ -193,7 +193,7 @@ export const APIKeyIndexPage: FC = memo(() => {
         setIsConfirmDialogOpen(false);
         dispatch(
           getAPIKey({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: data.apiKeyId,
           })
         );
@@ -269,7 +269,7 @@ export const APIKeyIndexPage: FC = memo(() => {
     async (data: AddApiKeyFormSchema) => {
       dispatch(
         createAPIKey({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           name: data.name,
         })
       ).then(() => {
@@ -288,14 +288,14 @@ export const APIKeyIndexPage: FC = memo(() => {
     async (data: UpdateApiKeyFormSchema) => {
       dispatch(
         updateAPIKey({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: apiKeyId,
           name: data.name,
         })
       ).then(() => {
         dispatch(
           getAPIKey({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: apiKeyId,
           })
         );

--- a/ui/web-v2/apps/admin/src/pages/auditLog/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/auditLog/index.tsx
@@ -97,7 +97,7 @@ export const AuditLogIndexPage: FC = memo(() => {
 
     dispatch(
       listAuditLogs({
-        environmentNamespace: currentEnvironment.namespace,
+        environmentNamespace: currentEnvironment.id,
         pageSize: AUDITLOG_LIST_PAGE_SIZE,
         cursor: String(cursor),
         searchKeyword: searchOptions.q as string,

--- a/ui/web-v2/apps/admin/src/pages/experiment/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/experiment/index.tsx
@@ -162,7 +162,7 @@ export const ExperimentIndexPage: FC = memo(() => {
         options && options.archived ? options.archived === 'true' : false;
       dispatch(
         listExperiments({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: EXPERIMENT_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -243,7 +243,7 @@ export const ExperimentIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createExperiment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           name: data.name,
           description: data.description,
           featureId: data.featureId,
@@ -275,7 +275,7 @@ export const ExperimentIndexPage: FC = memo(() => {
       }
       dispatch(
         updateExperiment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: experimentId,
           changeNameCommand: changeExperimentNameCommand,
           changeDescriptionCommand: changeExperimentDescriptionCommand,
@@ -283,7 +283,7 @@ export const ExperimentIndexPage: FC = memo(() => {
       ).then(() => {
         dispatch(
           getExperiment({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: experimentId,
           })
         );
@@ -317,7 +317,7 @@ export const ExperimentIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         archiveExperiment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.experiment.id,
         })
       ).then(() => {
@@ -333,7 +333,7 @@ export const ExperimentIndexPage: FC = memo(() => {
     if (isUpdate) {
       dispatch(
         getExperiment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: experimentId,
         })
       ).then((e) => {

--- a/ui/web-v2/apps/admin/src/pages/experiment/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/experiment/index.tsx
@@ -207,7 +207,7 @@ export const ExperimentIndexPage: FC = memo(() => {
   const handleOpenAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_EXPERIMENTS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_EXPERIMENTS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -221,7 +221,7 @@ export const ExperimentIndexPage: FC = memo(() => {
         maintainer: e.maintainer,
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_EXPERIMENTS}/${e.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_EXPERIMENTS}/${e.id}`,
         search: location.search,
       });
     },
@@ -234,7 +234,7 @@ export const ExperimentIndexPage: FC = memo(() => {
     resetUpdate();
     const { fid, ...opts } = searchParams;
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_EXPERIMENTS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_EXPERIMENTS}`,
       search: stringifySearchParams(opts),
     });
   }, [searchParams, setOpen, history, resetAdd, resetUpdate]);

--- a/ui/web-v2/apps/admin/src/pages/feature/autoops.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/autoops.tsx
@@ -147,7 +147,7 @@ export const FeatureAutoOpsPage: FC<FeatureAutoOpsPageProps> = memo(
         );
 
         const updateAutoOpsRuleParams = createUpdateAutoOpsRuleParams(
-          currentEnvironment.namespace,
+          currentEnvironment.id,
           defaultValues.autoOpsRules,
           data.autoOpsRules
         );
@@ -159,7 +159,7 @@ export const FeatureAutoOpsPage: FC<FeatureAutoOpsPageProps> = memo(
             new Promise((resolve) => {
               dispatch(
                 createAutoOpsRule({
-                  environmentNamespace: currentEnvironment.namespace,
+                  environmentNamespace: currentEnvironment.id,
                   command: command,
                 })
               ).then((res) => {
@@ -174,7 +174,7 @@ export const FeatureAutoOpsPage: FC<FeatureAutoOpsPageProps> = memo(
             new Promise((resolve) => {
               dispatch(
                 deleteAutoOpsRule({
-                  environmentNamespace: currentEnvironment.namespace,
+                  environmentNamespace: currentEnvironment.id,
                   id: id,
                 })
               ).then((res) => {
@@ -198,7 +198,7 @@ export const FeatureAutoOpsPage: FC<FeatureAutoOpsPageProps> = memo(
           dispatch(
             listAutoOpsRules({
               featureId: featureId,
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
             })
           );
         });
@@ -210,12 +210,12 @@ export const FeatureAutoOpsPage: FC<FeatureAutoOpsPageProps> = memo(
       dispatch(
         listAutoOpsRules({
           featureId: featureId,
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
         })
       );
       dispatch(
         listGoals({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: 99999,
           cursor: '',
           searchKeyword: '',

--- a/ui/web-v2/apps/admin/src/pages/feature/detail.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/detail.tsx
@@ -67,7 +67,7 @@ export const FeatureDetailPage: FC = memo(() => {
     if (featureId) {
       dispatch(
         getFeature({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: featureId,
         })
       );

--- a/ui/web-v2/apps/admin/src/pages/feature/detail.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/detail.tsx
@@ -94,7 +94,7 @@ export const FeatureDetailPage: FC = memo(() => {
                     hover:text-gray-700
                     whitespace-nowrap py-4 px-1 border-b-2
                     font-medium text-sm"
-                to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${featureId}${tab.to}`}
+                to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${featureId}${tab.to}`}
               >
                 {tab.message}
               </NavLink>

--- a/ui/web-v2/apps/admin/src/pages/feature/evaluation.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/evaluation.tsx
@@ -31,7 +31,7 @@ export const FeatureEvaluationPage: FC<FeatureEvaluationPageProps> = memo(
       dispatch(
         getEvaluationTimeseriesCount({
           featureId: featureId,
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           timeRange: TimeRange.LAST_THIRTY_DAYS,
         })
       );

--- a/ui/web-v2/apps/admin/src/pages/feature/experiments.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/experiments.tsx
@@ -158,7 +158,7 @@ export const FeatureExperimentsPage: FC<FeatureExperimentsPageProps> = memo(
                 disabled={false}
                 onClick={() =>
                   history.push(
-                    `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_EXPERIMENTS}/${experiment.id}`
+                    `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_EXPERIMENTS}/${experiment.id}`
                   )
                 }
               >
@@ -172,7 +172,7 @@ export const FeatureExperimentsPage: FC<FeatureExperimentsPageProps> = memo(
                 disabled={false}
                 onClick={() =>
                   history.push(
-                    `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_EXPERIMENTS}${PAGE_PATH_NEW}?fid=${featureId}`
+                    `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_EXPERIMENTS}${PAGE_PATH_NEW}?fid=${featureId}`
                   )
                 }
               >

--- a/ui/web-v2/apps/admin/src/pages/feature/experiments.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/experiments.tsx
@@ -94,13 +94,13 @@ export const FeatureExperimentsPage: FC<FeatureExperimentsPageProps> = memo(
     const handleStop = useCallback(async () => {
       dispatch(
         stopExperiment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           experimentId: experimentId,
         })
       ).then(() => {
         dispatch(
           getExperiment({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: experimentId,
           })
         );
@@ -112,7 +112,7 @@ export const FeatureExperimentsPage: FC<FeatureExperimentsPageProps> = memo(
       dispatch(
         listExperiments({
           featureId: featureId,
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           searchKeyword: '',
           pageSize: 1000,
           cursor: '',

--- a/ui/web-v2/apps/admin/src/pages/feature/formSchema.ts
+++ b/ui/web-v2/apps/admin/src/pages/feature/formSchema.ts
@@ -200,7 +200,8 @@ export const archiveFormSchema = yup.object().shape({
 });
 
 export const cloneSchema = yup.object().shape({
-  destinationEnvironmentId: yup.string().required(),
+  // Since some old environments have empty id, so we don't require it
+  // destinationEnvironmentId: yup.string().required(),
 });
 
 export const onVariationSchema = yup.object().shape({

--- a/ui/web-v2/apps/admin/src/pages/feature/history.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/history.tsx
@@ -65,7 +65,7 @@ export const FeatureHistoryPage: FC<FeatureHistoryPageProps> = memo(
         dispatch(
           listFeatureHistory({
             featureId: featureId,
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             pageSize: AUDITLOG_LIST_PAGE_SIZE,
             cursor: String(cursor),
             searchKeyword: options.q as string,

--- a/ui/web-v2/apps/admin/src/pages/feature/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/index.tsx
@@ -283,7 +283,7 @@ export const FeatureIndexPage: FC = memo(() => {
   const handleOpen = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -293,7 +293,7 @@ export const FeatureIndexPage: FC = memo(() => {
     reset();
     cloneReset();
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}`,
       search: location.search,
     });
   }, [setOpen, history, location, reset]);
@@ -321,7 +321,7 @@ export const FeatureIndexPage: FC = memo(() => {
       ).then(() => {
         setOpen(false);
         history.push(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}/${data.id}${PAGE_PATH_FEATURE_TARGETING}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${data.id}${PAGE_PATH_FEATURE_TARGETING}`
         );
         TagManager.dataLayer({
           dataLayer: {
@@ -360,7 +360,7 @@ export const FeatureIndexPage: FC = memo(() => {
         .then(() => {
           cloneReset();
           history.replace(
-            `${PAGE_PATH_ROOT}${destinationEnvironment.id}${PAGE_PATH_FEATURES}/${featureId}${PAGE_PATH_FEATURE_TARGETING}`
+            `${PAGE_PATH_ROOT}${destinationEnvironment.urlCode}${PAGE_PATH_FEATURES}/${featureId}${PAGE_PATH_FEATURE_TARGETING}`
           );
         })
         .catch(() => {
@@ -424,7 +424,7 @@ export const FeatureIndexPage: FC = memo(() => {
       setOpen(true);
       cloneSetValue('feature', feature);
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}${PAGE_PATH_FEATURE_CLONE}/${feature.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}${PAGE_PATH_FEATURE_CLONE}/${feature.id}`,
         search: location.search,
       });
     },
@@ -449,7 +449,7 @@ export const FeatureIndexPage: FC = memo(() => {
         archiveReset();
         setIsArchiveConfirmDialogOpen(false);
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}`
         );
         updateFeatureList(null, 1);
       });

--- a/ui/web-v2/apps/admin/src/pages/feature/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/index.tsx
@@ -226,7 +226,7 @@ export const FeatureIndexPage: FC = memo(() => {
 
       dispatch(
         listFeatures({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: FEATURE_LIST_PAGE_SIZE,
           cursor: String(cursor),
           tags,
@@ -302,7 +302,7 @@ export const FeatureIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createFeature({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.id,
           name: data.name,
           description: data.description,
@@ -351,9 +351,9 @@ export const FeatureIndexPage: FC = memo(() => {
       );
       dispatch(
         cloneFeature({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: featureId,
-          destinationEnvironmentNamespace: destinationEnvironment.namespace,
+          destinationEnvironmentNamespace: destinationEnvironment.id,
         })
       )
         .then(unwrapResult)
@@ -385,13 +385,13 @@ export const FeatureIndexPage: FC = memo(() => {
         (() => {
           if (data.enabled) {
             return enableFeature({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.featureId,
               comment: data.comment,
             });
           }
           return disableFeature({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: data.featureId,
             comment: data.comment,
           });
@@ -401,7 +401,7 @@ export const FeatureIndexPage: FC = memo(() => {
         setIsSwitchEnableConfirmDialogOpen(false);
         dispatch(
           getFeature({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: data.featureId,
           })
         );
@@ -436,12 +436,12 @@ export const FeatureIndexPage: FC = memo(() => {
       dispatch(
         data.feature.archived
           ? unarchiveFeature({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.feature.id,
               comment: data.comment,
             })
           : archiveFeature({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.feature.id,
               comment: data.comment,
             })
@@ -472,7 +472,7 @@ export const FeatureIndexPage: FC = memo(() => {
     if (isClone) {
       dispatch(
         getFeature({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: featureId,
         })
       ).then((e) => {
@@ -484,7 +484,7 @@ export const FeatureIndexPage: FC = memo(() => {
     }
     dispatch(
       listAccounts({
-        environmentNamespace: currentEnvironment.namespace,
+        environmentNamespace: currentEnvironment.id,
         pageSize: FEATURE_ACCOUNT_PAGE_SIZE,
         cursor: '',
       })
@@ -495,7 +495,7 @@ export const FeatureIndexPage: FC = memo(() => {
     );
     dispatch(
       listTags({
-        environmentNamespace: currentEnvironment.namespace,
+        environmentNamespace: currentEnvironment.id,
         pageSize: 99999,
         cursor: '',
         orderBy: ListTagsRequest.OrderBy.DEFAULT,

--- a/ui/web-v2/apps/admin/src/pages/feature/settings.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/settings.tsx
@@ -98,7 +98,7 @@ export const FeatureSettingsPage: FC<FeatureSettingsPageProps> = memo(
         }
         dispatch(
           updateFeatureDetails({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: feature.id,
             comment: data.comment,
             updateDetailCommands: commands,
@@ -107,7 +107,7 @@ export const FeatureSettingsPage: FC<FeatureSettingsPageProps> = memo(
           setIsConfirmDialogOpen(false);
           dispatch(
             getFeature({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: featureId,
             })
           );

--- a/ui/web-v2/apps/admin/src/pages/feature/targeting.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/targeting.tsx
@@ -224,7 +224,7 @@ export const FeatureTargetingPage: FC<FeatureTargetingPageProps> = memo(
 
         dispatch(
           updateFeatureTargeting({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: feature.id,
             comment: data.comment,
             commands: commands,
@@ -233,7 +233,7 @@ export const FeatureTargetingPage: FC<FeatureTargetingPageProps> = memo(
           setIsConfirmDialogOpen(false);
           dispatch(
             getFeature({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: featureId,
             })
           ).then(() => {
@@ -247,7 +247,7 @@ export const FeatureTargetingPage: FC<FeatureTargetingPageProps> = memo(
     useEffect(() => {
       dispatch(
         listSegments({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           cursor: '',
         })
       );
@@ -266,7 +266,7 @@ export const FeatureTargetingPage: FC<FeatureTargetingPageProps> = memo(
       }
     }, [feature]);
 
-  
+
 
     return (
       <FormProvider {...methods}>

--- a/ui/web-v2/apps/admin/src/pages/feature/variations.tsx
+++ b/ui/web-v2/apps/admin/src/pages/feature/variations.tsx
@@ -156,7 +156,7 @@ export const FeatureVariationsPage: FC<FeatureVariationsPageProps> = memo(
         data.resetSampling && commands.push(createResetSampleSeedCommand());
         dispatch(
           updateFeatureVariations({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: feature.id,
             comment: data.comment,
             commands: commands,
@@ -165,7 +165,7 @@ export const FeatureVariationsPage: FC<FeatureVariationsPageProps> = memo(
           setIsConfirmDialogOpen(false);
           dispatch(
             getFeature({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: featureId,
             })
           );

--- a/ui/web-v2/apps/admin/src/pages/goal/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/goal/index.tsx
@@ -123,7 +123,7 @@ export const GoalIndexPage: FC = memo(() => {
         setOpen(false);
         resetAdd();
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_GOALS}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_GOALS}`
         );
         updateGoalList(null, 1);
       });
@@ -230,7 +230,7 @@ export const GoalIndexPage: FC = memo(() => {
   const handleOpen = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_GOALS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_GOALS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -244,7 +244,7 @@ export const GoalIndexPage: FC = memo(() => {
         description: g.description,
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_GOALS}/${g.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_GOALS}/${g.id}`,
         search: location.search,
       });
     },
@@ -292,7 +292,7 @@ export const GoalIndexPage: FC = memo(() => {
     resetAdd();
     resetUpdate();
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_GOALS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_GOALS}`,
       search: location.search,
     });
   }, [setOpen, history, location, resetAdd, resetUpdate]);

--- a/ui/web-v2/apps/admin/src/pages/goal/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/goal/index.tsx
@@ -114,7 +114,7 @@ export const GoalIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createGoal({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.id,
           name: data.name,
           description: data.description,
@@ -143,7 +143,7 @@ export const GoalIndexPage: FC = memo(() => {
       }
       dispatch(
         updateGoal({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: goalId,
           name: name,
           description: description,
@@ -151,7 +151,7 @@ export const GoalIndexPage: FC = memo(() => {
       ).then(() => {
         dispatch(
           getGoal({
-            environmentNamespace: currentEnvironment.namespace,
+            environmentNamespace: currentEnvironment.id,
             id: goalId,
           })
         );
@@ -197,7 +197,7 @@ export const GoalIndexPage: FC = memo(() => {
           : false;
       dispatch(
         listGoals({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: GOAL_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -275,7 +275,7 @@ export const GoalIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         archiveGoal({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.goal.id,
         })
       ).then(() => {

--- a/ui/web-v2/apps/admin/src/pages/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/index.tsx
@@ -112,7 +112,7 @@ export const Root: FC = memo(() => {
           <Route path={PAGE_PATH_ADMIN} component={AdminRoot} />
           <Route
             key={pageKey}
-            path={'/:environmentId?'}
+            path={'/:environmentUrlCode?'}
             component={EnvironmentRoot}
           />
           <Route path="*">
@@ -150,12 +150,12 @@ export const EnvironmentRoot: FC = memo(() => {
   const me = useMe();
   const currentEnvironment = useCurrentEnvironment();
   const { url } = useRouteMatch();
-  const { environmentId } = useParams<{ environmentId: string }>();
+  const { environmentUrlCode } = useParams<{ environmentUrlCode: string }>();
 
-  if (environmentId == undefined) {
+  if (environmentUrlCode == undefined) {
     return (
       <Redirect
-        to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_FEATURES}`}
+        to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}`}
       />
     );
   }
@@ -163,12 +163,12 @@ export const EnvironmentRoot: FC = memo(() => {
     return null;
   }
   const environment = me.environmentRoles.find(
-    (environmentRole) => environmentRole.environment.id === environmentId
+    (environmentRole) => environmentRole.environment.urlCode === environmentUrlCode
   );
   if (!environment) {
     return <NotFound />;
   }
-  dispatch(setCurrentEnvironment(environmentId));
+  dispatch(setCurrentEnvironment(environment.environment.id));
 
   return (
     <>

--- a/ui/web-v2/apps/admin/src/pages/notification/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/notification/index.tsx
@@ -119,7 +119,7 @@ export const NotificationIndexPage: FC = memo(() => {
         options && options.enabled ? options.enabled === 'false' : null;
       dispatch(
         listNotification({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: NOTIFICATION_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -182,7 +182,7 @@ export const NotificationIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createNotification({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           name: data.name,
           sourceTypes: data.sourceTypes,
           webhookUrl: data.webhookUrl,
@@ -240,7 +240,7 @@ export const NotificationIndexPage: FC = memo(() => {
       }
       dispatch(
         updateNotification({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: notificationId,
           name: name,
           currentSourceTypes: notification.sourceTypesList,
@@ -289,11 +289,11 @@ export const NotificationIndexPage: FC = memo(() => {
       dispatch(
         data.notification.disabled
           ? enableNotification({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.notification.id,
             })
           : disableNotification({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: data.notification.id,
             })
       ).then(() => {
@@ -329,7 +329,7 @@ export const NotificationIndexPage: FC = memo(() => {
     (data) => {
       dispatch(
         deleteNotification({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.notification.id,
         })
       ).then(() => {

--- a/ui/web-v2/apps/admin/src/pages/notification/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/notification/index.tsx
@@ -162,7 +162,7 @@ export const NotificationIndexPage: FC = memo(() => {
   const handleOnClickAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -191,7 +191,7 @@ export const NotificationIndexPage: FC = memo(() => {
         setOpen(false);
         resetAdd();
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}`
         );
         updateNotificationList(null, 1);
       });
@@ -208,7 +208,7 @@ export const NotificationIndexPage: FC = memo(() => {
         sourceTypes: [...s.sourceTypesList].sort(),
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}/${s.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}/${s.id}`,
         search: location.search,
       });
     },
@@ -261,7 +261,7 @@ export const NotificationIndexPage: FC = memo(() => {
     resetAdd();
     setOpen(false);
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_NOTIFICATIONS}`,
       search: location.search,
     });
   }, [setOpen, history, location, resetAdd]);

--- a/ui/web-v2/apps/admin/src/pages/push/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/push/index.tsx
@@ -151,7 +151,7 @@ export const PushIndexPage: FC = memo(() => {
   const handleOnClickAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -180,7 +180,7 @@ export const PushIndexPage: FC = memo(() => {
         setOpen(false);
         resetAdd();
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}`
         );
         updatePushList(null, 1);
       });
@@ -197,7 +197,7 @@ export const PushIndexPage: FC = memo(() => {
         tags: p.tagsList,
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}/${p.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}/${p.id}`,
         search: location.search,
       });
     },
@@ -249,7 +249,7 @@ export const PushIndexPage: FC = memo(() => {
     resetUpdate();
     setOpen(false);
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_PUSHES}`,
       search: location.search,
     });
   }, [setOpen, history, location, resetAdd]);

--- a/ui/web-v2/apps/admin/src/pages/push/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/push/index.tsx
@@ -109,7 +109,7 @@ export const PushIndexPage: FC = memo(() => {
       const cursor = (page - 1) * PUSH_LIST_PAGE_SIZE;
       dispatch(
         listPushes({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: PUSH_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -171,7 +171,7 @@ export const PushIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createPush({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           name: data.name,
           fcmApiKey: data.fcmApiKey,
           tags: data.tags,
@@ -227,7 +227,7 @@ export const PushIndexPage: FC = memo(() => {
       }
       dispatch(
         updatePush({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: pushId,
           name: name,
           currentTags: push.tagsList,
@@ -276,7 +276,7 @@ export const PushIndexPage: FC = memo(() => {
     (data) => {
       dispatch(
         deletePush({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.push.id,
         })
       ).then(() => {
@@ -308,7 +308,7 @@ export const PushIndexPage: FC = memo(() => {
   useEffect(() => {
     dispatch(
       listTags({
-        environmentNamespace: currentEnvironment.namespace,
+        environmentNamespace: currentEnvironment.id,
         pageSize: 99999,
         cursor: '',
         orderBy: ListTagsRequest.OrderBy.DEFAULT,

--- a/ui/web-v2/apps/admin/src/pages/segment/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/segment/index.tsx
@@ -133,7 +133,7 @@ export const SegmentIndexPage: FC = memo(() => {
         options && options.inUse != null ? options.inUse === 'true' : null;
       dispatch(
         listSegments({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: SEGMENT_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -174,7 +174,7 @@ export const SegmentIndexPage: FC = memo(() => {
       setIsConfirmDialogOpen(false);
       dispatch(
         deleteSegmentUser({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.segment.id,
         })
       );
@@ -186,7 +186,7 @@ export const SegmentIndexPage: FC = memo(() => {
     (segment: Segment.AsObject) => {
       dispatch(
         bulkDownloadSegmentUsers({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           segmentId: segment.id,
         })
       ).then((data) => {
@@ -197,7 +197,7 @@ export const SegmentIndexPage: FC = memo(() => {
         link.href = url;
         link.setAttribute(
           'download',
-          `${currentEnvironment.namespace}-${segment.name}.csv`
+          `${currentEnvironment.name}-${segment.name}.csv`
         );
         window.document.body.appendChild(link);
         link.click();
@@ -292,7 +292,7 @@ export const SegmentIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createSegment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           name: data.name,
           description: data.description,
         })
@@ -311,7 +311,7 @@ export const SegmentIndexPage: FC = memo(() => {
           convertFileToUint8Array(file, (uint8Array) => {
             dispatch(
               bulkUploadSegmentUsers({
-                environmentNamespace: currentEnvironment.namespace,
+                environmentNamespace: currentEnvironment.id,
                 segmentId: response.payload as string,
                 data: uint8Array,
               })
@@ -371,14 +371,14 @@ export const SegmentIndexPage: FC = memo(() => {
         convertFileToUint8Array(file, (uint8Array) => {
           dispatch(
             bulkUploadSegmentUsers({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               segmentId: segmentId,
               data: uint8Array,
             })
           ).then(() => {
             dispatch(
               getSegment({
-                environmentNamespace: currentEnvironment.namespace,
+                environmentNamespace: currentEnvironment.id,
                 id: segmentId,
               })
             ).then(handleOnClose);
@@ -389,7 +389,7 @@ export const SegmentIndexPage: FC = memo(() => {
       // Name, description and file
       dispatch(
         updateSegment({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: segmentId,
           name: name,
           description: description,
@@ -398,7 +398,7 @@ export const SegmentIndexPage: FC = memo(() => {
         if (!file) {
           dispatch(
             getSegment({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               id: segmentId,
             })
           ).then(handleOnClose);
@@ -407,14 +407,14 @@ export const SegmentIndexPage: FC = memo(() => {
         convertFileToUint8Array(file, (uint8Array) => {
           dispatch(
             bulkUploadSegmentUsers({
-              environmentNamespace: currentEnvironment.namespace,
+              environmentNamespace: currentEnvironment.id,
               segmentId: segmentId,
               data: uint8Array,
             })
           ).then(() => {
             dispatch(
               getSegment({
-                environmentNamespace: currentEnvironment.namespace,
+                environmentNamespace: currentEnvironment.id,
                 id: segmentId,
               })
             ).then(handleOnClose);

--- a/ui/web-v2/apps/admin/src/pages/segment/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/segment/index.tsx
@@ -228,7 +228,7 @@ export const SegmentIndexPage: FC = memo(() => {
   const handleOnClickAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_USER_SEGMENTS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_USER_SEGMENTS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -248,7 +248,7 @@ export const SegmentIndexPage: FC = memo(() => {
           featureList: s.featuresList,
         });
         history.push({
-          pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_USER_SEGMENTS}/${s.id}`,
+          pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_USER_SEGMENTS}/${s.id}`,
           search: location.search,
         });
       }
@@ -283,7 +283,7 @@ export const SegmentIndexPage: FC = memo(() => {
     resetUpdate();
     setOpen(false);
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_USER_SEGMENTS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_USER_SEGMENTS}`,
       search: location.search,
     });
   }, [setOpen, history, location, resetAdd, resetUpdate]);
@@ -329,7 +329,7 @@ export const SegmentIndexPage: FC = memo(() => {
     resetAdd();
     setOpen(false);
     history.replace(
-      `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_USER_SEGMENTS}`
+      `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_USER_SEGMENTS}`
     );
     updateSegmentList(null, 1);
   };

--- a/ui/web-v2/apps/admin/src/pages/settings/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/settings/index.tsx
@@ -50,7 +50,7 @@ export const SettingsIndexPage: FC = memo(() => {
                     hover:text-gray-700
                     whitespace-nowrap py-4 px-5 border-b-2
                     font-medium text-sm"
-                to={`${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${tab.to}`}
+                to={`${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${tab.to}`}
               >
                 {tab.message}
               </NavLink>

--- a/ui/web-v2/apps/admin/src/pages/webhook/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/webhook/index.tsx
@@ -104,7 +104,7 @@ export const WebhookIndexPage: FC = memo(() => {
       const cursor = (page - 1) * PUSH_LIST_PAGE_SIZE;
       dispatch(
         listWebhooks({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           pageSize: PUSH_LIST_PAGE_SIZE,
           cursor: String(cursor),
           searchKeyword: options && (options.q as string),
@@ -165,7 +165,7 @@ export const WebhookIndexPage: FC = memo(() => {
     async (data) => {
       dispatch(
         createWebhook({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           name: data.name,
           description: data.description,
         })
@@ -220,7 +220,7 @@ export const WebhookIndexPage: FC = memo(() => {
       }
       dispatch(
         updateWebhook({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: webhookId,
           name: name,
           description,
@@ -268,7 +268,7 @@ export const WebhookIndexPage: FC = memo(() => {
     (data) => {
       dispatch(
         deleteWebhook({
-          environmentNamespace: currentEnvironment.namespace,
+          environmentNamespace: currentEnvironment.id,
           id: data.webhook.id,
         })
       ).then(() => {

--- a/ui/web-v2/apps/admin/src/pages/webhook/index.tsx
+++ b/ui/web-v2/apps/admin/src/pages/webhook/index.tsx
@@ -146,7 +146,7 @@ export const WebhookIndexPage: FC = memo(() => {
   const handleOnClickAdd = useCallback(() => {
     setOpen(true);
     history.push({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}${PAGE_PATH_NEW}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}${PAGE_PATH_NEW}`,
       search: location.search,
     });
   }, [setOpen, history, location]);
@@ -173,7 +173,7 @@ export const WebhookIndexPage: FC = memo(() => {
         setOpen(false);
         resetAdd();
         history.replace(
-          `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}`
+          `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}`
         );
         updateWebhookList(null, 1);
       });
@@ -189,7 +189,7 @@ export const WebhookIndexPage: FC = memo(() => {
         description: w.description,
       });
       history.push({
-        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}/${w.id}`,
+        pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}/${w.id}`,
         search: location.search,
       });
     },
@@ -241,7 +241,7 @@ export const WebhookIndexPage: FC = memo(() => {
     resetUpdate();
     setOpen(false);
     history.replace({
-      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.id}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}`,
+      pathname: `${PAGE_PATH_ROOT}${currentEnvironment.urlCode}${PAGE_PATH_SETTINGS}${PAGE_PATH_WEBHOOKS}`,
       search: location.search,
     });
   }, [setOpen, resetAdd, resetUpdate]);


### PR DESCRIPTION
- This PR updates the console to use the environment V2.
  - updates to use the  GetMeV2 API. https://github.com/bucketeer-io/bucketeer/pull/528/commits/55d1cf41ee9270302c664868d1b9bd0a15f365d5, https://github.com/bucketeer-io/bucketeer/pull/528/commits/8135f33077b3e7a6656b2ec5797e8834d5c0cca6
  -  updates the environment namespace field in the request body to environmentV2's ID. https://github.com/bucketeer-io/bucketeer/pull/528/commits/87f32458d1fe571c2d6e84d5c86cd34a6b35354f

  - updates the Environment Select component. https://github.com/bucketeer-io/bucketeer/pull/528/commits/9c1a57bb40d3d17038e9a566e7dfd942a1a09427
  - updates the URL path to use the environmentV2's urlCode instead of envV1's ID. https://github.com/bucketeer-io/bucketeer/pull/528/commits/f07ca2c641293d5f42c36eb70d43e31c20e9448d
  - updates the feature clone form component. https://github.com/bucketeer-io/bucketeer/pull/528/commits/193590a3f4e14398487ba16d832f0c61af5fe451


- What is not done in this PR.
  - updates to use ListEnvironmentV2, GetEnvironmentV2, CreateEnvironmentV2 API.