### PR TITLE
chore: add error logs when checking requests in the api-gateway

### DIFF
--- a/pkg/gateway/api/api.go
+++ b/pkg/gateway/api/api.go
@@ -397,10 +397,6 @@ func (s *gatewayService) checkGetEvaluationsRequest(
 	if req.Method != http.MethodPost {
 		return nil, getEvaluationsRequest{}, errInvalidHttpMethod
 	}
-	envAPIKey, err := s.checkRequest(req.Context(), req)
-	if err != nil {
-		return nil, getEvaluationsRequest{}, err
-	}
 	var body getEvaluationsRequest
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		s.logger.Error(
@@ -411,7 +407,23 @@ func (s *gatewayService) checkGetEvaluationsRequest(
 		)
 		return nil, getEvaluationsRequest{}, errInternal
 	}
+	envAPIKey, err := s.checkRequest(req.Context(), req)
+	if err != nil {
+		s.logger.Error("Failed to check GetEvaluations request",
+			zap.Error(err),
+			zap.String("tag", body.Tag),
+			zap.Any("user", body.User),
+			zap.Any("sourceId", body.SourceID),
+		)
+		return nil, getEvaluationsRequest{}, err
+	}
 	if err := s.validateGetEvaluationsRequest(&body); err != nil {
+		s.logger.Error("Failed to validate GetEvaluations request",
+			zap.Error(err),
+			zap.String("tag", body.Tag),
+			zap.Any("user", body.User),
+			zap.Any("sourceId", body.SourceID),
+		)
 		return nil, getEvaluationsRequest{}, err
 	}
 	return envAPIKey, body, nil
@@ -423,10 +435,6 @@ func (s *gatewayService) checkGetEvaluationRequest(
 	if req.Method != http.MethodPost {
 		return nil, getEvaluationRequest{}, errInvalidHttpMethod
 	}
-	envAPIKey, err := s.checkRequest(req.Context(), req)
-	if err != nil {
-		return nil, getEvaluationRequest{}, err
-	}
 	var body getEvaluationRequest
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		s.logger.Error(
@@ -437,7 +445,25 @@ func (s *gatewayService) checkGetEvaluationRequest(
 		)
 		return nil, getEvaluationRequest{}, errInternal
 	}
+	envAPIKey, err := s.checkRequest(req.Context(), req)
+	if err != nil {
+		s.logger.Error("Failed to check GetEvaluation request",
+			zap.Error(err),
+			zap.String("tag", body.Tag),
+			zap.Any("user", body.User),
+			zap.Any("sourceId", body.SourceId),
+			zap.String("featureId", body.FeatureID),
+		)
+		return nil, getEvaluationRequest{}, err
+	}
 	if err := s.validateGetEvaluationRequest(&body); err != nil {
+		s.logger.Error("Failed to validate GetEvaluation request",
+			zap.Error(err),
+			zap.String("tag", body.Tag),
+			zap.Any("user", body.User),
+			zap.Any("sourceId", body.SourceId),
+			zap.String("featureId", body.FeatureID),
+		)
 		return nil, getEvaluationRequest{}, err
 	}
 	return envAPIKey, body, nil
@@ -1194,10 +1220,6 @@ func (s *gatewayService) checkRegisterEvents(
 	if req.Method != http.MethodPost {
 		return nil, registerEventsRequest{}, errInvalidHttpMethod
 	}
-	envAPIKey, err := s.checkRequest(req.Context(), req)
-	if err != nil {
-		return nil, registerEventsRequest{}, err
-	}
 	var body registerEventsRequest
 	if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
 		if err == io.EOF {
@@ -1211,7 +1233,19 @@ func (s *gatewayService) checkRegisterEvents(
 		)
 		return nil, registerEventsRequest{}, errInternal
 	}
+	envAPIKey, err := s.checkRequest(req.Context(), req)
+	if err != nil {
+		s.logger.Error("Failed to check RegisterEvents request",
+			zap.Error(err),
+			zap.Any("events", body.Events),
+		)
+		return nil, registerEventsRequest{}, err
+	}
 	if len(body.Events) == 0 {
+		s.logger.Error("Failed to validate RegisterEvents request. Missing events.",
+			zap.Error(err),
+			zap.Any("events", body.Events),
+		)
 		return nil, registerEventsRequest{}, errMissingEvents
 	}
 	return envAPIKey, body, nil


### PR DESCRIPTION
I'm adding logs to track when a request fails while trying to check the API key.

- Added logs for checking API key
- Added logs for validating the request

---

This pull request primarily focuses on error handling and logging improvements in the `pkg/gateway/api` package. The changes enhance the error logging by including more context-specific details. In addition, the request validation process has been restructured in several functions, moving the `checkRequest` call after the request body decoding. Test cases have also been updated to reflect these changes.

Here are the most important changes:

Error Handling and Logging Improvements:

* [`pkg/gateway/api/api.go`](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940L400-L403): Enhanced error logging in `checkGetEvaluationsRequest`, `checkGetEvaluationRequest`, and `checkRegisterEvents` by adding more context-specific details. The `checkRequest` call is now made after the request body decoding. [[1]](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940L400-L403) [[2]](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940R410-R419) [[3]](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940L426-L429) [[4]](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940R442-R452) [[5]](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940L1197-L1200) [[6]](diffhunk://#diff-aeacd2d921540b49d9dde22d96b46c3f4c440e735314e2e1d9dec9a9b26c1940R1223-R1230)
* [`pkg/gateway/api/api_grpc.go`](diffhunk://#diff-4195f8894e4d329c671aa126d57124813202b5aaf1e2aac38e93813d74d3f63aL190-R213): Similar improvements were made in `Track`, `GetEvaluations`, `GetEvaluation`, and `RegisterEvents`. More context-specific details were added to the error logging, and the `checkRequest` call was moved as necessary. [[1]](diffhunk://#diff-4195f8894e4d329c671aa126d57124813202b5aaf1e2aac38e93813d74d3f63aL190-R213) [[2]](diffhunk://#diff-4195f8894e4d329c671aa126d57124813202b5aaf1e2aac38e93813d74d3f63aR304-R328) [[3]](diffhunk://#diff-4195f8894e4d329c671aa126d57124813202b5aaf1e2aac38e93813d74d3f63aR479-R502) [[4]](diffhunk://#diff-4195f8894e4d329c671aa126d57124813202b5aaf1e2aac38e93813d74d3f63aR558-R568) [[5]](diffhunk://#diff-4195f8894e4d329c671aa126d57124813202b5aaf1e2aac38e93813d74d3f63aR863-R878)

Test Case Updates:

* [`pkg/gateway/api/api_test.go`](diffhunk://#diff-4a6dfcd3e78c82a12d9d2018554b102ea0aa31f416d6a2e132bba4a04d3e0dd2R543-R568): Updated test cases in `TestGetEvaluationsContextCanceled`, `TestRegisterEventsContextCanceled`, and `TestRegisterEvents` to reflect the changes in the request validation process. [[1]](diffhunk://#diff-4a6dfcd3e78c82a12d9d2018554b102ea0aa31f416d6a2e132bba4a04d3e0dd2R543-R568) [[2]](diffhunk://#diff-4a6dfcd3e78c82a12d9d2018554b102ea0aa31f416d6a2e132bba4a04d3e0dd2L564-R578) [[3]](diffhunk://#diff-4a6dfcd3e78c82a12d9d2018554b102ea0aa31f416d6a2e132bba4a04d3e0dd2R2059-R2082) [[4]](diffhunk://#diff-4a6dfcd3e78c82a12d9d2018554b102ea0aa31f416d6a2e132bba4a04d3e0dd2L2063-R2091) [[5]](diffhunk://#diff-4a6dfcd3e78c82a12d9d2018554b102ea0aa31f416d6a2e132bba4a04d3e0dd2L2131-R2159)