### PR TITLE
chore: fix invalid links pushes and notifications

### DIFF
--- a/ui/web-v2/apps/admin/src/components/AdminNotificationList/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/AdminNotificationList/index.tsx
@@ -61,7 +61,7 @@ export const AdminNotificationList: FC<AdminNotificationListProps> = memo(
           <a
             className="link"
             target="_blank"
-            href="https://bucketeer.io/docs#/notification"
+            href="https://docs.bucketeer.io/integration/notifications"
             rel="noreferrer"
           >
             {f(messages.readMore)}

--- a/ui/web-v2/apps/admin/src/components/NotificationList/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/NotificationList/index.tsx
@@ -61,7 +61,7 @@ export const NotificationList: FC<NotificationListProps> = memo(
           <a
             className="link"
             target="_blank"
-            href="https://bucketeer.io/docs#/notification"
+            href="https://docs.bucketeer.io/integration/notifications"
             rel="noreferrer"
           >
             {f(messages.readMore)}

--- a/ui/web-v2/apps/admin/src/components/PushList/index.tsx
+++ b/ui/web-v2/apps/admin/src/components/PushList/index.tsx
@@ -59,7 +59,7 @@ export const PushList: FC<PushListProps> = memo(
           <a
             className="link"
             target="_blank"
-            href="https://bucketeer.io/docs#/push-propagation"
+            href="https://docs.bucketeer.io/integration/pushes"
             rel="noreferrer"
           >
             {f(messages.readMore)}


### PR DESCRIPTION
This PR fixes invalid links:

I think correct links are:
- https://docs.bucketeer.io/integration/pushes
- https://docs.bucketeer.io/integration/notifications