### PR TITLE
chore: remove the tag validation for evaluate feature api

### DIFF
--- a/pkg/feature/api/error.go
+++ b/pkg/feature/api/error.go
@@ -59,7 +59,6 @@ var (
 		codes.InvalidArgument,
 		"feature: feature must contain one or more tags",
 	)
-	statusMissingFeatureTag               = gstatus.New(codes.InvalidArgument, "feature: missing feature tag")
 	statusUnknownCommand                  = gstatus.New(codes.InvalidArgument, "feature: unknown command")
 	statusMissingRule                     = gstatus.New(codes.InvalidArgument, "feature: missing rule")
 	statusMissingRuleID                   = gstatus.New(codes.InvalidArgument, "feature: missing rule id")

--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -620,13 +620,6 @@ func TestEvaluateFeatures(t *testing.T) {
 			expectedErr: createError(statusMissingUserID, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "user_id")),
 		},
 		{
-			desc:        "fail: ErrMissingFeatureTag",
-			setup:       nil,
-			input:       &featureproto.EvaluateFeaturesRequest{User: &userproto.User{Id: "test-id"}, EnvironmentNamespace: "ns0"},
-			expected:    nil,
-			expectedErr: createError(statusMissingFeatureTag, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "tag")),
-		},
-		{
 			desc: "fail: return errInternal when getting features",
 			setup: func(s *FeatureService) {
 				s.featuresCache.(*cachev3mock.MockFeaturesCache).EXPECT().Get(gomock.Any()).Return(

--- a/pkg/feature/api/validation.go
+++ b/pkg/feature/api/validation.go
@@ -788,16 +788,6 @@ func validateEvaluateFeatures(req *featureproto.EvaluateFeaturesRequest, localiz
 		}
 		return dt.Err()
 	}
-	if req.Tag == "" {
-		dt, err := statusMissingFeatureTag.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "tag"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
 	return nil
 }
 

--- a/test/e2e/feature/feature_test.go
+++ b/test/e2e/feature/feature_test.go
@@ -1252,6 +1252,23 @@ func TestEvaluateFeatures(t *testing.T) {
 	}
 }
 
+func TestEvaluateFeaturesWithEmptyTag(t *testing.T) {
+	t.Parallel()
+	client := newFeatureClient(t)
+	featureID1 := newFeatureID(t)
+	cmd1 := newCreateFeatureCommand(featureID1)
+	createFeature(t, client, cmd1)
+	featureID2 := newFeatureID(t)
+	cmd2 := newCreateFeatureCommand(featureID2)
+	createFeature(t, client, cmd2)
+	enableFeature(t, cmd2.Id, client)
+	userID := "user-id-01"
+	res := evaluateFeatures(t, client, userID, "")
+	if len(res.UserEvaluations.Evaluations) < 2 {
+		t.Fatalf("length of user evaluations is not enough. Expected: >=%d, Actual: %d", 2, len(res.UserEvaluations.Evaluations))
+	}
+}
+
 // TODO: implement the process to delete new environments so that we can run "TestCloneFeature"
 /*
 func TestCloneFeature(t *testing.T) {


### PR DESCRIPTION
We need to remove the tag validation because the tag is now optional. Otherwise, linking the experiment to a flag could not work if the tag is empty.