### PR TITLE
chore: remove unnecessary Stop()

### DIFF
--- a/pkg/cache/v3/in_memory_cache.go
+++ b/pkg/cache/v3/in_memory_cache.go
@@ -52,7 +52,6 @@ func (c *InMemoryCache) startEvicter(evictionInterval time.Duration) {
 		case now := <-ticker.C:
 			c.evictExpired(now)
 		case <-c.doneCh:
-			ticker.Stop()
 			return
 		}
 	}


### PR DESCRIPTION
We already using `defer` [here](https://github.com/bucketeer-io/bucketeer/pull/867/files#diff-51b4f0933cab6b08c7fbea878aa8b862fd9a6a843788c6d35f7d9207c335ed6fR49), so we can remove calling unnecessary `Stop()` in `InMemoryCache`.

```go
func (c *InMemoryCache) startEvicter(evictionInterval time.Duration) {
	ticker := time.NewTicker(evictionInterval)
	defer ticker.Stop()
	for {
		select {
		case now := <-ticker.C:
			c.evictExpired(now)
		case <-c.doneCh:
			return
		}
	}
}
```