### PR TITLE
refactor: use system admin word correctly

### DIFF
--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -125,17 +125,17 @@ func (s *AccountService) GetMe(
 		}
 		return nil, dt.Err()
 	}
-	// admin account response
-	adminAccount, err := s.getAdminAccountV2(ctx, t.Email, localizer)
+	// system admin account response
+	sysAdminAccount, err := s.getSystemAdminAccountV2(ctx, t.Email, localizer)
 	if err != nil && status.Code(err) != codes.NotFound {
 		return nil, err
 	}
-	if adminAccount != nil && !adminAccount.Disabled {
+	if sysAdminAccount != nil && !sysAdminAccount.Disabled {
 		adminEnvRoles := s.getAdminConsoleAccountEnvironmentRoles(environments, projects)
 		return &accountproto.GetMeResponse{Account: &accountproto.ConsoleAccount{
-			Email:            adminAccount.Email,
-			Name:             adminAccount.Name,
-			AvatarUrl:        adminAccount.AvatarImageUrl,
+			Email:            sysAdminAccount.Email,
+			Name:             sysAdminAccount.Name,
+			AvatarUrl:        sysAdminAccount.AvatarImageUrl,
 			IsSystemAdmin:    true,
 			Organization:     organization,
 			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
@@ -326,12 +326,12 @@ func (s *AccountService) containsSystemAdminOrganization(
 	return false
 }
 
-func (s *AccountService) getAdminAccountV2(
+func (s *AccountService) getSystemAdminAccountV2(
 	ctx context.Context,
 	email string,
 	localizer locale.Localizer,
 ) (*domain.AccountV2, error) {
-	account, err := s.accountStorage.GetAdminAccountV2(ctx, email)
+	account, err := s.accountStorage.GetSystemAdminAccountV2(ctx, email)
 	if err != nil {
 		if errors.Is(err, v2as.ErrAdminAccountNotFound) {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
@@ -344,7 +344,7 @@ func (s *AccountService) getAdminAccountV2(
 			return nil, dt.Err()
 		}
 		s.logger.Error(
-			"Failed to get admin account",
+			"Failed to get system admin account",
 			log.FieldsFromImcomingContext(ctx).AddFields(
 				zap.Error(err),
 				zap.String("email", email),

--- a/pkg/account/api/admin_account_test.go
+++ b/pkg/account/api/admin_account_test.go
@@ -130,7 +130,7 @@ func TestGetMeMySQL(t *testing.T) {
 					},
 					nil,
 				)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAdminAccountV2(
+				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetSystemAdminAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil, v2as.ErrAdminAccountNotFound)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2(

--- a/pkg/account/storage/v2/admin_account.go
+++ b/pkg/account/storage/v2/admin_account.go
@@ -34,7 +34,7 @@ var (
 	selectAdminAccountV2SQL string
 )
 
-func (s *accountStorage) GetAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error) {
+func (s *accountStorage) GetSystemAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error) {
 	account := proto.AccountV2{}
 	var organizationRole int32
 	err := s.qe(ctx).QueryRowContext(

--- a/pkg/account/storage/v2/admin_account_test.go
+++ b/pkg/account/storage/v2/admin_account_test.go
@@ -80,7 +80,7 @@ func TestGetAdminAccountV2(t *testing.T) {
 			if p.setup != nil {
 				p.setup(storage)
 			}
-			_, err := storage.GetAdminAccountV2(context.Background(), p.email)
+			_, err := storage.GetSystemAdminAccountV2(context.Background(), p.email)
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}

--- a/pkg/account/storage/v2/mock/storage.go
+++ b/pkg/account/storage/v2/mock/storage.go
@@ -140,19 +140,19 @@ func (mr *MockAccountStorageMockRecorder) GetAccountsWithOrganization(ctx, email
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccountsWithOrganization", reflect.TypeOf((*MockAccountStorage)(nil).GetAccountsWithOrganization), ctx, email)
 }
 
-// GetAdminAccountV2 mocks base method.
-func (m *MockAccountStorage) GetAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error) {
+// GetSystemAdminAccountV2 mocks base method.
+func (m *MockAccountStorage) GetSystemAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAdminAccountV2", ctx, email)
+	ret := m.ctrl.Call(m, "GetSystemAdminAccountV2", ctx, email)
 	ret0, _ := ret[0].(*domain.AccountV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetAdminAccountV2 indicates an expected call of GetAdminAccountV2.
-func (mr *MockAccountStorageMockRecorder) GetAdminAccountV2(ctx, email interface{}) *gomock.Call {
+// GetSystemAdminAccountV2 indicates an expected call of GetSystemAdminAccountV2.
+func (mr *MockAccountStorageMockRecorder) GetSystemAdminAccountV2(ctx, email interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAdminAccountV2", reflect.TypeOf((*MockAccountStorage)(nil).GetAdminAccountV2), ctx, email)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemAdminAccountV2", reflect.TypeOf((*MockAccountStorage)(nil).GetSystemAdminAccountV2), ctx, email)
 }
 
 // ListAPIKeys mocks base method.

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -38,7 +38,7 @@ type AccountStorage interface {
 		orders []*mysql.Order,
 		limit, offset int,
 	) ([]*proto.AccountV2, int, int64, error)
-	GetAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error)
+	GetSystemAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error)
 	CreateAPIKey(ctx context.Context, k *domain.APIKey, environmentNamespace string) error
 	UpdateAPIKey(ctx context.Context, k *domain.APIKey, environmentNamespace string) error
 	GetAPIKey(ctx context.Context, id, environmentNamespace string) (*domain.APIKey, error)


### PR DESCRIPTION
Now we have two admins;
- system admin
- organizational admin

They should be explicitly used correctly to avoid confusion.