### PR TITLE
chore: write flag last used info in the persister evaluation count

### DIFF
--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/deployment.yaml
@@ -93,6 +93,16 @@ spec:
               value: "{{ .Values.env.redis.poolMaxIdle }}"
             - name: BUCKETEER_EVENT_PERSISTER_REDIS_POOL_MAX_ACTIVE
               value: "{{ .Values.env.redis.poolMaxActive }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_USER
+              value: "{{ .Values.env.mysqlUser }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_PASS
+              value: "{{ .Values.env.mysqlPass }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_HOST
+              value: "{{ .Values.env.mysqlHost }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_PORT
+              value: "{{ .Values.env.mysqlPort }}"
+            - name: BUCKETEER_EVENT_PERSISTER_MYSQL_DB_NAME
+              value: "{{ .Values.env.mysqlDBName }}"
           volumeMounts:
             - name: service-cert-secret
               mountPath: /usr/local/certs/service

--- a/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/values.yaml
+++ b/manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/values.yaml
@@ -27,6 +27,12 @@ env:
   pullerNumGoroutines: 5
   pullerMaxOutstandingMessages: "1000"
   pullerMaxOutstandingBytes: "1000000000"
+  # mysql
+  mysqlUser:
+  mysqlPass:
+  mysqlHost:
+  mysqlPort: 3306
+  mysqlDBName:
 
 affinity: {}
 

