### PR TITLE
feat: move segment persister to batch service

### DIFF
--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -69,6 +69,8 @@ spec:
               value: "{{ .Values.env.featureService }}"
             - name: BUCKETEER_BATCH_EXPERIMENT_CALCULATOR_SERVICE
               value: "{{ .Values.env.experimentCalculatorService }}"
+            - name: BUCKETEER_BATCH_BATCH_SERVICE
+              value: "{{ .Values.env.batchService }}"
             - name: BUCKETEER_OPS_EVENT_SCHEDULE_COUNT_WATCHER
               value: "{{ .Values.env.scheduleCountWatcher }}"
             - name: BUCKETEER_OPS_EVENT_SCHEDULE_DATETIME_WATCHER
@@ -103,6 +105,8 @@ spec:
               value: /usr/local/certs/service/tls.crt
             - name : BUCKETEER_BATCH_SUBSCRIBER_CONFIG
               value: /usr/local/conf/subscribers.json
+            - name: BUCKETEER_BATCH_PROCESSORS_CONFIG
+              value: /usr/local/conf/processors.json
             - name: BUCKETEER_BATCH_KEY
               value: /usr/local/certs/service/tls.key
             - name: BUCKETEER_BATCH_TIMEZONE

--- a/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
@@ -310,6 +310,18 @@ data:
                                   - name: content-type
                                     string_match:
                                       exact: application/grpc
+                                prefix: /bucketeer.batch.BatchService
+                              route:
+                                cluster: batch
+                                timeout: 30s
+                                retry_policy:
+                                  num_retries: 3
+                                  retry_on: 5xx
+                            - match:
+                                headers:
+                                  - name: content-type
+                                    string_match:
+                                      exact: application/grpc
                                 prefix: /bucketeer.feature.FeatureService
                               route:
                                 cluster: backend

--- a/manifests/bucketeer/charts/batch/templates/subscribers-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/subscribers-configmap.yaml
@@ -11,3 +11,6 @@ metadata:
 data:
   subscribers.json: |-
     {{ toJson .Values.subscribers }}
+
+  processors.json: |-
+    {{ toJson .Values.processors }}

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -158,8 +158,8 @@ subscribers:
     pullerMaxOutstandingMessages: 1000
     pullerMaxOutstandingBytes: 1000000000
     maxMps: 50
-    workerNum: 5
-  segmentPersister:
+    workerNum: 1
+  segmentUserPersister:
     project:
     topic:
     subscription:
@@ -167,13 +167,13 @@ subscribers:
     pullerMaxOutstandingMessages: 1000
     pullerMaxOutstandingBytes: 1000000000
     maxMps: 50
-    workerNum: 5
+    workerNum: 1
 
 # This configuration is used for add custom params to Processors
 processors:
   # This is the processor's name. It must match the same name defined in the
   # pkg/batch/subscriber/processor/processors.go
-  segmentPersister:
+  segmentUserPersister:
     domainEventProject:
     domainEventTopic:
     flushSize: 100

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -21,6 +21,7 @@ env:
   eventCounterService: localhost:9001
   featureService: localhost:9001
   experimentCalculatorService: localhost:9001
+  batchService: localhost:9001
   webURL:
   logLevel: info
   port: 9090
@@ -157,3 +158,21 @@ subscribers:
     pullerMaxOutstandingMessages: 1000
     pullerMaxOutstandingBytes: 1000000000
     maxMps: 50
+    workerNum: 5
+  segmentPersister:
+    project:
+    topic:
+    subscription:
+    pullerNumGoroutines: 5
+    pullerMaxOutstandingMessages: 1000
+    pullerMaxOutstandingBytes: 1000000000
+    maxMps: 50
+    workerNum: 5
+
+# This configuration is used for add custom params to Processors
+processors:
+  # This is the processor's name. It must match the same name defined in the
+  # pkg/batch/subscriber/processor/processors.go
+  segmentPersister:
+    flushSize: 100
+    flushInterval: 10

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -174,5 +174,7 @@ processors:
   # This is the processor's name. It must match the same name defined in the
   # pkg/batch/subscriber/processor/processors.go
   segmentPersister:
