### PR TITLE
chore: remove tx field in accountStorage

### DIFF
--- a/pkg/account/storage/v2/account_test.go
+++ b/pkg/account/storage/v2/account_test.go
@@ -412,5 +412,5 @@ func TestListAccountsV2(t *testing.T) {
 
 func newAccountStorageWithMock(t *testing.T, mockController *gomock.Controller) *accountStorage {
 	t.Helper()
-	return &accountStorage{mock.NewMockClient(mockController), nil}
+	return &accountStorage{mock.NewMockClient(mockController)}
 }

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -54,11 +54,10 @@ const transactionKey = "transaction"
 
 type accountStorage struct {
 	client mysql.Client
-	tx     mysql.Transaction
 }
 
 func NewAccountStorage(client mysql.Client) AccountStorage {
-	return &accountStorage{client, nil}
+	return &accountStorage{client}
 }
 
 func (s *accountStorage) RunInTransaction(ctx context.Context, f func() error) error {


### PR DESCRIPTION
We don't need `tx` field in `accountStorage`, we can remove it.

```go
type accountStorage struct {
	client mysql.Client
	tx     mysql.Transaction
}
```