### PR TITLE
fix: cannot create a rollout when the flag has a scheduled operation

### DIFF
--- a/pkg/autoops/api/error.go
+++ b/pkg/autoops/api/error.go
@@ -116,13 +116,9 @@ var (
 		codes.InvalidArgument,
 		"autoops: interval is unknown for a progressive rollout",
 	)
-	statusProgressiveRolloutAutoOpsHasDatetime = gstatus.New(
+	statusProgressiveRolloutWaitingOrRunningExperimentExists = gstatus.New(
 		codes.FailedPrecondition,
-		"autoops: can not create a progressive rollout when a schedule is set in the auto ops",
-	)
-	statusProgressiveRolloutAutoOpsHasWebhook = gstatus.New(
-		codes.FailedPrecondition,
-		"autoops: can not create a progressive rollout when a webhook is set",
+		"autoops: cannot create a progressive rollout when there is a scheduled or running experiment",
 	)
 	statusProgressiveRolloutInvalidVariationSize = gstatus.New(
 		codes.FailedPrecondition,

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -876,9 +876,20 @@ func (s *AutoOpsService) validateTargetFeature(
 		}
 		return dt.Err()
 	}
+	if err := s.checkIfHasExperiment(ctx, f.Id, localizer); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *AutoOpsService) checkIfHasExperiment(
+	ctx context.Context,
+	featureID string,
+	localizer locale.Localizer,
+) error {
 	// Check if the feature has scheduled or running experiment
 	resp, err := s.experimentClient.ListExperiments(ctx, &exprpto.ListExperimentsRequest{
-		FeatureId: f.Id,
+		FeatureId: featureID,
 		Statuses: []exprpto.Experiment_Status{
 			exprpto.Experiment_WAITING,
 			exprpto.Experiment_RUNNING,

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -37,8 +37,7 @@ import (
 )
 
 const (
-	fiveMinutes     = 5 * time.Minute
-	listRequestSize = 500
+	fiveMinutes = 5 * time.Minute
 )
 
 func (s *AutoOpsService) CreateProgressiveRollout(
@@ -845,36 +844,6 @@ func (s *AutoOpsService) validateCommand(
 		return nil
 	}
 	return nil
-}
-
-func (s *AutoOpsService) listAutoOpsRulesByFeatureID(
-	ctx context.Context,
-	req *autoopsproto.CreateProgressiveRolloutRequest,
-	localizer locale.Localizer,
-	storage v2as.AutoOpsRuleStorage,
-) ([]*autoopsproto.AutoOpsRule, error) {
-	allRules := []*autoopsproto.AutoOpsRule{}
-	cursor := ""
-	for {
-		rules, c, err := s.listAutoOpsRules(
-			ctx,
-			listRequestSize,
-			cursor,
-			[]string{req.Command.FeatureId},
-			req.EnvironmentNamespace,
-			localizer,
-			storage,
-		)
-		if err != nil {
-			return nil, err
-		}
-		allRules = append(allRules, rules...)
-		size := len(rules)
-		if size == 0 || size < listRequestSize {
-			return allRules, nil
-		}
-		cursor = c
-	}
 }
 
 func (s *AutoOpsService) getFeature(

--- a/pkg/autoops/api/progressive_rollout_test.go
+++ b/pkg/autoops/api/progressive_rollout_test.go
@@ -27,11 +27,13 @@ import (
 	gstatus "google.golang.org/grpc/status"
 
 	v2as "github.com/bucketeer-io/bucketeer/pkg/autoops/storage/v2"
+	experimentclientmock "github.com/bucketeer-io/bucketeer/pkg/experiment/client/mock"
 	featureclientmock "github.com/bucketeer-io/bucketeer/pkg/feature/client/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	autoopsproto "github.com/bucketeer-io/bucketeer/proto/autoops"
+	experimentproto "github.com/bucketeer-io/bucketeer/proto/experiment"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
@@ -173,6 +175,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -197,6 +203,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -223,6 +233,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -248,6 +262,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -275,6 +293,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -300,6 +322,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -327,6 +353,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -354,6 +384,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -388,6 +422,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -423,6 +461,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -453,6 +495,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -481,6 +527,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -511,6 +561,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -539,6 +593,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -569,6 +627,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -597,6 +659,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, errors.New("error"))
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
@@ -628,6 +694,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(), gomock.Any(),
@@ -662,6 +732,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(), gomock.Any(),
@@ -681,7 +755,7 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 			expectedErr: createError(statusProgressiveRolloutAlreadyExists, localizer.MustLocalize(locale.AlreadyExistsError)),
 		},
 		{
-			desc: "err: AutoOpsHasDatetime",
+			desc: "err: while listing experiments",
 			setup: func(aos *AutoOpsService) {
 				aos.featureClient.(*featureclientmock.MockClient).EXPECT().GetFeature(
 					gomock.Any(), gomock.Any(),
@@ -696,10 +770,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
-				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(errProgressiveRolloutAutoOpsHasDatetime)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					nil,
+					errors.New("internal error"),
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -712,10 +786,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: createError(statusProgressiveRolloutAutoOpsHasDatetime, localizer.MustLocalize(locale.AutoOpsHasDatetime)),
+			expectedErr: createError(statusProgressiveRolloutInternal, localizer.MustLocalize(locale.InternalServerError)),
 		},
 		{
-			desc: "err: AutoOpsHasWebhook",
+			desc: "err: AutoOpsWaitingOrRunningExperimentExists",
 			setup: func(aos *AutoOpsService) {
 				aos.featureClient.(*featureclientmock.MockClient).EXPECT().GetFeature(
 					gomock.Any(), gomock.Any(),
@@ -730,10 +804,16 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
-				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(errProgressiveRolloutAutoOpsHasWebhook)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{
+						Experiments: []*experimentproto.Experiment{
+							{
+								Id: "experiment-id",
+							},
+						},
+					},
+					nil,
+				)
 			},
 			req: &autoopsproto.CreateProgressiveRolloutRequest{
 				Command: &autoopsproto.CreateProgressiveRolloutCommand{
@@ -746,7 +826,7 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 				},
 			},
-			expectedErr: createError(statusProgressiveRolloutAutoOpsHasWebhook, localizer.MustLocalize(locale.AutoOpsHasWebhook)),
+			expectedErr: createError(statusProgressiveRolloutWaitingOrRunningExperimentExists, localizer.MustLocalize(locale.AutoOpsWaitingOrRunningExperimentExists)),
 		},
 		{
 			desc: "success",
@@ -764,6 +844,10 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 					},
 					Enabled: true,
 				}}, nil)
+				aos.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(gomock.Any(), gomock.Any()).Return(
+					&experimentproto.ListExperimentsResponse{Experiments: []*experimentproto.Experiment{}},
+					nil,
+				)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
 				aos.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(), gomock.Any(),

--- a/pkg/locale/localizedata/en.yaml
+++ b/pkg/locale/localizedata/en.yaml
@@ -86,16 +86,10 @@ InvalidChangingVariation: "You cannot change or delete a variation of a flag reg
 WaitingOrRunningProgressiveRolloutExists: "There is a progressive rollout scheduled to start or running. Please stop the progressive rollout before updating it"
 
 # Auto Ops errors
-AutoOpsFeatureDisabled: "The feature flag is not enabled. Please enable it before using the progressive rollout"
-AutoOpsFeatureHasIndividualTargeting: "There is an individual targeting configured in the feature flag. Please delete it before using the progressive rollout"
-AutoOpsFeatureHasPrerequisites: "There is a prerequisite configured in the feature flag. Please delete it before using the progressive rollout"
-AutoFeatureHasRules: "There is a rule configured in the feature flag. Please delete it before using the progressive rollout"
-AutoOpsHasDatetime: "There is a schedule configured in the auto operations. Please delete it before using the progressive rollout"
-AutoOpsHasWebhook: "There is a webhook configured in the auto operations. Please delete it before using the progressive rollout"
 AutoOpsInvalidScheduleSpans: "Scheduled time intervals must be at least 5 minutes apart"
 AutoOpsInvalidVariationSize: "Invalid number of variations for feature"
-AutoOpsWaitingOrRunningExperimentExists: "There is a scheduled to start or running experiment. Please stop it before updating the progressive rollout"
-AutoOpsProgressiveRolloutInProgress: "There is a Proressive Rollout in progress. Please delete it before making changes"
+AutoOpsWaitingOrRunningExperimentExists: "There is a scheduled or running experiment. Please stop the experiment before creating it"
+AutoOpsProgressiveRolloutInProgress: "There is a Proressive Rollout in progress. Please stop or delete it before making changes"
 
 # Event Counter errors
 StartAtIsAfterEndAt: "Start at must be before end at"

--- a/pkg/locale/localizedata/ja.yaml
+++ b/pkg/locale/localizedata/ja.yaml
@@ -86,16 +86,10 @@ InvalidChangingVariation: "前提条件のフラグとして登録されてい�
 WaitingOrRunningProgressiveRolloutExists: "開始予定、もしくは実行中のプログレッシブロールアウトが存在します。更新する場合はプログレッシブロールアウトを停止してください"
 
 # Auto Ops errors
-AutoOpsFeatureDisabled: "フィーチャーフラグにが有効でありません。更新する場合はフィーチャーフラグにを有効にしてください"
-AutoOpsFeatureHasIndividualTargeting: "フィーチャーフラグににターゲティングがあります。更新する場合はターゲティングを削除してください"
-AutoOpsFeatureHasPrerequisites: "フィーチャーフラグにに前提条件があります。更新する場合は前提条件を削除してください"
-AutoOpsFeatureHasRules: "フィーチャーフラグにルールがあります。更新する場合はルールを削除してください"
-AutoOpsHasDatetime: "オートオペレーションにスケジュールが設定されています。更新する場合はスケジュールを削除してください"
-AutoOpsHasWebhook: "オートオペレーションにWebhookが設定されています。更新する場合はWebhookを削除してください"
 AutoOpsInvalidScheduleSpans: "スケジュールされた時間の間隔は少なくとも5分以上必要です"
 AutoOpsInvalidVariationSize: "フィーチャーフラグのバリエーションの数が不正です"
-AutoOpsWaitingOrRunningExperimentExists: "開始予定、もしくは実行中のエクスペリメントが存在します。更新する場合はプログレッシブロールアウトを停止してください"
-AutoOpsProgressiveRolloutInProgress: "実行中のプログレッシブロールアウトがあります。更新する場合はプログレッシブロールアウトを削除してください"
+AutoOpsWaitingOrRunningExperimentExists: "開始予定、もしくは実行中のエクスペリメントが存在します。作成する場合はエクスペリメントを停止してください"
+AutoOpsProgressiveRolloutInProgress: "実行中のプログレッシブロールアウトがあります。更新する場合はプログレッシブロールアウトを停止もしくは、削除してください"
 
 # Event Counter errors
 StartAtIsAfterEndAt: "開始時間は終了時間以前を指定してください"

--- a/pkg/locale/localizer.go
+++ b/pkg/locale/localizer.go
@@ -116,12 +116,6 @@ const (
 	DifferentVariationsSize                  = "DifferentVariationsSize"
 	WaitingOrRunningProgressiveRolloutExists = "WaitingOrRunningProgressiveRolloutExists"
 	// auto ops
-	AutoOpsFeatureDisabled                  = "AutoOpsFeatureDisabled"
-	AutoOpsFeatureHasIndividualTargeting    = "AutoOpsFeatureHasIndividualTargeting"
-	AutoOpsFeatureHasPrerequisites          = "AutoOpsFeatureHasPrerequisites"
-	AutoOpsFeatureHasRules                  = "AutoOpsFeatureHasRules"
-	AutoOpsHasDatetime                      = "AutoOpsHasDatetime"
-	AutoOpsHasWebhook                       = "AutoOpsHasWebhook"
 	AutoOpsInvalidScheduleSpans             = "AutoOpsInvalidScheduleSpans"
 	AutoOpsInvalidVariationSize             = "AutoOpsInvalidVariationSize"
 	AutoOpsWaitingOrRunningExperimentExists = "AutoOpsWaitingOrRunningExperimentExists"


### PR DESCRIPTION
There was a validation for scheduled operations that should be removed, and the validation for running the experiment was missing.

#### Things done

- Removed validation for scheduled operations, creating a progressive rollout
- Added validation for waiting or running experiments when creating a progressive rollout
- Remove unused locale

---

This pull request includes changes to the `autoops` package, specifically the `progressive_rollout.go` and related test file `progressive_rollout_test.go`. The changes mainly focus on the removal of validation for auto ops rules, the addition of a check for scheduled or running experiments, and the modification of error messages.

Changes to validation and error handling:

* [`pkg/autoops/api/error.go`](diffhunk://#diff-6713b69b4756f893e138c9dc567f83d66eb192b7acc6697c14643ec4d10b8b75L119-R121): The error message for a failed precondition in a progressive rollout has been updated to reflect the new validation rules.
* [`pkg/autoops/api/progressive_rollout.go`](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949R35-L52): Removed the validation for auto ops rules and added a check for scheduled or running experiments. This includes the removal of the `validateTargetAutoOpsRules` function and the addition of a call to `ListExperiments` in the `validateTargetFeature` function. [[1]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949R35-L52) [[2]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949L87-L91) [[3]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949L123-L140) [[4]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949L884-L913) [[5]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949L929-L957) [[6]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949R879-R906)
* [`pkg/autoops/api/progressive_rollout_test.go`](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R178-R181): Updated the tests to reflect the changes in validation and error handling. This includes the addition of expected calls to `ListExperiments`. [[1]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R178-R181) [[2]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R206-R209) [[3]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R236-R239) [[4]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R265-R268) [[5]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R296-R299) [[6]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R325-R328) [[7]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R356-R359) [[8]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R387-R390) [[9]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R425-R428) [[10]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R464-R467) [[11]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R498-R501) [[12]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R530-R533) [[13]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R564-R567) [[14]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R596-R599) [[15]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R630-R633) [[16]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R662-R665) [[17]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R697-R700) [[18]](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R735-R738)

Changes to imports:

* [`pkg/autoops/api/progressive_rollout.go`](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949L19-L27): Removed the import of `errors` and `github.com/golang/protobuf/ptypes`, and added the import of `github.com/bucketeer-io/bucketeer/proto/experiment`. [[1]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949L19-L27) [[2]](diffhunk://#diff-0c3db025218a1fe713f6b9f15e288472ce07cf964670d3c0a27091a896c46949R35-L52)
* [`pkg/autoops/api/progressive_rollout_test.go`](diffhunk://#diff-9c566a29ad6bf280fb74bddd40809264d10067e2fb476ca56308d0493c2a73b5R30-R36): Added the import of `github.com/bucketeer-io/bucketeer/pkg/experiment/client/mock`.