### PR TITLE
perf: improve redis load in the event persisters

### DIFF
--- a/pkg/eventpersisterdwh/persister/evaluation_event.go
+++ b/pkg/eventpersisterdwh/persister/evaluation_event.go
@@ -94,10 +94,10 @@ func (w *evalEvtWriter) Write(
 			for id := range events {
 				fails[id] = true
 			}
-			return fails
+			continue
 		}
 		if len(experiments) == 0 {
-			return fails
+			continue
 		}
 		for id, event := range events {
 			switch evt := event.(type) {

--- a/pkg/eventpersisterdwh/persister/goal_event.go
+++ b/pkg/eventpersisterdwh/persister/goal_event.go
@@ -100,10 +100,10 @@ func (w *goalEvtWriter) Write(
 			for id := range events {
 				fails[id] = true
 			}
-			return fails
+			continue
 		}
 		if len(experiments) == 0 {
-			return fails
+			continue
 		}
 		for id, event := range events {
 			switch evt := event.(type) {

--- a/pkg/eventpersisterdwh/persister/metrics.go
+++ b/pkg/eventpersisterdwh/persister/metrics.go
@@ -24,13 +24,13 @@ const (
 	codeEvaluationsAreEmpty                 = "EvaluationsAreEmpty"
 	codeEventIssuedAfterExperimentEnded     = "EventIssuedAfterExperimentEnded"
 	codeEventOlderThanExperiment            = "EventOlderThanExperiment"
+	codeExperimentNotFound                  = "ExperimentNotFound"
 	codeGoalEventIssuedAfterExperimentEnded = "GoalEventIssuedAfterExperimentEnded"
 	codeFailedToEvaluateUser                = "FailedToEvaluateUser"
 	codeFailedToListExperiments             = "FailedToListExperiments"
 	codeFailedToAppendEvaluationEvents      = "FailedToAppendEvaluationEvents"
 	codeFailedToAppendGoalEvents            = "FailedToAppendGoalEvents"
 	codeLinked                              = "Linked"
-	codeNoLink                              = "NoLink"
 )
 
 var (

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -43,7 +43,6 @@ var (
 	ErrGoalEventIssuedAfterExperimentEnded = errors.New("eventpersister: goal event issued after experiment ended")
 	ErrFailedToEvaluateUser                = errors.New("eventpersister: failed to evaluate user")
 	ErrNoAutoOpsRules                      = errors.New("eventpersister: no auto ops rules")
-	ErrNoExperiments                       = errors.New("eventpersister: no experiments")
 	ErrNothingToLink                       = errors.New("eventpersister: nothing to link")
 	ErrInvalidEventTimestamp               = errors.New("eventpersister: invalid event timestamp")
 )

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -39,7 +39,7 @@ var (
 	ErrUnexpectedMessageType                     = errors.New("eventpersister: unexpected message type")
 	ErrAutoOpsRulesNotFound                      = errors.New("eventpersister: auto ops rules not found")
 	ErrEvaluationsAreEmpty                       = errors.New("eventpersister: evaluations are empty")
-	ErrEvaluationEventIssuedAfterExperimentEnded = errors.New("eventpersister: evaluation event issued after experiment ended")
+	ErrEvaluationEventIssuedAfterExperimentEnded = errors.New("eventpersister: evaluation event issued after experiment ended") //nolint:lll
 	ErrExperimentNotFound                        = errors.New("eventpersister: experiment not found")
 	ErrFailedToEvaluateUser                      = errors.New("eventpersister: failed to evaluate user")
 	ErrNoAutoOpsRules                            = errors.New("eventpersister: no auto ops rules")

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -41,7 +41,6 @@ var (
 	ErrEvaluationsAreEmpty                       = errors.New("eventpersister: evaluations are empty")
 	ErrEvaluationEventIssuedAfterExperimentEnded = errors.New("eventpersister: evaluation event issued after experiment ended")
 	ErrExperimentNotFound                        = errors.New("eventpersister: experiment not found")
-	ErrGoalEventIssuedAfterExperimentEnded       = errors.New("eventpersister: goal event issued after experiment ended")
 	ErrFailedToEvaluateUser                      = errors.New("eventpersister: failed to evaluate user")
 	ErrNoAutoOpsRules                            = errors.New("eventpersister: no auto ops rules")
 	ErrNothingToLink                             = errors.New("eventpersister: nothing to link")

--- a/pkg/eventpersisterdwh/persister/persister.go
+++ b/pkg/eventpersisterdwh/persister/persister.go
@@ -36,15 +36,16 @@ const (
 )
 
 var (
-	ErrUnexpectedMessageType               = errors.New("eventpersister: unexpected message type")
-	ErrAutoOpsRulesNotFound                = errors.New("eventpersister: auto ops rules not found")
-	ErrEvaluationsAreEmpty                 = errors.New("eventpersister: evaluations are empty")
-	ErrExperimentNotFound                  = errors.New("eventpersister: experiment not found")
-	ErrGoalEventIssuedAfterExperimentEnded = errors.New("eventpersister: goal event issued after experiment ended")
-	ErrFailedToEvaluateUser                = errors.New("eventpersister: failed to evaluate user")
-	ErrNoAutoOpsRules                      = errors.New("eventpersister: no auto ops rules")
-	ErrNothingToLink                       = errors.New("eventpersister: nothing to link")
-	ErrInvalidEventTimestamp               = errors.New("eventpersister: invalid event timestamp")
+	ErrUnexpectedMessageType                     = errors.New("eventpersister: unexpected message type")
+	ErrAutoOpsRulesNotFound                      = errors.New("eventpersister: auto ops rules not found")
+	ErrEvaluationsAreEmpty                       = errors.New("eventpersister: evaluations are empty")
+	ErrEvaluationEventIssuedAfterExperimentEnded = errors.New("eventpersister: evaluation event issued after experiment ended")
+	ErrExperimentNotFound                        = errors.New("eventpersister: experiment not found")
+	ErrGoalEventIssuedAfterExperimentEnded       = errors.New("eventpersister: goal event issued after experiment ended")
+	ErrFailedToEvaluateUser                      = errors.New("eventpersister: failed to evaluate user")
+	ErrNoAutoOpsRules                            = errors.New("eventpersister: no auto ops rules")
+	ErrNothingToLink                             = errors.New("eventpersister: nothing to link")
+	ErrInvalidEventTimestamp                     = errors.New("eventpersister: invalid event timestamp")
 )
 
 type PersisterDWH struct {

--- a/pkg/eventpersisterdwh/persister/persister_test.go
+++ b/pkg/eventpersisterdwh/persister/persister_test.go
@@ -381,7 +381,7 @@ func TestConvToEvaluationEvent(t *testing.T) {
 			expectedRepeatable: false,
 		},
 		{
-			desc:  "error: goal event was issued after the experiment ended",
+			desc:  "error: evaluation event was issued after the experiment ended",
 			input: evaluationEvent,
 			inputExperiment: []*exproto.Experiment{
 				{
@@ -395,7 +395,7 @@ func TestConvToEvaluationEvent(t *testing.T) {
 				},
 			},
 			expected:           nil,
-			expectedErr:        ErrGoalEventIssuedAfterExperimentEnded,
+			expectedErr:        ErrEvaluationEventIssuedAfterExperimentEnded,
 			expectedRepeatable: false,
 		},
 		{
@@ -654,6 +654,36 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 			},
 			expected:           nil,
 			expectedErr:        ErrEvaluationsAreEmpty,
+			expectedRepeatable: false,
+		},
+		{
+			desc: "error: goal event was issued after the experiment ended",
+			input: &eventproto.GoalEvent{
+				SourceId:  eventproto.SourceId_ANDROID,
+				Timestamp: now.Unix(),
+				GoalId:    "gid",
+				UserId:    "uid",
+				User: &userproto.User{
+					Id:   "uid",
+					Data: nil,
+				},
+				Value:       float64(1.2),
+				Evaluations: nil,
+				Tag:         "",
+			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					Status:         exproto.Experiment_STOPPED,
+					StartAt:        time.Now().Add(-time.Hour * 2).Unix(),
+					StopAt:         time.Now().Add(-time.Hour * 1).Unix(),
+				},
+			},
+			expected:           nil,
+			expectedErr:        ErrExperimentNotFound,
 			expectedRepeatable: false,
 		},
 		{

--- a/pkg/eventpersisterdwh/persister/persister_test.go
+++ b/pkg/eventpersisterdwh/persister/persister_test.go
@@ -145,6 +145,168 @@ var (
 	}
 )
 
+func TestListExperiments(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	now := time.Now()
+	environmentNamespace := "ns"
+	patterns := []struct {
+		desc        string
+		setup       func(context.Context, *evalEvtWriter)
+		expected    []*exproto.Experiment
+		expectedErr error
+	}{
+		{
+			desc: "error: failed to list experiments",
+			setup: func(ctx context.Context, p *evalEvtWriter) {
+				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
+					nil,
+					errors.New("internal"),
+				)
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             0,
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(nil, errors.New("internal"))
+			},
+			expected:    nil,
+			expectedErr: errors.New("internal"),
+		},
+		{
+			desc: "success: stop_at is older than 3 days",
+			setup: func(ctx context.Context, p *evalEvtWriter) {
+				experiments := &exproto.Experiments{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"goal-id"},
+							FeatureId:      "feature-id",
+							FeatureVersion: 1,
+							Status:         exproto.Experiment_STOPPED,
+							StopAt:         now.Unix() - 3*day,
+						},
+						{
+							Id:             "experiment-id-2",
+							GoalIds:        []string{"goal-id-2"},
+							FeatureId:      "feature-id-2",
+							FeatureVersion: 1,
+							Status:         exproto.Experiment_STOPPED,
+							StopAt:         now.Unix() - 1*day,
+						},
+					},
+				}
+				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
+					experiments,
+					nil,
+				)
+			},
+			expected: []*exproto.Experiment{
+				{
+					Id:             "experiment-id-2",
+					GoalIds:        []string{"goal-id-2"},
+					FeatureId:      "feature-id-2",
+					FeatureVersion: 1,
+					Status:         exproto.Experiment_STOPPED,
+					StopAt:         now.Unix() - 1*day,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "success: using the cache",
+			setup: func(ctx context.Context, p *evalEvtWriter) {
+				experiments := &exproto.Experiments{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"goal-id"},
+							FeatureId:      "feature-id",
+							FeatureVersion: 1,
+						},
+					},
+				}
+				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
+					experiments,
+					nil,
+				)
+			},
+			expected: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      "feature-id",
+					FeatureVersion: 1,
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "success: using the API",
+			setup: func(ctx context.Context, p *evalEvtWriter) {
+				experiments := &exproto.Experiments{
+					Experiments: []*exproto.Experiment{
+						{
+							Id:             "experiment-id",
+							GoalIds:        []string{"goal-id"},
+							FeatureId:      "feature-id",
+							FeatureVersion: 1,
+						},
+					},
+				}
+				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
+					nil,
+					errors.New("internal"),
+				)
+				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
+					nil,
+				)
+				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
+					ctx,
+					&exproto.ListExperimentsRequest{
+						PageSize:             0,
+						EnvironmentNamespace: environmentNamespace,
+						Statuses: []exproto.Experiment_Status{
+							exproto.Experiment_RUNNING,
+							exproto.Experiment_STOPPED,
+						},
+					},
+				).Return(&exproto.ListExperimentsResponse{
+					Experiments: experiments.Experiments,
+				}, nil)
+			},
+			expected: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      "feature-id",
+					FeatureVersion: 1,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			persister := newEvalEventWriter(mockController)
+			p.setup(ctx, persister)
+			actual, err := persister.listExperiments(ctx, environmentNamespace)
+			assert.Equal(t, p.expected, actual)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
 func TestConvToEvaluationEvent(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
@@ -197,229 +359,59 @@ func TestConvToEvaluationEvent(t *testing.T) {
 	eventID := "event-id"
 	patterns := []struct {
 		desc               string
-		setup              func(context.Context, *evalEvtWriter)
 		input              *eventproto.EvaluationEvent
+		inputExperiment    []*exproto.Experiment
 		expected           *epproto.EvaluationEvent
 		expectedErr        error
 		expectedRepeatable bool
 	}{
 		{
-			desc: "error: failed to list experiments",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(nil, errors.New("internal"))
+			desc:  "error: experiment not found",
+			input: evaluationEvent,
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      "invalid",
+					FeatureVersion: -1,
+				},
 			},
-			input:              evaluationEvent,
-			expected:           nil,
-			expectedErr:        errors.New("internal"),
-			expectedRepeatable: true,
-		},
-		{
-			desc: "error: experiment does not exist",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: []*exproto.Experiment{}},
-					nil,
-				)
-			},
-			input:              evaluationEvent,
-			expected:           nil,
-			expectedErr:        ErrNoExperiments,
-			expectedRepeatable: false,
-		},
-		{
-			desc: "error: stop_at is older than 3 days",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      evaluationEvent.FeatureId,
-							FeatureVersion: evaluation.FeatureVersion,
-							Status:         exproto.Experiment_STOPPED,
-							StopAt:         time.Now().Unix() - 3*day,
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
-			},
-			input:              evaluationEvent,
-			expected:           nil,
-			expectedErr:        ErrNoExperiments,
-			expectedRepeatable: false,
-		},
-		{
-			desc: "error: experiment not found",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      "invalid",
-							FeatureVersion: -1,
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
-			},
-			input:              evaluationEvent,
 			expected:           nil,
 			expectedErr:        ErrExperimentNotFound,
 			expectedRepeatable: false,
 		},
 		{
-			desc: "error: goal event was issued after the experiment ended",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      evaluationEvent.FeatureId,
-							FeatureVersion: evaluation.FeatureVersion,
-							Status:         exproto.Experiment_STOPPED,
-							StartAt:        t1.Add(-time.Hour * 3).Unix(),
-							StopAt:         t1.Add(-time.Hour * 2).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
+			desc:  "error: goal event was issued after the experiment ended",
+			input: evaluationEvent,
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      evaluationEvent.FeatureId,
+					FeatureVersion: evaluation.FeatureVersion,
+					Status:         exproto.Experiment_STOPPED,
+					StartAt:        t1.Add(-time.Hour * 3).Unix(),
+					StopAt:         t1.Add(-time.Hour * 2).Unix(),
+				},
 			},
