### PR TITLE
refactor: sql query to binary files for Auditlog 

### DIFF
--- a/pkg/auditlog/storage/v2/admin_audit_log.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
@@ -100,18 +101,8 @@ func (s *adminAuditLogStorage) ListAdminAuditLogs(
 	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	var query strings.Builder
-	query.WriteString(selectAdminAuditLogV2SQL)
-	if len(whereSQL) != 0 {
-		query.WriteString(whereSQL)
-	}
-	if len(orderBySQL) != 0 {
-		query.WriteString(orderBySQL)
-	}
-	if len(limitOffsetSQL) != 0 {
-		query.WriteString(limitOffsetSQL)
-	}
-	rows, err := s.qe.QueryContext(ctx, query.String(), whereArgs...)
+	query := fmt.Sprintf(selectAdminAuditLogV2SQL, whereSQL, orderBySQL, limitOffsetSQL)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -143,15 +134,8 @@ func (s *adminAuditLogStorage) ListAdminAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	var countQuery strings.Builder
-	countQuery.WriteString(selectAdminAuditLogV2CountSQL)
-	if len(whereSQL) != 0 {
-		countQuery.WriteString(whereSQL)
-	}
-	if len(orderBySQL) != 0 {
-		countQuery.WriteString(orderBySQL)
-	}
-	err = s.qe.QueryRowContext(ctx, countQuery.String(), whereArgs...).Scan(&totalCount)
+	countQuery := fmt.Sprintf(selectAdminAuditLogV2CountSQL, whereSQL, orderBySQL)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/admin_audit_log_test.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log_test.go
@@ -19,12 +19,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/auditlog"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 )
 
 func TestNewAdminSubscriptionStorage(t *testing.T) {

--- a/pkg/auditlog/storage/v2/admin_audit_log_test.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log_test.go
@@ -19,13 +19,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/auditlog"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNewAdminSubscriptionStorage(t *testing.T) {
@@ -40,6 +39,9 @@ func TestCreateAdminAuditLogs(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
+
+	id0 := "id-0"
+	id1 := "id-1"
 	patterns := []struct {
 		desc        string
 		setup       func(*adminAuditLogStorage)
@@ -82,12 +84,15 @@ func TestCreateAdminAuditLogs(t *testing.T) {
 			desc: "Success",
 			setup: func(s *adminAuditLogStorage) {
 				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(),
+					gomock.Regex("^INSERT INTO admin_audit_log\\s+\\(\\s*id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options\\s*\\)\\s+VALUES\\s*\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\),\\s*\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\)$"),
+					id0, int64(1), int32(2), "e0", int32(3), gomock.Any(), gomock.Any(), gomock.Any(),
+					id1, int64(10), int32(3), "e2", int32(4), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
 			input: []*domain.AuditLog{
-				{AuditLog: &proto.AuditLog{Id: "id-0"}},
-				{AuditLog: &proto.AuditLog{Id: "id-1"}},
+				{AuditLog: &proto.AuditLog{Id: id0, Timestamp: 1, EntityType: 2, EntityId: "e0", Type: 3}, EnvironmentNamespace: "ns0"},
+				{AuditLog: &proto.AuditLog{Id: id1, Timestamp: 10, EntityType: 3, EntityId: "e2", Type: 4}, EnvironmentNamespace: "ns1"},
 			},
 			expectedErr: nil,
 		},
@@ -108,16 +113,22 @@ func TestListAdminAuditLogs(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
+
+	getSize := 2
+	offset := 5
+	limit := 10
+	timestamp := 4
+	entityType := 2
 	patterns := []struct {
-		desc           string
-		setup          func(*adminAuditLogStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
-		expected       []*proto.AuditLog
-		expectedCursor int
-		expectedErr    error
+		desc                string
+		setup               func(*adminAuditLogStorage)
+		whereParts          []mysql.WherePart
+		orders              []*mysql.Order
+		limit               int
+		offset              int
+		expectedResultCount int
+		expectedCursor      int
+		expectedErr         error
 	}{
 		{
 			desc: "Error",
@@ -126,39 +137,79 @@ func TestListAdminAuditLogs(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
-			expected:       nil,
-			expectedCursor: 0,
-			expectedErr:    errors.New("error"),
+			whereParts:          nil,
+			orders:              nil,
+			limit:               0,
+			offset:              0,
+			expectedResultCount: 0,
+			expectedCursor:      0,
+			expectedErr:         errors.New("error"),
 		},
 		{
-			desc: "Success",
+			desc: "Success: No whereParts and no orderParts and no limit and no offset",
 			setup: func(s *adminAuditLogStorage) {
 				rows := mock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
 				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options\\s+FROM\\s+admin_audit_log\\s*$"),
+					[]interface{}{},
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
 				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+COUNT\\(1\\)\\s+FROM\\s+admin_audit_log\\s*$"),
+					[]interface{}{},
 				).Return(row)
 			},
-			whereParts: nil,
+			whereParts:          nil,
+			orders:              nil,
+			limit:               0,
+			offset:              0,
+			expectedResultCount: 0,
+			expectedCursor:      0,
+		},
+		{
+			desc: "Success",
+			setup: func(s *adminAuditLogStorage) {
+				var nextCallCount = 0
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().DoAndReturn(func() bool {
+					nextCallCount++
+					return nextCallCount <= getSize
+				}).Times(getSize + 1)
+				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options\\s+FROM\\s+admin_audit_log\\s+WHERE timestamp >= \\? AND entity_type = \\? ORDER BY id ASC, timestamp DESC LIMIT 10 OFFSET 5\\s*$"),
+					timestamp, entityType,
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+COUNT\\(1\\)\\s+FROM\\s+admin_audit_log\\s+WHERE timestamp >= \\? AND entity_type = \\? ORDER BY id ASC, timestamp DESC\\s*$"),
+					timestamp, entityType,
+				).Return(row)
+			},
+			whereParts: []mysql.WherePart{
+				mysql.NewFilter("timestamp", ">=", timestamp),
+				mysql.NewFilter("entity_type", "=", entityType),
+			},
 			orders: []*mysql.Order{
+				mysql.NewOrder("id", mysql.OrderDirectionAsc),
 				mysql.NewOrder("timestamp", mysql.OrderDirectionDesc),
 			},
-			limit:          10,
-			offset:         5,
-			expected:       []*proto.AuditLog{},
-			expectedCursor: 5,
-			expectedErr:    nil,
+			limit:               limit,
+			offset:              offset,
+			expectedResultCount: getSize,
+			expectedCursor:      offset + getSize,
+			expectedErr:         nil,
 		},
 	}
 	for _, p := range patterns {
@@ -174,7 +225,10 @@ func TestListAdminAuditLogs(t *testing.T) {
 				p.limit,
 				p.offset,
 			)
-			assert.Equal(t, p.expected, auditLogs)
+			assert.Equal(t, p.expectedResultCount, len(auditLogs))
+			if auditLogs != nil {
+				assert.IsType(t, auditLogs, []*proto.AuditLog{})
+			}
 			assert.Equal(t, p.expectedCursor, cursor)
 			assert.Equal(t, p.expectedErr, err)
 		})

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -104,15 +104,12 @@ func (s *auditLogStorage) ListAuditLogs(
 	var query strings.Builder
 	query.WriteString(selectAuditLogV2SQL)
 	if len(whereArgs) != 0 {
-		query.WriteString(" ")
 		query.WriteString(whereSQL)
 	}
 	if len(orderBySQL) != 0 {
-		query.WriteString(" ")
 		query.WriteString(orderBySQL)
 	}
 	if len(limitOffsetSQL) != 0 {
-		query.WriteString(" ")
 		query.WriteString(limitOffsetSQL)
 	}
 	rows, err := s.qe.QueryContext(ctx, query.String(), whereArgs...)
@@ -150,11 +147,9 @@ func (s *auditLogStorage) ListAuditLogs(
 	var countQuery strings.Builder
 	countQuery.WriteString(selectAuditLogV2CountSQL)
 	if len(whereArgs) != 0 {
-		countQuery.WriteString(" ")
 		countQuery.WriteString(whereSQL)
 	}
 	if len(orderBySQL) != 0 {
-		countQuery.WriteString(" ")
 		countQuery.WriteString(orderBySQL)
 	}
 	err = s.qe.QueryRowContext(ctx, countQuery.String(), whereArgs...).Scan(&totalCount)

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
@@ -100,18 +101,8 @@ func (s *auditLogStorage) ListAuditLogs(
 	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	var query strings.Builder
-	query.WriteString(selectAuditLogV2SQL)
-	if len(whereArgs) != 0 {
-		query.WriteString(whereSQL)
-	}
-	if len(orderBySQL) != 0 {
-		query.WriteString(orderBySQL)
-	}
-	if len(limitOffsetSQL) != 0 {
-		query.WriteString(limitOffsetSQL)
-	}
-	rows, err := s.qe.QueryContext(ctx, query.String(), whereArgs...)
+	query := fmt.Sprintf(selectAuditLogV2SQL, whereSQL, orderBySQL, limitOffsetSQL)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -143,15 +134,8 @@ func (s *auditLogStorage) ListAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	var countQuery strings.Builder
-	countQuery.WriteString(selectAuditLogV2CountSQL)
-	if len(whereArgs) != 0 {
-		countQuery.WriteString(whereSQL)
-	}
-	if len(orderBySQL) != 0 {
-		countQuery.WriteString(orderBySQL)
-	}
-	err = s.qe.QueryRowContext(ctx, countQuery.String(), whereArgs...).Scan(&totalCount)
+	countQuery := fmt.Sprintf(selectAuditLogV2CountSQL, whereSQL, orderBySQL)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -17,6 +17,7 @@ package v2
 
 import (
 	"context"
+	_ "embed"
 	"errors"
 	"fmt"
 	"strings"
@@ -29,6 +30,12 @@ import (
 
 var (
 	ErrAuditLogAlreadyExists = errors.New("auditlog: auditlog already exists")
+	//go:embed sql/auditlog/insert_audit_log_v2.sql
+	insertAuditLogV2SQL string
+	//go:embed sql/auditlog/select_audit_log_v2.sql
+	selectAuditLogV2SQL string
+	//go:embed sql/auditlog/select_audit_log_v2_count.sql
+	selectAuditLogV2CountSQL string
 )
 
 type AuditLogStorage interface {
@@ -54,23 +61,12 @@ func (s *auditLogStorage) CreateAuditLogs(ctx context.Context, auditLogs []*doma
 		return nil
 	}
 	var query strings.Builder
-	query.WriteString(`
-		INSERT INTO audit_log (
-			id,
-			timestamp,
-			entity_type,
-			entity_id,
-			type,
-			event,
-			editor,
-			options,
-			environment_namespace
-		) VALUES
-	`)
 	args := []interface{}{}
 	for i, al := range auditLogs {
 		if i != 0 {
 			query.WriteString(",")
+		} else {
+			query.WriteString(insertAuditLogV2SQL)
 		}
 		query.WriteString(" (?, ?, ?, ?, ?, ?, ?, ?, ?)")
 		args = append(
@@ -105,22 +101,21 @@ func (s *auditLogStorage) ListAuditLogs(
 	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	query := fmt.Sprintf(`
-		SELECT
-			id,
-			timestamp,
-			entity_type,
-			entity_id,
-			type,
-			event,
-			editor,
-			options
-		FROM
-			audit_log
-		%s %s %s
-		`, whereSQL, orderBySQL, limitOffsetSQL,
-	)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	var query strings.Builder
+	query.WriteString(selectAuditLogV2SQL)
+	if len(whereArgs) != 0 {
+		query.WriteString(" ")
+		query.WriteString(whereSQL)
+	}
+	if len(orderBySQL) != 0 {
+		query.WriteString(" ")
+		query.WriteString(orderBySQL)
+	}
+	if len(limitOffsetSQL) != 0 {
+		query.WriteString(" ")
+		query.WriteString(limitOffsetSQL)
+	}
+	rows, err := s.qe.QueryContext(ctx, query.String(), whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -152,15 +147,17 @@ func (s *auditLogStorage) ListAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	countQuery := fmt.Sprintf(`
-		SELECT
-			COUNT(1)
-		FROM
-			audit_log
-		%s %s
-		`, whereSQL, orderBySQL,
-	)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	var countQuery strings.Builder
+	countQuery.WriteString(selectAuditLogV2CountSQL)
+	if len(whereArgs) != 0 {
+		countQuery.WriteString(" ")
+		countQuery.WriteString(whereSQL)
+	}
+	if len(orderBySQL) != 0 {
+		countQuery.WriteString(" ")
+		countQuery.WriteString(orderBySQL)
+	}
+	err = s.qe.QueryRowContext(ctx, countQuery.String(), whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/audit_log_test.go
+++ b/pkg/auditlog/storage/v2/audit_log_test.go
@@ -19,13 +19,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/auditlog"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNewSubscriptionStorage(t *testing.T) {
@@ -40,6 +39,9 @@ func TestCreateAuditLogs(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
+
+	id0 := "id-0"
+	id1 := "id-1"
 	patterns := []struct {
 		desc        string
 		setup       func(*auditLogStorage)
@@ -54,8 +56,8 @@ func TestCreateAuditLogs(t *testing.T) {
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
 			input: []*domain.AuditLog{
-				{AuditLog: &proto.AuditLog{Id: "id-0"}},
-				{AuditLog: &proto.AuditLog{Id: "id-1"}},
+				{AuditLog: &proto.AuditLog{Id: id0}},
+				{AuditLog: &proto.AuditLog{Id: id1}},
 			},
 			expectedErr: ErrAuditLogAlreadyExists,
 		},
@@ -67,8 +69,8 @@ func TestCreateAuditLogs(t *testing.T) {
 				).Return(nil, errors.New("error"))
 			},
 			input: []*domain.AuditLog{
-				{AuditLog: &proto.AuditLog{Id: "id-0"}},
-				{AuditLog: &proto.AuditLog{Id: "id-1"}},
+				{AuditLog: &proto.AuditLog{Id: id0}},
+				{AuditLog: &proto.AuditLog{Id: id1}},
 			},
 			expectedErr: errors.New("error"),
 		},
@@ -82,12 +84,17 @@ func TestCreateAuditLogs(t *testing.T) {
 			desc: "Success",
 			setup: func(s *auditLogStorage) {
 				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(),
+					gomock.Regex("^INSERT INTO audit_log\\s+\\(\\s*id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options,\\s*environment_namespace\\s*\\)\\s+VALUES\\s*\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\),\\s*\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\)$"),
+					[]interface{}{
+						id0, int64(1), int32(2), "e0", int32(3), mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, "ns0",
+						id1, int64(10), int32(3), "e2", int32(4), mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, "ns1",
+					},
 				).Return(nil, nil)
 			},
 			input: []*domain.AuditLog{
-				{AuditLog: &proto.AuditLog{Id: "id-0"}},
-				{AuditLog: &proto.AuditLog{Id: "id-1"}},
+				{AuditLog: &proto.AuditLog{Id: id0, Timestamp: 1, EntityType: 2, EntityId: "e0", Type: 3}, EnvironmentNamespace: "ns0"},
+				{AuditLog: &proto.AuditLog{Id: id1, Timestamp: 10, EntityType: 3, EntityId: "e2", Type: 4}, EnvironmentNamespace: "ns1"},
 			},
 			expectedErr: nil,
 		},
@@ -108,16 +115,23 @@ func TestListAuditLogs(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
+
+	getSize := 2
+	offset := 5
+	limit := 10
+	timestamp := 4
+	entityType := 2
+
 	patterns := []struct {
-		desc           string
-		setup          func(*auditLogStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
-		expected       []*proto.AuditLog
-		expectedCursor int
-		expectedErr    error
+		desc                string
+		setup               func(*auditLogStorage)
+		whereParts          []mysql.WherePart
+		orders              []*mysql.Order
+		limit               int
+		offset              int
+		expectedResultCount int
+		expectedCursor      int
+		expectedErr         error
 	}{
 		{
 			desc: "Error",
@@ -126,39 +140,81 @@ func TestListAuditLogs(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
-			expected:       nil,
-			expectedCursor: 0,
-			expectedErr:    errors.New("error"),
+			whereParts:          nil,
+			orders:              nil,
+			limit:               0,
+			offset:              0,
+			expectedResultCount: 0,
+			expectedCursor:      0,
+			expectedErr:         errors.New("error"),
 		},
 		{
-			desc: "Success",
+			desc: "Success:No wereParts and no orderParts and no limit and no offset",
 			setup: func(s *auditLogStorage) {
 				rows := mock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
 				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options\\s+FROM\\s+audit_log\\s*$"),
+					[]interface{}{},
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
 				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+COUNT\\(1\\)\\s+FROM\\s+audit_log\\s*$"),
+					[]interface{}{},
 				).Return(row)
 			},
-			whereParts: nil,
+			whereParts:          nil,
+			orders:              nil,
+			limit:               0,
+			offset:              0,
+			expectedResultCount: 0,
+			expectedCursor:      0,
+			expectedErr:         nil,
+		},
+		{
+			desc: "Success",
+			setup: func(s *auditLogStorage) {
+				var nextCallCount = 0
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().DoAndReturn(func() bool {
+					nextCallCount++
+					return nextCallCount <= getSize
+				}).Times(getSize + 1)
+				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options\\s+FROM\\s+audit_log\\s+WHERE timestamp >= \\? AND entity_type = \\? ORDER BY id ASC, timestamp DESC LIMIT 10 OFFSET 5\\s*$"),
+					timestamp, entityType,
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Regex("^SELECT\\s+COUNT\\(1\\)\\s+FROM\\s+audit_log\\s+WHERE timestamp >= \\? AND entity_type = \\? ORDER BY id ASC, timestamp DESC\\s*$"),
+					timestamp, entityType,
+				).Return(row)
+			},
+			whereParts: []mysql.WherePart{
+				mysql.NewFilter("timestamp", ">=", timestamp),
+				mysql.NewFilter("entity_type", "=", entityType),
+			},
+
 			orders: []*mysql.Order{
+				mysql.NewOrder("id", mysql.OrderDirectionAsc),
 				mysql.NewOrder("timestamp", mysql.OrderDirectionDesc),
 			},
-			limit:          10,
-			offset:         5,
-			expected:       []*proto.AuditLog{},
-			expectedCursor: 5,
-			expectedErr:    nil,
+			limit:               limit,
+			offset:              offset,
+			expectedResultCount: getSize,
+			expectedCursor:      offset + getSize,
+			expectedErr:         nil,
 		},
 	}
 	for _, p := range patterns {
@@ -174,7 +230,10 @@ func TestListAuditLogs(t *testing.T) {
 				p.limit,
 				p.offset,
 			)
-			assert.Equal(t, p.expected, auditLogs)
+			assert.Equal(t, p.expectedResultCount, len(auditLogs))
+			if len(auditLogs) > 0 {
+				assert.IsType(t, auditLogs, []*proto.AuditLog{})
+			}
 			assert.Equal(t, p.expectedCursor, cursor)
 			assert.Equal(t, p.expectedErr, err)
 		})

--- a/pkg/auditlog/storage/v2/audit_log_test.go
+++ b/pkg/auditlog/storage/v2/audit_log_test.go
@@ -19,12 +19,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/auditlog"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 )
 
 func TestNewSubscriptionStorage(t *testing.T) {

--- a/pkg/auditlog/storage/v2/audit_log_test.go
+++ b/pkg/auditlog/storage/v2/audit_log_test.go
@@ -86,10 +86,8 @@ func TestCreateAuditLogs(t *testing.T) {
 				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Regex("^INSERT INTO audit_log\\s+\\(\\s*id,\\s*timestamp,\\s*entity_type,\\s*entity_id,\\s*type,\\s*event,\\s*editor,\\s*options,\\s*environment_namespace\\s*\\)\\s+VALUES\\s*\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\),\\s*\\(\\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?, \\?\\)$"),
-					[]interface{}{
-						id0, int64(1), int32(2), "e0", int32(3), mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, "ns0",
-						id1, int64(10), int32(3), "e2", int32(4), mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, mysql.JSONObject{Val: nil}, "ns1",
-					},
+					id0, int64(1), int32(2), "e0", int32(3), gomock.Any(), gomock.Any(), gomock.Any(), "ns0",
+					id1, int64(10), int32(3), "e2", int32(4), gomock.Any(), gomock.Any(), gomock.Any(), "ns1",
 				).Return(nil, nil)
 			},
 			input: []*domain.AuditLog{
@@ -149,7 +147,7 @@ func TestListAuditLogs(t *testing.T) {
 			expectedErr:         errors.New("error"),
 		},
 		{
-			desc: "Success:No wereParts and no orderParts and no limit and no offset",
+			desc: "Success:No whereParts and no orderParts and no limit and no offset",
 			setup: func(s *auditLogStorage) {
 				rows := mock.NewMockRows(mockController)
 				rows.EXPECT().Close().Return(nil)
@@ -205,7 +203,6 @@ func TestListAuditLogs(t *testing.T) {
 				mysql.NewFilter("timestamp", ">=", timestamp),
 				mysql.NewFilter("entity_type", "=", entityType),
 			},
-
 			orders: []*mysql.Order{
 				mysql.NewOrder("id", mysql.OrderDirectionAsc),
 				mysql.NewOrder("timestamp", mysql.OrderDirectionDesc),
@@ -231,7 +228,7 @@ func TestListAuditLogs(t *testing.T) {
 				p.offset,
 			)
 			assert.Equal(t, p.expectedResultCount, len(auditLogs))
-			if len(auditLogs) > 0 {
+			if auditLogs != nil {
 				assert.IsType(t, auditLogs, []*proto.AuditLog{})
 			}
 			assert.Equal(t, p.expectedCursor, cursor)

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/insert_admin_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/insert_admin_audit_log_v2.sql
@@ -1,0 +1,10 @@
+INSERT INTO admin_audit_log (
+    id,
+    timestamp,
+    entity_type,
+    entity_id,
+    type,
+    event,
+    editor,
+    options
+) VALUES

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2.sql
@@ -9,3 +9,4 @@ SELECT
     options
 FROM
     admin_audit_log
+    %s %s %s

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2.sql
@@ -1,0 +1,11 @@
+SELECT
+    id,
+    timestamp,
+    entity_type,
+    entity_id,
+    type,
+    event,
+    editor,
+    options
+FROM
+    admin_audit_log

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2_count.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2_count.sql
@@ -1,0 +1,4 @@
+SELECT
+    COUNT(1)
+FROM
+    admin_audit_log

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2_count.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2_count.sql
@@ -2,3 +2,4 @@ SELECT
     COUNT(1)
 FROM
     admin_audit_log
+    %s %s

--- a/pkg/auditlog/storage/v2/sql/auditlog/insert_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/insert_audit_log_v2.sql
@@ -1,0 +1,11 @@
+INSERT INTO audit_log (
+    id,
+    timestamp,
+    entity_type,
+    entity_id,
+    type,
+    event,
+    editor,
+    options,
+    environment_namespace
+) VALUES

--- a/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2.sql
@@ -1,0 +1,11 @@
+SELECT
+    id,
+    timestamp,
+    entity_type,
+    entity_id,
+    type,
+    event,
+    editor,
+    options
+FROM
+    audit_log

--- a/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2.sql
@@ -9,3 +9,4 @@ SELECT
     options
 FROM
     audit_log
+    %s %s %s

--- a/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2_count.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2_count.sql
@@ -2,3 +2,4 @@ SELECT
     COUNT(1)
 FROM
     audit_log
+    %s %s

--- a/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2_count.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2_count.sql
@@ -1,0 +1,4 @@
+SELECT
+    COUNT(1)
+FROM
+    audit_log

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -227,7 +227,7 @@ func ConstructWhereSQLString(wps []WherePart) (sql string, args []interface{}) {
 		return "", nil
 	}
 	var sb strings.Builder
-	sb.WriteString(" WHERE ")
+	sb.WriteString("WHERE ")
 	for i, wp := range wps {
 		if i != 0 {
 			sb.WriteString(" AND ")
@@ -276,7 +276,7 @@ func ConstructOrderBySQLString(orders []*Order) string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString(" ORDER BY ")
+	sb.WriteString("ORDER BY ")
 	for i, o := range orders {
 		if i != 0 {
 			sb.WriteString(", ")
@@ -302,10 +302,10 @@ func ConstructLimitOffsetSQLString(limit, offset int) string {
 		return ""
 	}
 	if limit == QueryNoLimit && offset != QueryNoOffset {
-		return fmt.Sprintf(" LIMIT %d OFFSET %d", queryLimitAllRows, offset)
+		return fmt.Sprintf("LIMIT %d OFFSET %d", queryLimitAllRows, offset)
 	}
 	if limit != QueryNoLimit && offset == QueryNoOffset {
-		return fmt.Sprintf(" LIMIT %d", limit)
+		return fmt.Sprintf("LIMIT %d", limit)
 	}
-	return fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
+	return fmt.Sprintf("LIMIT %d OFFSET %d", limit, offset)
 }

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -227,7 +227,7 @@ func ConstructWhereSQLString(wps []WherePart) (sql string, args []interface{}) {
 		return "", nil
 	}
 	var sb strings.Builder
-	sb.WriteString("WHERE ")
+	sb.WriteString(" WHERE ")
 	for i, wp := range wps {
 		if i != 0 {
 			sb.WriteString(" AND ")
@@ -276,7 +276,7 @@ func ConstructOrderBySQLString(orders []*Order) string {
 		return ""
 	}
 	var sb strings.Builder
-	sb.WriteString("ORDER BY ")
+	sb.WriteString(" ORDER BY ")
 	for i, o := range orders {
 		if i != 0 {
 			sb.WriteString(", ")
@@ -302,10 +302,10 @@ func ConstructLimitOffsetSQLString(limit, offset int) string {
 		return ""
 	}
 	if limit == QueryNoLimit && offset != QueryNoOffset {
-		return fmt.Sprintf("LIMIT %d OFFSET %d", queryLimitAllRows, offset)
+		return fmt.Sprintf(" LIMIT %d OFFSET %d", queryLimitAllRows, offset)
 	}
 	if limit != QueryNoLimit && offset == QueryNoOffset {
-		return fmt.Sprintf("LIMIT %d", limit)
+		return fmt.Sprintf(" LIMIT %d", limit)
 	}
-	return fmt.Sprintf("LIMIT %d OFFSET %d", limit, offset)
+	return fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
 }

--- a/pkg/storage/v2/mysql/query_test.go
+++ b/pkg/storage/v2/mysql/query_test.go
@@ -276,7 +276,7 @@ func TestConstructWhereSQLString(t *testing.T) {
 				NewFilter("name", "=", "feature"),
 				NewJSONFilter("enums", JSONContainsNumber, []interface{}{1, 3}),
 			},
-			expectedSQL:  " WHERE name = ? AND JSON_CONTAINS(enums, ?)",
+			expectedSQL:  "WHERE name = ? AND JSON_CONTAINS(enums, ?)",
 			expectedArgs: []interface{}{"feature", "[1, 3]"},
 		},
 	}
@@ -307,7 +307,7 @@ func TestConstructOrderBySQLString(t *testing.T) {
 				NewOrder("created_at", OrderDirectionDesc),
 				NewOrder("id", OrderDirectionAsc),
 			},
-			expectedSQL: " ORDER BY created_at DESC, id ASC",
+			expectedSQL: "ORDER BY created_at DESC, id ASC",
 		},
 	}
 	for _, p := range patterns {
@@ -336,19 +336,19 @@ func TestConstructLimitOffsetSQLString(t *testing.T) {
 			desc:        "no limit & offset",
 			limit:       0,
 			offset:      5,
-			expectedSQL: " LIMIT 9223372036854775807 OFFSET 5",
+			expectedSQL: "LIMIT 9223372036854775807 OFFSET 5",
 		},
 		{
 			desc:        "limit & no offset",
 			limit:       10,
 			offset:      0,
-			expectedSQL: " LIMIT 10",
+			expectedSQL: "LIMIT 10",
 		},
 		{
 			desc:        "limit & offset",
 			limit:       10,
 			offset:      5,
-			expectedSQL: " LIMIT 10 OFFSET 5",
+			expectedSQL: "LIMIT 10 OFFSET 5",
 		},
 	}
 	for _, p := range patterns {

--- a/pkg/storage/v2/mysql/query_test.go
+++ b/pkg/storage/v2/mysql/query_test.go
@@ -276,7 +276,7 @@ func TestConstructWhereSQLString(t *testing.T) {
 				NewFilter("name", "=", "feature"),
 				NewJSONFilter("enums", JSONContainsNumber, []interface{}{1, 3}),
 			},
-			expectedSQL:  "WHERE name = ? AND JSON_CONTAINS(enums, ?)",
+			expectedSQL:  " WHERE name = ? AND JSON_CONTAINS(enums, ?)",
 			expectedArgs: []interface{}{"feature", "[1, 3]"},
 		},
 	}
@@ -307,7 +307,7 @@ func TestConstructOrderBySQLString(t *testing.T) {
 				NewOrder("created_at", OrderDirectionDesc),
 				NewOrder("id", OrderDirectionAsc),
 			},
-			expectedSQL: "ORDER BY created_at DESC, id ASC",
+			expectedSQL: " ORDER BY created_at DESC, id ASC",
 		},
 	}
 	for _, p := range patterns {
@@ -336,19 +336,19 @@ func TestConstructLimitOffsetSQLString(t *testing.T) {
 			desc:        "no limit & offset",
 			limit:       0,
 			offset:      5,
-			expectedSQL: "LIMIT 9223372036854775807 OFFSET 5",
+			expectedSQL: " LIMIT 9223372036854775807 OFFSET 5",
 		},
 		{
 			desc:        "limit & no offset",
 			limit:       10,
 			offset:      0,
-			expectedSQL: "LIMIT 10",
+			expectedSQL: " LIMIT 10",
 		},
 		{
 			desc:        "limit & offset",
 			limit:       10,
 			offset:      5,
-			expectedSQL: "LIMIT 10 OFFSET 5",
+			expectedSQL: " LIMIT 10 OFFSET 5",
 		},
 	}
 	for _, p := range patterns {


### PR DESCRIPTION
This pull request primarily focuses on improving the code quality and maintainability of the `pkg/auditlog/storage/v2` package. The changes include the use of embedded SQL files for query strings, simplification of query construction, and updates to the corresponding tests to reflect these changes.

resolve https://github.com/bucketeer-io/bucketeer/issues/850

Here are the most important changes:

Embedding SQL files and using them in the code:
* [`pkg/auditlog/storage/v2/admin_audit_log.go`](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122R32-R38): Embedded SQL files for insert, select, and count operations, and used them in the corresponding methods. [[1]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122R32-R38) [[2]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L57-R69) [[3]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L106-R114) [[4]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L153-R154)
* [`pkg/auditlog/storage/v2/audit_log.go`](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebR33-R38): Similar changes as in `admin_audit_log.go`. [[1]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebR33-R38) [[2]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL57-R69) [[3]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL108-R115) [[4]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL155-R155)

Simplification of query construction:
* [`pkg/auditlog/storage/v2/admin_audit_log.go`](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L57-R69): Replaced `fmt.Sprintf` with `strings.Builder` for constructing SQL queries. [[1]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L57-R69) [[2]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L106-R114) [[3]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122L153-R154)
* [`pkg/auditlog/storage/v2/audit_log.go`](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL57-R69): Similar changes as in `admin_audit_log.go`. [[1]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL57-R69) [[2]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL108-R115) [[3]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebL155-R155)

Test updates to reflect the above changes:
* [`pkg/auditlog/storage/v2/admin_audit_log_test.go`](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286R42-R44): Updated the tests to reflect the changes in `admin_audit_log.go` and improved the test cases. [[1]](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286R42-R44) [[2]](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286L85-R95) [[3]](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286R116-R129) [[4]](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286L133-R211) [[5]](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286L177-R231)
* [`pkg/auditlog/storage/v2/audit_log_test.go`](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eR42-R44): Similar changes as in `admin_audit_log_test.go`. [[1]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eR42-R44) [[2]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eL57-R60) [[3]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eL70-R73) [[4]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eL85-R95) [[5]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eR116-R130) [[6]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eL133-R213)

Minor changes:
* `pkg/auditlog/storage/v2/admin_audit_log.go` and `pkg/auditlog/storage/v2/audit_log.go`: Imported the `embed` package. [[1]](diffhunk://#diff-cc43acba578843c53b12f2caeadc05475659808cc2221e0e25414681145f9122R20-L21) [[2]](diffhunk://#diff-993585632f08dbcb4070ef876f0ba9eb23a7539a746f4e03ab0af084a67e81ebR20)
* `pkg/auditlog/storage/v2/admin_audit_log_test.go` and `pkg/auditlog/storage/v2/audit_log_test.go`: Rearranged the import statements. [[1]](diffhunk://#diff-981238e7c92d73b854d83b1da6ba60524da8f225b932f349608bf36ba34c2286L22-R27) [[2]](diffhunk://#diff-621de6e371133e0da6881694548f6fd7aeb21c7ec7f31e199e49036cc7f2b16eL22-R27)