### PR TITLE
fix: validation while creating a progressive rollout

### DIFF
--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -743,6 +743,9 @@ func (s *AutoOpsService) validateTargetAutoOpsRules(
 		return err
 	}
 	for _, r := range rules {
+		if r.TriggeredAt > 0 {
+			continue
+		}
 		for _, c := range r.Clauses {
 			// Return an error when Clause is DatetimeClause or WebhookClause.
 			if ptypes.Is(c.Clause, domain.DatetimeClause) {


### PR DESCRIPTION
It returns an error even if the operation is completed.