-			input:              evaluationEvent,
 			expected:           nil,
 			expectedErr:        ErrGoalEventIssuedAfterExperimentEnded,
 			expectedRepeatable: false,
 		},
 		{
-			desc: "success: evaluation event with running status",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      evaluationEvent.FeatureId,
-							FeatureVersion: evaluation.FeatureVersion,
-							Status:         exproto.Experiment_RUNNING,
-							StartAt:        t1.Add(-time.Hour).Unix(),
-							StopAt:         t1.Add(time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
-			},
+			desc:  "success: evaluation event with running status",
 			input: evaluationEvent,
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      evaluationEvent.FeatureId,
+					FeatureVersion: evaluation.FeatureVersion,
+					Status:         exproto.Experiment_RUNNING,
+					StartAt:        t1.Add(-time.Hour).Unix(),
+					StopAt:         t1.Add(time.Hour).Unix(),
+				},
+			},
 			expected: &epproto.EvaluationEvent{
 				Id:                   eventID,
 				FeatureId:            evaluationEvent.FeatureId,
@@ -437,43 +429,19 @@ func TestConvToEvaluationEvent(t *testing.T) {
 			expectedRepeatable: false,
 		},
 		{
-			desc: "success: evaluation event with stopped status",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      evaluationEvent.FeatureId,
-							FeatureVersion: evaluation.FeatureVersion,
-							Status:         exproto.Experiment_RUNNING,
-							StartAt:        t1.Add(-time.Hour).Unix(),
-							StopAt:         t1.Add(time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
-			},
+			desc:  "success: evaluation event with stopped status",
 			input: evaluationEvent,
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      evaluationEvent.FeatureId,
+					FeatureVersion: evaluation.FeatureVersion,
+					Status:         exproto.Experiment_RUNNING,
+					StartAt:        t1.Add(-time.Hour).Unix(),
+					StopAt:         t1.Add(time.Hour).Unix(),
+				},
+			},
 			expected: &epproto.EvaluationEvent{
 				Id:                   eventID,
 				FeatureId:            evaluationEvent.FeatureId,
@@ -491,43 +459,19 @@ func TestConvToEvaluationEvent(t *testing.T) {
 			expectedRepeatable: false,
 		},
 		{
-			desc: "success: with empty tag and user data is nil",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      evaluationEventWithTagEmpty.FeatureId,
-							FeatureVersion: evaluation.FeatureVersion,
-							Status:         exproto.Experiment_STOPPED,
-							StartAt:        t1.Add(-time.Hour * 2).Unix(),
-							StopAt:         t1.Add(-time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
-			},
+			desc:  "success: with empty tag and user data is nil",
 			input: evaluationEventWithTagEmpty,
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      evaluationEventWithTagEmpty.FeatureId,
+					FeatureVersion: evaluation.FeatureVersion,
+					Status:         exproto.Experiment_STOPPED,
+					StartAt:        t1.Add(-time.Hour * 2).Unix(),
+					StopAt:         t1.Add(-time.Hour).Unix(),
+				},
+			},
 			expected: &epproto.EvaluationEvent{
 				Id:                   eventID,
 				FeatureId:            evaluationEventWithTagEmpty.FeatureId,
@@ -545,27 +489,19 @@ func TestConvToEvaluationEvent(t *testing.T) {
 			expectedRepeatable: false,
 		},
 		{
-			desc: "success: using cache",
-			setup: func(ctx context.Context, p *evalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"goal-id"},
-							FeatureId:      evaluationEventWithTagEmpty.FeatureId,
-							FeatureVersion: evaluation.FeatureVersion,
-							Status:         exproto.Experiment_STOPPED,
-							StartAt:        t1.Add(-time.Hour * 2).Unix(),
-							StopAt:         t1.Add(-time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					experiments,
-					nil,
-				)
-			},
+			desc:  "success: using cache",
 			input: evaluationEventWithTagEmpty,
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"goal-id"},
+					FeatureId:      evaluationEventWithTagEmpty.FeatureId,
+					FeatureVersion: evaluation.FeatureVersion,
+					Status:         exproto.Experiment_STOPPED,
+					StartAt:        t1.Add(-time.Hour * 2).Unix(),
+					StopAt:         t1.Add(-time.Hour).Unix(),
+				},
+			},
 			expected: &epproto.EvaluationEvent{
 				Id:                   eventID,
 				FeatureId:            evaluationEventWithTagEmpty.FeatureId,
@@ -586,10 +522,7 @@ func TestConvToEvaluationEvent(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			persister := newEvalEventWriter(mockController)
-			if p.setup != nil {
-				p.setup(ctx, persister)
-			}
-			actual, repeatable, err := persister.convToEvaluationEvent(ctx, p.input, eventID, environmentNamespace)
+			actual, repeatable, err := persister.convToEvaluationEvent(ctx, p.input, eventID, environmentNamespace, p.inputExperiment)
 			assert.Equal(t, p.expectedRepeatable, repeatable)
 			assert.Equal(t, p.expected, actual)
 			assert.Equal(t, p.expectedErr, err)
@@ -621,123 +554,13 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 		desc               string
 		setup              func(context.Context, *goalEvtWriter)
 		input              *eventproto.GoalEvent
+		inputExperiment    []*exproto.Experiment
 		expected           []*epproto.GoalEvent
 		expectedErr        error
 		expectedRepeatable bool
 	}{
 		{
-			desc: "err: list experiment internal",
-			setup: func(ctx context.Context, p *goalEvtWriter) {
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(nil, errors.New("internal"))
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: now.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected:           nil,
-			expectedErr:        errors.New("internal"),
-			expectedRepeatable: true,
-		},
-		{
-			desc: "err: list experiment empty",
-			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: []*exproto.Experiment{}},
-					nil,
-				)
-			},
-			input: &eventproto.GoalEvent{
-				SourceId:  eventproto.SourceId_ANDROID,
-				Timestamp: now.Unix(),
-				GoalId:    "gid",
-				UserId:    "uid",
-				User: &userproto.User{
-					Id:   "uid",
-					Data: map[string]string{"atr": "av"},
-				},
-				Value:       float64(1.2),
-				Evaluations: nil,
-				Tag:         "tag",
-			},
-			expected:           nil,
-			expectedErr:        ErrNoExperiments,
-			expectedRepeatable: false,
-		},
-		{
 			desc: "err: experiment not found",
-			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:      "experiment-id",
-							GoalIds: []string{"goal-id"},
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
-			},
 			input: &eventproto.GoalEvent{
 				SourceId:  eventproto.SourceId_ANDROID,
 				Timestamp: now.Unix(),
@@ -750,6 +573,12 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Value:       float64(1.2),
 				Evaluations: nil,
 				Tag:         "tag",
+			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:      "experiment-id",
+					GoalIds: []string{"goal-id"},
+				},
 			},
 			expected:           nil,
 			expectedErr:        ErrExperimentNotFound,