+    domainEventProject:
+    domainEventTopic:
     flushSize: 100
     flushInterval: 10

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -26,6 +26,7 @@ import (
 	acclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
 	autoopsclient "github.com/bucketeer-io/bucketeer/pkg/autoops/client"
 	"github.com/bucketeer-io/bucketeer/pkg/batch/api"
+	btclient "github.com/bucketeer-io/bucketeer/pkg/batch/client"
 	"github.com/bucketeer-io/bucketeer/pkg/batch/jobs"
 	cacher "github.com/bucketeer-io/bucketeer/pkg/batch/jobs/cacher"
 	"github.com/bucketeer-io/bucketeer/pkg/batch/jobs/calculator"
@@ -57,9 +58,11 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 )
 
-const command = "server"
-
-var serverShutDownTimeout = 10 * time.Second
+const (
+	command               = "server"
+	clientDialTimeout     = 30 * time.Second
+	serverShutDownTimeout = 10 * time.Second
+)
 
 type server struct {
 	*kingpin.CmdClause
@@ -87,8 +90,10 @@ type server struct {
 	featureService              *string
 	notificationService         *string
 	experimentCalculatorService *string
+	batchService                *string
 	// PubSub config
 	subscriberConfig *string
+	processorsConfig *string
 	// Persistent Redis
 	persistentRedisServerName    *string
 	persistentRedisAddr          *string
@@ -153,9 +158,17 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"experiment-calculator-service",
 			"bucketeer-experiment-calculator-service address.",
 		).Default("experiment-calculator:9090").String(),
+		batchService: cmd.Flag(
+			"batch-service",
+			"bucketeer-batch-service address.",
+		).Default("localhost:9001").String(),
 		subscriberConfig: cmd.Flag(
 			"subscriber-config",
 			"Path to subscribers config.",
+		).Required().String(),
+		processorsConfig: cmd.Flag(
+			"processors-config",
+			"Path to processors config.",
 		).Required().String(),
 		persistentRedisServerName: cmd.Flag(
 			"persistent-redis-server-name",
@@ -349,6 +362,19 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	}
 	defer nonPersistentRedisClient.Close()
 
+	// batchClient
+	batchClient, err := btclient.NewClient(*s.batchService, *s.certPath,
+		client.WithPerRPCCredentials(creds),
+		client.WithDialTimeout(clientDialTimeout),
+		client.WithBlock(),
+		client.WithMetrics(registerer),
+		client.WithLogger(logger),
+	)
+	if err != nil {
+		return err
+	}
+	defer batchClient.Close()
+
 	service := api.NewBatchService(
 		experiment.NewExperimentStatusUpdater(
 			environmentClient,
@@ -487,12 +513,18 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	)
 	go server.Run()
 
-	processors := s.registerProcessorMap(
+	processors, err := s.registerProcessorMap(
 		environmentClient,
+		mysqlClient,
+		batchClient,
 		notificationSender,
 		registerer,
 		logger,
 	)
+	if err != nil {
+		return err
+	}
+
 	multiPubSub, err := s.startMultiPubSub(ctx, processors, logger)
 	if err != nil {
 		return err
@@ -575,9 +607,26 @@ func (s *server) startMultiPubSub(
 
 func (s *server) registerProcessorMap(
 	environmentClient environmentclient.Client,
+	mysqlClient mysql.Client,
+	batchClient btclient.Client,
 	sender notificationsender.Sender,
 	registerer metrics.Registerer,
-	logger *zap.Logger) *processor.Processors {
+	logger *zap.Logger,
+) (*processor.Processors, error) {
+	bytes, err := os.ReadFile(*s.processorsConfig)
+	if err != nil {
+		logger.Error("subscriber: failed to read processors config",
+			zap.Error(err),
+		)
+		return nil, err
+	}
+	var configMap map[string]string
+	if err := json.Unmarshal(bytes, &configMap); err != nil {
+		logger.Error("subscriber: failed to unmarshal processors config",
+			zap.Error(err),
+		)
+		return nil, err
+	}
 	processors := processor.NewProcessors(registerer)
 
 	processors.RegisterProcessor(
@@ -585,7 +634,21 @@ func (s *server) registerProcessorMap(
 		processor.NewDomainEventInformer(environmentClient, sender, logger),
 	)
 
-	return processors
+	segmentPersister, err := processor.NewSegmentPersister(
+		configMap[processor.SegmentPersisterName],
+		batchClient,
+		mysqlClient,
+		logger,
+	)
+	if err != nil {
+		return nil, err
+	}
+	processors.RegisterProcessor(
+		processor.SegmentPersisterName,
+		segmentPersister,
+	)
+
+	return processors, nil
 }
 
 func (s *server) insertTelepresenceMountRoot(path string) string {

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -634,8 +634,8 @@ func (s *server) registerProcessorMap(
 		processor.NewDomainEventInformer(environmentClient, sender, logger),
 	)
 
-	segmentPersister, err := processor.NewSegmentPersister(
-		configMap[processor.SegmentPersisterName],
+	segmentPersister, err := processor.NewSegmentUserPersister(
+		configMap[processor.SegmentUserPersisterName],
 		batchClient,
 		mysqlClient,
 		logger,
@@ -644,7 +644,7 @@ func (s *server) registerProcessorMap(
 		return nil, err
 	}
 	processors.RegisterProcessor(
-		processor.SegmentPersisterName,
+		processor.SegmentUserPersisterName,
 		segmentPersister,
 	)
 

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -620,7 +620,7 @@ func (s *server) registerProcessorMap(
 		)
 		return nil, err
 	}
-	var configMap map[string]string
+	var configMap map[string]interface{}
 	if err := json.Unmarshal(bytes, &configMap); err != nil {
 		logger.Error("subscriber: failed to unmarshal processors config",
 			zap.Error(err),

--- a/pkg/batch/subscriber/processor/metrics.go
+++ b/pkg/batch/subscriber/processor/metrics.go
@@ -23,6 +23,7 @@ import (
 
 const (
 	typeDomainEvent = "DomainEvent"
+	typeSegment     = "Segment"
 )
 
 var (

--- a/pkg/batch/subscriber/processor/processors.go
+++ b/pkg/batch/subscriber/processor/processors.go
@@ -23,8 +23,8 @@ import (
 )
 
 const (
-	DomainEventInformerName = "domainEventInformer"
-	SegmentPersisterName    = "segmentPersister"
+	DomainEventInformerName  = "domainEventInformer"
+	SegmentUserPersisterName = "segmentUserPersister"
 )
 
 var (

--- a/pkg/batch/subscriber/processor/processors.go
+++ b/pkg/batch/subscriber/processor/processors.go
@@ -24,6 +24,7 @@ import (
 
 const (
 	DomainEventInformerName = "domainEventInformer"
+	SegmentPersisterName    = "segmentPersister"
 )
 
 var (

--- a/pkg/batch/subscriber/processor/segment_persister.go
+++ b/pkg/batch/subscriber/processor/segment_persister.go
@@ -1,0 +1,379 @@
+// Copyright 2024 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	btclient "github.com/bucketeer-io/bucketeer/pkg/batch/client"
+	"github.com/bucketeer-io/bucketeer/pkg/batch/subscriber"
+	"github.com/bucketeer-io/bucketeer/pkg/feature/command"
+	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
+	v2fs "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
+	"github.com/bucketeer-io/bucketeer/pkg/storage"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
+	btproto "github.com/bucketeer-io/bucketeer/proto/batch"
+	domainproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
+	serviceevent "github.com/bucketeer-io/bucketeer/proto/event/service"
+	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
+)
+
+const (
+	maxUserIDLength = 100
+)
+
+var (
+	errSegmentInUse            = errors.New("segment: segment is in use")
+	errExceededMaxUserIDLength = fmt.Errorf("segment: max user id length allowed is %d", maxUserIDLength)
+)
+
+type segmentPersisterConfig struct {
+	DomainEventProject string `json:"domainEventProject"`
+	DomainEventTopic   string `json:"domainEventTopic"`
+	FlushSize          int    `json:"flushSize"`
+	FlushInterval      int    `json:"flushInterval"`
+}
+
+type segmentPersister struct {
+	segmentPersisterConfig segmentPersisterConfig
+	domainPublisher        publisher.Publisher
+	batchClient            btclient.Client
+	mysqlClient            mysql.Client
+	logger                 *zap.Logger
+}
+
+func NewSegmentPersister(
+	config string,
+	batchClient btclient.Client,
+	mysqlClient mysql.Client,
+	logger *zap.Logger,
+) (subscriber.Processor, error) {
+	var segmentPersisterConfig segmentPersisterConfig
+	err := json.Unmarshal([]byte(config), &segmentPersisterConfig)
+	if err != nil {
+		logger.Error("SegmentPersister: failed to unmarshal config", zap.Error(err))
+		return nil, err
+	}
+	// create domain publisher
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	client, err := pubsub.NewClient(
+		ctx,
+		segmentPersisterConfig.DomainEventProject,
+		pubsub.WithLogger(logger),
+	)
+	if err != nil {
+		logger.Error("SegmentPersister: failed to create pubsub client", zap.Error(err))
+		return nil, err
+	}
+	domainPublisher, err := client.CreatePublisher(segmentPersisterConfig.DomainEventTopic)
+	if err != nil {
+		logger.Error("SegmentPersister: failed to create domain publisher", zap.Error(err))
+		return nil, err
+	}
+	return &segmentPersister{
+		segmentPersisterConfig: segmentPersisterConfig,
+		domainPublisher:        domainPublisher,
+		batchClient:            batchClient,
+		mysqlClient:            mysqlClient,
+		logger:                 logger,
+	}, nil
+}
+
+func (p *segmentPersister) Process(ctx context.Context, msgChan <-chan *puller.Message) error {
+	chunk := make(map[string]*puller.Message, p.segmentPersisterConfig.FlushSize)
+	ticker := time.NewTicker(time.Duration(p.segmentPersisterConfig.FlushInterval) * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case msg, ok := <-msgChan:
+			if !ok {
+				return nil
+			}
+			id := msg.Attributes["id"]
+			if id == "" {
+				msg.Ack()
+				handledCounter.WithLabelValues(codes.MissingID.String()).Inc()
+				continue
+			}
+			if _, ok := chunk[id]; ok {
+				p.logger.Warn("message with duplicate id", zap.String("id", id))
+				handledCounter.WithLabelValues(codes.DuplicateID.String()).Inc()
+			}
+			chunk[id] = msg
+			if len(chunk) >= p.segmentPersisterConfig.FlushSize {
+				p.handleChunk(ctx, chunk)
+				chunk = make(map[string]*puller.Message, p.segmentPersisterConfig.FlushSize)
+			}
+		case <-ticker.C:
+			if len(chunk) > 0 {
+				p.handleChunk(ctx, chunk)
+				chunk = make(map[string]*puller.Message, p.segmentPersisterConfig.FlushSize)
+			}
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (p *segmentPersister) handleChunk(ctx context.Context, chunk map[string]*puller.Message) {
+	for _, msg := range chunk {
+		p.logger.Debug("handling a message", zap.String("msgID", msg.ID))
+		event, err := p.unmarshalMessage(msg)
+		if err != nil {
+			msg.Ack()
+			p.logger.Error("failed to unmarshal message", zap.Error(err), zap.String("msgID", msg.ID))
+			handledCounter.WithLabelValues(typeSegment, codes.BadMessage.String()).Inc()
+			continue
+		}
+		if !validateSegmentUserState(event.State) {
+			msg.Ack()
+			p.logger.Error(
+				"invalid state",
+				zap.String("environmentNamespace", event.EnvironmentNamespace),
+				zap.Int32("state", int32(event.State)),
+			)
+			handledCounter.WithLabelValues(typeSegment, codes.BadMessage.String()).Inc()
+			if err := p.updateSegmentStatus(
+				ctx,
+				event.Editor,
+				event.EnvironmentNamespace,
+				event.SegmentId,
+				0,
+				event.State,
+				featureproto.Segment_FAILED,
+			); err != nil {
+				p.logger.Error(
+					"failed to update segment status",
+					zap.Error(err),
+					zap.String("environmentNamespace", event.EnvironmentNamespace),
+				)
+			}
+			continue
+		}
+		if err := p.handleEvent(ctx, event); err != nil {
+			switch {
+			case errors.Is(err, storage.ErrKeyNotFound), errors.Is(err, v2fs.ErrSegmentNotFound):
+				msg.Ack()
+				p.logger.Warn(
+					"segment not found",
+					zap.Error(err),
+					zap.String("environmentNamespace", event.EnvironmentNamespace),
+				)
+				handledCounter.WithLabelValues(typeSegment, codes.NonRepeatableError.String()).Inc()
+			case errors.Is(err, errSegmentInUse):
+				msg.Ack()
+				p.logger.Warn(
+					"segment is in use",
+					zap.Error(err),
+					zap.String("environmentNamespace", event.EnvironmentNamespace),
+				)
+				handledCounter.WithLabelValues(typeSegment, codes.NonRepeatableError.String()).Inc()
+			case errors.Is(err, errExceededMaxUserIDLength):
+				msg.Ack()
+				p.logger.Warn(
+					"exceeded max user id length",
+					zap.Error(err),
+					zap.String("environmentNamespace", event.EnvironmentNamespace),
+				)
+				handledCounter.WithLabelValues(typeSegment, codes.NonRepeatableError.String()).Inc()
+				if err := p.updateSegmentStatus(
+					ctx,
+					event.Editor,
+					event.EnvironmentNamespace,
+					event.SegmentId,
+					0,
+					event.State,
+					featureproto.Segment_FAILED,
+				); err != nil {
+					p.logger.Error(
+						"failed to update segment status",
+						zap.Error(err),
+						zap.String("environmentNamespace", event.EnvironmentNamespace),
+					)
+				}
+			default:
+				// retryable
+				msg.Nack()
+				p.logger.Error(
+					"failed to handle event",
+					zap.Error(err),
+					zap.String("environmentNamespace", event.EnvironmentNamespace),
+				)
+				handledCounter.WithLabelValues(typeSegment, codes.RepeatableError.String()).Inc()
+			}
+			continue
+		}
+		msg.Ack()
+		p.logger.Debug(
+			"suceeded to persist segment users",
+			zap.String("msgID", msg.ID),
+			zap.String("environmentNamespace", event.EnvironmentNamespace),
+			zap.String("segmentId", event.SegmentId),
+		)
+		handledCounter.WithLabelValues(typeSegment, codes.OK.String()).Inc()
+	}
+}
+
+func (p *segmentPersister) unmarshalMessage(msg *puller.Message) (*serviceevent.BulkSegmentUsersReceivedEvent, error) {
+	event := &serviceevent.BulkSegmentUsersReceivedEvent{}
+	err := proto.Unmarshal(msg.Data, event)
+	if err != nil {
+		return nil, err
+	}
+	return event, nil
+}
+
+func validateSegmentUserState(state featureproto.SegmentUser_State) bool {
+	switch state {
+	case featureproto.SegmentUser_INCLUDED:
+		return true
+	default:
+		return false
+	}
+}
+
+func (p *segmentPersister) handleEvent(ctx context.Context, event *serviceevent.BulkSegmentUsersReceivedEvent) error {
+	segmentStorage := v2fs.NewSegmentStorage(p.mysqlClient)
+	segment, _, err := segmentStorage.GetSegment(ctx, event.SegmentId, event.EnvironmentNamespace)
+	if err != nil {
+		return err
+	}
+	if segment.IsInUseStatus {
+		return errSegmentInUse
+	}
+	cnt, err := p.persistSegmentUsers(ctx, event.EnvironmentNamespace, event.SegmentId, event.Data, event.State)
+	if err != nil {
+		return err
+	}
+	return p.updateSegmentStatus(
+		ctx,
+		event.Editor,
+		event.EnvironmentNamespace,
+		event.SegmentId,
+		cnt,
+		event.State,
+		featureproto.Segment_SUCEEDED,
+	)
+}
+
+func (p *segmentPersister) persistSegmentUsers(
+	ctx context.Context,
+	environmentNamespace string,
+	segmentID string,
+	data []byte,
+	state featureproto.SegmentUser_State,
+) (int64, error) {
+	segmentUserIDs := strings.Split(
+		strings.NewReplacer(
+			",", "\n",
+			"\r\n", "\n",
+		).Replace(string(data)),
+		"\n",
+	)
+	uniqueSegmentUserIDs := make(map[string]struct{}, len(segmentUserIDs))
+	for _, id := range segmentUserIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if len(id) > maxUserIDLength {
+			return 0, errExceededMaxUserIDLength
+		}
+		uniqueSegmentUserIDs[id] = struct{}{}
+	}
+	allSegmentUsers := make([]*featureproto.SegmentUser, 0, len(uniqueSegmentUserIDs))
+	var cnt int64
+	for id := range uniqueSegmentUserIDs {
+		cnt++
+		user := domain.NewSegmentUser(segmentID, id, state, false)
+		allSegmentUsers = append(allSegmentUsers, user.SegmentUser)
+	}
+	tx, err := p.mysqlClient.BeginTx(ctx)
+	if err != nil {
+		p.logger.Error("Failed to begin transaction", zap.Error(err))
+		return 0, err
+	}
+	err = p.mysqlClient.RunInTransaction(ctx, tx, func() error {
+		segmentUserStorage := v2fs.NewSegmentUserStorage(tx)
+		if err := segmentUserStorage.UpsertSegmentUsers(ctx, allSegmentUsers, environmentNamespace); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, nil
+	}
+	p.updateSegmentUserCache(ctx)
+	return cnt, nil
+}
+
+func (p *segmentPersister) updateSegmentStatus(
+	ctx context.Context,
+	editor *domainproto.Editor,
+	environmentNamespace string,
+	segmentID string,
+	cnt int64,
+	state featureproto.SegmentUser_State,
+	status featureproto.Segment_Status,
+) error {
+	tx, err := p.mysqlClient.BeginTx(ctx)
+	if err != nil {
+		p.logger.Error("Failed to begin transaction", zap.Error(err))
+		return err
+	}
+	return p.mysqlClient.RunInTransaction(ctx, tx, func() error {
+		segmentStorage := v2fs.NewSegmentStorage(tx)
+		segment, _, err := segmentStorage.GetSegment(ctx, segmentID, environmentNamespace)
+		if err != nil {
+			return err
+		}
+		changeCmd := &featureproto.ChangeBulkUploadSegmentUsersStatusCommand{
+			Status: status,
+			State:  state,
+			Count:  cnt,
+		}
+		handler := command.NewSegmentCommandHandler(editor, segment, p.domainPublisher, environmentNamespace)
+		if err := handler.Handle(ctx, changeCmd); err != nil {
+			return err
+		}
+		return segmentStorage.UpdateSegment(ctx, segment, environmentNamespace)
+	})
+}
+
+// Even if the update request fails, the cronjob will keep trying
+// to update the cache every minute, so we don't need to retry.
+func (p *segmentPersister) updateSegmentUserCache(ctx context.Context) {
+	req := &btproto.BatchJobRequest{
+		Job: btproto.BatchJob_SegmentUserCacher,
+	}
+	_, err := p.batchClient.ExecuteBatchJob(ctx, req)
+	if err != nil {
+		p.logger.Error("Failed to update segment user cache", zap.Error(err))
+	}
+}

--- a/pkg/batch/subscriber/processor/segment_user_persister.go
+++ b/pkg/batch/subscriber/processor/segment_user_persister.go
@@ -251,7 +251,8 @@ func (p *segmentUserPersister) handleChunk(ctx context.Context, chunk map[string
 	}
 }
 
-func (p *segmentUserPersister) unmarshalMessage(msg *puller.Message) (*serviceevent.BulkSegmentUsersReceivedEvent, error) {
+func (p *segmentUserPersister) unmarshalMessage(msg *puller.Message,
+) (*serviceevent.BulkSegmentUsersReceivedEvent, error) {
 	event := &serviceevent.BulkSegmentUsersReceivedEvent{}
 	err := proto.Unmarshal(msg.Data, event)
 	if err != nil {
@@ -269,7 +270,8 @@ func validateSegmentUserState(state featureproto.SegmentUser_State) bool {
 	}
 }
 
-func (p *segmentUserPersister) handleEvent(ctx context.Context, event *serviceevent.BulkSegmentUsersReceivedEvent) error {
+func (p *segmentUserPersister) handleEvent(
+	ctx context.Context, event *serviceevent.BulkSegmentUsersReceivedEvent) error {
 	segmentStorage := v2fs.NewSegmentStorage(p.mysqlClient)
 	segment, _, err := segmentStorage.GetSegment(ctx, event.SegmentId, event.EnvironmentNamespace)
 	if err != nil {


### PR DESCRIPTION
This PR will move the feature-segment-persister to the batch service. Additionally, it will add support for custom `Processor` parameters in the multi pubsub architecture.

## Key changes

- Create a new json configmap for the `Processor`: [[1]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-186ceb07184707bd9312a6f564dde8b86c7025ad9a3fd7d74e2688860f64c12aR14-R16) [[2]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-da142715fb447fa09cd1b8854c0f9caa732a8d7d0555e25ae2bd0d8cb52d4b4dR176-R180)
- Parse `Processor` json config: [[1]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-9f3bffbf9b659d0228f7f25aeb18a14d9fa79a72e2a8100e7371b1d112faa00cR615-R629) [[2]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-9f3bffbf9b659d0228f7f25aeb18a14d9fa79a72e2a8100e7371b1d112faa00cR638) [[3]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-c0de99b99bbe00b84d221910753680f4d5a4915fa9cf7179e5f3d89759ece376R77-R92)
- Modify the `Processor` interface to grant it complete control over the message channel: [[1]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-6e1312d8eb4c761a6bed38a73030372d365031c859b3de0eb331c01633f01e47L53)
  - **domainEventInformer**: [[1]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-903b46afeb8f1ee3bcdccf3f06c4f16d33e006ffe3cf13fc185958d675237bc4R62-R76)
  - **segmentPersister**: [[1]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-c0de99b99bbe00b84d221910753680f4d5a4915fa9cf7179e5f3d89759ece376R119-R153)
- Add worker number params for subscriber: [[1]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-da142715fb447fa09cd1b8854c0f9caa732a8d7d0555e25ae2bd0d8cb52d4b4dR170) [[2]](https://github.com/bucketeer-io/bucketeer/pull/896/files#diff-6e1312d8eb4c761a6bed38a73030372d365031c859b3de0eb331c01633f01e47R109-R113)