### PR TITLE
test: add PermissionDenied error test for EventCounter APIs

### DIFF
--- a/pkg/eventcounter/api/api_test.go
+++ b/pkg/eventcounter/api/api_test.go
@@ -1870,22 +1870,22 @@ func getDate(t time.Time) int64 {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, jpLocation).Unix()
 }
 
-func newEventCounterService(t *testing.T, mockController *gomock.Controller, SpecifiedEnvironmentId *string, SpecifiedOrgRole *accountproto.AccountV2_Role_Organization, SpecifiedEnvRole *accountproto.AccountV2_Role_Environment) *eventCounterService {
+func newEventCounterService(t *testing.T, mockController *gomock.Controller, specifiedEnvironmentId *string, specifiedOrgRole *accountproto.AccountV2_Role_Organization, specifiedEnvRole *accountproto.AccountV2_Role_Environment) *eventCounterService {
 	var or accountproto.AccountV2_Role_Organization
 	var er accountproto.AccountV2_Role_Environment
 	var envId string
-	if SpecifiedOrgRole != nil {
-		or = *SpecifiedOrgRole
+	if specifiedOrgRole != nil {
+		or = *specifiedOrgRole
 	} else {
 		or = accountproto.AccountV2_Role_Organization_ADMIN
 	}
-	if SpecifiedEnvRole != nil {
-		er = *SpecifiedEnvRole
+	if specifiedEnvRole != nil {
+		er = *specifiedEnvRole
 	} else {
 		er = accountproto.AccountV2_Role_Environment_EDITOR
 	}
-	if SpecifiedEnvironmentId != nil {
-		envId = *SpecifiedEnvironmentId
+	if specifiedEnvironmentId != nil {
+		envId = *specifiedEnvironmentId
 	} else {
 		envId = "ns0"
 	}


### PR DESCRIPTION
This pull request introduces changes to the test functions in the `pkg/eventcounter/api/api_test.go` file. The changes primarily involve adding organization and environment roles to the test functions to simulate different user permissions. This will help in testing the permission handling logic of the application. 

resolves https://github.com/bucketeer-io/bucketeer/issues/809

The changes can be grouped into two main categories:

1. Addition of `orgRole` and `envRole` to test functions: These roles simulate the permissions of different users in the organization and environment respectively. They are added to the test function parameters and passed to the `newEventCounterService` function. This allows the tests to simulate different user permissions and test the permission handling logic of the application. 

    * `func TestGetExperimentEvaluationCount(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R100-R101) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R143-R161) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L223-R242)
    * `func TestGetExperimentResultMySQL(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R334-R335) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R358-R371) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L352-R386)
    * `func TestListExperimentResultsMySQL(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R420-R421) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R461-R476) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L504-R555)
    * `func TestGetExperimentGoalCount(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R596-R597) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R654-R669) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L702-R769)
    * `func TestGetMAUCount(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R803-R804) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R830-R841) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L778-R857)
    * `func TestSummarizeMAUCounts(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R892-R893) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L874-R955)
    * `func TestGetEvaluationTimeseriesCount(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R1230-R1231) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R1378-R1393) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L1365-R1462)
    * `func TestGetOpsEvaluationUserCount(t *testing.T) {` [[1]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R1514-R1516) [[2]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R1576-R1592) [[3]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4R1614) [[4]](diffhunk://#diff-d94e58cb68d5fe4a192804102827bb26296bd8435a4a521fd126562354cc5de4L1520-R1636)
    * `func TestGetOpsGoalUserCount(t *testing.T) {`

2. Modification of service creation in test functions: The `newEventCounterService` function now takes in the `orgRole` and `envRole` as parameters. This function is used to create a new instance of the `eventCounterService` for each test run.

    * `func TestListExperiments(t *testing.T) {`
    * `func TestGetTotalEventCounts(t *testing.T) {`
    * `func TestGetTimestamps(t *testing.T) {`