### PR TITLE
fix: stopped_by value being reported incorrectly

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1094,9 +1094,9 @@ func (s *AutoOpsService) stopProgressiveRollout(
 		return dt.Err()
 	}
 	if hasScheduleOps {
-		stoppedBy = autoopsproto.ProgressiveRollout_OPS_KILL_SWITCH
-	} else {
 		stoppedBy = autoopsproto.ProgressiveRollout_OPS_SCHEDULE
+	} else {
+		stoppedBy = autoopsproto.ProgressiveRollout_OPS_KILL_SWITCH
 	}
 	if err := executeStopProgressiveRolloutOperation(
 		ctx,


### PR DESCRIPTION
The `stoppedBy` is being reported as `OPS_KILL_SWITCH` when the flag is disabled by a Scheduled operation.