### PR TITLE
chore: change not to save events after the experiment is ended

### DIFF
--- a/pkg/eventpersisterdwh/persister/goal_event.go
+++ b/pkg/eventpersisterdwh/persister/goal_event.go
@@ -256,7 +256,13 @@ func (w *goalEvtWriter) linkGoalEventByExperiment(
 			// If the goal event was issued before the experiment started running,
 			// we ignore those events to avoid issues in the conversion rate
 			if exp.StartAt > event.Timestamp {
-				handledCounter.WithLabelValues(codeGoalEventOlderThanExperiment).Inc()
+				handledCounter.WithLabelValues(codeEventOlderThanExperiment).Inc()
+				continue
+			}
+			// If the goal event was issued after the experiment ended,
+			// we ignore those events to avoid issues in the conversion rate
+			if exp.StopAt < event.Timestamp {
+				handledCounter.WithLabelValues(codeGoalEventIssuedAfterExperimentEnded).Inc()
 				continue
 			}
 			exps = append(exps, exp)

--- a/pkg/eventpersisterdwh/persister/metrics.go
+++ b/pkg/eventpersisterdwh/persister/metrics.go
@@ -21,14 +21,16 @@ import (
 )
 
 const (
-	codeEvaluationsAreEmpty            = "EvaluationsAreEmpty"
-	codeGoalEventOlderThanExperiment   = "GoalEventOlderThanExperiment"
-	codeFailedToEvaluateUser           = "FailedToEvaluateUser"
-	codeFailedToListExperiments        = "FailedToListExperiments"
-	codeFailedToAppendEvaluationEvents = "FailedToAppendEvaluationEvents"
-	codeFailedToAppendGoalEvents       = "FailedToAppendGoalEvents"
-	codeLinked                         = "Linked"
-	codeNoLink                         = "NoLink"
+	codeEvaluationsAreEmpty                 = "EvaluationsAreEmpty"
+	codeEventIssuedAfterExperimentEnded     = "EventIssuedAfterExperimentEnded"
+	codeEventOlderThanExperiment            = "EventOlderThanExperiment"
+	codeGoalEventIssuedAfterExperimentEnded = "GoalEventIssuedAfterExperimentEnded"
+	codeFailedToEvaluateUser                = "FailedToEvaluateUser"
+	codeFailedToListExperiments             = "FailedToListExperiments"
+	codeFailedToAppendEvaluationEvents      = "FailedToAppendEvaluationEvents"
+	codeFailedToAppendGoalEvents            = "FailedToAppendGoalEvents"
+	codeLinked                              = "Linked"
+	codeNoLink                              = "NoLink"
 )
 
 var (

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -37,15 +37,16 @@ const (
 )
 
 var (
-	ErrUnexpectedMessageType = errors.New("eventpersister: unexpected message type")
-	ErrAutoOpsRulesNotFound  = errors.New("eventpersister: auto ops rules not found")
-	ErrEvaluationsAreEmpty   = errors.New("eventpersister: evaluations are empty")
-	ErrExperimentNotFound    = errors.New("eventpersister: experiment not found")
-	ErrFailedToEvaluateUser  = errors.New("eventpersister: failed to evaluate user")
-	ErrNoAutoOpsRules        = errors.New("eventpersister: no auto ops rules")
-	ErrNoExperiments         = errors.New("eventpersister: no experiments")
-	ErrNothingToLink         = errors.New("eventpersister: nothing to link")
-	ErrInvalidEventTimestamp = errors.New("eventpersister: invalid event timestamp")
+	ErrUnexpectedMessageType               = errors.New("eventpersister: unexpected message type")
+	ErrAutoOpsRulesNotFound                = errors.New("eventpersister: auto ops rules not found")
+	ErrEvaluationsAreEmpty                 = errors.New("eventpersister: evaluations are empty")
+	ErrExperimentNotFound                  = errors.New("eventpersister: experiment not found")
+	ErrGoalEventIssuedAfterExperimentEnded = errors.New("eventpersister: goal event issued after experiment ended")
+	ErrFailedToEvaluateUser                = errors.New("eventpersister: failed to evaluate user")
+	ErrNoAutoOpsRules                      = errors.New("eventpersister: no auto ops rules")
+	ErrNoExperiments                       = errors.New("eventpersister: no experiments")
+	ErrNothingToLink                       = errors.New("eventpersister: nothing to link")
+	ErrInvalidEventTimestamp               = errors.New("eventpersister: invalid event timestamp")
 )
 
 type PersisterDWH struct {


### PR DESCRIPTION
To avoid saving events that won't be calculated by the experiment calculator, I changed the condition to ignore events older than the experiment's `stopAt`.