@@ -758,38 +587,6 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 		{
 			desc: "err: ErrFailedToEvaluateUser",
 			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
 				p.featureClient.(*ftmock.MockClient).EXPECT().EvaluateFeatures(
 					ctx,
 					gomock.Any(),
@@ -808,6 +605,16 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Evaluations: nil,
 				Tag:         "tag",
 			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+			},
 			expected:           nil,
 			expectedErr:        ErrFailedToEvaluateUser,
 			expectedRepeatable: true,
@@ -815,38 +622,6 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 		{
 			desc: "err: ErrEvaluationsAreEmpty",
 			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
 				p.featureClient.(*ftmock.MockClient).EXPECT().EvaluateFeatures(
 					ctx,
 					gomock.Any(),
@@ -867,6 +642,16 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Evaluations: nil,
 				Tag:         "tag",
 			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+			},
 			expected:           nil,
 			expectedErr:        ErrEvaluationsAreEmpty,
 			expectedRepeatable: false,
@@ -874,56 +659,6 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						{
-							Id:             "experiment-id-2",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						// This experiment won't be computed
-						// because the startAt is higher than the goal event timestamp
-						{
-							Id:             "experiment-id-3",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
 				p.featureClient.(*ftmock.MockClient).EXPECT().EvaluateFeatures(
 					ctx,
 					&featureproto.EvaluateFeaturesRequest{
@@ -987,6 +722,34 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Evaluations: nil,
 				Tag:         "tag",
 			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				{
+					Id:             "experiment-id-2",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				// This experiment won't be computed
+				// because the startAt is higher than the goal event timestamp
+				{
+					Id:             "experiment-id-3",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+			},
 			expected: []*epproto.GoalEvent{
 				{
 					SourceId:             eventproto.SourceId_ANDROID.String(),
@@ -1025,50 +788,6 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 		{
 			desc: "success: using cache",
 			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						{
-							Id:             "experiment-id-2",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						// This experiment won't be computed
-						// because the startAt is higher than the goal event timestamp
-						{
-							Id:             "experiment-id-3",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						// This experiment won't be computed
-						// because the goal event was issued after the experiment ended
-						{
-							Id:             "experiment-id-3",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour * 3).Unix(),
-							StopAt:         time.Now().Add(-time.Hour * 2).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					experiments,
-					nil,
-				)
 				p.featureClient.(*ftmock.MockClient).EXPECT().EvaluateFeatures(
 					ctx,
 					&featureproto.EvaluateFeaturesRequest{
@@ -1140,6 +859,44 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Value:       float64(1.2),
 				Evaluations: nil,
 				Tag:         "",
+			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				{
+					Id:             "experiment-id-2",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				// This experiment won't be computed
+				// because the startAt is higher than the goal event timestamp
+				{
+					Id:             "experiment-id-3",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				// This experiment won't be computed
+				// because the goal event was issued after the experiment ended
+				{
+					Id:             "experiment-id-3",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour * 3).Unix(),
+					StopAt:         time.Now().Add(-time.Hour * 2).Unix(),
+				},
 			},
 			expected: []*epproto.GoalEvent{
 				{
@@ -1179,66 +936,6 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 		{
 			desc: "success: with empty tag and user data is nil",
 			setup: func(ctx context.Context, p *goalEvtWriter) {
-				experiments := &exproto.Experiments{
-					Experiments: []*exproto.Experiment{
-						{
-							Id:             "experiment-id",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						{
-							Id:             "experiment-id-2",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						// This experiment won't be computed
-						// because the startAt is higher than the goal event timestamp
-						{
-							Id:             "experiment-id-3",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(time.Hour).Unix(),
-							StopAt:         time.Now().Add(time.Hour).Unix(),
-						},
-						// This experiment won't be computed
-						// because the goal event was issued after the experiment ended
-						{
-							Id:             "experiment-id-3",
-							GoalIds:        []string{"gid"},
-							FeatureId:      "fid-2",
-							FeatureVersion: int32(1),
-							StartAt:        time.Now().Add(-time.Hour * 3).Unix(),
-							StopAt:         time.Now().Add(-time.Hour * 2).Unix(),
-						},
-					},
-				}
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Get(environmentNamespace).Return(
-					nil,
-					errors.New("internal"),
-				)
-				p.cache.(*cachemock.MockExperimentsCache).EXPECT().Put(experiments, environmentNamespace).Return(
-					nil,
-				)
-				p.experimentClient.(*ecmock.MockClient).EXPECT().ListExperiments(
-					ctx,
-					&exproto.ListExperimentsRequest{
-						PageSize:             0,
-						EnvironmentNamespace: environmentNamespace,
-						Statuses: []exproto.Experiment_Status{
-							exproto.Experiment_RUNNING,
-							exproto.Experiment_STOPPED,
-						},
-					},
-				).Return(&exproto.ListExperimentsResponse{
-					Experiments: experiments.Experiments,
-				}, nil)
 				p.featureClient.(*ftmock.MockClient).EXPECT().EvaluateFeatures(
 					ctx,
 					&featureproto.EvaluateFeaturesRequest{
@@ -1310,6 +1007,44 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				Value:       float64(1.2),
 				Evaluations: nil,
 				Tag:         "",
+			},
+			inputExperiment: []*exproto.Experiment{
+				{
+					Id:             "experiment-id",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				{
+					Id:             "experiment-id-2",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				// This experiment won't be computed
+				// because the startAt is higher than the goal event timestamp
+				{
+					Id:             "experiment-id-3",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(time.Hour).Unix(),
+					StopAt:         time.Now().Add(time.Hour).Unix(),
+				},
+				// This experiment won't be computed
+				// because the goal event was issued after the experiment ended
+				{
+					Id:             "experiment-id-3",
+					GoalIds:        []string{"gid"},
+					FeatureId:      "fid-2",
+					FeatureVersion: int32(1),
+					StartAt:        time.Now().Add(-time.Hour * 3).Unix(),
+					StopAt:         time.Now().Add(-time.Hour * 2).Unix(),
+				},
 			},
 			expected: []*epproto.GoalEvent{
 				{
@@ -1358,6 +1093,7 @@ func TestConvToGoalEventWithExperiments(t *testing.T) {
 				p.input,
 				eventID,
 				environmentNamespace,
+				p.inputExperiment,
 			)
 			assert.Equal(t, p.expectedRepeatable, repeatable)
 			assert.Equal(t, p.expected, actual)

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -74,10 +74,10 @@ func (u *evalEvtUpdater) UpdateUserCounts(ctx context.Context, evt environmentEv
 			for id := range events {
 				fails[id] = true
 			}
-			return fails
+			continue
 		}
 		if len(listAutoOpsRules) == 0 {
-			return fails
+			continue
 		}
 		for id, event := range events {
 			switch evt := event.(type) {

--- a/pkg/eventpersisterops/persister/evaluation_event.go
+++ b/pkg/eventpersisterops/persister/evaluation_event.go
@@ -63,12 +63,33 @@ func NewEvalUserCountUpdater(
 func (u *evalEvtUpdater) UpdateUserCounts(ctx context.Context, evt environmentEventMap) map[string]bool {
 	fails := map[string]bool{}
 	for environmentNamespace, events := range evt {
+		listAutoOpsRules, err := u.listAutoOpsRules(ctx, environmentNamespace)
+		if err != nil {
+			u.logger.Error("failed to list auto ops rules",
+				zap.Error(err),
+				zap.String("environmentNamespace", environmentNamespace),
+			)
+			handledCounter.WithLabelValues(codeNoLink).Inc()
+			// Make sure to retry all the events in the next pulling
+			for id := range events {
+				fails[id] = true
+			}
+			return fails
+		}
+		if len(listAutoOpsRules) == 0 {
+			handledCounter.WithLabelValues(codeNoLink).Inc()
+			// Make sure to purge the events from PubSub because there are no experiments to link
+			for id := range events {
+				fails[id] = false
+			}
+			return fails
+		}
 		for id, event := range events {
 			switch evt := event.(type) {
 			case *eventproto.EvaluationEvent:
-				retriable, err := u.updateUserCount(ctx, environmentNamespace, evt)
+				retriable, err := u.updateUserCount(ctx, environmentNamespace, evt, listAutoOpsRules)
 				if err != nil {
-					if err == ErrNoAutoOpsRules || err == ErrAutoOpsRulesNotFound {
+					if err == ErrAutoOpsRulesNotFound {
 						// If there is nothing to link, we don't report it as an error
 						handledCounter.WithLabelValues(codeNoLink).Inc()
 						u.logger.Debug(
@@ -108,18 +129,9 @@ func (u *evalEvtUpdater) updateUserCount(
 	ctx context.Context,
 	environmentNamespace string,
 	event *eventproto.EvaluationEvent,
+	listAutoOpsRules []*aoproto.AutoOpsRule,
 ) (bool, error) {
-	// List all the auto ops rules
-	list, err := u.listAutoOpsRules(ctx, environmentNamespace)
-	if err != nil {
-		handledCounter.WithLabelValues(codeFailedToListAutoOpsRules).Inc()
-		return true, err
-	}
-	if len(list) == 0 {
-		return false, ErrNoAutoOpsRules
-	}
-	// Link the rules by feature ID
-	rules := u.linkOpsRulesByFeatureID(event.FeatureId, list)
+	rules := u.linkOpsRulesByFeatureID(event.FeatureId, listAutoOpsRules)
 	if len(rules) == 0 {
 		return false, ErrAutoOpsRulesNotFound
 	}

--- a/pkg/eventpersisterops/persister/goal_event.go
+++ b/pkg/eventpersisterops/persister/goal_event.go
@@ -81,10 +81,10 @@ func (u *evalGoalUpdater) UpdateUserCounts(ctx context.Context, evt environmentE
 			for id := range events {
 				fails[id] = true
 			}
-			return fails
+			continue
 		}
 		if len(listAutoOpsRules) == 0 {
-			return fails
+			continue
 		}
 		for id, event := range events {
 			switch evt := event.(type) {

--- a/pkg/eventpersisterops/persister/metrics.go
+++ b/pkg/eventpersisterops/persister/metrics.go
@@ -21,6 +21,7 @@ import (
 )
 
 const (
+	codeAutoOpsRuleNotFound                = "ErrAutoOpsRuleNotFound"
 	codeFailedToExtractOpsEventRateClauses = "FailedToExtractOpsEventRateClauses"
 	codeFailedToGetFeatures                = "FailedToGetFeatures"
 	codeFailedToFindFeatureVersion         = "FailedToFindFeatureVersion"
@@ -28,7 +29,6 @@ const (
 	codeFailedToUpdateUserCount            = "FailedToUpdateUserCount"
 	codeGetFeaturesReturnedEmpty           = "GetFeaturesReturnedEmpty"
 	codeLinked                             = "Linked"
-	codeNoLink                             = "NoLink"
 )
 
 var (

--- a/pkg/eventpersisterops/persister/persister.go
+++ b/pkg/eventpersisterops/persister/persister.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	ErrAutoOpsRulesNotFound   = errors.New("eventpersister: auto ops rules not found")
+	ErrAutoOpsRuleNotFound    = errors.New("eventpersister: auto ops rule not found")
 	ErrFeatureEmptyList       = errors.New("eventpersister: list feature returned empty")
 	ErrFeatureVersionNotFound = errors.New("eventpersister: feature version not found")
 	ErrNoExperiments          = errors.New("eventpersister: no experiments")

--- a/pkg/eventpersisterops/persister/persister.go
+++ b/pkg/eventpersisterops/persister/persister.go
@@ -35,7 +35,6 @@ var (
 	ErrAutoOpsRulesNotFound   = errors.New("eventpersister: auto ops rules not found")
 	ErrFeatureEmptyList       = errors.New("eventpersister: list feature returned empty")
 	ErrFeatureVersionNotFound = errors.New("eventpersister: feature version not found")
-	ErrNoAutoOpsRules         = errors.New("eventpersister: no auto ops rules")
 	ErrNoExperiments          = errors.New("eventpersister: no experiments")
 	ErrNothingToLink          = errors.New("eventpersister: nothing to link")
 	ErrUnexpectedMessageType  = errors.New("eventpersister: unexpected message type")


### PR DESCRIPTION
Instead of requesting the same data for each event, I changed it to request just once per batch. This will improve the load on Redis.