### PR TITLE
ci: fix push-image triggering when pushing ci code

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -27,7 +27,7 @@ on:
       - "CLA.md"
       - "CONTRIBUTING.md"
       - "DEPLOYMENT.md"
-      - ".github/workflows/**"
+      - ".github/**"
 
 env:
   GHCR_REGISTRY: ghcr.io/bucketeer-io


### PR DESCRIPTION
Fixes https://github.com/bucketeer-io/bucketeer/issues/717

We didn't have the directory `.devcontainer` when this workflow was created. When we made changes to the `.devcontainer`, it triggered only the `push-image` workflow, causing errors on the PipeCD because the helm chart doesn't exist, which is expected. So, I'm fixing the condition to match the `push_chart` workflow.