### PR TITLE
chore: update the process getting AdminAccount

### DIFF
--- a/pkg/account/api/admin_account_test.go
+++ b/pkg/account/api/admin_account_test.go
@@ -164,7 +164,7 @@ func TestGetMeV2MySQL(t *testing.T) {
 					},
 					nil,
 				)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
+				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccount(
@@ -268,7 +268,7 @@ func TestGetMeByEmailV2MySQL(t *testing.T) {
 					},
 					nil,
 				)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
+				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccount(
@@ -1011,7 +1011,7 @@ func TestGetMeMySQL(t *testing.T) {
 					},
 					nil,
 				)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccount(
+				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2(

--- a/pkg/account/storage/v2/mock/storage.go
+++ b/pkg/account/storage/v2/mock/storage.go
@@ -198,6 +198,21 @@ func (mr *MockAccountStorageMockRecorder) GetAdminAccount(ctx, id interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdminAccount", reflect.TypeOf((*MockAccountStorage)(nil).GetAdminAccount), ctx, id)
 }
 
+// GetAdminAccountV2 mocks base method.
+func (m *MockAccountStorage) GetAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAdminAccountV2", ctx, email)
+	ret0, _ := ret[0].(*domain.AccountV2)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAdminAccountV2 indicates an expected call of GetAdminAccountV2.
+func (mr *MockAccountStorageMockRecorder) GetAdminAccountV2(ctx, email interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdminAccountV2", reflect.TypeOf((*MockAccountStorage)(nil).GetAdminAccountV2), ctx, email)
+}
+
 // ListAPIKeys mocks base method.
 func (m *MockAccountStorage) ListAPIKeys(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*account.APIKey, int, int64, error) {
 	m.ctrl.T.Helper()

--- a/pkg/account/storage/v2/sql/account_v2/select_admin_account_v2.sql
+++ b/pkg/account/storage/v2/sql/account_v2/select_admin_account_v2.sql
@@ -1,0 +1,19 @@
+SELECT
+    a.email,
+    a.name,
+    a.avatar_image_url,
+    a.organization_id,
+    a.organization_role,
+    a.environment_roles,
+    a.disabled,
+    a.created_at,
+    a.updated_at
+FROM
+    account_v2 AS a
+        INNER JOIN
+    organization AS o
+    ON
+            a.organization_id = o.id
+WHERE
+        o.system_admin = 1
+  AND a.email = ?

--- a/pkg/account/storage/v2/sql/account_v2/select_admin_account_v2.sql
+++ b/pkg/account/storage/v2/sql/account_v2/select_admin_account_v2.sql
@@ -10,10 +10,10 @@ SELECT
     a.updated_at
 FROM
     account_v2 AS a
-        INNER JOIN
+INNER JOIN
     organization AS o
-    ON
-            a.organization_id = o.id
+ON
+    a.organization_id = o.id
 WHERE
-        o.system_admin = 1
-  AND a.email = ?
+    o.system_admin = 1
+    AND a.email = ?

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -56,6 +56,7 @@ type AccountStorage interface {
 		orders []*mysql.Order,
 		limit, offset int,
 	) ([]*proto.Account, int, int64, error)
+	GetAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error)
 	CreateAPIKey(ctx context.Context, k *domain.APIKey, environmentNamespace string) error
 	UpdateAPIKey(ctx context.Context, k *domain.APIKey, environmentNamespace string) error
 	GetAPIKey(ctx context.Context, id, environmentNamespace string) (*domain.APIKey, error)


### PR DESCRIPTION
## Summary

- The old getAdminAccount() function retrieves objects from the `admin_account` table.
- The new getAdminAccountV2() function retrieves the account belonging to the System Admin Organization.
