### PR TITLE
test: fix delete e2e data not working

### DIFF
--- a/test/e2e/feature/feature_flag_trigger_test.go
+++ b/test/e2e/feature/feature_flag_trigger_test.go
@@ -80,7 +80,7 @@ func TestUpdateFlagTrigger(t *testing.T) {
 		Id:                   createResp.FlagTrigger.Id,
 		EnvironmentNamespace: *environmentNamespace,
 		ChangeFlagTriggerDescriptionCommand: &featureproto.ChangeFlagTriggerDescriptionCommand{
-			Description: "change flag trigger description test",
+			Description: newTriggerDescription(t),
 		},
 	}
 	_, err := client.UpdateFlagTrigger(context.Background(), updateFlagTriggerReq)


### PR DESCRIPTION
The delete e2e data workflow fails when deleting the feature flags because we must delete the trigger first.
There was one place that didn't set the test id in the description.