### PR TITLE
chore: remove webhook table from delete-e2e targets

### DIFF
--- a/hack/delete-e2e-data-mysql/command.go
+++ b/hack/delete-e2e-data-mysql/command.go
@@ -48,7 +48,6 @@ var (
 		{table: "ops_progressive_rollout", targetField: "feature_id"},
 		{table: "flag_trigger", targetField: "description"},
 		{table: "feature", targetField: "id"},
-		{table: "webhook", targetField: "name"},
 	}
 	targetEntitiesInOrganization = []*mysqlE2EInfo{
 		{table: "account_v2", targetField: "email"},


### PR DESCRIPTION
## Summary

- We've already deleted the webhook table.