### PR TITLE
chore: build dev container base image

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -1,0 +1,94 @@
+FROM ubuntu:focal
+
+COPY first-run-notice.txt /tmp/scripts/
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    # Restore man command
+    && yes | unminimize 2>&1 
+
+ENV LANG="C.UTF-8"
+
+# Install basic build tools
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        make \
+        unzip \
+        # The tools in this package are used when installing packages for Python
+        build-essential \
+        swig3.0 \
+        # Required for Microsoft SQL Server
+        unixodbc-dev \
+        # Required for PostgreSQL
+        libpq-dev \
+        # Required for mysqlclient
+        default-libmysqlclient-dev \
+        # Required for ts
+        moreutils \
+        rsync \
+        zip \
+        libgdiplus \
+        jq \
+        # By default pip is not available in the buildpacks image
+        python-pip-whl \
+        python3-pip \
+        #.NET Core related pre-requisites
+        libc6 \
+        libgcc1 \
+        libgssapi-krb5-2 \
+        libncurses5 \
+        liblttng-ust0 \
+        libssl-dev \
+        libstdc++6 \
+        zlib1g \
+        libuuid1 \
+        libunwind8 \
+        sqlite3 \
+        libsqlite3-dev \
+        software-properties-common \
+        tk-dev \
+        uuid-dev \
+        curl \
+        gettext \
+    && rm -rf /var/lib/apt/lists/* \
+    # This is the folder containing 'links' to benv and build script generator
+    && apt-get update \
+    && apt-get upgrade -y \
+    && add-apt-repository universe \
+    && rm -rf /var/lib/apt/lists/*
+
+# Verify expected build and debug tools are present
+RUN apt-get update \
+    && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb python3-dev \
+    # Install tools and shells not in common script
+    && apt-get install -yq vim vim-doc xtail software-properties-common libsecret-1-dev \
+    # Install additional tools (useful for 'puppeteer' project)
+    && apt-get install -y --no-install-recommends libnss3 libnspr4 libatk-bridge2.0-0 libatk1.0-0 libx11-6 libpangocairo-1.0-0 \
+                                                  libx11-xcb1 libcups2 libxcomposite1 libxdamage1 libxfixes3 libpango-1.0-0 libgbm1 libgtk-3-0 \
+    # Clean up
+    && apt-get autoremove -y && apt-get clean -y \
+    # Move first run notice to right spot
+    && mkdir -p "/usr/local/etc/vscode-dev-containers/" \
+    && mv -f /tmp/scripts/first-run-notice.txt /usr/local/etc/vscode-dev-containers/
+
+# Default to bash shell (other shells available at /usr/bin/fish and /usr/bin/zsh)
+ENV SHELL=/bin/bash \
+    DOCKER_BUILDKIT=1
+
+# Remove scripts now that we're done with them
+RUN apt-get clean -y && rm -rf /tmp/scripts
+
+# Mount for docker-in-docker 
+VOLUME [ "/var/lib/docker" ]
+
+# Fire Docker/Moby script if needed
+ENTRYPOINT [ "/usr/local/share/docker-init.sh", "/usr/local/share/ssh-init.sh"]
+CMD [ "sleep", "infinity" ]
+
+# [Optional] Install debugger for development of Codespaces - Not in resulting image by default
+ARG DeveloperBuild
+RUN if [ -z $DeveloperBuild ]; then \
+        echo "not including debugger" ; \
+    else \
+        curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg ; \
+    fi

--- a/.github/.devcontainer/devcontainer-lock.json
+++ b/.github/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,49 @@
+{
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/protoc:1": {
+      "version": "1.0.2",
+      "resolved": "ghcr.io/devcontainers-contrib/features/protoc@sha256:436d25961d1c3bbc39a565c004d0eca8dd9c0cb80c0319d089d0aa49dc2ad070",
+      "integrity": "sha256:436d25961d1c3bbc39a565c004d0eca8dd9c0cb80c0319d089d0aa49dc2ad070"
+    },
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.3.0",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:b1eb0e78fd8fc79ac12cac8ef5e821e030da2da56adc651667c15335ea7b6ced",
+      "integrity": "sha256:b1eb0e78fd8fc79ac12cac8ef5e821e030da2da56adc651667c15335ea7b6ced"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.7.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:f6a73ee06601d703db7d95d03e415cab229e78df92bb5002e8559bcfc047fec6",
+      "integrity": "sha256:f6a73ee06601d703db7d95d03e415cab229e78df92bb5002e8559bcfc047fec6"
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/devcontainers/features/git-lfs@sha256:7d5756073af0c36287d59465292c44131c98b84d8a2408127d8f3de45095daee",
+      "integrity": "sha256:7d5756073af0c36287d59465292c44131c98b84d8a2408127d8f3de45095daee"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.1.6",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:f839be8a0203abe12c917b262b1a1330b8286f9576ef21ea4a26ed60c5bc9947",
+      "integrity": "sha256:f839be8a0203abe12c917b262b1a1330b8286f9576ef21ea4a26ed60c5bc9947"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.0.11",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:464564228ccdd6028f01f8a62a3cfbaf76e9ba7953b29ac0e53ba2c262604312",
+      "integrity": "sha256:464564228ccdd6028f01f8a62a3cfbaf76e9ba7953b29ac0e53ba2c262604312"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.2.2",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d5e34970f31942a4d9f6b3f6f52da1176b2dcb35aeba3f0fc93b974e287d3b16",
+      "integrity": "sha256:d5e34970f31942a4d9f6b3f6f52da1176b2dcb35aeba3f0fc93b974e287d3b16"
+    },
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "1.1.5",
+      "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:23aca9dfe058b498b4d7fa2d5592c75b1ff06e581b950419a56e19568d8ecaf7",
+      "integrity": "sha256:23aca9dfe058b498b4d7fa2d5592c75b1ff06e581b950419a56e19568d8ecaf7"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "1.0.9",
+      "resolved": "ghcr.io/devcontainers/features/sshd@sha256:7f6467f25d23c47371ba59f6f3350c9de3439a4d4cdf7497ae50e8aca40bc0e0",
+      "integrity": "sha256:7f6467f25d23c47371ba59f6f3350c9de3439a4d4cdf7497ae50e8aca40bc0e0"
+    }
+  }
+}

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -1,0 +1,79 @@
+{
+  "name": "bucketeer",
+  "build": {
+    "dockerfile": "./Dockerfile",
+    "context": "."
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "username": "codespace",
+      "userUid": "1000",
+      "userGid": "1000"
+    },
+    "ghcr.io/devcontainers-contrib/features/protoc:1": {
+      "version": "23.4"
+    },
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest",
+      "ppa": "false"
+    },
+    "ghcr.io/devcontainers/features/git-lfs:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "latest"
+    },
+    "./local-features/setup-user": "latest"
+  },
+  "overrideFeatureInstallOrder": [
+    "ghcr.io/devcontainers/features/common-utils",
+    "ghcr.io/devcontainers/features/git",
+    "ghcr.io/devcontainers/features/sshd",
+    "ghcr.io/devcontainers/features/git-lfs",
+    "ghcr.io/devcontainers/features/github-cli",
+    "ghcr.io/devcontainers/features/docker-in-docker",
+    "ghcr.io/devcontainers/features/kubectl-helm-minikube",
+    "ghcr.io/devcontainers/features/go",
+    "./local-features/setup-user"
+  ],
+  "remoteUser": "codespace",
+  "containerUser": "codespace",
+  "customizations": {
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        "DEVELOPMENT.md",
+        "Makefile"
+      ]
+    },
+    "vscode": {
+      // Set *default* container specific settings.json values on container create.
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "local",
+        "go.useLanguageServer": true,
+        "go.gopath": "/go"
+      },
+      // Add the IDs of extensions you want installed when the container is created.
+      "extensions": [
+        "GitHub.vscode-pull-request-github"
+      ]
+    }
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb",
+    "storage": "32gb"
+  }
+}

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -4,6 +4,8 @@
     "dockerfile": "./Dockerfile",
     "context": "."
   },
+  "remoteUser": "codespace",
+  "containerUser": "codespace",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {
       "username": "codespace",

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -48,32 +48,4 @@
     "ghcr.io/devcontainers/features/go",
     "./local-features/setup-user"
   ],
-  "remoteUser": "codespace",
-  "containerUser": "codespace",
-  "customizations": {
-    "codespaces": {
-      "openFiles": [
-        "README.md",
-        "DEVELOPMENT.md",
-        "Makefile"
-      ]
-    },
-    "vscode": {
-      // Set *default* container specific settings.json values on container create.
-      "settings": {
-        "go.toolsManagement.checkForUpdates": "local",
-        "go.useLanguageServer": true,
-        "go.gopath": "/go"
-      },
-      // Add the IDs of extensions you want installed when the container is created.
-      "extensions": [
-        "GitHub.vscode-pull-request-github"
-      ]
-    }
-  },
-  "hostRequirements": {
-    "cpus": 4,
-    "memory": "8gb",
-    "storage": "32gb"
-  }
 }

--- a/.github/.devcontainer/first-run-notice.txt
+++ b/.github/.devcontainer/first-run-notice.txt
@@ -1,0 +1,8 @@
+👋 Welcome to Codespaces! You are on our default image. 
+   - It includes runtimes and tools for Python, Node.js, Docker, and more. See the full list here: https://aka.ms/ghcs-default-image
+   - Want to use a custom image instead? Learn more here: https://aka.ms/configure-codespace
+
+🔍 To explore VS Code to its fullest, search using the Command Palette (Cmd/Ctrl + Shift + P or F1).
+
+📝 Edit away, run your app as usual, and we'll automatically make it available for you to access.
+

--- a/.github/.devcontainer/local-features/setup-user/devcontainer-feature.json
+++ b/.github/.devcontainer/local-features/setup-user/devcontainer-feature.json
@@ -1,0 +1,29 @@
+{
+    "id": "setup-user",
+    "name": "Setup user configs",
+    "containerEnv": {
+        "RUBY_HOME": "/usr/local/rvm/rubies/default",
+        "JAVA_ROOT": "/home/codespace/java",
+        "NODE_ROOT": "/home/codespace/nvm",
+        "PHP_ROOT": "/home/codespace/.php",
+        "PYTHON_ROOT": "/home/codespace/.python",
+        "RUBY_ROOT": "/home/codespace/.ruby",
+        "MAVEN_ROOT": "/home/codespace/.maven",
+        "HUGO_ROOT": "/home/codespace/.hugo",
+        "DOTNET_SKIP_FIRST_TIME_EXPERIENCE": "1",
+        "NUGET_XMLDOC_MODE": "skip",
+        "ORYX_ENV_TYPE": "vsonline-present",
+        "PYTHONIOENCODING": "UTF-8",
+        "NPM_GLOBAL": "/home/codespace/.npm-global",
+        "NVS_HOME": "/home/codespace/.nvs",
+        "RVM_PATH": "/usr/local/rvm",
+        "RAILS_DEVELOPMENT_HOSTS": ".githubpreview.dev,.preview.app.github.dev,.app.github.dev",
+        "GOROOT": "/usr/local/go",
+        "JUPYTERLAB_PATH": "/home/codespace/.local/bin",
+        "PATH": "/home/codespace/.dotnet:/home/codespace/nvm/current/bin:/home/codespace/.php/current/bin:/home/codespace/.python/current/bin:/home/codespace/java/current/bin:/home/codespace/.ruby/current/bin:/home/codespace/.local/bin:${PATH}"
+    },
+    "install": {
+        "app": "",
+        "file": "install.sh"
+    }
+}

--- a/.github/.devcontainer/local-features/setup-user/install.sh
+++ b/.github/.devcontainer/local-features/setup-user/install.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+USERNAME=${USERNAME:-"codespace"}
+
+set -eux
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
+  exit 1
+fi
+
+# Ensure that login shells get the correct path if the user updated the PATH using ENV.
+rm -f /etc/profile.d/00-restore-env.sh
+echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" >/etc/profile.d/00-restore-env.sh
+chmod +x /etc/profile.d/00-restore-env.sh
+
+export DEBIAN_FRONTEND=noninteractive
+
+sudo_if() {
+  COMMAND="$*"
+  if [ "$(id -u)" -eq 0 ] && [ "$USERNAME" != "root" ]; then
+    su - "$USERNAME" -c "$COMMAND"
+  else
+    "$COMMAND"
+  fi
+}
+
+HOME_DIR="/home/${USERNAME}/"
+chown -R ${USERNAME}:${USERNAME} ${HOME_DIR}
+chmod -R g+r+w "${HOME_DIR}"
+find "${HOME_DIR}" -type d | xargs -n 1 chmod g+s
+
+echo "Defaults secure_path=\"/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/share:/home/${USERNAME}/.local/bin:${PATH}\"" >>/etc/sudoers.d/$USERNAME
+
+echo "Done!"

--- a/.github/workflows/devcontainer-image-build.yaml
+++ b/.github/workflows/devcontainer-image-build.yaml
@@ -1,0 +1,25 @@
+name: Bucketeer Dev Container Build and Push Image
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (GitHub)
+        uses: actions/checkout@v3
+      - name: Set up QEMU for multi-architecture builds
+        uses: docker/setup-qemu-action@v2
+      - name: Setup Docker buildx for multi-architecture builds
+        uses: docker/setup-buildx-action@v2
+        with:
+          use: true
+      - name: Build and release devcontainer Multi-Platform
+        uses: devcontainers/ci@v0.3
+        with:
+          imageName: ghcr.io/bucketeer-io/bucketeer-devcontainer
+          platform: linux/amd64,linux/arm64
+          subFolder: .github
+          push: never
+

--- a/.github/workflows/devcontainer-image-build.yaml
+++ b/.github/workflows/devcontainer-image-build.yaml
@@ -15,10 +15,17 @@ jobs:
         uses: docker/setup-buildx-action@v2
         with:
           use: true
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release devcontainer Multi-Platform
         uses: devcontainers/ci@v0.3
         with:
-          imageName: ghcr.io/bucketeer-io/bucketeer-devcontainer
+          imageName: ghcr.io/${{ github.repository }}-devcontainer
+          cacheFrom: ghcr.io/${{ github.repository }}-devcontainer
           platform: linux/amd64,linux/arm64
           subFolder: .github
           push: never

--- a/.github/workflows/devcontainer-image-build.yaml
+++ b/.github/workflows/devcontainer-image-build.yaml
@@ -10,9 +10,11 @@ jobs:
       - name: Checkout (GitHub)
         uses: actions/checkout@v3
       - name: Set up QEMU for multi-architecture builds
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v2.2.0
+        with:
+          platforms: linux/amd64,linux/arm64
       - name: Setup Docker buildx for multi-architecture builds
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v2.7.0
         with:
           use: true
       - name: Login to GitHub Container Registry
@@ -23,10 +25,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and release devcontainer Multi-Platform
         uses: devcontainers/ci@v0.3
+        env:
+          BUILDX_NO_DEFAULT_ATTESTATIONS: true
         with:
-          imageName: ghcr.io/${{ github.repository }}-devcontainer
-          cacheFrom: ghcr.io/${{ github.repository }}-devcontainer
+          imageName: ghcr.io/ubisoft-potato/bucketeer-devcontainer
+          cacheFrom: ghcr.io/ubisoft-potato/bucketeer-devcontainer
           platform: linux/amd64,linux/arm64
           subFolder: .github
-          push: never
+          push: always
 

--- a/.github/workflows/devcontainer-image-build.yaml
+++ b/.github/workflows/devcontainer-image-build.yaml
@@ -28,9 +28,8 @@ jobs:
         env:
           BUILDX_NO_DEFAULT_ATTESTATIONS: true
         with:
-          imageName: ghcr.io/ubisoft-potato/bucketeer-devcontainer
-          cacheFrom: ghcr.io/ubisoft-potato/bucketeer-devcontainer
+          imageName: ghcr.io/bucketeer-io/bucketeer-devcontainer
+          cacheFrom: ghcr.io/bucketeer-io/bucketeer-devcontainer
           platform: linux/amd64,linux/arm64
           subFolder: .github
           push: always
-


### PR DESCRIPTION
Fixes https://github.com/bucketeer-io/bucketeer/issues/134

- This PR will add a Github Workflow file that builds the base image used by the Dev Container.

- This Workflow is designed to be run manually. Whenever we update the Bucketeer project dependency or tools, we can trigger the build workflow as needed.

The dev container image name will be: `ghcr.io/bucketeer-io/bucketeer-devcontainer`