### PR TITLE
fix: failed to GetAccountV2ByEnvironmentID with empty ID

### DIFF
--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -39,7 +39,12 @@ func (s *AccountService) CreateAccount(
 	req *accountproto.CreateAccountRequest,
 ) (*accountproto.CreateAccountResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		accountproto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +164,12 @@ func (s *AccountService) ChangeAccountRole(
 	req *accountproto.ChangeAccountRoleRequest,
 ) (*accountproto.ChangeAccountRoleResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		accountproto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +257,12 @@ func (s *AccountService) EnableAccount(
 	req *accountproto.EnableAccountRequest,
 ) (*accountproto.EnableAccountResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		accountproto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -335,7 +350,12 @@ func (s *AccountService) DisableAccount(
 	req *accountproto.DisableAccountRequest,
 ) (*accountproto.DisableAccountResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		accountproto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -423,7 +443,7 @@ func (s *AccountService) GetAccount(
 	req *accountproto.GetAccountRequest,
 ) (*accountproto.GetAccountResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +506,7 @@ func (s *AccountService) ListAccounts(
 	req *accountproto.ListAccountsRequest,
 ) (*accountproto.ListAccountsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -1812,24 +1812,6 @@ func TestGetAccountV2ByEnvironmentIDMySQL(t *testing.T) {
 			expectedErr: createError(statusInvalidEmail, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "email")),
 		},
 		{
-			desc: "errEnvironmentIDIsEmpty",
-			setup: func(s *AccountService) {
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2ByEnvironmentID(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(&domain.AccountV2{
-					AccountV2: &accountproto.AccountV2{
-						Email:            "bucketeer@example.com",
-						Name:             "test",
-						OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
-					},
-				}, nil)
-			},
-			req: &accountproto.GetAccountV2ByEnvironmentIDRequest{
-				Email: "bucketeer@example.com",
-			},
-			expectedErr: createError(statusMissingEnvironmentID, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "environment_id")),
-		},
-		{
 			desc: "errAccountNotFound",
 			setup: func(s *AccountService) {
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2ByEnvironmentID(

--- a/pkg/account/api/api.go
+++ b/pkg/account/api/api.go
@@ -187,17 +187,22 @@ func (s *AccountService) checkAdminRole(ctx context.Context, localizer locale.Lo
 
 func (s *AccountService) checkRole(
 	ctx context.Context,
-	requiredRole proto.Account_Role,
+	requiredRole proto.AccountV2_Role_Environment,
 	environmentNamespace string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*proto.GetAccountResponse, error) {
-		account, err := s.getAccount(ctx, email, environmentNamespace, localizer)
-		if err != nil {
-			return nil, err
-		}
-		return &proto.GetAccountResponse{Account: account.Account}, nil
-	})
+	editor, err := role.CheckRole(
+		ctx,
+		requiredRole,
+		environmentNamespace,
+		func(email string) (*proto.AccountV2, error) {
+			account, err := s.getAccountV2ByEnvironmentID(ctx, email, environmentNamespace, localizer)
+			if err != nil {
+				return nil, err
+			}
+			return account.AccountV2, nil
+		},
+	)
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:

--- a/pkg/account/api/api_key.go
+++ b/pkg/account/api/api_key.go
@@ -36,7 +36,12 @@ func (s *AccountService) CreateAPIKey(
 	req *proto.CreateAPIKeyRequest,
 ) (*proto.CreateAPIKeyResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, proto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		proto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +110,12 @@ func (s *AccountService) ChangeAPIKeyName(
 	req *proto.ChangeAPIKeyNameRequest,
 ) (*proto.ChangeAPIKeyNameResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, proto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		proto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +166,12 @@ func (s *AccountService) EnableAPIKey(
 	req *proto.EnableAPIKeyRequest,
 ) (*proto.EnableAPIKeyResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, proto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		proto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +221,12 @@ func (s *AccountService) DisableAPIKey(
 	req *proto.DisableAPIKeyRequest,
 ) (*proto.DisableAPIKeyResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, proto.Account_OWNER, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkOrganizationRoleByEnvironmentID(
+		ctx,
+		proto.AccountV2_Role_Organization_ADMIN,
+		req.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +292,7 @@ func (s *AccountService) updateAPIKeyMySQL(
 
 func (s *AccountService) GetAPIKey(ctx context.Context, req *proto.GetAPIKeyRequest) (*proto.GetAPIKeyResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, proto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, proto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +343,7 @@ func (s *AccountService) ListAPIKeys(
 	req *proto.ListAPIKeysRequest,
 ) (*proto.ListAPIKeysResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, proto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, proto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/account/api/error.go
+++ b/pkg/account/api/error.go
@@ -25,7 +25,6 @@ var (
 	statusNoCommand               = gstatus.New(codes.InvalidArgument, "account: command must not be empty")
 	statusMissingAccountID        = gstatus.New(codes.InvalidArgument, "account: account id must be specified")
 	statusMissingOrganizationID   = gstatus.New(codes.InvalidArgument, "account: organization id must be specified")
-	statusMissingEnvironmentID    = gstatus.New(codes.InvalidArgument, "account: environment id must be specified")
 	statusEmailIsEmpty            = gstatus.New(codes.InvalidArgument, "account: email is empty")
 	statusInvalidEmail            = gstatus.New(codes.InvalidArgument, "account: invalid email format")
 	statusNameIsEmpty             = gstatus.New(codes.InvalidArgument, "account: name is empty")

--- a/pkg/account/api/validation.go
+++ b/pkg/account/api/validation.go
@@ -724,6 +724,7 @@ func validateGetAccountV2ByEnvironmentIDRequest(
 	req *accountproto.GetAccountV2ByEnvironmentIDRequest,
 	localizer locale.Localizer,
 ) error {
+	// We don't check the environmentID because there is environment with empty ID.
 	if req.Email == "" {
 		dt, err := statusEmailIsEmpty.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
@@ -738,16 +739,6 @@ func validateGetAccountV2ByEnvironmentIDRequest(
 		dt, err := statusInvalidEmail.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "email"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if req.EnvironmentId == "" {
-		dt, err := statusMissingEnvironmentID.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "environment_id"),
 		})
 		if err != nil {
 			return statusInternal.Err()

--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -98,7 +98,7 @@ func (s *auditlogService) ListAuditLogs(
 	req *proto.ListAuditLogsRequest,
 ) (*proto.ListAuditLogsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (s *auditlogService) ListFeatureHistory(
 	req *proto.ListFeatureHistoryRequest,
 ) (*proto.ListFeatureHistoryResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -414,16 +414,24 @@ func (s *auditlogService) newFeatureHistoryAuditLogListOrders(
 
 func (s *auditlogService) checkRole(
 	ctx context.Context,
-	requiredRole accountproto.Account_Role,
+	requiredRole accountproto.AccountV2_Role_Environment,
 	environmentNamespace string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
-		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{
-			Email:                email,
-			EnvironmentNamespace: environmentNamespace,
+	editor, err := role.CheckRole(
+		ctx,
+		requiredRole,
+		environmentNamespace,
+		func(email string) (*accountproto.AccountV2, error) {
+			resp, err := s.accountClient.GetAccountV2ByEnvironmentID(ctx, &accountproto.GetAccountV2ByEnvironmentIDRequest{
+				Email:         email,
+				EnvironmentId: environmentNamespace,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp.Account, nil
 		})
-	})
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:

--- a/pkg/autoops/api/api_test.go
+++ b/pkg/autoops/api/api_test.go
@@ -704,7 +704,7 @@ func TestGetAutoOpsRuleMySQL(t *testing.T) {
 	}{
 		{
 			desc:        "err: ErrIDRequired",
-			req:         &autoopsproto.GetAutoOpsRuleRequest{},
+			req:         &autoopsproto.GetAutoOpsRuleRequest{EnvironmentNamespace: "ns0"},
 			expectedErr: createError(statusIDRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id")),
 		},
 		{
@@ -921,13 +921,23 @@ func createAutoOpsService(c *gomock.Controller, db storage.Client) *AutoOpsServi
 	mysqlClientMock := mysqlmock.NewMockClient(c)
 	featureClientMock := featureclientmock.NewMockClient(c)
 	accountClientMock := accountclientmock.NewMockClient(c)
-	ar := &accountproto.GetAccountResponse{
-		Account: &accountproto.Account{
-			Email: "email",
-			Role:  accountproto.Account_VIEWER,
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: "ns0",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+				{
+					EnvironmentId: "",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+			},
 		},
 	}
-	accountClientMock.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	accountClientMock.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
 	experimentClientMock := experimentclientmock.NewMockClient(c)
 	authClientMock := authclientmock.NewMockClient(c)
 	p := publishermock.NewMockPublisher(c)

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -55,7 +55,7 @@ func (s *AutoOpsService) CreateProgressiveRollout(
 	req *autoopsproto.CreateProgressiveRolloutRequest,
 ) (*autoopsproto.CreateProgressiveRolloutResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (s *AutoOpsService) GetProgressiveRollout(
 	req *autoopsproto.GetProgressiveRolloutRequest,
 ) (*autoopsproto.GetProgressiveRolloutResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -206,7 +206,7 @@ func (s *AutoOpsService) DeleteProgressiveRollout(
 	req *autoopsproto.DeleteProgressiveRolloutRequest,
 ) (*autoopsproto.DeleteProgressiveRolloutResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -282,7 +282,7 @@ func (s *AutoOpsService) ListProgressiveRollouts(
 	req *autoopsproto.ListProgressiveRolloutsRequest,
 ) (*autoopsproto.ListProgressiveRolloutsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (s *AutoOpsService) ExecuteProgressiveRollout(
 	req *autoopsproto.ExecuteProgressiveRolloutRequest,
 ) (*autoopsproto.ExecuteProgressiveRolloutResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/autoops/api/progressive_rollout_test.go
+++ b/pkg/autoops/api/progressive_rollout_test.go
@@ -933,7 +933,7 @@ func TestGetProgressiveRolloutMySQL(t *testing.T) {
 	}{
 		{
 			desc:        "err: ErrIDRequired",
-			req:         &autoopsproto.GetProgressiveRolloutRequest{},
+			req:         &autoopsproto.GetProgressiveRolloutRequest{EnvironmentNamespace: "ns0"},
 			expectedErr: createError(statusProgressiveRolloutIDRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id")),
 		},
 		{

--- a/pkg/autoops/api/webhook.go
+++ b/pkg/autoops/api/webhook.go
@@ -44,7 +44,7 @@ func (s *AutoOpsService) CreateWebhook(
 	req *autoopspb.CreateWebhookRequest,
 ) (*autoopspb.CreateWebhookResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountpb.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (s *AutoOpsService) GetWebhook(
 	req *autoopspb.GetWebhookRequest,
 ) (*autoopspb.GetWebhookResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountpb.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountpb.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -231,7 +231,7 @@ func (s *AutoOpsService) ListWebhooks(
 	req *autoopspb.ListWebhooksRequest,
 ) (*autoopspb.ListWebhooksResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountpb.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountpb.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -329,7 +329,7 @@ func (s *AutoOpsService) UpdateWebhook(
 	req *autoopspb.UpdateWebhookRequest,
 ) (*autoopspb.UpdateWebhookResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountpb.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -431,7 +431,7 @@ func (s *AutoOpsService) DeleteWebhook(
 	req *autoopspb.DeleteWebhookRequest,
 ) (*autoopspb.DeleteWebhookResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountpb.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountpb.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/eventcounter/api/api_test.go
+++ b/pkg/eventcounter/api/api_test.go
@@ -1744,13 +1744,23 @@ func newEventCounterService(t *testing.T, mockController *gomock.Controller) *ev
 	)
 	reg := metrics.DefaultRegisterer()
 	accountClientMock := accountclientmock.NewMockClient(mockController)
-	ar := &accountproto.GetAccountResponse{
-		Account: &accountproto.Account{
-			Email: "email",
-			Role:  accountproto.Account_VIEWER,
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: "ns0",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+				{
+					EnvironmentId: "",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+			},
 		},
 	}
-	accountClientMock.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	accountClientMock.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
 	return &eventCounterService{
 		experimentClient:             experimentclientmock.NewMockClient(mockController),
 		featureClient:                featureclientmock.NewMockClient(mockController),

--- a/pkg/experiment/api/api_test.go
+++ b/pkg/experiment/api/api_test.go
@@ -73,13 +73,19 @@ func createExperimentService(c *gomock.Controller, s storage.Client) *experiment
 	}
 	featureClientMock.EXPECT().GetFeatures(gomock.Any(), gomock.Any()).Return(fsr, nil).AnyTimes()
 	accountClientMock := accountclientmock.NewMockClient(c)
-	ar := &accountproto.GetAccountResponse{
-		Account: &accountproto.Account{
-			Email: "email",
-			Role:  accountproto.Account_VIEWER,
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: "ns0",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+			},
 		},
 	}
-	accountClientMock.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	accountClientMock.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
 	mysqlClient := mysqlmock.NewMockClient(c)
 	p := publishermock.NewMockPublisher(c)
 	p.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/pkg/experiment/api/experiment.go
+++ b/pkg/experiment/api/experiment.go
@@ -45,7 +45,7 @@ func (s *experimentService) GetExperiment(
 	req *proto.GetExperimentRequest,
 ) (*proto.GetExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +98,7 @@ func (s *experimentService) ListExperiments(
 	req *proto.ListExperimentsRequest,
 ) (*proto.ListExperimentsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (s *experimentService) CreateExperiment(
 	req *proto.CreateExperimentRequest,
 ) (*proto.CreateExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -450,7 +450,7 @@ func (s *experimentService) UpdateExperiment(
 	req *proto.UpdateExperimentRequest,
 ) (*proto.UpdateExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -583,7 +583,7 @@ func (s *experimentService) StartExperiment(
 	req *proto.StartExperimentRequest,
 ) (*proto.StartExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -625,7 +625,7 @@ func (s *experimentService) FinishExperiment(
 	req *proto.FinishExperimentRequest,
 ) (*proto.FinishExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -667,7 +667,7 @@ func (s *experimentService) StopExperiment(
 	req *proto.StopExperimentRequest,
 ) (*proto.StopExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +709,7 @@ func (s *experimentService) ArchiveExperiment(
 	req *proto.ArchiveExperimentRequest,
 ) (*proto.ArchiveExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -759,7 +759,7 @@ func (s *experimentService) DeleteExperiment(
 	req *proto.DeleteExperimentRequest,
 ) (*proto.DeleteExperimentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/experiment/api/goal.go
+++ b/pkg/experiment/api/goal.go
@@ -37,7 +37,7 @@ var goalIDRegex = regexp.MustCompile("^[a-zA-Z0-9-]+$")
 
 func (s *experimentService) GetGoal(ctx context.Context, req *proto.GetGoalRequest) (*proto.GetGoalResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (s *experimentService) ListGoals(
 	req *proto.ListGoalsRequest,
 ) (*proto.ListGoalsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (s *experimentService) CreateGoal(
 	req *proto.CreateGoalRequest,
 ) (*proto.CreateGoalResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -340,7 +340,7 @@ func (s *experimentService) UpdateGoal(
 	req *proto.UpdateGoalRequest,
 ) (*proto.UpdateGoalResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -397,7 +397,7 @@ func (s *experimentService) ArchiveGoal(
 	req *proto.ArchiveGoalRequest,
 ) (*proto.ArchiveGoalResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -447,7 +447,7 @@ func (s *experimentService) DeleteGoal(
 	req *proto.DeleteGoalRequest,
 ) (*proto.DeleteGoalResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feature/api/api.go
+++ b/pkg/feature/api/api.go
@@ -108,16 +108,24 @@ func (s *FeatureService) Register(server *grpc.Server) {
 
 func (s *FeatureService) checkRole(
 	ctx context.Context,
-	requiredRole accountproto.Account_Role,
+	requiredRole accountproto.AccountV2_Role_Environment,
 	environmentNamespace string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
-		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{
-			Email:                email,
-			EnvironmentNamespace: environmentNamespace,
+	editor, err := role.CheckRole(
+		ctx,
+		requiredRole,
+		environmentNamespace,
+		func(email string) (*accountproto.AccountV2, error) {
+			resp, err := s.accountClient.GetAccountV2ByEnvironmentID(ctx, &accountproto.GetAccountV2ByEnvironmentIDRequest{
+				Email:         email,
+				EnvironmentId: environmentNamespace,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp.Account, nil
 		})
-	})
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:

--- a/pkg/feature/api/api_test.go
+++ b/pkg/feature/api/api_test.go
@@ -101,13 +101,19 @@ func createFeatureService(c *gomock.Controller) *FeatureService {
 	p.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	p.EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	a := accountclientmock.NewMockClient(c)
-	ar := &accountproto.GetAccountResponse{
-		Account: &accountproto.Account{
-			Email: "email",
-			Role:  accountproto.Account_VIEWER,
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: "ns0",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+			},
 		},
 	}
-	a.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	a.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
 	e := experimentclientmock.NewMockClient(c)
 	e.EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(&experimentproto.ListExperimentsResponse{}, nil).AnyTimes()
 	at := autoopsclientmock.NewMockClient(c)

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -56,7 +56,7 @@ func (s *FeatureService) GetFeature(
 	req *featureproto.GetFeatureRequest,
 ) (*featureproto.GetFeatureResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +109,7 @@ func (s *FeatureService) GetFeatures(
 	req *featureproto.GetFeaturesRequest,
 ) (*featureproto.GetFeaturesResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (s *FeatureService) ListFeatures(
 	req *featureproto.ListFeaturesRequest,
 ) (*featureproto.ListFeaturesResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -459,7 +459,7 @@ func (s *FeatureService) ListEnabledFeatures(
 	req *featureproto.ListEnabledFeaturesRequest,
 ) (*featureproto.ListEnabledFeaturesResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -527,7 +527,7 @@ func (s *FeatureService) CreateFeature(
 	req *featureproto.CreateFeatureRequest,
 ) (*featureproto.CreateFeatureResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -665,7 +665,7 @@ func (s *FeatureService) UpdateFeatureDetails(
 	req *featureproto.UpdateFeatureDetailsRequest,
 ) (*featureproto.UpdateFeatureDetailsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -1077,7 +1077,7 @@ func (s *FeatureService) updateFeature(
 	id, environmentNamespace, comment string,
 	localizer locale.Localizer,
 ) error {
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, environmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, environmentNamespace, localizer)
 	if err != nil {
 		return err
 	}
@@ -1258,7 +1258,7 @@ func (s *FeatureService) UpdateFeatureVariations(
 	req *featureproto.UpdateFeatureVariationsRequest,
 ) (*featureproto.UpdateFeatureVariationsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -1448,7 +1448,7 @@ func (s *FeatureService) UpdateFeatureTargeting(
 	req *featureproto.UpdateFeatureTargetingRequest,
 ) (*featureproto.UpdateFeatureTargetingResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -1886,7 +1886,7 @@ func (s *FeatureService) EvaluateFeatures(
 	req *featureproto.EvaluateFeaturesRequest,
 ) (*featureproto.EvaluateFeaturesResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -2055,7 +2055,12 @@ func (s *FeatureService) CloneFeature(
 	if err := validateCloneFeatureRequest(req, localizer); err != nil {
 		return nil, err
 	}
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.Command.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		req.Command.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -45,7 +45,12 @@ func (s *FeatureService) CreateFlagTrigger(
 	request *featureproto.CreateFlagTriggerRequest,
 ) (*featureproto.CreateFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, request.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		request.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -153,7 +158,12 @@ func (s *FeatureService) UpdateFlagTrigger(
 	request *featureproto.UpdateFlagTriggerRequest,
 ) (*featureproto.UpdateFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, request.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		request.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +260,12 @@ func (s *FeatureService) EnableFlagTrigger(
 	request *featureproto.EnableFlagTriggerRequest,
 ) (*featureproto.EnableFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, request.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		request.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -347,7 +362,12 @@ func (s *FeatureService) DisableFlagTrigger(
 	request *featureproto.DisableFlagTriggerRequest,
 ) (*featureproto.DisableFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, request.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		request.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -441,7 +461,12 @@ func (s *FeatureService) ResetFlagTrigger(
 	request *featureproto.ResetFlagTriggerRequest,
 ) (*featureproto.ResetFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, request.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		request.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -541,7 +566,12 @@ func (s *FeatureService) DeleteFlagTrigger(
 	request *featureproto.DeleteFlagTriggerRequest,
 ) (*featureproto.DeleteFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, request.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		request.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -627,7 +657,7 @@ func (s *FeatureService) GetFlagTrigger(
 	request *featureproto.GetFlagTriggerRequest,
 ) (*featureproto.GetFlagTriggerResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, request.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, request.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -685,7 +715,7 @@ func (s *FeatureService) ListFlagTriggers(
 	request *featureproto.ListFlagTriggersRequest,
 ) (*featureproto.ListFlagTriggersResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, request.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, request.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -856,7 +886,12 @@ func (s *FeatureService) FlagTriggerWebhook(
 		}
 		return nil, dt.Err()
 	}
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, trigger.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(
+		ctx,
+		accountproto.AccountV2_Role_Environment_EDITOR,
+		trigger.EnvironmentNamespace,
+		localizer,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feature/api/segment.go
+++ b/pkg/feature/api/segment.go
@@ -43,7 +43,7 @@ func (s *FeatureService) CreateSegment(
 	req *featureproto.CreateSegmentRequest,
 ) (*featureproto.CreateSegmentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (s *FeatureService) DeleteSegment(
 	req *featureproto.DeleteSegmentRequest,
 ) (*featureproto.DeleteSegmentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -265,7 +265,7 @@ func (s *FeatureService) UpdateSegment(
 	req *featureproto.UpdateSegmentRequest,
 ) (*featureproto.UpdateSegmentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		s.logger.Info(
 			"Permission denied",
@@ -406,7 +406,7 @@ func (s *FeatureService) GetSegment(
 	req *featureproto.GetSegmentRequest,
 ) (*featureproto.GetSegmentResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +484,7 @@ func (s *FeatureService) ListSegments(
 	req *featureproto.ListSegmentsRequest,
 ) (*featureproto.ListSegmentsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feature/api/segment_user.go
+++ b/pkg/feature/api/segment_user.go
@@ -43,7 +43,7 @@ func (s *FeatureService) AddSegmentUser(
 	req *featureproto.AddSegmentUserRequest,
 ) (*featureproto.AddSegmentUserResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (s *FeatureService) DeleteSegmentUser(
 	req *featureproto.DeleteSegmentUserRequest,
 ) (*featureproto.DeleteSegmentUserResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (s *FeatureService) GetSegmentUser(
 	req *featureproto.GetSegmentUserRequest,
 ) (*featureproto.GetSegmentUserResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -296,7 +296,7 @@ func (s *FeatureService) ListSegmentUsers(
 	req *featureproto.ListSegmentUsersRequest,
 ) (*featureproto.ListSegmentUsersResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (s *FeatureService) BulkUploadSegmentUsers(
 	req *featureproto.BulkUploadSegmentUsersRequest,
 ) (*featureproto.BulkUploadSegmentUsersResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -529,7 +529,7 @@ func (s *FeatureService) BulkDownloadSegmentUsers(
 	req *featureproto.BulkDownloadSegmentUsersRequest,
 ) (*featureproto.BulkDownloadSegmentUsersResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/feature/api/tag.go
+++ b/pkg/feature/api/tag.go
@@ -36,7 +36,7 @@ func (s *FeatureService) ListTags(
 	req *featureproto.ListTagsRequest,
 ) (*featureproto.ListTagsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/notification/api/api.go
+++ b/pkg/notification/api/api.go
@@ -132,16 +132,24 @@ func (s *NotificationService) checkAdminRole(
 
 func (s *NotificationService) checkRole(
 	ctx context.Context,
-	requiredRole accountproto.Account_Role,
+	requiredRole accountproto.AccountV2_Role_Environment,
 	environmentNamespace string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
-		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{
-			Email:                email,
-			EnvironmentNamespace: environmentNamespace,
+	editor, err := role.CheckRole(
+		ctx,
+		requiredRole,
+		environmentNamespace,
+		func(email string) (*accountproto.AccountV2, error) {
+			resp, err := s.accountClient.GetAccountV2ByEnvironmentID(ctx, &accountproto.GetAccountV2ByEnvironmentIDRequest{
+				Email:         email,
+				EnvironmentId: environmentNamespace,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp.Account, nil
 		})
-	})
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -39,7 +39,7 @@ func (s *NotificationService) CreateSubscription(
 	req *notificationproto.CreateSubscriptionRequest,
 ) (*notificationproto.CreateSubscriptionResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +241,7 @@ func (s *NotificationService) UpdateSubscription(
 	req *notificationproto.UpdateSubscriptionRequest,
 ) (*notificationproto.UpdateSubscriptionResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +270,7 @@ func (s *NotificationService) EnableSubscription(
 	req *notificationproto.EnableSubscriptionRequest,
 ) (*notificationproto.EnableSubscriptionResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +331,7 @@ func (s *NotificationService) DisableSubscription(
 	req *notificationproto.DisableSubscriptionRequest,
 ) (*notificationproto.DisableSubscriptionResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +545,7 @@ func (s *NotificationService) DeleteSubscription(
 	req *notificationproto.DeleteSubscriptionRequest,
 ) (*notificationproto.DeleteSubscriptionResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -681,7 +681,7 @@ func (s *NotificationService) GetSubscription(
 	req *notificationproto.GetSubscriptionRequest,
 ) (*notificationproto.GetSubscriptionResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -739,7 +739,7 @@ func (s *NotificationService) ListSubscriptions(
 	req *notificationproto.ListSubscriptionsRequest,
 ) (*notificationproto.ListSubscriptionsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -823,7 +823,7 @@ func (s *NotificationService) ListEnabledSubscriptions(
 	req *notificationproto.ListEnabledSubscriptionsRequest,
 ) (*notificationproto.ListEnabledSubscriptionsResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/push/api/api.go
+++ b/pkg/push/api/api.go
@@ -101,7 +101,7 @@ func (s *PushService) CreatePush(
 	req *pushproto.CreatePushRequest,
 ) (*pushproto.CreatePushResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -287,7 +287,7 @@ func (s *PushService) UpdatePush(
 	req *pushproto.UpdatePushRequest,
 ) (*pushproto.UpdatePushResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -481,7 +481,7 @@ func (s *PushService) DeletePush(
 	req *pushproto.DeletePushRequest,
 ) (*pushproto.DeletePushResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	editor, err := s.checkRole(ctx, accountproto.Account_EDITOR, req.EnvironmentNamespace, localizer)
+	editor, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_EDITOR, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +671,7 @@ func (s *PushService) ListPushes(
 	req *pushproto.ListPushesRequest,
 ) (*pushproto.ListPushesResponse, error) {
 	localizer := locale.NewLocalizer(ctx)
-	_, err := s.checkRole(ctx, accountproto.Account_VIEWER, req.EnvironmentNamespace, localizer)
+	_, err := s.checkRole(ctx, accountproto.AccountV2_Role_Environment_VIEWER, req.EnvironmentNamespace, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -794,16 +794,24 @@ func (s *PushService) listPushes(
 
 func (s *PushService) checkRole(
 	ctx context.Context,
-	requiredRole accountproto.Account_Role,
+	requiredRole accountproto.AccountV2_Role_Environment,
 	environmentNamespace string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckRole(ctx, requiredRole, func(email string) (*accountproto.GetAccountResponse, error) {
-		return s.accountClient.GetAccount(ctx, &accountproto.GetAccountRequest{
-			Email:                email,
-			EnvironmentNamespace: environmentNamespace,
+	editor, err := role.CheckRole(
+		ctx,
+		requiredRole,
+		environmentNamespace,
+		func(email string) (*accountproto.AccountV2, error) {
+			resp, err := s.accountClient.GetAccountV2ByEnvironmentID(ctx, &accountproto.GetAccountV2ByEnvironmentIDRequest{
+				Email:         email,
+				EnvironmentId: environmentNamespace,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp.Account, nil
 		})
-	})
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:


### PR DESCRIPTION
- This PR fixes the GetAccountV2ByEnvironmentID API.
  - It failed to retrieve the account when it received an empty environment ID.
  - So, I removed the needless validation. (The 2nd commit: https://github.com/bucketeer-io/bucketeer/commit/9c227626c78e41a8778198805423da8063f55286)
  - The 1st commit reverts the revert. (https://github.com/bucketeer-io/bucketeer/commit/839415594231cb28fc6b462863049bf4c47fc821)