### PR TITLE
test: add PermissionDenied error test for Experiment, Notification, Push APIs

### DIFF
--- a/pkg/experiment/api/experiment_test.go
+++ b/pkg/experiment/api/experiment_test.go
@@ -19,13 +19,14 @@ import (
 	"testing"
 	"time"
 
-	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/metadata"
 	gstatus "google.golang.org/grpc/status"
+
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 
 	v2es "github.com/bucketeer-io/bucketeer/pkg/experiment/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"

--- a/pkg/experiment/api/experiment_test.go
+++ b/pkg/experiment/api/experiment_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,7 +29,6 @@ import (
 
 	v2es "github.com/bucketeer-io/bucketeer/pkg/experiment/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
-	storagetesting "github.com/bucketeer-io/bucketeer/pkg/storage/testing"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	experimentproto "github.com/bucketeer-io/bucketeer/proto/experiment"
@@ -91,7 +91,7 @@ func TestGetExperimentMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -101,17 +101,43 @@ func TestGetExperimentMySQL(t *testing.T) {
 	}
 }
 
-func TestListExperimentMySQL(t *testing.T) {
+func TestListExperimentsMySQL(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
+	ctx := createContextWithTokenAndMetadata(metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
 	patterns := []struct {
+		desc        string
+		orgRole     *accountproto.AccountV2_Role_Organization
+		envRole     *accountproto.AccountV2_Role_Environment
 		setup       func(*experimentService)
 		req         *experimentproto.ListExperimentsRequest
 		expectedErr error
 	}{
 		{
+			desc:        "error: ErrPermissionDenied",
+			orgRole:     toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:     toPtr(accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			req:         &experimentproto.ListExperimentsRequest{FeatureId: "id-0", EnvironmentNamespace: "ns0"},
+			expectedErr: createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:    "success",
+			orgRole: toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole: toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *experimentService) {
 				rows := mysqlmock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
@@ -131,12 +157,14 @@ func TestListExperimentMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
-		if p.setup != nil {
-			p.setup(service)
-		}
-		_, err := service.ListExperiments(createContextWithTokenRoleUnassigned(), p.req)
-		assert.Equal(t, p.expectedErr, err)
+		t.Run(p.desc, func(t *testing.T) {
+			service := createExperimentService(mockController, nil, p.orgRole, p.envRole)
+			if p.setup != nil {
+				p.setup(service)
+			}
+			_, err := service.ListExperiments(ctx, p.req)
+			assert.Equal(t, p.expectedErr, err)
+		})
 	}
 }
 
@@ -176,7 +204,7 @@ func TestCreateExperimentMySQL(t *testing.T) {
 	}
 	ctx := createContextWithToken()
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -358,7 +386,7 @@ func TestUpdateExperimentMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -441,7 +469,7 @@ func TestStartExperimentMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			service := createExperimentService(mockController, nil)
+			service := createExperimentService(mockController, nil, nil, nil)
 			if p.setup != nil {
 				p.setup(service)
 			}
@@ -525,7 +553,7 @@ func TestFinishExperimentMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			service := createExperimentService(mockController, nil)
+			service := createExperimentService(mockController, nil, nil, nil)
 			if p.setup != nil {
 				p.setup(service)
 			}
@@ -603,7 +631,7 @@ func TestStopExperimentMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -680,7 +708,7 @@ func TestArchiveExperimentMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -757,7 +785,7 @@ func TestDeleteExperimentMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -771,8 +799,7 @@ func TestExperimentPermissionDenied(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 	ctx := createContextWithTokenRoleUnassigned()
-	s := storagetesting.NewInMemoryStorage()
-	service := createExperimentService(mockController, s)
+	service := createExperimentService(mockController, nil, nil, nil)
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
 		"accept-language": []string{"ja"},
 	})

--- a/pkg/experiment/api/goal_test.go
+++ b/pkg/experiment/api/goal_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -27,7 +28,6 @@ import (
 
 	v2es "github.com/bucketeer-io/bucketeer/pkg/experiment/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
-	storeclient "github.com/bucketeer-io/bucketeer/pkg/storage/testing"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	experimentproto "github.com/bucketeer-io/bucketeer/proto/experiment"
@@ -53,18 +53,23 @@ func TestGetGoalMySQL(t *testing.T) {
 	}
 
 	patterns := []struct {
+		desc                 string
 		setup                func(*experimentService)
+		orgRole              *accountproto.AccountV2_Role_Organization
+		envRole              *accountproto.AccountV2_Role_Environment
 		id                   string
 		environmentNamespace string
 		expectedErr          error
 	}{
 		{
+			desc:                 "error: ErrRequiredFieldTemplate",
 			setup:                nil,
 			id:                   "",
 			environmentNamespace: "ns0",
 			expectedErr:          createError(statusGoalIDRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "goal_id")),
 		},
 		{
+			desc: "error: ErrNotFound",
 			setup: func(s *experimentService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
@@ -77,6 +82,17 @@ func TestGetGoalMySQL(t *testing.T) {
 			expectedErr:          createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError)),
 		},
 		{
+			desc:                 "error: ErrPermissionDenied",
+			orgRole:              toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:              toPtr(accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			id:                   "id-1",
+			environmentNamespace: "ns0",
+			expectedErr:          createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:    "success",
+			orgRole: toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole: toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *experimentService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
@@ -90,13 +106,15 @@ func TestGetGoalMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
-		if p.setup != nil {
-			p.setup(service)
-		}
-		req := &experimentproto.GetGoalRequest{Id: p.id, EnvironmentNamespace: p.environmentNamespace}
-		_, err := service.GetGoal(ctx, req)
-		assert.Equal(t, p.expectedErr, err)
+		t.Run(p.desc, func(t *testing.T) {
+			service := createExperimentService(mockController, nil, p.orgRole, p.envRole)
+			if p.setup != nil {
+				p.setup(service)
+			}
+			req := &experimentproto.GetGoalRequest{Id: p.id, EnvironmentNamespace: p.environmentNamespace}
+			_, err := service.GetGoal(ctx, req)
+			assert.Equal(t, p.expectedErr, err)
+		})
 	}
 }
 
@@ -105,12 +123,39 @@ func TestListGoalMySQL(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
+	ctx := createContextWithTokenRoleUnassigned()
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
 	patterns := []struct {
+		desc        string
+		orgRole     *accountproto.AccountV2_Role_Organization
+		envRole     *accountproto.AccountV2_Role_Environment
 		setup       func(*experimentService)
 		req         *experimentproto.ListGoalsRequest
 		expectedErr error
 	}{
 		{
+			desc:        "error: ErrPermissionDenied",
+			orgRole:     toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:     toPtr(accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			req:         &experimentproto.ListGoalsRequest{EnvironmentNamespace: "ns0"},
+			expectedErr: createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:    "success",
+			orgRole: toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole: toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *experimentService) {
 				rows := mysqlmock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
@@ -130,12 +175,14 @@ func TestListGoalMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
-		if p.setup != nil {
-			p.setup(service)
-		}
-		_, err := service.ListGoals(createContextWithTokenRoleUnassigned(), p.req)
-		assert.Equal(t, p.expectedErr, err)
+		t.Run(p.desc, func(t *testing.T) {
+			service := createExperimentService(mockController, nil, p.orgRole, p.envRole)
+			if p.setup != nil {
+				p.setup(service)
+			}
+			_, err := service.ListGoals(ctx, p.req)
+			assert.Equal(t, p.expectedErr, err)
+		})
 	}
 }
 
@@ -222,7 +269,7 @@ func TestCreateGoalMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -299,7 +346,7 @@ func TestUpdateGoalMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -376,7 +423,7 @@ func TestArchiveGoalMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -453,7 +500,7 @@ func TestDeleteGoalMySQL(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		service := createExperimentService(mockController, nil)
+		service := createExperimentService(mockController, nil, nil, nil)
 		if p.setup != nil {
 			p.setup(service)
 		}
@@ -467,8 +514,7 @@ func TestGoalPermissionDenied(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 	ctx := createContextWithTokenRoleUnassigned()
-	s := storeclient.NewInMemoryStorage()
-	service := createExperimentService(mockController, s)
+	service := createExperimentService(mockController, nil, nil, nil)
 	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
 		"accept-language": []string{"ja"},
 	})

--- a/pkg/experiment/api/goal_test.go
+++ b/pkg/experiment/api/goal_test.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"testing"
 
-	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/metadata"
 	gstatus "google.golang.org/grpc/status"
+
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 
 	v2es "github.com/bucketeer-io/bucketeer/pkg/experiment/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"

--- a/pkg/notification/api/api_test.go
+++ b/pkg/notification/api/api_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -61,6 +62,51 @@ func newNotificationServiceWithMock(
 	return &NotificationService{
 		mysqlClient:          mysqlmock.NewMockClient(c),
 		accountClient:        accountclientmock.NewMockClient(c),
+		domainEventPublisher: publishermock.NewMockPublisher(c),
+		logger:               zap.NewNop(),
+	}
+}
+
+func newNotificationService(c *gomock.Controller, specifiedEnvironmentId *string, specifiedOrgRole *accountproto.AccountV2_Role_Organization, specifiedEnvRole *accountproto.AccountV2_Role_Environment) *NotificationService {
+	var or accountproto.AccountV2_Role_Organization
+	var er accountproto.AccountV2_Role_Environment
+	var envId string
+	if specifiedOrgRole != nil {
+		or = *specifiedOrgRole
+	} else {
+		or = accountproto.AccountV2_Role_Organization_ADMIN
+	}
+	if specifiedEnvRole != nil {
+		er = *specifiedEnvRole
+	} else {
+		er = accountproto.AccountV2_Role_Environment_EDITOR
+	}
+	if specifiedEnvironmentId != nil {
+		envId = *specifiedEnvironmentId
+	} else {
+		envId = "ns0"
+	}
+
+	accountClientMock := accountclientmock.NewMockClient(c)
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: or,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: envId,
+					Role:          er,
+				},
+			},
+		},
+	}
+	accountClientMock.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	mysqlClient := mysqlmock.NewMockClient(c)
+	p := publishermock.NewMockPublisher(c)
+	p.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	return &NotificationService{
+		mysqlClient:          mysqlClient,
+		accountClient:        accountClientMock,
 		domainEventPublisher: publishermock.NewMockPublisher(c),
 		logger:               zap.NewNop(),
 	}
@@ -126,4 +172,9 @@ func putSubscription(t *testing.T, s storage.Client, kind, namespace string, dis
 	require.NoError(t, err)
 	err = s.Put(context.Background(), key, subscription.Subscription)
 	require.NoError(t, err)
+}
+
+// convert to pointer
+func toPtr[T any](value T) *T {
+	return &value
 }

--- a/pkg/notification/api/api_test.go
+++ b/pkg/notification/api/api_test.go
@@ -20,11 +20,12 @@ import (
 	"testing"
 	"time"
 
-	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
+
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 
 	accountclientmock "github.com/bucketeer-io/bucketeer/pkg/account/client/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"

--- a/pkg/notification/api/subscription_test.go
+++ b/pkg/notification/api/subscription_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -563,18 +564,33 @@ func TestGetSubscriptionMySQL(t *testing.T) {
 	}
 
 	patterns := []struct {
-		desc        string
-		setup       func(*NotificationService)
-		input       *proto.GetSubscriptionRequest
-		expectedErr error
+		desc          string
+		orgRole       *accountproto.AccountV2_Role_Organization
+		envRole       *accountproto.AccountV2_Role_Environment
+		isSystemAdmin bool
+		setup         func(*NotificationService)
+		input         *proto.GetSubscriptionRequest
+		expectedErr   error
 	}{
 		{
-			desc:        "err: ErrIDRequired",
-			input:       &proto.GetSubscriptionRequest{},
-			expectedErr: createError(statusIDRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id")),
+			desc:          "err: ErrIDRequired",
+			isSystemAdmin: true,
+			input:         &proto.GetSubscriptionRequest{},
+			expectedErr:   createError(statusIDRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id")),
 		},
 		{
-			desc: "success",
+			desc:          "err: ErrPermissionDenied",
+			isSystemAdmin: false,
+			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:       toPtr(accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			input:         &proto.GetSubscriptionRequest{},
+			expectedErr:   createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:          "success",
+			isSystemAdmin: false,
+			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
@@ -582,17 +598,17 @@ func TestGetSubscriptionMySQL(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
-			input:       &proto.GetSubscriptionRequest{Id: "key-0"},
+			input:       &proto.GetSubscriptionRequest{Id: "key-0", EnvironmentNamespace: "ns0"},
 			expectedErr: nil,
 		},
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			service := newNotificationServiceWithMock(t, mockController)
+			service := newNotificationService(mockController, nil, p.orgRole, p.envRole)
 			if p.setup != nil {
 				p.setup(service)
 			}
-			ctx = setToken(t, ctx, true)
+			ctx = setToken(t, ctx, p.isSystemAdmin)
 			actual, err := service.GetSubscription(ctx, p.input)
 			assert.Equal(t, p.expectedErr, err)
 			if err == nil {
@@ -610,15 +626,50 @@ func TestListSubscriptionsMySQL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
 	patterns := []struct {
-		desc        string
-		setup       func(*NotificationService)
-		input       *proto.ListSubscriptionsRequest
-		expected    *proto.ListSubscriptionsResponse
-		expectedErr error
+		desc          string
+		orgRole       *accountproto.AccountV2_Role_Organization
+		envRole       *accountproto.AccountV2_Role_Environment
+		isSystemAdmin bool
+		setup         func(*NotificationService)
+		input         *proto.ListSubscriptionsRequest
+		expected      *proto.ListSubscriptionsResponse
+		expectedErr   error
 	}{
 		{
-			desc: "success",
+			desc:          "err: ErrPermissionDenied",
+			isSystemAdmin: false,
+			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:       toPtr(accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			input: &proto.ListSubscriptionsRequest{
+				PageSize: 2,
+				Cursor:   "",
+				SourceTypes: []proto.Subscription_SourceType{
+					proto.Subscription_DOMAIN_EVENT_ACCOUNT,
+					proto.Subscription_DOMAIN_EVENT_SUBSCRIPTION,
+				},
+				EnvironmentNamespace: "ns0",
+			},
+			expectedErr: createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:          "success",
+			isSystemAdmin: false,
+			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
 				rows := mysqlmock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
@@ -640,6 +691,7 @@ func TestListSubscriptionsMySQL(t *testing.T) {
 					proto.Subscription_DOMAIN_EVENT_ACCOUNT,
 					proto.Subscription_DOMAIN_EVENT_SUBSCRIPTION,
 				},
+				EnvironmentNamespace: "ns0",
 			},
 			expected:    &proto.ListSubscriptionsResponse{Subscriptions: []*proto.Subscription{}, Cursor: "0"},
 			expectedErr: nil,
@@ -647,11 +699,11 @@ func TestListSubscriptionsMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := newNotificationServiceWithMock(t, mockController)
+			s := newNotificationService(mockController, nil, p.orgRole, p.envRole)
 			if p.setup != nil {
 				p.setup(s)
 			}
-			ctx = setToken(t, ctx, true)
+			ctx = setToken(t, ctx, p.isSystemAdmin)
 			actual, err := s.ListSubscriptions(ctx, p.input)
 			assert.Equal(t, p.expectedErr, err)
 			assert.Equal(t, p.expected, actual)
@@ -667,15 +719,50 @@ func TestListEnabledSubscriptionsMySQL(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
 	patterns := []struct {
-		desc        string
-		setup       func(*NotificationService)
-		input       *proto.ListEnabledSubscriptionsRequest
-		expected    *proto.ListEnabledSubscriptionsResponse
-		expectedErr error
+		desc          string
+		orgRole       *accountproto.AccountV2_Role_Organization
+		envRole       *accountproto.AccountV2_Role_Environment
+		isSystemAdmin bool
+		setup         func(*NotificationService)
+		input         *proto.ListEnabledSubscriptionsRequest
+		expected      *proto.ListEnabledSubscriptionsResponse
+		expectedErr   error
 	}{
 		{
-			desc: "success",
+			desc:          "err: ErrPermissionDenied",
+			isSystemAdmin: false,
+			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:       toPtr(accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			input: &proto.ListEnabledSubscriptionsRequest{
+				PageSize: 2,
+				Cursor:   "1",
+				SourceTypes: []proto.Subscription_SourceType{
+					proto.Subscription_DOMAIN_EVENT_ACCOUNT,
+					proto.Subscription_DOMAIN_EVENT_SUBSCRIPTION,
+				},
+				EnvironmentNamespace: "ns0",
+			},
+			expectedErr: createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:          "success",
+			isSystemAdmin: false,
+			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
+			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
 				rows := mysqlmock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
@@ -697,6 +784,7 @@ func TestListEnabledSubscriptionsMySQL(t *testing.T) {
 					proto.Subscription_DOMAIN_EVENT_ACCOUNT,
 					proto.Subscription_DOMAIN_EVENT_SUBSCRIPTION,
 				},
+				EnvironmentNamespace: "ns0",
 			},
 			expected:    &proto.ListEnabledSubscriptionsResponse{Subscriptions: []*proto.Subscription{}, Cursor: "1"},
 			expectedErr: nil,
@@ -704,11 +792,11 @@ func TestListEnabledSubscriptionsMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := newNotificationServiceWithMock(t, mockController)
+			s := newNotificationService(mockController, nil, p.orgRole, p.envRole)
 			if p.setup != nil {
 				p.setup(s)
 			}
-			ctx = setToken(t, ctx, true)
+			ctx = setToken(t, ctx, p.isSystemAdmin)
 			actual, err := s.ListEnabledSubscriptions(ctx, p.input)
 			assert.Equal(t, p.expectedErr, err)
 			assert.Equal(t, p.expected, actual)

--- a/pkg/notification/api/subscription_test.go
+++ b/pkg/notification/api/subscription_test.go
@@ -18,13 +18,14 @@ import (
 	"context"
 	"testing"
 
-	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/metadata"
 	gstatus "google.golang.org/grpc/status"
+
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	v2ss "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2"

--- a/pkg/push/api/api_test.go
+++ b/pkg/push/api/api_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -28,6 +27,8 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/metadata"
 	gstatus "google.golang.org/grpc/status"
+
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 
 	accountclientmock "github.com/bucketeer-io/bucketeer/pkg/account/client/mock"
 	experimentclientmock "github.com/bucketeer-io/bucketeer/pkg/experiment/client/mock"


### PR DESCRIPTION
This pull request contains changes to improve the handling of permissions and roles in the `pkg/experiment/api` and `pkg/notification/api` packages. The most significant changes include the addition of new parameters to the `createExperimentService` function, the removal of the `storage` import in `api_test.go`, and the introduction of a new `toPtr` function. 

resolves https://github.com/bucketeer-io/bucketeer/issues/809

Changes to `createExperimentService` and related functions:

* [`pkg/experiment/api/api_test.go`](diffhunk://#diff-53481da3d90c97f610a448784446e20d2900f41dfe7041a8b543aa3118fc7980L57-R75): The `createExperimentService` function now accepts new parameters for `specifiedEnvironmentId`, `specifiedOrgRole`, and `specifiedEnvRole`. These changes also affect the `TestNewExperimentService` and `createExperimentService` functions. [[1]](diffhunk://#diff-53481da3d90c97f610a448784446e20d2900f41dfe7041a8b543aa3118fc7980L57-R75) [[2]](diffhunk://#diff-53481da3d90c97f610a448784446e20d2900f41dfe7041a8b543aa3118fc7980L79-R101)

* [`pkg/experiment/api/experiment_test.go`](diffhunk://#diff-7bc2bfb4b2d51432a2d4797972811dfec48c57ee2a1fbcb6bcca4ae3256cc88cL94-R94): The `createExperimentService` function is updated in multiple test functions such as `TestGetExperimentMySQL`, `TestListExperimentsMySQL`, `TestCreateExperimentMySQL`, and others. [[1]](diffhunk://#diff-7bc2bfb4b2d51432a2d4797972811dfec48c57ee2a1fbcb6bcca4ae3256cc88cL94-R94) [[2]](diffhunk://#diff-7bc2bfb4b2d51432a2d4797972811dfec48c57ee2a1fbcb6bcca4ae3256cc88cL179-R207) [[3]](diffhunk://#diff-7bc2bfb4b2d51432a2d4797972811dfec48c57ee2a1fbcb6bcca4ae3256cc88cL361-R389) [[4]](diffhunk://#diff-7bc2bfb4b2d51432a2d4797972811dfec48c57ee2a1fbcb6bcca4ae3256cc88cL444-R472)

* [`pkg/experiment/api/goal_test.go`](diffhunk://#diff-46dd4fe08a9a047f232ac846fa0adf51c6c0aa46718fdc16d3ec2bf49247daa4R56-R72): The `createExperimentService` function is updated in multiple test functions such as `TestGetGoalMySQL`, `TestListGoalMySQL`, `TestCreateGoalMySQL`, and others. [[1]](diffhunk://#diff-46dd4fe08a9a047f232ac846fa0adf51c6c0aa46718fdc16d3ec2bf49247daa4R56-R72) [[2]](diffhunk://#diff-46dd4fe08a9a047f232ac846fa0adf51c6c0aa46718fdc16d3ec2bf49247daa4R126-R158) [[3]](diffhunk://#diff-46dd4fe08a9a047f232ac846fa0adf51c6c0aa46718fdc16d3ec2bf49247daa4L225-R272)

Changes to imports:

* [`pkg/experiment/api/api_test.go`](diffhunk://#diff-53481da3d90c97f610a448784446e20d2900f41dfe7041a8b543aa3118fc7980L31): Removed the import for `storage`.
* [`pkg/experiment/api/experiment_test.go`](diffhunk://#diff-7bc2bfb4b2d51432a2d4797972811dfec48c57ee2a1fbcb6bcca4ae3256cc88cL31): Removed the import for `storagetesting`.
* [`pkg/experiment/api/goal_test.go`](diffhunk://#diff-46dd4fe08a9a047f232ac846fa0adf51c6c0aa46718fdc16d3ec2bf49247daa4L30): Removed the import for `storeclient`.

New function:

* [`pkg/experiment/api/api_test.go`](diffhunk://#diff-53481da3d90c97f610a448784446e20d2900f41dfe7041a8b543aa3118fc7980R146-R150): Added a new `toPtr` function to convert values to pointers.

These changes are designed to improve the handling of permissions and roles in the testing of the `pkg/experiment/api` and `pkg/notification/api` packages.