### PR TITLE
fix: project hack script not creating environment correctly

### DIFF
--- a/hack/create-project/README.md
+++ b/hack/create-project/README.md
@@ -1,11 +1,18 @@
 ## Run Command
 
+The flag `description` and the `create-environment` are optional.
+
+E.g.
+
 ```
 go run ./hack/create-project create \
   --cert=full-path-to-certificate \
   --web-gateway=web-gateway-address \
   --service-token=full-path-to-service-token-file \
-  --id=project-id \
-  --description=optional-project-description \
-  --create-environments(optional)
+  --name="Project name" \
+  --url-code=url-code \
+  --description="Project description" \
+  --create-environment=dev \
+  --no-profile \
+  --no-gcp-trace-enabled
 ```

--- a/hack/create-project/command.go
+++ b/hack/create-project/command.go
@@ -27,7 +27,6 @@ import (
 	environmentclient "github.com/bucketeer-io/bucketeer/pkg/environment/client"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc/client"
-	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	environmentproto "github.com/bucketeer-io/bucketeer/proto/environment"
 )
 
@@ -37,8 +36,9 @@ type command struct {
 	serviceTokenPath   *string
 	webGatewayAddress  *string
 	name               *string
+	urlCode            *string
 	description        *string
-	createEnvironments *bool
+	createEnvironments *[]string
 }
 
 func registerCommand(r cli.CommandRegistry, p cli.ParentCommand) *command {
@@ -49,14 +49,20 @@ func registerCommand(r cli.CommandRegistry, p cli.ParentCommand) *command {
 		serviceTokenPath:   cmd.Flag("service-token", "Path to service token file.").Required().String(),
 		webGatewayAddress:  cmd.Flag("web-gateway", "Address of web-gateway.").Required().String(),
 		name:               cmd.Flag("name", "Name of an project.").Required().String(),
+		urlCode:            cmd.Flag("url-code", "URL code for the project.").Required().String(),
 		description:        cmd.Flag("description", "(optional) Description of an project.").String(),
-		createEnvironments: cmd.Flag("create-environments", "create environments or not").Bool(),
+		createEnvironments: cmd.Flag("create-environment", "A list of environment names to be created").Strings(),
 	}
 	r.RegisterCommand(command)
 	return command
 }
 
 func (c *command) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.Logger) error {
+	logger.Info("Yeah babe",
+		zap.String("webGatewayAddress", *c.webGatewayAddress),
+		zap.String("serviceTokenPath", *c.serviceTokenPath),
+		zap.String("certPath", *c.certPath),
+	)
 	client, err := createEnvironmentClient(*c.webGatewayAddress, *c.certPath, *c.serviceTokenPath, logger)
 	if err != nil {
 		logger.Error("Failed to create environment client", zap.Error(err))
@@ -66,44 +72,37 @@ func (c *command) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.
 	req := &environmentproto.CreateProjectRequest{
 		Command: &environmentproto.CreateProjectCommand{
 			Name:        *c.name,
-			UrlCode:     *c.name,
+			UrlCode:     strings.ToLower(strings.ReplaceAll(*c.urlCode, " ", "-")),
 			Description: *c.description,
 		},
 	}
-	if _, err = client.CreateProject(ctx, req); err != nil {
+	resp, err := client.CreateProject(ctx, req)
+	if err != nil {
 		logger.Error("Failed to create project", zap.Error(err))
 		return err
 	}
-	logger.Info(fmt.Sprintf("%s project created", *c.name))
+	projID := resp.Project.Id
+	logger.Info(fmt.Sprintf("%s project created. ID: %s", resp.Project.Name, projID))
 	// create environments (optional)
-	if *c.createEnvironments {
-		envIDs := []string{
-			fmt.Sprintf("%s-development", *c.name),
-			fmt.Sprintf("%s-staging", *c.name),
-			fmt.Sprintf("%s-production", *c.name),
+	for _, envName := range *c.createEnvironments {
+		req := &environmentproto.CreateEnvironmentV2Request{
+			Command: &environmentproto.CreateEnvironmentV2Command{
+				Name:      envName,
+				UrlCode:   strings.ToLower(strings.ReplaceAll(envName, " ", "-")),
+				ProjectId: projID,
+			},
 		}
-		for _, envID := range envIDs {
-			id, err := uuid.NewUUID()
-			if err != nil {
-				logger.Error("Failed to create uuid", zap.Error(err))
-				return err
-			}
-			uid := strings.ReplaceAll(id.String(), "-", "")
-			req := &environmentproto.CreateEnvironmentV2Request{
-				Command: &environmentproto.CreateEnvironmentV2Command{
-					Name:      envID,
-					UrlCode:   envID,
-					ProjectId: uid,
-				},
-			}
-			if _, err = client.CreateEnvironmentV2(ctx, req); err != nil {
-				logger.Error("Failed to create environment", zap.Error(err))
-				return err
-			}
-			logger.Info(fmt.Sprintf("%s environment created", envID))
+		resp, err := client.CreateEnvironmentV2(ctx, req)
+		if err != nil {
+			logger.Error("Failed to create environment", zap.Error(err))
+			return err
 		}
+		logger.Info(fmt.Sprintf(
+			"%s environment created. ID: %s",
+			resp.Environment.Name, resp.Environment.Id,
+		))
 	}
-	logger.Info("Succeeded")
+	logger.Info("Project created successfully")
 	return nil
 }
 

--- a/hack/create-project/command.go
+++ b/hack/create-project/command.go
@@ -58,11 +58,6 @@ func registerCommand(r cli.CommandRegistry, p cli.ParentCommand) *command {
 }
 
 func (c *command) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.Logger) error {
-	logger.Info("Yeah babe",
-		zap.String("webGatewayAddress", *c.webGatewayAddress),
-		zap.String("serviceTokenPath", *c.serviceTokenPath),
-		zap.String("certPath", *c.certPath),
-	)
 	client, err := createEnvironmentClient(*c.webGatewayAddress, *c.certPath, *c.serviceTokenPath, logger)
 	if err != nil {
 		logger.Error("Failed to create environment client", zap.Error(err))


### PR DESCRIPTION
There is a bug while creating the environment. Instead of passing the project ID, it passes a random uuid as the project ID.

### Things done

- Fixed the project ID
- Changed the flag from `bool` to `strings` so the user can pass the environment he wants instead of always creating 3 environments as default.
- Added the flag `url-code` instead of using the name
- Updated the README