### PR TITLE
fix: event persister subscribing to pubsub when running scheduled operations

### DIFF
--- a/pkg/eventpersisterops/storage/v2/sql/count_auto_ops_rules.sql
+++ b/pkg/eventpersisterops/storage/v2/sql/count_auto_ops_rules.sql
@@ -2,3 +2,5 @@ SELECT COUNT(*)
 FROM auto_ops_rule
 WHERE triggered_at = 0
   AND deleted = 0
+  AND JSON_EXTRACT(JSON_EXTRACT(clauses, '$[*].clause'), '$[0].type_url') != 'type.googleapis.com/bucketeer.autoops.DatetimeClause'
+  -- Schedule operation is not based on events, so we don't include in the result


### PR DESCRIPTION
Because the Scheduled operations are not based on events, they must not be included in the query results. Otherwise, the `event-persister-evaluation-events-ops` will subscribe to PubSUb, pulling messages unnecessarily.

Because we no longer support multiple clauses in the same rule, I will refactor the proto structure so we can add a new column to know the operations, simplifying the query, too.

### Query  result

![Screenshot 2024-02-20 at 12 57 45 PM](https://github.com/bucketeer-io/bucketeer/assets/2486691/899afc26-6b7f-4ea3-86ff-952d3f94a572)
