### PR TITLE
test: add unit test for flag trigger

### DIFF
--- a/pkg/feature/api/api.go
+++ b/pkg/feature/api/api.go
@@ -17,6 +17,8 @@ package api
 import (
 	"context"
 
+	v2fs "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
+	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
@@ -36,7 +38,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
-	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
 type options struct {
@@ -52,6 +53,7 @@ func WithLogger(l *zap.Logger) Option {
 }
 
 type FeatureService struct {
+	flagTriggerStorage    v2fs.FlagTriggerStorage
 	mysqlClient           mysql.Client
 	accountClient         accountclient.Client
 	experimentClient      experimentclient.Client
@@ -84,6 +86,7 @@ func NewFeatureService(
 		opt(dopts)
 	}
 	return &FeatureService{
+		flagTriggerStorage:    v2fs.NewFlagTriggerStorage(mysqlClient),
 		mysqlClient:           mysqlClient,
 		accountClient:         accountClient,
 		experimentClient:      experimentClient,

--- a/pkg/feature/api/api.go
+++ b/pkg/feature/api/api.go
@@ -17,14 +17,15 @@ package api
 import (
 	"context"
 
-	v2fs "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
-	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	v2fs "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
+	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 
 	accountclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
 	autoopsclient "github.com/bucketeer-io/bucketeer/pkg/autoops/client"

--- a/pkg/feature/api/api.go
+++ b/pkg/feature/api/api.go
@@ -54,6 +54,7 @@ func WithLogger(l *zap.Logger) Option {
 
 type FeatureService struct {
 	flagTriggerStorage    v2fs.FlagTriggerStorage
+	featureStorage        v2fs.FeatureStorage
 	mysqlClient           mysql.Client
 	accountClient         accountclient.Client
 	experimentClient      experimentclient.Client
@@ -87,6 +88,7 @@ func NewFeatureService(
 	}
 	return &FeatureService{
 		flagTriggerStorage:    v2fs.NewFlagTriggerStorage(mysqlClient),
+		featureStorage:        v2fs.NewFeatureStorage(mysqlClient),
 		mysqlClient:           mysqlClient,
 		accountClient:         accountClient,
 		experimentClient:      experimentClient,

--- a/pkg/feature/api/api_test.go
+++ b/pkg/feature/api/api_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2/mock"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
@@ -120,6 +121,7 @@ func createFeatureService(c *gomock.Controller) *FeatureService {
 	at := autoopsclientmock.NewMockClient(c)
 	at.EXPECT().ListProgressiveRollouts(gomock.Any(), gomock.Any()).Return(&autoopsproto.ListProgressiveRolloutsResponse{}, nil).AnyTimes()
 	return &FeatureService{
+		mock.NewMockFlagTriggerStorage(c),
 		mysqlmock.NewMockClient(c),
 		a,
 		e,
@@ -146,6 +148,7 @@ func createFeatureServiceNew(c *gomock.Controller) *FeatureService {
 	}
 	a.EXPECT().GetAccountV2(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
 	return &FeatureService{
+		flagTriggerStorage:    mock.NewMockFlagTriggerStorage(c),
 		mysqlClient:           mysqlmock.NewMockClient(c),
 		accountClient:         a,
 		autoOpsClient:         aoclientmock.NewMockClient(c),

--- a/pkg/feature/api/api_test.go
+++ b/pkg/feature/api/api_test.go
@@ -122,6 +122,7 @@ func createFeatureService(c *gomock.Controller) *FeatureService {
 	at.EXPECT().ListProgressiveRollouts(gomock.Any(), gomock.Any()).Return(&autoopsproto.ListProgressiveRolloutsResponse{}, nil).AnyTimes()
 	return &FeatureService{
 		mock.NewMockFlagTriggerStorage(c),
+		mock.NewMockFeatureStorage(c),
 		mysqlmock.NewMockClient(c),
 		a,
 		e,
@@ -149,6 +150,7 @@ func createFeatureServiceNew(c *gomock.Controller) *FeatureService {
 	a.EXPECT().GetAccountV2(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
 	return &FeatureService{
 		flagTriggerStorage:    mock.NewMockFlagTriggerStorage(c),
+		featureStorage:        mock.NewMockFeatureStorage(c),
 		mysqlClient:           mysqlmock.NewMockClient(c),
 		accountClient:         a,
 		autoOpsClient:         aoclientmock.NewMockClient(c),

--- a/pkg/feature/api/api_test.go
+++ b/pkg/feature/api/api_test.go
@@ -19,10 +19,11 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2/mock"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
+
+	"github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2/mock"
 
 	accountclientmock "github.com/bucketeer-io/bucketeer/pkg/account/client/mock"
 	aoclientmock "github.com/bucketeer-io/bucketeer/pkg/autoops/client/mock"

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -539,7 +539,14 @@ func (s *FeatureService) ResetFlagTrigger(
 			}
 			return nil, dt.Err()
 		}
-		return nil, err
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return nil, statusInternal.Err()
+		}
+		return nil, dt.Err()
 	}
 	triggerURL, err := s.generateTriggerURL(ctx, trigger.Token, false)
 	if err != nil {
@@ -642,7 +649,14 @@ func (s *FeatureService) DeleteFlagTrigger(
 			}
 			return nil, dt.Err()
 		}
-		return nil, err
+		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalize(locale.InternalServerError),
+		})
+		if err != nil {
+			return nil, statusInternal.Err()
+		}
+		return nil, dt.Err()
 	}
 	return &featureproto.DeleteFlagTriggerResponse{}, nil
 }

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -824,8 +824,7 @@ func (s *FeatureService) FlagTriggerWebhook(
 		}
 		return nil, dt.Err()
 	}
-	storage := v2fs.NewFlagTriggerStorage(s.mysqlClient)
-	trigger, err := storage.GetFlagTriggerByToken(ctx, token)
+	trigger, err := s.flagTriggerStorage.GetFlagTriggerByToken(ctx, token)
 	if err != nil {
 		s.logger.Error(
 			"Failed to get flag trigger",
@@ -857,8 +856,7 @@ func (s *FeatureService) FlagTriggerWebhook(
 	if err != nil {
 		return nil, err
 	}
-	featureStorage := v2fs.NewFeatureStorage(s.mysqlClient)
-	feature, err := featureStorage.GetFeature(ctx, trigger.FeatureId, trigger.EnvironmentNamespace)
+	feature, err := s.featureStorage.GetFeature(ctx, trigger.FeatureId, trigger.EnvironmentNamespace)
 	if err != nil {
 		if errors.Is(err, v2fs.ErrFeatureNotFound) {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -666,7 +666,7 @@ func (s *FeatureService) GetFlagTrigger(
 		)
 		return nil, err
 	}
-	trigger, err := v2fs.NewFlagTriggerStorage(s.mysqlClient).GetFlagTrigger(
+	trigger, err := s.flagTriggerStorage.GetFlagTrigger(
 		ctx,
 		request.Id,
 		request.EnvironmentNamespace,

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -139,14 +139,7 @@ func (s *FeatureService) CreateFlagTrigger(
 		}
 		return nil, dt.Err()
 	}
-	triggerURL, err := s.generateTriggerURL(ctx, flagTrigger.Token, false)
-	if err != nil {
-		s.logger.Error(
-			"Failed to generate trigger url",
-			log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
-		)
-		return nil, err
-	}
+	triggerURL := s.generateTriggerURL(ctx, flagTrigger.Token, false)
 	flagTrigger.FlagTrigger.Token = ""
 	return &featureproto.CreateFlagTriggerResponse{
 		FlagTrigger: flagTrigger.FlagTrigger,
@@ -548,14 +541,7 @@ func (s *FeatureService) ResetFlagTrigger(
 		}
 		return nil, dt.Err()
 	}
-	triggerURL, err := s.generateTriggerURL(ctx, trigger.Token, false)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
-		)
-		return nil, err
-	}
+	triggerURL := s.generateTriggerURL(ctx, trigger.Token, false)
 	trigger.FlagTrigger.Token = ""
 	return &featureproto.ResetFlagTriggerResponse{
 		FlagTrigger: trigger.FlagTrigger,
@@ -698,14 +684,7 @@ func (s *FeatureService) GetFlagTrigger(
 		}
 		return nil, err
 	}
-	triggerURL, err := s.generateTriggerURL(ctx, trigger.Token, true)
-	if err != nil {
-		s.logger.Error(
-			"Failed to generate trigger url",
-			log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
-		)
-		return nil, err
-	}
+	triggerURL := s.generateTriggerURL(ctx, trigger.Token, true)
 	trigger.FlagTrigger.Token = ""
 	return &featureproto.GetFlagTriggerResponse{
 		FlagTrigger: trigger.FlagTrigger,
@@ -766,14 +745,7 @@ func (s *FeatureService) ListFlagTriggers(
 	)
 	triggerWithUrls := make([]*featureproto.ListFlagTriggersResponse_FlagTriggerWithUrl, 0, len(flagTriggers))
 	for _, trigger := range flagTriggers {
-		triggerURL, err := s.generateTriggerURL(ctx, trigger.Token, true)
-		if err != nil {
-			s.logger.Error(
-				"Failed to generate trigger url",
-				log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
-			)
-			return nil, err
-		}
+		triggerURL := s.generateTriggerURL(ctx, trigger.Token, true)
 		trigger.Token = ""
 		triggerWithUrls = append(triggerWithUrls, &featureproto.ListFlagTriggersResponse_FlagTriggerWithUrl{
 			FlagTrigger: trigger,
@@ -1070,10 +1042,10 @@ func (s *FeatureService) generateTriggerURL(
 	ctx context.Context,
 	token string,
 	masked bool,
-) (string, error) {
+) string {
 	if masked {
-		return fmt.Sprintf("%s/%s", s.triggerURL, token[:numOfSecretCharsToShow]+maskURI), nil
+		return fmt.Sprintf("%s/%s", s.triggerURL, token[:numOfSecretCharsToShow]+maskURI)
 	} else {
-		return fmt.Sprintf("%s/%s", s.triggerURL, token), nil
+		return fmt.Sprintf("%s/%s", s.triggerURL, token)
 	}
 }

--- a/pkg/feature/api/flag_trigger_test.go
+++ b/pkg/feature/api/flag_trigger_test.go
@@ -17,16 +17,113 @@ package api
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/metadata"
+	gstatus "google.golang.org/grpc/status"
+
 	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
+	v2fs "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/locale"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/feature"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-	"google.golang.org/grpc/metadata"
 )
+
+func TestCreateFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.CreateFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc:  "Error Invalid Argument",
+			setup: nil,
+			input: &proto.CreateFlagTriggerRequest{
+				EnvironmentNamespace: "namespace",
+			},
+			expectedErr: createError(statusMissingCommand, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "create_flag_trigger_command")),
+		},
+		{
+			desc: "Error Internal",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+			},
+			input: &proto.CreateFlagTriggerRequest{
+				EnvironmentNamespace: "namespace",
+				CreateFlagTriggerCommand: &proto.CreateFlagTriggerCommand{
+					FeatureId: "id-1",
+					Type:      proto.FlagTrigger_Type_WEBHOOK,
+					Action:    proto.FlagTrigger_Action_ON,
+				},
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			input: &proto.CreateFlagTriggerRequest{
+				EnvironmentNamespace: "namespace",
+				CreateFlagTriggerCommand: &proto.CreateFlagTriggerCommand{
+					FeatureId: "id-1",
+					Type:      proto.FlagTrigger_Type_WEBHOOK,
+					Action:    proto.FlagTrigger_Action_ON,
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.CreateFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if resp != nil {
+				assert.True(t, len(resp.FlagTrigger.Id) > 0)
+				assert.Equal(t, p.input.CreateFlagTriggerCommand.FeatureId, resp.FlagTrigger.FeatureId)
+				assert.Equal(t, p.input.CreateFlagTriggerCommand.Type, resp.FlagTrigger.Type)
+				assert.Equal(t, p.input.CreateFlagTriggerCommand.Action, resp.FlagTrigger.Action)
+				assert.True(t, len(resp.Url) > 0)
+			}
+		})
+	}
+}
 
 func TestGetFlagTrigger(t *testing.T) {
 	t.Parallel()
@@ -37,6 +134,16 @@ func TestGetFlagTrigger(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
 		"accept-language": []string{"ja"},
 	})
+
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
 
 	baseFlagTrigger := &proto.FlagTrigger{
 		Id:                   "1",
@@ -59,6 +166,23 @@ func TestGetFlagTrigger(t *testing.T) {
 		input       *proto.GetFlagTriggerRequest
 		expectedErr error
 	}{
+		{
+			desc:        "Error Validate",
+			setup:       nil,
+			input:       &proto.GetFlagTriggerRequest{},
+			expectedErr: createError(statusMissingTriggerID, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate)),
+		},
+		{
+			desc: "Error Not Found",
+			setup: func(s *FeatureService) {
+				s.flagTriggerStorage.(*mock.MockFlagTriggerStorage).EXPECT().GetFlagTrigger(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, v2fs.ErrFlagTriggerNotFound)
+			},
+			input:       &proto.GetFlagTriggerRequest{Id: "1", EnvironmentNamespace: "namespace"},
+			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError)),
+		},
+
 		{
 			desc: "Success",
 			setup: func(s *FeatureService) {
@@ -87,6 +211,426 @@ func TestGetFlagTrigger(t *testing.T) {
 	}
 }
 
+func TestUpdateFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.UpdateFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc:  "Error Invalid Argument",
+			setup: func(s *FeatureService) {},
+			input: &proto.UpdateFlagTriggerRequest{
+				Id:                   "id",
+				EnvironmentNamespace: "namespace",
+			},
+			expectedErr: createError(statusMissingCommand, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "change_flag_trigger_description_command")),
+		},
+		{
+			desc: "Error Internal",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+			},
+			input: &proto.UpdateFlagTriggerRequest{
+				Id:                   "id",
+				EnvironmentNamespace: "namespace",
+				ChangeFlagTriggerDescriptionCommand: &proto.ChangeFlagTriggerDescriptionCommand{
+					Description: "description",
+				},
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalizeWithTemplate(locale.InternalServerError)),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			input: &proto.UpdateFlagTriggerRequest{
+				Id:                   "id",
+				EnvironmentNamespace: "namespace",
+				ChangeFlagTriggerDescriptionCommand: &proto.ChangeFlagTriggerDescriptionCommand{
+					Description: "description",
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.UpdateFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestEnableFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.EnableFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc:  "Error Invalid Argument",
+			setup: func(s *FeatureService) {},
+			input: &proto.EnableFlagTriggerRequest{
+				Id:                   "id",
+				EnvironmentNamespace: "namespace",
+			},
+			expectedErr: createError(statusMissingCommand, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError)),
+		},
+		{
+			desc: "Error Internal",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+			},
+			input: &proto.EnableFlagTriggerRequest{
+				Id:                       "id",
+				EnvironmentNamespace:     "namespace",
+				EnableFlagTriggerCommand: &proto.EnableFlagTriggerCommand{},
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalizeWithTemplate(locale.InternalServerError)),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			input: &proto.EnableFlagTriggerRequest{
+				Id:                       "id",
+				EnvironmentNamespace:     "namespace",
+				EnableFlagTriggerCommand: &proto.EnableFlagTriggerCommand{},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.EnableFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestDisableFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.DisableFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc:  "Error Invalid Argument",
+			setup: func(s *FeatureService) {},
+			input: &proto.DisableFlagTriggerRequest{
+				Id:                   "id",
+				EnvironmentNamespace: "namespace",
+			},
+			expectedErr: createError(statusMissingCommand, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError)),
+		},
+		{
+			desc: "Error Internal",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+			},
+			input: &proto.DisableFlagTriggerRequest{
+				Id:                        "id",
+				EnvironmentNamespace:      "namespace",
+				DisableFlagTriggerCommand: &proto.DisableFlagTriggerCommand{},
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalizeWithTemplate(locale.InternalServerError)),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			input: &proto.DisableFlagTriggerRequest{
+				Id:                        "id",
+				EnvironmentNamespace:      "namespace",
+				DisableFlagTriggerCommand: &proto.DisableFlagTriggerCommand{},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.DisableFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestResetFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.ResetFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc:        "Error Invalid Argument",
+			setup:       func(s *FeatureService) {},
+			input:       &proto.ResetFlagTriggerRequest{},
+			expectedErr: createError(statusMissingCommand, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError)),
+		},
+		{
+			desc: "Error GetFlagTrigger",
+			setup: func(s *FeatureService) {
+				row := mysqlmock.NewMockRow(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+			},
+			input: &proto.ResetFlagTriggerRequest{
+				ResetFlagTriggerCommand: &proto.ResetFlagTriggerCommand{},
+			},
+			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError)),
+		},
+		{
+			desc: "Error Internal",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				row := mysqlmock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			input: &proto.ResetFlagTriggerRequest{
+				ResetFlagTriggerCommand: &proto.ResetFlagTriggerCommand{},
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalizeWithTemplate(locale.InternalServerError)),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				row := mysqlmock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			input: &proto.ResetFlagTriggerRequest{
+				ResetFlagTriggerCommand: &proto.ResetFlagTriggerCommand{},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.ResetFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if resp != nil {
+				assert.Equal(t, resp.FlagTrigger.Token, "")
+			}
+		})
+	}
+}
+
+func TestDeleteFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.DeleteFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc:        "Error Invalid Argument",
+			setup:       func(s *FeatureService) {},
+			input:       &proto.DeleteFlagTriggerRequest{},
+			expectedErr: createError(statusMissingCommand, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError)),
+		},
+		{
+			desc: "Error Internal",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+			},
+			input: &proto.DeleteFlagTriggerRequest{
+				DeleteFlagTriggerCommand: &proto.DeleteFlagTriggerCommand{},
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalizeWithTemplate(locale.InternalServerError)),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			input: &proto.DeleteFlagTriggerRequest{
+				DeleteFlagTriggerCommand: &proto.DeleteFlagTriggerCommand{},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.DeleteFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
 func TestFlagTriggerWebhook(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
@@ -96,6 +640,16 @@ func TestFlagTriggerWebhook(t *testing.T) {
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
 		"accept-language": []string{"ja"},
 	})
+
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
 
 	baseFlagTrigger := &proto.FlagTrigger{
 		Id:                   "1",
@@ -117,7 +671,22 @@ func TestFlagTriggerWebhook(t *testing.T) {
 		setup       func(service *FeatureService)
 		input       *proto.FlagTriggerWebhookRequest
 		expectedErr error
-	}{
+	}{{
+		desc:        "Error Invalid Argument",
+		setup:       func(s *FeatureService) {},
+		input:       &proto.FlagTriggerWebhookRequest{},
+		expectedErr: createError(statusSecretRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "secret")),
+	},
+		{
+			desc: "Error Not Found",
+			setup: func(s *FeatureService) {
+				s.flagTriggerStorage.(*mock.MockFlagTriggerStorage).EXPECT().GetFlagTriggerByToken(
+					gomock.Any(), gomock.Any(),
+				).Return(nil, v2fs.ErrFlagTriggerNotFound)
+			},
+			input:       &proto.FlagTriggerWebhookRequest{Token: "token"},
+			expectedErr: createError(statusTriggerNotFound, localizer.MustLocalizeWithTemplate(locale.NotFoundError)),
+		},
 		{
 			desc: "Success",
 			setup: func(s *FeatureService) {
@@ -163,6 +732,80 @@ func TestFlagTriggerWebhook(t *testing.T) {
 	}
 }
 
+func TestListFlagTriggers(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.ListFlagTriggersRequest
+		expected    *proto.ListFlagTriggersResponse
+		expectedErr error
+	}{
+		{
+			desc:        "Error Validate",
+			setup:       nil,
+			input:       &proto.ListFlagTriggersRequest{},
+			expected:    nil,
+			expectedErr: createError(statusMissingTriggerFeatureID, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate)),
+		},
+		{
+			desc:        "Error Invalid Argument",
+			setup:       nil,
+			input:       &proto.ListFlagTriggersRequest{FeatureId: "1", Cursor: "XXX"},
+			expected:    nil,
+			expectedErr: createError(statusInvalidCursor, localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "cursor")),
+		},
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				rows := mysqlmock.NewMockRows(mockController)
+				rows.EXPECT().Next().Return(false)
+				rows.EXPECT().Close().Return(nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(rows, nil)
+				row := mysqlmock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			input:       &proto.ListFlagTriggersRequest{FeatureId: "1", PageSize: 2, Cursor: ""},
+			expected:    &proto.ListFlagTriggersResponse{FlagTriggers: []*proto.ListFlagTriggersResponse_FlagTriggerWithUrl{}, Cursor: "0"},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			actual, err := s.ListFlagTriggers(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			assert.Equal(t, p.expected, actual)
+		})
+	}
+}
+
 func TestFeatureServiceGenerateTriggerURL(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
@@ -184,7 +827,7 @@ func TestFeatureServiceGenerateTriggerURL(t *testing.T) {
 		t.Errorf("GenerateToken() error = %v", err)
 	}
 	t.Logf("GenerateToken() token = %v", trigger.Token)
-	triggerURL, err := featureService.generateTriggerURL(context.Background(), trigger.Token, false)
+	triggerURL := featureService.generateTriggerURL(context.Background(), trigger.Token, false)
 	if err != nil {
 		t.Errorf("generateTriggerURL() [full] error = %v", err)
 	}
@@ -192,7 +835,7 @@ func TestFeatureServiceGenerateTriggerURL(t *testing.T) {
 		t.Errorf("generateTriggerURL() [full] triggerURL is empty")
 	}
 	t.Logf("generateTriggerURL() [full] triggerURL = %v", triggerURL)
-	triggerURL, err = featureService.generateTriggerURL(context.Background(), trigger.Token, true)
+	triggerURL = featureService.generateTriggerURL(context.Background(), trigger.Token, true)
 	if err != nil {
 		t.Errorf("generateTriggerURL() [masked] error = %v", err)
 	}

--- a/pkg/feature/api/flag_trigger_test.go
+++ b/pkg/feature/api/flag_trigger_test.go
@@ -828,17 +828,11 @@ func TestFeatureServiceGenerateTriggerURL(t *testing.T) {
 	}
 	t.Logf("GenerateToken() token = %v", trigger.Token)
 	triggerURL := featureService.generateTriggerURL(context.Background(), trigger.Token, false)
-	if err != nil {
-		t.Errorf("generateTriggerURL() [full] error = %v", err)
-	}
 	if triggerURL == "" {
 		t.Errorf("generateTriggerURL() [full] triggerURL is empty")
 	}
 	t.Logf("generateTriggerURL() [full] triggerURL = %v", triggerURL)
 	triggerURL = featureService.generateTriggerURL(context.Background(), trigger.Token, true)
-	if err != nil {
-		t.Errorf("generateTriggerURL() [masked] error = %v", err)
-	}
 	if triggerURL == "" {
 		t.Errorf("generateTriggerURL() [masked] triggerURL is empty")
 	}

--- a/pkg/feature/api/flag_trigger_test.go
+++ b/pkg/feature/api/flag_trigger_test.go
@@ -41,10 +41,10 @@ func TestCreateFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -130,11 +130,10 @@ func TestGetFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
-
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -216,10 +215,10 @@ func TestUpdateFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -300,11 +299,10 @@ func TestEnableFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
-
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -381,11 +379,10 @@ func TestDisableFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
-
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -462,11 +459,10 @@ func TestResetFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
-
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -562,11 +558,10 @@ func TestDeleteFlagTrigger(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
-
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -636,11 +631,10 @@ func TestFlagTriggerWebhook(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
-
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{
@@ -737,10 +731,10 @@ func TestListFlagTriggers(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	ctx := createContextWithToken()
-	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
-		"accept-language": []string{"ja"},
-	})
+	ctx := metadata.NewIncomingContext(
+		createContextWithToken(),
+		metadata.MD{"accept-language": []string{"ja"}},
+	)
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
 		st, err := status.WithDetails(&errdetails.LocalizedMessage{

--- a/pkg/feature/api/flag_trigger_test.go
+++ b/pkg/feature/api/flag_trigger_test.go
@@ -19,11 +19,149 @@ import (
 	"context"
 	"testing"
 
-	"go.uber.org/mock/gomock"
-
 	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
+	"github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2/mock"
+	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/feature"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/metadata"
 )
+
+func TestGetFlagTrigger(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+
+	baseFlagTrigger := &proto.FlagTrigger{
+		Id:                   "1",
+		FeatureId:            "featureId",
+		EnvironmentNamespace: "namespace",
+		Type:                 proto.FlagTrigger_Type_WEBHOOK,
+		Action:               proto.FlagTrigger_Action_ON,
+		Description:          "base",
+		TriggerCount:         100,
+		LastTriggeredAt:      500,
+		Token:                "test-token",
+		Disabled:             false,
+		CreatedAt:            200,
+		UpdatedAt:            300,
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.GetFlagTriggerRequest
+		expectedErr error
+	}{
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.flagTriggerStorage.(*mock.MockFlagTriggerStorage).EXPECT().GetFlagTrigger(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(&domain.FlagTrigger{
+					FlagTrigger: baseFlagTrigger,
+				}, nil)
+			},
+			input:       &proto.GetFlagTriggerRequest{Id: baseFlagTrigger.Id, EnvironmentNamespace: baseFlagTrigger.EnvironmentNamespace},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.GetFlagTrigger(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
+
+func TestFlagTriggerWebhook(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithToken()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+
+	baseFlagTrigger := &proto.FlagTrigger{
+		Id:                   "1",
+		FeatureId:            "featureId",
+		EnvironmentNamespace: "namespace",
+		Type:                 proto.FlagTrigger_Type_WEBHOOK,
+		Action:               proto.FlagTrigger_Action_ON,
+		Description:          "base",
+		TriggerCount:         100,
+		LastTriggeredAt:      500,
+		Token:                "test-token",
+		Disabled:             false,
+		CreatedAt:            200,
+		UpdatedAt:            300,
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(service *FeatureService)
+		input       *proto.FlagTriggerWebhookRequest
+		expectedErr error
+	}{
+		{
+			desc: "Success",
+			setup: func(s *FeatureService) {
+				s.flagTriggerStorage.(*mock.MockFlagTriggerStorage).EXPECT().GetFlagTriggerByToken(
+					gomock.Any(), gomock.Any(),
+				).Return(&domain.FlagTrigger{
+					FlagTrigger: baseFlagTrigger,
+				}, nil)
+
+				s.featureStorage.(*mock.MockFeatureStorage).EXPECT().GetFeature(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(&domain.Feature{
+					Feature: &proto.Feature{
+						Id:      "id",
+						Name:    "test feature",
+						Version: 1,
+						Enabled: true,
+					},
+				}, nil)
+
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			input:       &proto.FlagTriggerWebhookRequest{Token: "token"},
+			expectedErr: nil,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createFeatureServiceNew(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.FlagTriggerWebhook(ctx, p.input)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}
 
 func TestFeatureServiceGenerateTriggerURL(t *testing.T) {
 	mockController := gomock.NewController(t)


### PR DESCRIPTION
This pull request primarily includes adding unit tests for FlagTrigger and changes to the Bucketeer project's "pkg/feature/api" package. This change focuses on refactoring the `FeatureService` structure and related methods in `api.go` and `flag_trigger.go` to use the new `v2fs` package for feature storage. Additionally, error handling has been simplified for several methods, and the "generateTriggerURL" method no longer returns an error.

Here are the most important changes:

Add unit test for flag trigger.

Refactoring to use `v2fs` package:

* [`pkg/feature/api/api.go`](diffhunk://#diff-982bed6b45a5128e1cac0183ec37fca993ed8174a115201c70c168f63f8e9043R27-R29): Imported the `v2fs` package and its `FeatureStorage` and `FlagTriggerStorage` types. These were then added as fields to the `FeatureService` struct, replacing direct usage of the `mysqlClient`. The `NewFeatureService` function was also updated to initialize these new fields. [[1]](diffhunk://#diff-982bed6b45a5128e1cac0183ec37fca993ed8174a115201c70c168f63f8e9043R27-R29) [[2]](diffhunk://#diff-982bed6b45a5128e1cac0183ec37fca993ed8174a115201c70c168f63f8e9043R57-R58) [[3]](diffhunk://#diff-982bed6b45a5128e1cac0183ec37fca993ed8174a115201c70c168f63f8e9043R91-R92)
* [`pkg/feature/api/api_test.go`](diffhunk://#diff-b900941517f1d0f0d7f739282ddc32ac4cbdb33f4bd2291b1a00d4d7d10912dbR26-R27): Similar changes were made in the test file, where mock instances of `FeatureStorage` and `FlagTriggerStorage` are now created and used in the `createFeatureService` and `createFeatureServiceNew` functions. [[1]](diffhunk://#diff-b900941517f1d0f0d7f739282ddc32ac4cbdb33f4bd2291b1a00d4d7d10912dbR26-R27) [[2]](diffhunk://#diff-b900941517f1d0f0d7f739282ddc32ac4cbdb33f4bd2291b1a00d4d7d10912dbR125-R126) [[3]](diffhunk://#diff-b900941517f1d0f0d7f739282ddc32ac4cbdb33f4bd2291b1a00d4d7d10912dbR153-R154)

Simplification of error handling:

* [`pkg/feature/api/flag_trigger.go`](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L142-R142): In several methods, the error handling for `generateTriggerURL` has been removed, as this function no longer returns errors. Instead, the URL is directly assigned to `triggerURL`. Additionally, error handling in `ResetFlagTrigger` and `DeleteFlagTrigger` has been simplified to return a single error status. [[1]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L142-R142) [[2]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L542-R544) [[3]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L645-R645) [[4]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L669-R669) [[5]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L687-R687) [[6]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L755-R748) [[7]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L827-R813) [[8]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L860-R845) [[9]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L1061-R1049)

Refactoring of `FeatureService` methods:

* [`pkg/feature/api/flag_trigger.go`](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L669-R669): All methods in this file that previously created new instances of `FlagTriggerStorage` or `FeatureStorage` now use the instances stored in the `FeatureService` struct. This includes the `GetFlagTrigger`, `FlagTriggerWebhook`, and `generateTriggerURL` methods. [[1]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L669-R669) [[2]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L827-R813) [[3]](diffhunk://#diff-33bed37b43315e58942e192c4c1c99954795817fae734470f6a5ea5c8a218706L860-R845)