### PR TITLE
fix: experiment variation results order

### DIFF
--- a/pkg/eventcounter/api/api.go
+++ b/pkg/eventcounter/api/api.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -231,10 +230,10 @@ func (s *eventCounterService) convertEvaluationCounts(
 		vcsMap[row.VariationID] = vc
 	}
 	vcs := make([]*ecproto.VariationCount, 0, len(vcsMap))
-	for _, vc := range vcsMap {
-		vcs = append(vcs, vc)
+	// we should keep the order of variationIDs
+	for _, vid := range variationIDs {
+		vcs = append(vcs, vcsMap[vid])
 	}
-	sort.SliceStable(vcs, func(i, j int) bool { return vcs[i].VariationId < vcs[j].VariationId })
 	return vcs
 }
 
@@ -1012,10 +1011,10 @@ func (s *eventCounterService) convertGoalCounts(
 		vcsMap[row.VariationID] = vc
 	}
 	vcs := make([]*ecproto.VariationCount, 0, len(vcsMap))
-	for _, vc := range vcsMap {
-		vcs = append(vcs, vc)
+	// we should keep the order of variationIDs
+	for _, vid := range variationIDs {
+		vcs = append(vcs, vcsMap[vid])
 	}
-	sort.SliceStable(vcs, func(i, j int) bool { return vcs[i].VariationId < vcs[j].VariationId })
 	return vcs
 }
 

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -418,8 +418,8 @@ func TestGrpcExperimentResult(t *testing.T) {
 			if len(gr.VariationResults) != 2 {
 				t.Fatalf("the number of variation results is not correct: %d", len(gr.VariationResults))
 			}
-			vsA := getVariationResult(gr.VariationResults, experiment.Variations[0].Id)
-			vsB := getVariationResult(gr.VariationResults, experiment.Variations[1].Id)
+			vsA := gr.VariationResults[0]
+			vsB := gr.VariationResults[1]
 			// These counts are based on the number of events sent earlier
 			if vsA.EvaluationCount.EventCount != 4 || // variation A
 				vsA.EvaluationCount.UserCount != 3 ||
@@ -657,8 +657,8 @@ func TestExperimentResult(t *testing.T) {
 			if len(gr.VariationResults) != 2 {
 				t.Fatalf("the number of variation results is not correct: %d", len(gr.VariationResults))
 			}
-			vsA := getVariationResult(gr.VariationResults, experiment.Variations[0].Id)
-			vsB := getVariationResult(gr.VariationResults, experiment.Variations[1].Id)
+			vsA := gr.VariationResults[0]
+			vsB := gr.VariationResults[1]
 			// These counts are based on the number of events sent earlier
 			if vsA.EvaluationCount.EventCount != 4 || // variation A
 				vsA.EvaluationCount.UserCount != 3 ||
@@ -1580,15 +1580,6 @@ LOOP:
 }
 
 func getVariationCount(vcs []*ecproto.VariationCount, id string) *ecproto.VariationCount {
-	for _, vc := range vcs {
-		if vc.VariationId == id {
-			return vc
-		}
-	}
-	return nil
-}
-
-func getVariationResult(vcs []*ecproto.VariationResult, id string) *ecproto.VariationResult {
 	for _, vc := range vcs {
 		if vc.VariationId == id {
 			return vc


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/807

This PR will fix the flaky `eventcounter` e2e tests. [[1]](https://github.com/bucketeer-io/bucketeer/blob/main/test/e2e/eventcounter/eventcounter_test.go#L421-L436) [[2]](https://github.com/bucketeer-io/bucketeer/blob/main/test/e2e/eventcounter/eventcounter_test.go#L660-L675)

The reason of causing flaky behavior is the [reordering](https://github.com/bucketeer-io/bucketeer/blob/d9a33e4f040914002c5e43632b9762f714f289e0/pkg/experimentcalculator/experimentcalc/experiment_calculator.go#L350-L352) experiment variation results by variation id.

So we should keep the original order of experiment variations to fix this issue. [[1]](https://github.com/bucketeer-io/bucketeer/pull/845/files#diff-b0f1a6e9d024e46f089e3bc6573a1c8f6dfaf821d6b3898e3c06794bbc4d0dd8R350)





