### PR TITLE
test: fix possible e2e flaky test while getting experiment results

### DIFF
--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -1463,7 +1463,7 @@ func createExperimentWithMultiGoals(
 	// Update experiment cache
 	batchClient := newBatchClient(t)
 	defer batchClient.Close()
-	numRetries := 5
+	numRetries := 6
 	for i := 0; i < numRetries; i++ {
 		_, err = batchClient.ExecuteBatchJob(
 			ctx,
@@ -1475,7 +1475,7 @@ func createExperimentWithMultiGoals(
 		if st.Code() == codes.Internal {
 			t.Fatal(err)
 		}
-		fmt.Printf("Failed to execute experiment cacher batch. Error code: %d\n. Retrying in 5 seconds.", st.Code())
+		fmt.Printf("Failed to execute experiment cacher batch. Error code: %d. Retrying in 5 seconds.\n", st.Code())
 		time.Sleep(5 * time.Second)
 	}
 	if err != nil {
@@ -1489,7 +1489,7 @@ func updateFeatueFlagCache(t *testing.T) {
 	defer cancel()
 	batchClient := newBatchClient(t)
 	defer batchClient.Close()
-	numRetries := 5
+	numRetries := 6
 	var err error
 	for i := 0; i < numRetries; i++ {
 		_, err = batchClient.ExecuteBatchJob(
@@ -1502,7 +1502,7 @@ func updateFeatueFlagCache(t *testing.T) {
 		if st.Code() == codes.Internal {
 			t.Fatal(err)
 		}
-		fmt.Printf("Failed to execute feature flag cacher batch. Error code: %d\n. Retrying in 5 seconds.", st.Code())
+		fmt.Printf("Failed to execute feature flag cacher batch. Error code: %d. Retrying in 5 seconds.\n", st.Code())
 		time.Sleep(5 * time.Second)
 	}
 	if err != nil {
@@ -1941,7 +1941,21 @@ func getEvaluation(t *testing.T, tag string, userID string) *gatewayproto.GetEva
 		Tag:  tag,
 		User: &userproto.User{Id: userID},
 	}
-	response, err := c.GetEvaluations(ctx, req)
+	var response *gatewayproto.GetEvaluationsResponse
+	var err error
+	numRetries := 6
+	for i := 0; i < numRetries; i++ {
+		response, err = c.GetEvaluations(ctx, req)
+		if err == nil {
+			break
+		}
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Internal {
+			t.Fatal(err)
+		}
+		fmt.Printf("Failed to get evaluations. Error code: %d. Retrying in 5 seconds.\n", st.Code())
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1956,14 +1970,25 @@ func getExperiment(t *testing.T, c experimentclient.Client, id string) *experime
 		EnvironmentNamespace: *environmentNamespace,
 		Id:                   id,
 	}
-	res, err := c.GetExperiment(ctx, req)
-	if err != nil {
-		// pass not found error
-		if err.Error() != "rpc error: code = NotFound desc = eventcounter: not found" {
+	var response *experimentproto.GetExperimentResponse
+	var err error
+	numRetries := 6
+	for i := 0; i < numRetries; i++ {
+		response, err = c.GetExperiment(ctx, req)
+		if err == nil {
+			break
+		}
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Internal {
 			t.Fatal(err)
 		}
+		fmt.Printf("Failed to get experiment. Experiment ID: %s. Error code: %d. Retrying in 5 seconds.\n", id, st.Code())
+		time.Sleep(5 * time.Second)
 	}
-	return res
+	if err != nil {
+		t.Fatal(err)
+	}
+	return response
 }
 
 func getExperimentResult(t *testing.T, c ecclient.Client, experimentID string) *ecproto.GetExperimentResultResponse {
@@ -1974,12 +1999,23 @@ func getExperimentResult(t *testing.T, c ecclient.Client, experimentID string) *
 		ExperimentId:         experimentID,
 		EnvironmentNamespace: *environmentNamespace,
 	}
-	response, err := c.GetExperimentResult(ctx, req)
-	if err != nil {
-		// pass not found error
-		if err.Error() != "rpc error: code = NotFound desc = eventcounter: not found" {
+	var response *ecproto.GetExperimentResultResponse
+	var err error
+	numRetries := 6
+	for i := 0; i < numRetries; i++ {
+		response, err = c.GetExperimentResult(ctx, req)
+		if err == nil {
+			break
+		}
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Internal {
 			t.Fatal(err)
 		}
+		fmt.Printf("Failed to get experiment result. Experiment ID: %s. Error code: %d. Retrying in 5 seconds.\n", experimentID, st.Code())
+		time.Sleep(5 * time.Second)
+	}
+	if err != nil {
+		t.Fatal(err)
 	}
 	return response
 }
@@ -1997,7 +2033,21 @@ func getExperimentEvaluationCount(t *testing.T, c ecclient.Client, featureID str
 		FeatureVersion:       featureVersion,
 		VariationIds:         variationIDs,
 	}
-	response, err := c.GetExperimentEvaluationCount(ctx, req)
+	var response *ecproto.GetExperimentEvaluationCountResponse
+	var err error
+	numRetries := 6
+	for i := 0; i < numRetries; i++ {
+		response, err = c.GetExperimentEvaluationCount(ctx, req)
+		if err == nil {
+			break
+		}
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Internal {
+			t.Fatal(err)
+		}
+		fmt.Printf("Failed to get experiment evaluation count. Error code: %d. Retrying in 5 seconds.\n", st.Code())
+		time.Sleep(5 * time.Second)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2020,7 +2070,7 @@ func getExperimentGoalCount(t *testing.T, c ecclient.Client, goalID, featureID s
 	}
 	var response *ecproto.GetExperimentGoalCountResponse
 	var err error
-	numRetries := 5
+	numRetries := 6
 	for i := 0; i < numRetries; i++ {
 		response, err = c.GetExperimentGoalCount(ctx, req)
 		if err == nil {
@@ -2030,7 +2080,7 @@ func getExperimentGoalCount(t *testing.T, c ecclient.Client, goalID, featureID s
 		if st.Code() == codes.Internal {
 			t.Fatal(err)
 		}
-		fmt.Printf("Failed to get experiment goal count. Error code: %d\n. Retrying in 5 seconds.", st.Code())
+		fmt.Printf("Failed to get experiment goal count. Error code: %d. Retrying in 5 seconds.\n", st.Code())
 		time.Sleep(5 * time.Second)
 	}
 	if err != nil {
@@ -2047,9 +2097,20 @@ func getFeature(t *testing.T, client featureclient.Client, featureID string) *fe
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	response, err := client.GetFeature(ctx, getReq)
-	if err != nil {
-		t.Fatal("Failed to get feature:", err)
+	var response *featureproto.GetFeatureResponse
+	var err error
+	numRetries := 6
+	for i := 0; i < numRetries; i++ {
+		response, err = client.GetFeature(ctx, getReq)
+		if err == nil {
+			break
+		}
+		st, _ := status.FromError(err)
+		if st.Code() == codes.Internal {
+			t.Fatal(err)
+		}
+		fmt.Printf("Failed to get feature. ID: %s. Error code: %d. Retrying in 5 seconds.\n", featureID, st.Code())
+		time.Sleep(5 * time.Second)
 	}
 	return response.Feature
 }


### PR DESCRIPTION
The `TestGetExperimentResults` takes between 3-5 minutes. During the tests, I noticed that the auto scaler rescheduled the pods, causing random errors. So, I implemented a retry logic in all the get functions to retry if an error that is not internal occurs.

It returned `NotFound` and `Unavailable` errors during the tests.

```
=== CONT  TestHTTPTrack
--- PASS: TestGetEvaluationTimeseriesCount (83.45s)
Failed to get experiment goal count. Error code: 14. Retrying in 5 seconds.
Failed to get experiment goal count. Error code: 14. Retrying in 5 seconds.
--- PASS: TestExperimentEvaluationEventCount (84.87s)
--- PASS: TestGrpcExperimentEvaluationEventCount (85.20s)
--- PASS: TestHTTPTrack (85.22s)
--- PASS: TestGrpcExperimentGoalCount (85.37s)
Failed to get experiment result. Experiment ID: dfa4e1fb-a3b1-4827-94a4-806c6ba00585. Error code: 5. Retrying in 5 seconds.
--- PASS: TestExperimentGoalCount (85.61s)
--- PASS: TestGrpcExperimentResult (95.49s)
--- PASS: TestMultiGoalsEventCounter (96.97s)
--- PASS: TestGrpcMultiGoalsEventCounter (98.17s)
--- PASS: TestExperimentResult (260.81s)
PASS
ok  	github.com/bucketeer-io/bucketeer/test/e2e/eventcounter	261.073s
```

The retry logic will retry for up to 30 seconds. That should be enough time for the pods to restart.

---

This pull request primarily focuses on improving the resilience of the test suite in `test/e2e/eventcounter/eventcounter_test.go` by introducing retry logic in multiple functions. The changes are designed to handle transient errors more gracefully by retrying certain operations up to 6 times before failing. Each retry is delayed by 5 seconds to allow for temporary issues to resolve. The changes also include an increase in the number of retries from 5 to 6 in a couple of functions.

Here are the most important changes:

- `func createExperimentWithMultiGoals(` and `func updateFeatueFlagCache(t *testing.T) {`: The number of retries has been increased from 5 to 6. [[1]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L1466-R1466) [[2]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L1492-R1492)

- `func getEvaluation(t *testing.T, tag string, userID string) *gatewayproto.GetEva`: Retry logic has been introduced to handle transient errors when getting evaluations.

- `func getExperiment(t *testing.T, c experimentclient.Client, id string) *experime`, `func getExperimentResult(t *testing.T, c ecclient.Client, experimentID string) *`, `func getExperimentEvaluationCount(t *testing.T, c ecclient.Client, featureID str`, `func getExperimentGoalCount(t *testing.T, c ecclient.Client, goalID, featureID s`, and `func getFeature(t *testing.T, client featureclient.Client, featureID string) *fe`: These functions now use a retry loop to handle transient errors when making requests. If a request fails, it is retried up to 6 times, with a 5-second delay between each attempt. [[1]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L1959-R1991) [[2]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L1977-R2018) [[3]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L2000-R2050) [[4]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L2023-R2073) [[5]](diffhunk://#diff-fafe94e90f3efcbbcfe66c2e842bbbbe177e54aef2462808d1924bddb464c888L2050-R2113)