### PR TITLE
chore: update the deprecated kubernetes api

### DIFF
--- a/manifests/bucketeer/charts/account-apikey-cacher/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/account-apikey-cacher/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "account-apikey-cacher.fullname" . }}

--- a/manifests/bucketeer/charts/api-gateway/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "api-gateway.fullname" . }}

--- a/manifests/bucketeer/charts/api-gateway/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/api-gateway/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "api-gateway.fullname" . }}

--- a/manifests/bucketeer/charts/auditlog-persister/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/auditlog-persister/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "auditlog-persister.fullname" . }}

--- a/manifests/bucketeer/charts/backend/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/backend/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "backend.fullname" . }}

--- a/manifests/bucketeer/charts/backend/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/backend/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "backend.fullname" . }}

--- a/manifests/bucketeer/charts/batch/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/batch/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "batch-server.fullname" . }}

--- a/manifests/bucketeer/charts/dex/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/dex/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "dex.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-dwh/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "event-persister-evaluation-events-dwh.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "event-persister-evaluation-events-evaluation-count.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-ops/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "event-persister-evaluation-events-ops.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-dwh/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "event-persister-goal-events-dwh.fullname" . }}

--- a/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/event-persister-goal-events-ops/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "event-persister-goal-events-ops.fullname" . }}

--- a/manifests/bucketeer/charts/experiment-calculator/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/experiment-calculator/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "experiment-calculator.fullname" . }}

--- a/manifests/bucketeer/charts/experiment-calculator/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/experiment-calculator/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "experiment-calculator.fullname" . }}

--- a/manifests/bucketeer/charts/feature-segment-persister/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/feature-segment-persister/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "feature-segment-persister.fullname" . }}

--- a/manifests/bucketeer/charts/metrics-event-persister/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/metrics-event-persister/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "metrics-event-persister.fullname" . }}

--- a/manifests/bucketeer/charts/user-persister/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/user-persister/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "user-persister.fullname" . }}

--- a/manifests/bucketeer/charts/web-gateway/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "web-gateway.fullname" . }}

--- a/manifests/bucketeer/charts/web-gateway/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/web-gateway/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "web-gateway.fullname" . }}

--- a/manifests/bucketeer/charts/web/templates/hpa.yaml
+++ b/manifests/bucketeer/charts/web/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.hpa.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ template "web.fullname" . }}

--- a/manifests/bucketeer/charts/web/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/web/templates/pdb.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "web.fullname" . }}


### PR DESCRIPTION
- `autoscaling/v2beta1` and `policy/v1beta1` API are deleted on the Kubernetes1.25.