--- a/pkg/eventpersister/persister/persister.go
+++ b/pkg/eventpersister/persister/persister.go
@@ -26,13 +26,19 @@ import (
 
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
 	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
+	ftdomain "github.com/bucketeer-io/bucketeer/pkg/feature/domain"
+	ftstorage "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/health"
 	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
+
+type lastUsedInfoCache map[string]*ftdomain.FeatureLastUsedInfo
+type environmentLastUsedInfoCache map[string]lastUsedInfoCache
 
 var (
 	ErrUnexpectedMessageType = errors.New("eventpersister: unexpected message type")
@@ -48,18 +54,20 @@ const (
 	eventCountKey      = "ec"
 	userCountKey       = "uc"
 	defaultVariationID = "default"
+	userDataAppVersion = "app_version"
 )
 
-type eventMap map[string]proto.Message
+type eventMap map[string]*eventproto.EvaluationEvent
 type environmentEventMap map[string]eventMap
 
 type options struct {
-	maxMPS        int
-	numWorkers    int
-	flushSize     int
-	flushInterval time.Duration
-	metrics       metrics.Registerer
-	logger        *zap.Logger
+	maxMPS             int
+	numWorkers         int
+	flushSize          int
+	flushInterval      time.Duration
+	writeCacheInterval time.Duration
+	metrics            metrics.Registerer
+	logger             *zap.Logger
 }
 
 type Option func(*options)
@@ -88,6 +96,12 @@ func WithFlushInterval(i time.Duration) Option {
 	}
 }
 
+func WithWriteCacheInterval(i time.Duration) Option {
+	return func(opts *options) {
+		opts.writeCacheInterval = i
+	}
+}
+
 func WithMetrics(r metrics.Registerer) Option {
 	return func(opts *options) {
 		opts.metrics = r
@@ -102,6 +116,7 @@ func WithLogger(l *zap.Logger) Option {
 
 type Persister struct {
 	puller                puller.RateLimitedPuller
+	mysqlClient           mysql.Client
 	group                 errgroup.Group
 	opts                  *options
 	logger                *zap.Logger
@@ -113,15 +128,17 @@ type Persister struct {
 
 func NewPersister(
 	p puller.Puller,
+	mysqlClient mysql.Client,
 	v3Cache cache.MultiGetDeleteCountCache,
 	opts ...Option,
 ) *Persister {
 	dopts := &options{
-		maxMPS:        1000,
-		numWorkers:    1,
-		flushSize:     50,
-		flushInterval: 5 * time.Second,
-		logger:        zap.NewNop(),
+		maxMPS:             1000,
+		numWorkers:         1,
+		flushSize:          50,
+		flushInterval:      5 * time.Second,
+		writeCacheInterval: 1 * time.Minute,
+		logger:             zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)
@@ -138,6 +155,7 @@ func NewPersister(
 		cancel:                cancel,
 		doneCh:                make(chan struct{}),
 		evaluationCountCacher: v3Cache,
+		mysqlClient:           mysqlClient,
 	}
 }
 
@@ -173,8 +191,19 @@ func (p *Persister) Check(ctx context.Context) health.Status {
 
 func (p *Persister) batch() error {
 	batch := make(map[string]*puller.Message)
+	envCache := environmentLastUsedInfoCache{}
 	timer := time.NewTimer(p.opts.flushInterval)
+	timerWriteCache := time.NewTimer(p.opts.writeCacheInterval)
 	defer timer.Stop()
+	updateEvaluationCounter := func(envEvents environmentEventMap) {
+		// Increment the evaluation event count in the Redis
+		fails := p.incrementEnvEvents(envEvents)
+		// Check to Ack or Nack the messages
+		p.checkMessages(batch, fails)
+		// Reset the maps and the timer
+		batch = make(map[string]*puller.Message)
+		timer.Reset(p.opts.flushInterval)
+	}
 	for {
 		select {
 		case msg, ok := <-p.puller.MessageCh():
@@ -198,20 +227,31 @@ func (p *Persister) batch() error {
 			if len(batch) < p.opts.flushSize {
 				continue
 			}
-			p.send(batch)
-			batch = make(map[string]*puller.Message)
-			timer.Reset(p.opts.flushInterval)
+			envEvents := p.extractEvents(batch)
+			// Update the feature flag last-used cache
+			p.cacheLastUsedInfoPerEnv(envEvents, envCache)
+			updateEvaluationCounter(envEvents)
 		case <-timer.C:
-			if len(batch) > 0 {
-				p.send(batch)
-				batch = make(map[string]*puller.Message)
-			}
-			timer.Reset(p.opts.flushInterval)
+			envEvents := p.extractEvents(batch)
+			// Update the feature flag last-used cache
+			p.cacheLastUsedInfoPerEnv(envEvents, envCache)
+			updateEvaluationCounter(envEvents)
+		case <-timerWriteCache.C:
+			p.logger.Debug("Write cache timer triggered")
+			// Write the feature flag last-used cache in the MySQL
+			p.writeEnvLastUsedInfo(envCache)
+			// Reset the cache and the timer
+			envCache = make(environmentLastUsedInfoCache)
+			timerWriteCache.Reset(p.opts.writeCacheInterval)
 		case <-p.ctx.Done():
+			// Because the feature flag last-used cache is not mandatory
+			// when the context is done, we don't try to write the cache
+			// to speed up the shutdown process
 			batchSize := len(batch)
 			p.logger.Info("Context is done", zap.Int("batchSize", batchSize))
 			if len(batch) > 0 {
-				p.send(batch)
+				envEvents := p.extractEvents(batch)
+				p.incrementEnvEvents(envEvents)
 				p.logger.Info("All the left messages are processed successfully", zap.Int("batchSize", batchSize))
 			}
 			return nil
@@ -219,18 +259,14 @@ func (p *Persister) batch() error {
 	}
 }
 
-func (p *Persister) send(messages map[string]*puller.Message) {
-	envEvents := p.extractEvents(messages)
-	if len(envEvents) == 0 {
-		p.logger.Error("all messages were bad")
-		return
-	}
-	fails := make(map[string]bool, len(messages))
+func (p *Persister) incrementEnvEvents(envEvents environmentEventMap) map[string]bool {
+	fails := make(map[string]bool, len(envEvents))
 	for environmentNamespace, events := range envEvents {
 		for id, event := range events {
-			if err := p.upsertEvaluationCount(event, environmentNamespace); err != nil {
+			// Increment the evaluation event count in the Redis
+			if err := p.incrementEvaluationCount(event, environmentNamespace); err != nil {
 				p.logger.Error(
-					"Failed to upsert an evaluation event in redis",
+					"Failed to increment the evaluation event in the Redis",
 					zap.Error(err),
 					zap.String("id", id),
 					zap.String("environmentNamespace", environmentNamespace),
@@ -239,6 +275,10 @@ func (p *Persister) send(messages map[string]*puller.Message) {
 			}
 		}
 	}
+	return fails
+}
+
+func (p *Persister) checkMessages(messages map[string]*puller.Message, fails map[string]bool) {
 	for id, m := range messages {
 		if repeatable, ok := fails[id]; ok {
 			if repeatable {
@@ -259,7 +299,7 @@ func (p *Persister) extractEvents(messages map[string]*puller.Message) environme
 	envEvents := environmentEventMap{}
 	handleBadMessage := func(m *puller.Message, err error) {
 		m.Ack()
-		p.logger.Error("bad message", zap.Error(err), zap.Any("msg", m))
+		p.logger.Error("Bad proto message", zap.Error(err), zap.Any("msg", m))
 		handledCounter.WithLabelValues(codes.BadMessage.String()).Inc()
 	}
 	for _, m := range messages {
@@ -268,16 +308,16 @@ func (p *Persister) extractEvents(messages map[string]*puller.Message) environme
 			handleBadMessage(m, err)
 			continue
 		}
-		var innerEvent ptypes.DynamicAny
-		if err := ptypes.UnmarshalAny(event.Event, &innerEvent); err != nil {
+		innerEvent := &eventproto.EvaluationEvent{}
+		if err := ptypes.UnmarshalAny(event.Event, innerEvent); err != nil {
 			handleBadMessage(m, err)
 			continue
 		}
 		if innerEvents, ok := envEvents[event.EnvironmentNamespace]; ok {
-			innerEvents[event.Id] = innerEvent.Message
+			innerEvents[event.Id] = innerEvent
 			continue
 		}
-		envEvents[event.EnvironmentNamespace] = eventMap{event.Id: innerEvent.Message}
+		envEvents[event.EnvironmentNamespace] = eventMap{event.Id: innerEvent}
 	}
 	return envEvents
 }
@@ -292,7 +332,7 @@ func getVariationID(reason *featureproto.Reason, vID string) (string, error) {
 	return vID, nil
 }
 
-func (p *Persister) upsertEvaluationCount(event proto.Message, environmentNamespace string) error {
+func (p *Persister) incrementEvaluationCount(event proto.Message, environmentNamespace string) error {
 	if e, ok := event.(*eventproto.EvaluationEvent); ok {
 		vID, err := getVariationID(e.Reason, e.VariationId)
 		if err != nil {
@@ -335,6 +375,139 @@ func (p *Persister) countEvent(key string) error {
 
 func (p *Persister) countUser(key, userID string) error {
 	_, err := p.evaluationCountCacher.PFAdd(key, userID)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (p *Persister) cacheLastUsedInfoPerEnv(
+	envEvents environmentEventMap,
+	envCache environmentLastUsedInfoCache,
+) {
+	for environmentNamespace, events := range envEvents {
+		for _, event := range events {
+			p.cacheEnvLastUsedInfo(event, envCache, environmentNamespace)
+		}
+		p.logger.Debug("Cache has been updated",
+			zap.String("environmentNamespace", environmentNamespace),
+			zap.Int("cacheSize", len(envCache[environmentNamespace])),
+			zap.Int("eventSize", len(events)),
+		)
+	}
+}
+
+func (p *Persister) cacheEnvLastUsedInfo(
+	event *eventproto.EvaluationEvent,
+	envCache environmentLastUsedInfoCache,
+	environmentNamespace string,
+) {
+	clientVersion := event.User.Data[userDataAppVersion]
+	id := ftdomain.FeatureLastUsedInfoID(event.FeatureId, event.FeatureVersion)
+	if cache, ok := envCache[environmentNamespace]; ok {
+		if info, ok := cache[id]; ok {
+			info.UsedAt(event.Timestamp)
+			if err := info.SetClientVersion(clientVersion); err != nil {
+				p.logger.Error("Failed to set client version",
+					zap.Error(err),
+					zap.String("environmentNamespace", environmentNamespace),
+					zap.String("featureId", info.FeatureId),
+					zap.Int32("featureVersion", info.Version),
+					zap.String("clientVersion", clientVersion))
+			}
+			return
+		}
+		cache[id] = ftdomain.NewFeatureLastUsedInfo(
+			event.FeatureId,
+			event.FeatureVersion,
+			event.Timestamp,
+			clientVersion,
+		)
+		return
+	}
+	cache := lastUsedInfoCache{}
+	cache[id] = ftdomain.NewFeatureLastUsedInfo(
+		event.FeatureId,
+		event.FeatureVersion,
+		event.Timestamp,
+		clientVersion,
+	)
+	envCache[environmentNamespace] = cache
+}
+
+func (p *Persister) writeEnvLastUsedInfo(envCache environmentLastUsedInfoCache) {
+	for environmentNamespace, cache := range envCache {
+		info := make([]*ftdomain.FeatureLastUsedInfo, 0, len(cache))
+		for _, v := range cache {
+			info = append(info, v)
+		}
+		if err := p.upsertMultiFeatureLastUsedInfo(context.Background(), info, environmentNamespace); err != nil {
+			p.logger.Error("Failed to write featureLastUsedInfo", zap.Error(err),
+				zap.String("environmentNamespace", environmentNamespace))
+			continue
+		}
+		p.logger.Debug("Cache has been written",
+			zap.String("environmentNamespace", environmentNamespace),
+			zap.Int("cacheSize", len(info)),
+		)
+	}
+}
+
+func (p *Persister) upsertMultiFeatureLastUsedInfo(
+	ctx context.Context,
+	featureLastUsedInfos []*ftdomain.FeatureLastUsedInfo,
+	environmentNamespace string,
+) error {
+	ids := make([]string, 0, len(featureLastUsedInfos))
+	for _, f := range featureLastUsedInfos {
+		ids = append(ids, f.ID())
+	}
+	tx, err := p.mysqlClient.BeginTx(ctx)
+	if err != nil {
+		p.logger.Error("Failed to begin transaction", zap.Error(err))
+		return err
+	}
+	err = p.mysqlClient.RunInTransaction(ctx, tx, func() error {
+		storage := ftstorage.NewFeatureLastUsedInfoStorage(p.mysqlClient)
+		updatedInfo := make([]*ftdomain.FeatureLastUsedInfo, 0, len(ids))
+		currentInfo, err := storage.GetFeatureLastUsedInfos(ctx, ids, environmentNamespace)
+		if err != nil {
+			return err
+		}
+		currentInfoMap := make(map[string]*ftdomain.FeatureLastUsedInfo, len(currentInfo))
+		for _, c := range currentInfo {
+			currentInfoMap[c.ID()] = c
+		}
+		for _, f := range featureLastUsedInfos {
+			v, ok := currentInfoMap[f.ID()]
+			if !ok {
+				updatedInfo = append(updatedInfo, f)
+				continue
+			}
+			var update bool
+			if v.LastUsedAt < f.LastUsedAt {
+				update = true
+				v.LastUsedAt = f.LastUsedAt
+			}
+			if v.ClientOldestVersion != f.ClientOldestVersion {
+				update = true
+				v.ClientOldestVersion = f.ClientOldestVersion
+			}
+			if v.ClientLatestVersion != f.ClientLatestVersion {
+				update = true
+				v.ClientLatestVersion = f.ClientLatestVersion
+			}
+			if update {
+				updatedInfo = append(updatedInfo, v)
+			}
+		}
+		for _, info := range updatedInfo {
+			if err := storage.UpsertFeatureLastUsedInfo(ctx, info, environmentNamespace); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes https://github.com/bucketeer-io/bucketeer/issues/612
Part of https://github.com/bucketeer-io/bucketeer/issues/405

To reduce cost in the PubSub, I'm implementing it to update the feature flag for last-used info when the evaluation count is incremented in the `event-persister-evaluation-count`.

Note: The update and write cache code is the same as the one being used in the `feature-recorder` service.

---

This pull request introduces changes to support MySQL in the event persister service of the Bucketeer system. The changes include adding MySQL environment variables, importing the MySQL client, and adding a write cache interval. The pull request also includes improvements in error handling and logging.

Here are the top five most important changes, grouped by theme:

MySQL Support:
* [`manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/templates/deployment.yaml`](diffhunk://#diff-9c46a3cb94cfe15e3a7b9beed83dd3ade190d7fdb93237969a70b3882a50a367R96-R105): Added MySQL environment variables to the Kubernetes deployment configuration.
* [`manifests/bucketeer/charts/event-persister-evaluation-events-evaluation-count/values.yaml`](diffhunk://#diff-9a2697e2310a53b9c4a27515595c1074194691ce456933431eeccc0d19dcb2beR30-R35): Added MySQL environment variables to the Helm chart values file.
* [`pkg/eventpersister/cmd/server/server.go`](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7R33): Imported the MySQL client, added a write cache interval, and modified the server struct and `RegisterServerCommand` function to support MySQL. [[1]](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7R33) [[2]](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7R51) [[3]](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7L60-R62) [[4]](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7R85-R86) [[5]](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7L98-R106)
* [`pkg/eventpersister/cmd/server/server.go`](diffhunk://#diff-dc668ded0157604190357902f91de52140462bf74f2f62729bce95c87b403cb7R149-R172): Created a new MySQL client in the `Run` function.
* [`pkg/eventpersister/persister/persister.go`](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR29-R42): Imported the MySQL client and added it to the `Persister` struct. Also added a write cache interval to the options struct. [[1]](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR29-R42) [[2]](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR57-R68) [[3]](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR119) [[4]](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR131)

Error Handling and Logging Improvements:
* [`pkg/eventpersister/persister/persister.go`](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR194-R206): Improved error handling and logging in the `batch` function. [[1]](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR194-R206) [[2]](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cL201-R269)
* [`pkg/eventpersister/persister/persister.go`](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cL262-R302): Improved error handling and logging in the `extractEvents` function.
* [`pkg/eventpersister/persister/persister.go`](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cL295-R335): Improved error handling and logging in the `incrementEvaluationCount` function.
* [`pkg/eventpersister/persister/persister.go`](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR383-R515): Added error handling and logging for setting the client version in the `cacheEnvLastUsedInfo` function.
* [`pkg/eventpersister/persister/persister.go`](diffhunk://#diff-ad00cb580cd315d8619de51e511dc06052ace57d6146c30b60366e3a97b56d6cR383-R515): Added error handling and logging for writing the feature last-used information in the `writeEnvLastUsedInfo` and `upsertMultiFeatureLastUsedInfo` functions.