### PR TITLE
chore: add system admin flag to idtoken

### DIFF
--- a/hack/generate-service-token/command.go
+++ b/hack/generate-service-token/command.go
@@ -17,7 +17,7 @@ package main
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"time"
 
 	"go.uber.org/zap"
@@ -68,20 +68,21 @@ func (c *command) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.
 		return errors.New("wrong role parameter")
 	}
 	idToken := &token.IDToken{
-		Issuer:    *c.issuer,
-		Subject:   *c.sub,
-		Audience:  *c.audience,
-		Expiry:    time.Now().AddDate(100, 0, 0),
-		IssuedAt:  time.Now(),
-		Email:     *c.email,
-		AdminRole: accountproto.Account_Role(role),
+		Issuer:        *c.issuer,
+		Subject:       *c.sub,
+		Audience:      *c.audience,
+		Expiry:        time.Now().AddDate(100, 0, 0),
+		IssuedAt:      time.Now(),
+		Email:         *c.email,
+		AdminRole:     accountproto.Account_Role(role),
+		IsSystemAdmin: true,
 	}
 	signedIDToken, err := signer.Sign(idToken)
 	if err != nil {
 		logger.Error("Failed to sign token", zap.Error(err))
 		return err
 	}
-	if err := ioutil.WriteFile(*c.output, []byte(signedIDToken), 0644); err != nil {
+	if err := os.WriteFile(*c.output, []byte(signedIDToken), 0644); err != nil {
 		logger.Error("Failed to write token to file", zap.Error(err), zap.String("output", *c.output))
 		return err
 	}

--- a/pkg/token/idtoken.go
+++ b/pkg/token/idtoken.go
@@ -31,10 +31,12 @@ type IDToken struct {
 	Expiry   time.Time `json:"exp"`
 	IssuedAt time.Time `json:"iat"`
 	Email    string    `json:"email"`
+	// Deprecated. Use IsSystemAdmin instead. It will be removed in the future.
 	// Use "role" as json tag to keep compatibility.
 	// AdminRole is accountproto.Account_OWNER in the case of AdminAccount.
 	// AdminRole is accountproto.Account_UNASSIGNED in the case of Account.
-	AdminRole accountproto.Account_Role `json:"role"`
+	AdminRole     accountproto.Account_Role `json:"role"`
+	IsSystemAdmin bool                      `json:"is_system_admin"`
 }
 
 func (t *IDToken) IsAdmin() bool {


### PR DESCRIPTION
part of https://github.com/ca-dp/bucketeer-issue/issues/5

This pull request primarily focuses on refactoring the token generation process in the `hack/generate-service-token/command.go` file and updating the `IDToken` struct in the `pkg/token/idtoken.go` file. The key changes include replacing the `ioutil.WriteFile` function with `os.WriteFile`, adding an `IsSystemAdmin` field to the `IDToken` struct, and updating the token generation process to set `IsSystemAdmin` to `true`.

Here are the main changes:

* `hack/generate-service-token/command.go`: 
  * Replaced the `ioutil.WriteFile` function with `os.WriteFile` to write the signed ID token to a file. This change is in line with the deprecation of `ioutil` in Go 1.16. [[1]](diffhunk://#diff-cb32802d4e8e7750abbbc9e43742a3694197cb014d853d99a1724dc9cde38941L20-R20) [[2]](diffhunk://#diff-cb32802d4e8e7750abbbc9e43742a3694197cb014d853d99a1724dc9cde38941R78-R85)
  * Updated the token generation process to set `IsSystemAdmin` to `true` when creating a new ID token.

* `pkg/token/idtoken.go`: 
  * Added a new `IsSystemAdmin` field to the `IDToken` struct. This field is intended to replace the `AdminRole` field, which is now deprecated and will be removed in the future.