### PR TITLE
chore: add cronjob for the batch cachers

### DIFF
--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -135,3 +135,18 @@ cronjob:
     - name: mau-partition-creator
       jobId: MauPartitionCreator
       schedule: "0 2 2 * *"
+    - name: feature-flag-cacher
+      jobId: FeatureFlagCacher
+      schedule: "* * * * *"
+    - name: segment-user-cacher
+      jobId: SegmentUserCacher
+      schedule: "* * * * *"
+    - name: api-key-cacher
+      jobId: ApiKeyCacher
+      schedule: "* * * * *"
+    - name: experiment-cacher
+      jobId: ExperimentCacher
+      schedule: "* * * * *"
+    - name: auto-ops-rules-cacher
+      jobId: AutoOpsRulesCacher
+      schedule: "* * * * *"

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -439,26 +439,31 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 			environmentClient,
 			featureClient,
 			cachev3.NewRedisCache(redisV3Client),
+			jobs.WithLogger(logger),
 		),
 		cacher.NewSegmentUserCacher(
 			environmentClient,
 			featureClient,
 			cachev3.NewRedisCache(redisV3Client),
+			jobs.WithLogger(logger),
 		),
 		cacher.NewAPIKeyCacher(
 			environmentClient,
 			accountClient,
 			cachev3.NewRedisCache(redisV3Client),
+			jobs.WithLogger(logger),
 		),
 		cacher.NewExperimentCacher(
 			environmentClient,
 			experimentClient,
 			cachev3.NewRedisCache(redisV3Client),
+			jobs.WithLogger(logger),
 		),
 		cacher.NewAutoOpsRulesCacher(
 			environmentClient,
 			autoOpsClient,
 			cachev3.NewRedisCache(redisV3Client),
+			jobs.WithLogger(logger),
 		),
 		logger,
 	)

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -487,6 +487,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 
 	defer func() {
 		server.Stop(serverShutDownTimeout)
+		accountClient.Close()
 		notificationClient.Close()
 		experimentClient.Close()
 		environmentClient.Close()

--- a/pkg/batch/jobs/cacher/apikeycacher.go
+++ b/pkg/batch/jobs/cacher/apikeycacher.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	acclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
 	"github.com/bucketeer-io/bucketeer/pkg/batch/jobs"
@@ -87,6 +88,7 @@ func (c *apiKeyCacher) listAllEnvironments(
 ) ([]*envproto.EnvironmentV2, error) {
 	req := &envproto.ListEnvironmentsV2Request{
 		PageSize: 0,
+		Archived: wrapperspb.Bool(false),
 	}
 	resp, err := c.environmentClient.ListEnvironmentsV2(ctx, req)
 	if err != nil {

--- a/pkg/batch/jobs/cacher/apikeycacher.go
+++ b/pkg/batch/jobs/cacher/apikeycacher.go
@@ -62,18 +62,24 @@ func NewAPIKeyCacher(
 func (c *apiKeyCacher) Run(ctx context.Context) error {
 	envs, err := c.listAllEnvironments(ctx)
 	if err != nil {
-		c.logger.Error("Failed to list all environments")
+		c.logger.Error("Failed to list all environments", zap.Error(err))
 		return err
 	}
 	for _, env := range envs {
 		envAPIKeys, err := c.listEnvAPIKeys(ctx, env)
 		if err != nil {
-			c.logger.Error("Failed to list environment api keys", zap.String("environmentId", env.Id))
+			c.logger.Error("Failed to list environment api keys",
+				zap.Error(err),
+				zap.String("environmentId", env.Id),
+			)
 			return err
 		}
 		for _, envAPIKey := range envAPIKeys {
 			if err := c.cache.Put(envAPIKey); err != nil {
-				c.logger.Error("Failed to cache environment api key", zap.Any("envAPIKey", envAPIKey))
+				c.logger.Error("Failed to cache environment api key",
+					zap.Error(err),
+					zap.Any("envAPIKey", envAPIKey),
+				)
 				continue
 			}
 		}
@@ -110,6 +116,7 @@ func (c *apiKeyCacher) listEnvAPIKeys(
 	proj, err := c.getProject(ctx, environment.ProjectId)
 	if err != nil {
 		c.logger.Error("Failed to get project",
+			zap.Error(err),
 			zap.String("organizationId", environment.OrganizationId),
 			zap.String("projectId", environment.ProjectId),
 		)

--- a/pkg/batch/jobs/cacher/apikeycacher.go
+++ b/pkg/batch/jobs/cacher/apikeycacher.go
@@ -17,7 +17,6 @@ package cacher
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -46,8 +45,7 @@ func NewAPIKeyCacher(
 	opts ...jobs.Option,
 ) jobs.Job {
 	dopts := &jobs.Options{
-		Timeout: 1 * time.Minute,
-		Logger:  zap.NewNop(),
+		Logger: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)

--- a/pkg/batch/jobs/cacher/autoopsrulescacher.go
+++ b/pkg/batch/jobs/cacher/autoopsrulescacher.go
@@ -17,7 +17,6 @@ package cacher
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -45,8 +44,7 @@ func NewAutoOpsRulesCacher(
 	opts ...jobs.Option,
 ) jobs.Job {
 	dopts := &jobs.Options{
-		Timeout: 1 * time.Minute,
-		Logger:  zap.NewNop(),
+		Logger: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)

--- a/pkg/batch/jobs/cacher/experimentcacher.go
+++ b/pkg/batch/jobs/cacher/experimentcacher.go
@@ -17,7 +17,6 @@ package cacher
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -46,8 +45,7 @@ func NewExperimentCacher(
 	opts ...jobs.Option,
 ) jobs.Job {
 	dopts := &jobs.Options{
-		Timeout: 1 * time.Minute,
-		Logger:  zap.NewNop(),
+		Logger: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)

--- a/pkg/batch/jobs/cacher/featureflagcacher.go
+++ b/pkg/batch/jobs/cacher/featureflagcacher.go
@@ -17,7 +17,6 @@ package cacher
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 
@@ -46,8 +45,7 @@ func NewFeatureFlagCacher(
 	opts ...jobs.Option,
 ) jobs.Job {
 	dopts := &jobs.Options{
-		Timeout: 1 * time.Minute,
-		Logger:  zap.NewNop(),
+		Logger: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)

--- a/pkg/batch/jobs/cacher/segmentusercacher.go
+++ b/pkg/batch/jobs/cacher/segmentusercacher.go
@@ -17,7 +17,6 @@ package cacher
 
 import (
 	"context"
-	"time"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -46,8 +45,7 @@ func NewSegmentUserCacher(
 	opts ...jobs.Option,
 ) jobs.Job {
 	dopts := &jobs.Options{
-		Timeout: 1 * time.Minute,
-		Logger:  zap.NewNop(),
+		Logger: zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt(dopts)


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/820

![Screenshot 2024-02-22 at 7 12 53 PM](https://github.com/bucketeer-io/bucketeer/assets/2486691/aa859869-c110-4027-8b4a-c93ded0fcc61)


----

This pull request primarily focuses on enhancing the logging and caching mechanisms in the batch processing system. The most significant changes include the addition of new cron jobs in the `values.yaml` file, the inclusion of a logger in various cacher functions, and the removal of timeout options in cacher initializations. Error handling has also been improved with more detailed logging messages.

Addition of new cron jobs:

* [`manifests/bucketeer/charts/batch/values.yaml`](diffhunk://#diff-da142715fb447fa09cd1b8854c0f9caa732a8d7d0555e25ae2bd0d8cb52d4b4dR138-R152): Added new cron jobs for `feature-flag-cacher`, `segment-user-cacher`, `api-key-cacher`, `experiment-cacher`, and `auto-ops-rules-cacher` with a schedule of every minute.

Enhancements to logging:

* [`pkg/batch/cmd/server/server.go`](diffhunk://#diff-9f3bffbf9b659d0228f7f25aeb18a14d9fa79a72e2a8100e7371b1d112faa00cR442-R466): Added `jobs.WithLogger(logger)` to various cacher initializations to enhance logging.
* [`pkg/batch/jobs/cacher/apikeycacher.go`](diffhunk://#diff-619176b0dd2af78a2fef84c44f6c7330046664df244b43ffe260a08a6021456dL66-R82): Improved error logging messages in `Run`, `listAllEnvironments`, and `listEnvAPIKeys` functions by including the error in the log. [[1]](diffhunk://#diff-619176b0dd2af78a2fef84c44f6c7330046664df244b43ffe260a08a6021456dL66-R82) [[2]](diffhunk://#diff-619176b0dd2af78a2fef84c44f6c7330046664df244b43ffe260a08a6021456dR95) [[3]](diffhunk://#diff-619176b0dd2af78a2fef84c44f6c7330046664df244b43ffe260a08a6021456dR119)

Removal of timeout options and other changes:

* `pkg/batch/jobs/cacher/apikeycacher.go`, `pkg/batch/jobs/cacher/autoopsrulescacher.go`, `pkg/batch/jobs/cacher/experimentcacher.go`, `pkg/batch/jobs/cacher/featureflagcacher.go`, `pkg/batch/jobs/cacher/segmentusercacher.go`: Removed `Timeout: 1 * time.Minute` from the options in the initialization of various cachers. [[1]](diffhunk://#diff-619176b0dd2af78a2fef84c44f6c7330046664df244b43ffe260a08a6021456dL48) [[2]](diffhunk://#diff-f42a02e22c255f06b39e05b36041c511a1f459a36775adcda14beaa21319fbdcL48) [[3]](diffhunk://#diff-eaa13ee8b875f1c8afc5894bd000663b9bcf525bd18c1f383216986002773719L49) [[4]](diffhunk://#diff-83a53d9123b1d4ba605ba8f2b1c4d4a4e5e1f522110be01d4d7ebf40e2f34eb3L49) [[5]](diffhunk://#diff-c2032df6595356c775ce35f402a8d8e508b3fd88a3745508a5bb22adc083b650L49)
* [`pkg/batch/cmd/server/server.go`](diffhunk://#diff-9f3bffbf9b659d0228f7f25aeb18a14d9fa79a72e2a8100e7371b1d112faa00cR490): Added a close function for `accountClient` in the server's defer function.
* [`pkg/batch/jobs/cacher/apikeycacher.go`](diffhunk://#diff-619176b0dd2af78a2fef84c44f6c7330046664df244b43ffe260a08a6021456dR95): Added `Archived: wrapperspb.Bool(false)` to the `ListEnvironmentsV2Request` in the `listAllEnvironments` function.