### PR TITLE
chore: add redis connection status to health check

### DIFF
--- a/pkg/account/cmd/apikeycacher/apikeycacher.go
+++ b/pkg/account/cmd/apikeycacher/apikeycacher.go
@@ -162,6 +162,7 @@ func (c *apiKeyCacher) Run(ctx context.Context, metrics metrics.Metrics, logger 
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
 		health.WithCheck("cacher", cacher.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/backend/cmd/server/server.go
+++ b/pkg/backend/cmd/server/server.go
@@ -317,21 +317,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	if err != nil {
 		return err
 	}
-	// healthCheckService
-	restHealthChecker := health.NewRestChecker(
-		"", "",
-		health.WithTimeout(healthCheckTimeout),
-		health.WithCheck("metrics", metrics.Check),
-	)
-	go restHealthChecker.Run(ctx)
-	// healthcheckService
-	healthcheckServer := rest.NewServer(
-		*s.certPath, *s.keyPath,
-		rest.WithLogger(logger),
-		rest.WithService(restHealthChecker),
-		rest.WithMetrics(registerer),
-	)
-	go healthcheckServer.Run()
 	// mysqlClient
 	mysqlClient, err := s.createMySQLClient(ctx, registerer, logger)
 	if err != nil {
@@ -363,6 +348,23 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		return err
 	}
 	nonPersistentRedisV3Cache := cachev3.NewRedisCache(nonPersistentRedisClient)
+	// healthCheckService
+	restHealthChecker := health.NewRestChecker(
+		"", "",
+		health.WithTimeout(healthCheckTimeout),
+		health.WithCheck("metrics", metrics.Check),
+		health.WithCheck("persistent-redis", persistentRedisClient.Check),
+		health.WithCheck("non-persistent-redis", nonPersistentRedisClient.Check),
+	)
+	go restHealthChecker.Run(ctx)
+	// healthcheckService
+	healthcheckServer := rest.NewServer(
+		*s.certPath, *s.keyPath,
+		rest.WithLogger(logger),
+		rest.WithService(restHealthChecker),
+		rest.WithMetrics(registerer),
+	)
+	go healthcheckServer.Run()
 	// bigQueryQuerier
 	bigQueryQuerier, err := s.createBigQueryQuerier(ctx, *s.project, *s.bigQueryDataLocation, registerer, logger)
 	if err != nil {

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -409,6 +409,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	healthChecker := health.NewGrpcChecker(
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/eventpersister/cmd/server/server.go
+++ b/pkg/eventpersister/cmd/server/server.go
@@ -159,6 +159,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
 		health.WithCheck("persister", p.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/eventpersisterops/cmd/server/eventpersisterops.go
+++ b/pkg/eventpersisterops/cmd/server/eventpersisterops.go
@@ -206,6 +206,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
 		health.WithCheck("persister", p.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/feature/cmd/segmentpersister/persister.go
+++ b/pkg/feature/cmd/segmentpersister/persister.go
@@ -178,6 +178,7 @@ func (p *persister) Run(ctx context.Context, metrics metrics.Metrics, logger *za
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
 		health.WithCheck("segment-persister", persister.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/gateway/cmd/server.go
+++ b/pkg/gateway/cmd/server.go
@@ -254,9 +254,8 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		api.WithLogger(logger),
 	)
 
-	// By checking the Redis in the API Gateway, if it fails, it won't get the features from the DB.
-	// But if we don't test it, the DB might fail due to high requests until the container restarts.
-	// So we don't check it because we want to avoid internal errors as much as possible.
+	// We don't check the Redis health status because if the check fails,
+	// the Kubernetes will restart the container and it might cause internal errors.
 	healthChecker := health.NewGrpcChecker(
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),

--- a/pkg/gateway/cmd/server.go
+++ b/pkg/gateway/cmd/server.go
@@ -254,10 +254,12 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		api.WithLogger(logger),
 	)
 
+	// By checking the Redis in the API Gateway, if it fails, it won't get the features from the DB.
+	// But if we don't test it, the DB might fail due to high requests until the container restarts.
+	// So we don't check it because we want to avoid internal errors as much as possible.
 	healthChecker := health.NewGrpcChecker(
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
-		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/gateway/cmd/server.go
+++ b/pkg/gateway/cmd/server.go
@@ -257,6 +257,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	healthChecker := health.NewGrpcChecker(
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 

--- a/pkg/push/cmd/sender/sender.go
+++ b/pkg/push/cmd/sender/sender.go
@@ -181,6 +181,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		health.WithTimeout(time.Second),
 		health.WithCheck("metrics", metrics.Check),
 		health.WithCheck("sender", t.Check),
+		health.WithCheck("redis", redisV3Client.Check),
 	)
 	go healthChecker.Run(ctx)
 


### PR DESCRIPTION
We already have an interface to check the Redis status, but we didn't implement it in the container health check.
By implementing this If for some reason the container gets a Redis connection failure, it will restart the container to recreate the connection.