### PR TITLE
ci: fix setup job fails in workflow

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -56,7 +56,7 @@ jobs:
         run: echo "value=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
       - name: Store the first line of commit message
         id: commit_message
-        run: echo "${{ github.event.head_commit.message }}" | head -n 1 >> $GITHUB_OUTPUT
+        run: echo "value=$(echo '${{ github.event.head_commit.message }}' | head -n 1)" >> $GITHUB_OUTPUT
 
   go:
     needs: setup


### PR DESCRIPTION
Checked locally 👍 

```sh
> act -j setup -e event.json
...
[push-image/setup]   ✅  Success - Main Store the first line of commit message
[push-image/setup]   ⚙  ::set-output:: value=Update README.md
```