### PR TITLE
ci: trigger code butler when the PR changes to ready_for_review state

### DIFF
--- a/.github/workflows/code-butler.yaml
+++ b/.github/workflows/code-butler.yaml
@@ -7,10 +7,15 @@ permissions:
 on:
   issue_comment:
     types: [created]
+  pull_request:
+      branches:
+        - main
+      types:
+        - ready_for_review
 
 jobs:
   review:
-    if: startsWith(github.event.comment.body, '/review')
+    if: ${{ (startsWith(github.event.comment.body, '/review')) || (github.event.pull_request.draft == false) }}
     runs-on: ubuntu-latest
     steps:
       - uses: ca-dp/code-butler@v1


### PR DESCRIPTION
Changing to automatically trigger the code butler when the PR's state changes to `ready_for_review`.