### PR TITLE
fix: cannot delete or update a parent row when deleting e2e data

### DIFF
--- a/hack/delete-e2e-data-mysql/command.go
+++ b/hack/delete-e2e-data-mysql/command.go
@@ -46,6 +46,7 @@ var (
 		{table: "experiment", targetField: "feature_id"},
 		{table: "tag", targetField: ""},
 		{table: "ops_progressive_rollout", targetField: "feature_id"},
+		{table: "flag_trigger", targetField: "description"},
 		{table: "feature", targetField: "id"},
 		{table: "webhook", targetField: "name"},
 	}

--- a/test/e2e/feature/feature_flag_trigger_test.go
+++ b/test/e2e/feature/feature_flag_trigger_test.go
@@ -39,7 +39,7 @@ func TestCreateFeatureFlagTrigger(t *testing.T) {
 	// Create flag trigger
 	createFlagTriggerCommand := newCreateFlagTriggerCmd(
 		cmd.Id,
-		"create flag trigger test",
+		newTriggerDescription(t),
 		featureproto.FlagTrigger_Action_ON,
 	)
 	resp := createFeatureFlagTrigger(t, client, createFlagTriggerCommand)
@@ -71,7 +71,7 @@ func TestUpdateFlagTrigger(t *testing.T) {
 	// Create flag trigger
 	createFlagTriggerCommand := newCreateFlagTriggerCmd(
 		command.Id,
-		"create flag trigger test",
+		newTriggerDescription(t),
 		featureproto.FlagTrigger_Action_ON,
 	)
 	createResp := createFeatureFlagTrigger(t, client, createFlagTriggerCommand)
@@ -107,7 +107,7 @@ func TestDisableEnableFlagTrigger(t *testing.T) {
 	// Create flag trigger
 	createFlagTriggerCommand := newCreateFlagTriggerCmd(
 		command.Id,
-		"create flag trigger test",
+		newTriggerDescription(t),
 		featureproto.FlagTrigger_Action_ON,
 	)
 	createResp := createFeatureFlagTrigger(t, client, createFlagTriggerCommand)
@@ -156,7 +156,7 @@ func TestResetFlagTrigger(t *testing.T) {
 	// Create flag trigger
 	createFlagTriggerCommand := newCreateFlagTriggerCmd(
 		command.Id,
-		"create flag trigger test",
+		newTriggerDescription(t),
 		featureproto.FlagTrigger_Action_ON,
 	)
 	createResp := createFeatureFlagTrigger(t, client, createFlagTriggerCommand)
@@ -184,7 +184,7 @@ func TestDeleteFlagTrigger(t *testing.T) {
 	// Create flag trigger
 	createFlagTriggerCommand := newCreateFlagTriggerCmd(
 		command.Id,
-		"create flag trigger test",
+		newTriggerDescription(t),
 		featureproto.FlagTrigger_Action_ON,
 	)
 	createResp := createFeatureFlagTrigger(t, client, createFlagTriggerCommand)
@@ -220,7 +220,7 @@ func TestListFlagTriggers(t *testing.T) {
 		EnvironmentNamespace: *environmentNamespace,
 		CreateFlagTriggerCommand: newCreateFlagTriggerCmd(
 			command.Id,
-			"create flag trigger test 1",
+			newTriggerDescription(t),
 			featureproto.FlagTrigger_Action_ON,
 		),
 	})
@@ -232,7 +232,7 @@ func TestListFlagTriggers(t *testing.T) {
 		EnvironmentNamespace: *environmentNamespace,
 		CreateFlagTriggerCommand: newCreateFlagTriggerCmd(
 			command.Id,
-			"create flag trigger test 2",
+			newTriggerDescription(t),
 			featureproto.FlagTrigger_Action_ON,
 		),
 	})
@@ -288,7 +288,7 @@ func TestFeatureFlagWebhook(t *testing.T) {
 		EnvironmentNamespace: *environmentNamespace,
 		CreateFlagTriggerCommand: newCreateFlagTriggerCmd(
 			command.Id,
-			"webhook flag trigger test action: on",
+			newTriggerDescription(t),
 			featureproto.FlagTrigger_Action_ON,
 		),
 	})
@@ -323,7 +323,7 @@ func TestFeatureFlagWebhook(t *testing.T) {
 		EnvironmentNamespace: *environmentNamespace,
 		CreateFlagTriggerCommand: newCreateFlagTriggerCmd(
 			command.Id,
-			"webhook flag trigger test action: off",
+			newTriggerDescription(t),
 			featureproto.FlagTrigger_Action_OFF,
 		),
 	})
@@ -420,4 +420,12 @@ func createFeatureFlagTrigger(
 		t.Fatal(err)
 	}
 	return resp
+}
+
+func newTriggerDescription(t *testing.T) string {
+	t.Helper()
+	if *testID != "" {
+		return fmt.Sprintf("%s-%s-trigger-description", prefixID, *testID)
+	}
+	return fmt.Sprintf("%s-trigger-description", prefixID)
 }


### PR DESCRIPTION
Fixes the following error when deleting the e2e data.

``
{"severity":"ERROR","eventTime":1703534508.67749,"logger":"delete.delete","caller":"delete-e2e-data-mysql/command.go:92","message":"Failed to delete data","serviceContext":{"service":"delete.delete","version":"-"},"error":"Error 1451 (23000): Cannot delete or update a parent row: a foreign key constraint fails (`master`.`flag_trigger`, CONSTRAINT `foreign_flag_trigger_feature_id_environment_namespace` FOREIGN KEY (`feature_id`, `environment_namespace`) REFERENCES `feature` (`id`, `environment_namespa)","table":"feature","stacktrace":"main.
``