### PR TITLE
chore: add double write account v1 and v2

### DIFF
--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -71,6 +71,25 @@ func (s *AccountService) CreateAccount(
 		}
 		return nil, dt.Err()
 	}
+	orgID, err := s.getOrganizationID(ctx, req.EnvironmentNamespace)
+	if err != nil {
+		s.logger.Error(
+			"Failed to get organization id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.Error(err),
+				zap.String("environmentNamespace", req.EnvironmentNamespace),
+			)...,
+		)
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return nil, statusInternal.Err()
+		}
+		return nil, dt.Err()
+	}
+	accountV2 := domain.ConvertAccountV2(account, req.EnvironmentNamespace, orgID)
 	// check if an Admin Account that has the same email already exists
 	_, err = s.getAdminAccount(ctx, account.Id, localizer)
 	if status.Code(err) != codes.NotFound {
@@ -98,7 +117,22 @@ func (s *AccountService) CreateAccount(
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
-		return s.accountStorage.CreateAccount(ctx, account, req.EnvironmentNamespace)
+		err := s.accountStorage.CreateAccount(ctx, account, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		// TODO: temporary implementation: double write account v2
+		handlerV2 := command.NewAccountV2CommandHandler(editor, accountV2, s.publisher, orgID)
+		if err := handlerV2.Handle(ctx, accountproto.CreateAccountV2Command{
+			Email:            accountV2.Email,
+			Name:             accountV2.Email,
+			AvatarImageUrl:   accountV2.AvatarImageUrl,
+			OrganizationRole: accountV2.OrganizationRole,
+			EnvironmentRoles: accountV2.EnvironmentRoles,
+		}); err != nil {
+			return err
+		}
+		return s.accountStorage.CreateAccountV2(ctx, accountV2)
 	})
 	if err != nil {
 		if err == v2as.ErrAccountAlreadyExists {
@@ -149,7 +183,46 @@ func (s *AccountService) ChangeAccountRole(
 		)
 		return nil, err
 	}
-	if err := s.updateAccountMySQL(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	orgID, err := s.getOrganizationID(ctx, req.EnvironmentNamespace)
+	if err != nil {
+		s.logger.Error(
+			"Failed to get organization id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.Error(err),
+				zap.String("environmentNamespace", req.EnvironmentNamespace),
+			)...,
+		)
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return nil, statusInternal.Err()
+		}
+		return nil, dt.Err()
+	}
+	err = s.accountStorage.RunInTransaction(ctx, func() error {
+		account, err := s.accountStorage.GetAccount(ctx, req.Id, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		handler := command.NewAccountCommandHandler(editor, account, s.publisher, req.EnvironmentNamespace)
+		if err := handler.Handle(ctx, req.Command); err != nil {
+			return err
+		}
+		err = s.accountStorage.UpdateAccount(ctx, account, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		// TODO: temporary implementation: double write account v2
+		accountV2, err := s.accountStorage.GetAccountV2(ctx, req.Id, orgID)
+		if err != nil {
+			return err
+		}
+		accountV2.PatchAccountV2EnvironmentRoles(req.EnvironmentNamespace, req.Command.Role)
+		return s.accountStorage.UpdateAccountV2(ctx, accountV2)
+	})
+	if err != nil {
 		if err == v2as.ErrAccountNotFound || err == v2as.ErrAccountUnexpectedAffectedRows {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
@@ -198,7 +271,46 @@ func (s *AccountService) EnableAccount(
 		)
 		return nil, err
 	}
-	if err := s.updateAccountMySQL(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	orgID, err := s.getOrganizationID(ctx, req.EnvironmentNamespace)
+	if err != nil {
+		s.logger.Error(
+			"Failed to get organization id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.Error(err),
+				zap.String("environmentNamespace", req.EnvironmentNamespace),
+			)...,
+		)
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return nil, statusInternal.Err()
+		}
+		return nil, dt.Err()
+	}
+	err = s.accountStorage.RunInTransaction(ctx, func() error {
+		accountV1, err := s.accountStorage.GetAccount(ctx, req.Id, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		handler := command.NewAccountCommandHandler(editor, accountV1, s.publisher, req.EnvironmentNamespace)
+		if err := handler.Handle(ctx, req.Command); err != nil {
+			return err
+		}
+		err = s.accountStorage.UpdateAccount(ctx, accountV1, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		// TODO: temporary implementation: double write account v2
+		accountV2, err := s.accountStorage.GetAccountV2(ctx, req.Id, orgID)
+		if err != nil {
+			return err
+		}
+		accountV2.PatchAccountV2EnvironmentRoles(req.EnvironmentNamespace, accountV1.Role)
+		return s.accountStorage.UpdateAccountV2(ctx, accountV2)
+	})
+	if err != nil {
 		if err == v2as.ErrAccountNotFound || err == v2as.ErrAccountUnexpectedAffectedRows {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
@@ -247,7 +359,46 @@ func (s *AccountService) DisableAccount(
 		)
 		return nil, err
 	}
-	if err := s.updateAccountMySQL(ctx, editor, req.Command, req.Id, req.EnvironmentNamespace); err != nil {
+	orgID, err := s.getOrganizationID(ctx, req.EnvironmentNamespace)
+	if err != nil {
+		s.logger.Error(
+			"Failed to get organization id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.Error(err),
+				zap.String("environmentNamespace", req.EnvironmentNamespace),
+			)...,
+		)
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return nil, statusInternal.Err()
+		}
+		return nil, dt.Err()
+	}
+	err = s.accountStorage.RunInTransaction(ctx, func() error {
+		accountV1, err := s.accountStorage.GetAccount(ctx, req.Id, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		handler := command.NewAccountCommandHandler(editor, accountV1, s.publisher, req.EnvironmentNamespace)
+		if err := handler.Handle(ctx, req.Command); err != nil {
+			return err
+		}
+		err = s.accountStorage.UpdateAccount(ctx, accountV1, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
+		// TODO: temporary implementation: double write account v2
+		accountV2, err := s.accountStorage.GetAccountV2(ctx, req.Id, orgID)
+		if err != nil {
+			return err
+		}
+		accountV2.RemoveAccountV2EnvironmentRole(req.EnvironmentNamespace)
+		return s.accountStorage.UpdateAccountV2(ctx, accountV2)
+	})
+	if err != nil {
 		if err == v2as.ErrAccountNotFound || err == v2as.ErrAccountUnexpectedAffectedRows {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
@@ -275,25 +426,6 @@ func (s *AccountService) DisableAccount(
 		return nil, dt.Err()
 	}
 	return &accountproto.DisableAccountResponse{}, nil
-}
-
-func (s *AccountService) updateAccountMySQL(
-	ctx context.Context,
-	editor *eventproto.Editor,
-	cmd command.Command,
-	id, environmentNamespace string,
-) error {
-	return s.accountStorage.RunInTransaction(ctx, func() error {
-		account, err := s.accountStorage.GetAccount(ctx, id, environmentNamespace)
-		if err != nil {
-			return err
-		}
-		handler := command.NewAccountCommandHandler(editor, account, s.publisher, environmentNamespace)
-		if err := handler.Handle(ctx, cmd); err != nil {
-			return err
-		}
-		return s.accountStorage.UpdateAccount(ctx, account, environmentNamespace)
-	})
 }
 
 func (s *AccountService) GetAccount(
@@ -465,6 +597,22 @@ func (s *AccountService) newAccountListOrders(
 		direction = mysql.OrderDirectionDesc
 	}
 	return []*mysql.Order{mysql.NewOrder(column, direction)}, nil
+}
+
+func (s *AccountService) getOrganizationID(
+	ctx context.Context,
+	environmentNamespace string,
+) (string, error) {
+	environments, err := s.listEnvironments(ctx)
+	if err != nil {
+		return "", err
+	}
+	for _, e := range environments {
+		if e.Id == environmentNamespace {
+			return e.OrganizationId, nil
+		}
+	}
+	return "", statusEnvironmentNotFound.Err()
 }
 
 func (s *AccountService) CreateAccountV2(

--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -89,7 +89,6 @@ func (s *AccountService) CreateAccount(
 		}
 		return nil, dt.Err()
 	}
-	accountV2 := domain.ConvertAccountV2(account, req.EnvironmentNamespace, orgID)
 	// check if an Admin Account that has the same email already exists
 	_, err = s.getAdminAccount(ctx, account.Id, localizer)
 	if status.Code(err) != codes.NotFound {
@@ -122,16 +121,7 @@ func (s *AccountService) CreateAccount(
 			return err
 		}
 		// TODO: temporary implementation: double write account v2
-		handlerV2 := command.NewAccountV2CommandHandler(editor, accountV2, s.publisher, orgID)
-		if err := handlerV2.Handle(ctx, accountproto.CreateAccountV2Command{
-			Email:            accountV2.Email,
-			Name:             accountV2.Email,
-			AvatarImageUrl:   accountV2.AvatarImageUrl,
-			OrganizationRole: accountV2.OrganizationRole,
-			EnvironmentRoles: accountV2.EnvironmentRoles,
-		}); err != nil {
-			return err
-		}
+		accountV2 := domain.ConvertAccountV2(account, req.EnvironmentNamespace, orgID)
 		return s.accountStorage.CreateAccountV2(ctx, accountV2)
 	})
 	if err != nil {

--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -21,8 +21,6 @@ import (
 	"testing"
 	"time"
 
-	ecmock "github.com/bucketeer-io/bucketeer/pkg/environment/client/mock"
-	environmentproto "github.com/bucketeer-io/bucketeer/proto/environment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -31,13 +29,14 @@ import (
 	gstatus "google.golang.org/grpc/status"
 
 	"github.com/bucketeer-io/bucketeer/pkg/account/domain"
-
 	v2as "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
 	accstoragemock "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2/mock"
+	ecmock "github.com/bucketeer-io/bucketeer/pkg/environment/client/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
 	"github.com/bucketeer-io/bucketeer/pkg/token"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
+	environmentproto "github.com/bucketeer-io/bucketeer/proto/environment"
 )
 
 func TestCreateAccountMySQL(t *testing.T) {

--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	ecmock "github.com/bucketeer-io/bucketeer/pkg/environment/client/mock"
+	environmentproto "github.com/bucketeer-io/bucketeer/proto/environment"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -56,6 +58,13 @@ func TestCreateAccountMySQL(t *testing.T) {
 		})
 		require.NoError(t, err)
 		return st.Err()
+	}
+	envs := []*environmentproto.EnvironmentV2{
+		{
+			Id:             "ns0",
+			Name:           "env0",
+			OrganizationId: "org0",
+		},
 	}
 
 	patterns := []struct {
@@ -95,6 +104,13 @@ func TestCreateAccountMySQL(t *testing.T) {
 		{
 			desc: "errAlreadyExists_AdminAccount",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
 					gomock.Any(), gomock.Any(),
 				).Return(&domain.Account{
@@ -117,6 +133,13 @@ func TestCreateAccountMySQL(t *testing.T) {
 		{
 			desc: "errAlreadyExists_EnvironmentAccount",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
@@ -134,6 +157,13 @@ func TestCreateAccountMySQL(t *testing.T) {
 		{
 			desc: "errInternal",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
@@ -154,6 +184,13 @@ func TestCreateAccountMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
@@ -204,6 +241,13 @@ func TestChangeAccountRoleMySQL(t *testing.T) {
 		require.NoError(t, err)
 		return st.Err()
 	}
+	envs := []*environmentproto.EnvironmentV2{
+		{
+			Id:             "ns0",
+			Name:           "env0",
+			OrganizationId: "org0",
+		},
+	}
 
 	patterns := []struct {
 		desc        string
@@ -234,6 +278,13 @@ func TestChangeAccountRoleMySQL(t *testing.T) {
 		{
 			desc: "errNotFound",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(v2as.ErrAccountNotFound)
@@ -251,6 +302,13 @@ func TestChangeAccountRoleMySQL(t *testing.T) {
 		{
 			desc: "errInternal",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(errors.New("error"))
@@ -268,6 +326,13 @@ func TestChangeAccountRoleMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
@@ -315,6 +380,13 @@ func TestEnableAccountMySQL(t *testing.T) {
 		require.NoError(t, err)
 		return st.Err()
 	}
+	envs := []*environmentproto.EnvironmentV2{
+		{
+			Id:             "ns0",
+			Name:           "env0",
+			OrganizationId: "org0",
+		},
+	}
 
 	patterns := []struct {
 		desc        string
@@ -345,6 +417,13 @@ func TestEnableAccountMySQL(t *testing.T) {
 		{
 			desc: "errNotFound",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(v2as.ErrAccountNotFound)
@@ -363,6 +442,13 @@ func TestEnableAccountMySQL(t *testing.T) {
 		{
 			desc: "errInternal",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(errors.New("error"))
@@ -378,6 +464,13 @@ func TestEnableAccountMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
@@ -423,6 +516,13 @@ func TestDisableAccountMySQL(t *testing.T) {
 		require.NoError(t, err)
 		return st.Err()
 	}
+	envs := []*environmentproto.EnvironmentV2{
+		{
+			Id:             "ns0",
+			Name:           "env0",
+			OrganizationId: "org0",
+		},
+	}
 
 	patterns := []struct {
 		desc        string
@@ -453,6 +553,13 @@ func TestDisableAccountMySQL(t *testing.T) {
 		{
 			desc: "errNotFound",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(v2as.ErrAccountNotFound)
@@ -468,6 +575,13 @@ func TestDisableAccountMySQL(t *testing.T) {
 		{
 			desc: "errInternal",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(errors.New("error"))
@@ -483,6 +597,13 @@ func TestDisableAccountMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AccountService) {
+				s.environmentClient.(*ecmock.MockClient).EXPECT().ListEnvironmentsV2(
+					gomock.Any(), gomock.Any(),
+				).Return(&environmentproto.ListEnvironmentsV2Response{
+					Environments: envs,
+					Cursor:       "1",
+					TotalCount:   1,
+				}, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)

--- a/pkg/account/api/error.go
+++ b/pkg/account/api/error.go
@@ -35,6 +35,7 @@ var (
 	statusMissingAPIKeyName       = gstatus.New(codes.InvalidArgument, "account: apikey name must be not empty")
 	statusInvalidOrderBy          = gstatus.New(codes.InvalidArgument, "account: order_by is invalid")
 	statusNotFound                = gstatus.New(codes.NotFound, "account: not found")
+	statusEnvironmentNotFound     = gstatus.New(codes.NotFound, "account: environment is not found")
 	statusAlreadyExists           = gstatus.New(codes.AlreadyExists, "account: already exists")
 	statusUnauthenticated         = gstatus.New(codes.Unauthenticated, "account: unauthenticated")
 	statusPermissionDenied        = gstatus.New(codes.PermissionDenied, "account: permission denied")

--- a/pkg/account/domain/account.go
+++ b/pkg/account/domain/account.go
@@ -82,6 +82,74 @@ func NewAccountV2(
 	}}
 }
 
+// TODO remove this function after migration
+func ConvertAccountV2(account *Account, environmentID, organizationID string) *AccountV2 {
+	envRole := convertEnvironmentRoleForV2(environmentID, account.Role)
+	return &AccountV2{&proto.AccountV2{
+		Email:            account.Email,
+		Name:             account.Name,
+		AvatarImageUrl:   "",
+		OrganizationId:   organizationID,
+		OrganizationRole: convertOrganizationRoleForV2(account.Role),
+		EnvironmentRoles: []*proto.AccountV2_EnvironmentRole{envRole},
+		Disabled:         account.Disabled,
+		CreatedAt:        account.CreatedAt,
+		UpdatedAt:        account.UpdatedAt,
+	}}
+}
+
+// TODO remove this function after migration
+func convertEnvironmentRoleForV2(environmentID string, role proto.Account_Role) *proto.AccountV2_EnvironmentRole {
+	v2Role := proto.AccountV2_Role_Environment_VIEWER
+	switch role {
+	case proto.Account_VIEWER:
+		v2Role = proto.AccountV2_Role_Environment_VIEWER
+	case proto.Account_EDITOR, proto.Account_OWNER:
+		v2Role = proto.AccountV2_Role_Environment_EDITOR
+	}
+	return &proto.AccountV2_EnvironmentRole{
+		EnvironmentId: environmentID,
+		Role:          v2Role,
+	}
+}
+
+// TODO remove this function after migration
+func convertOrganizationRoleForV2(role proto.Account_Role) proto.AccountV2_Role_Organization {
+	switch role {
+	case proto.Account_VIEWER, proto.Account_EDITOR:
+		return proto.AccountV2_Role_Organization_MEMBER
+	case proto.Account_OWNER:
+		return proto.AccountV2_Role_Organization_ADMIN
+	}
+	return proto.AccountV2_Role_Organization_MEMBER
+}
+
+// TODO remove this function after migration
+func (a *AccountV2) PatchAccountV2EnvironmentRoles(environmentID string, newRole proto.Account_Role) {
+	newEnvironmentRole := convertEnvironmentRoleForV2(environmentID, newRole)
+	for _, e := range a.AccountV2.EnvironmentRoles {
+		if e.EnvironmentId == newEnvironmentRole.EnvironmentId {
+			e.Role = newEnvironmentRole.Role
+			a.UpdatedAt = time.Now().Unix()
+			return
+		}
+	}
+	a.AccountV2.EnvironmentRoles = append(a.AccountV2.EnvironmentRoles, newEnvironmentRole)
+	a.UpdatedAt = time.Now().Unix()
+}
+
+// TODO remove this function after migration
+func (a *AccountV2) RemoveAccountV2EnvironmentRole(rmEnvironmentID string) {
+	roles := make([]*proto.AccountV2_EnvironmentRole, 0, len(a.AccountV2.EnvironmentRoles))
+	for _, r := range a.AccountV2.EnvironmentRoles {
+		if r.EnvironmentId != rmEnvironmentID {
+			roles = append(roles, r)
+		}
+	}
+	a.AccountV2.EnvironmentRoles = roles
+	a.UpdatedAt = time.Now().Unix()
+}
+
 func (a *AccountV2) ChangeName(newName string) error {
 	a.AccountV2.Name = newName
 	a.UpdatedAt = time.Now().Unix()


### PR DESCRIPTION
## This PR
- adds implementation for double write accounts v1 and v2.
  - This implementation is needed so that the users can create/update/delete account v2 at the same time as account v1.