### PR TITLE
fix: infinite loop when trying to enable/disable a flag when using auto operation

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1003,17 +1003,15 @@ func (s *AutoOpsService) ExecuteAutoOps(
 		}
 		if err := executeAutoOpsRuleOperation(
 			ctx,
+			ftStorage,
 			req.EnvironmentNamespace,
-			autoOpsRule,
+			autoOpsRule.OpsType,
 			feature,
 			s.logger,
 			localizer,
 		); err != nil {
-			return err
-		}
-		if err := ftStorage.UpdateFeature(ctx, feature, req.EnvironmentNamespace); err != nil {
 			s.logger.Error(
-				"Failed to update feature flag",
+				"Failed to execute auto ops rule operation",
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.Error(err),
 					zap.String("environmentNamespace", req.EnvironmentNamespace),

--- a/pkg/autoops/api/flag_trigger_operation_test.go
+++ b/pkg/autoops/api/flag_trigger_operation_test.go
@@ -1,0 +1,185 @@
+// Copyright 2024 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/metadata"
+
+	ftdomain "github.com/bucketeer-io/bucketeer/pkg/feature/domain"
+	ftmock "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/locale"
+	autoopsproto "github.com/bucketeer-io/bucketeer/proto/autoops"
+	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
+)
+
+func TestEnableFeature(t *testing.T) {
+	t.Parallel()
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	storageMock := ftmock.NewMockFeatureStorage(mockController)
+
+	ctx := createContextWithTokenRoleOwner(t)
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	logger := zap.NewNop()
+	localizer := locale.NewLocalizer(ctx)
+
+	patterns := []struct {
+		desc            string
+		feature         *featureproto.Feature
+		autoOpsRuleType autoopsproto.OpsType
+		updateCallTimes int
+		expected        bool
+		expectedErr     error
+	}{
+		{
+			desc: "err: internal",
+			feature: &featureproto.Feature{
+				Enabled: false,
+			},
+			updateCallTimes: 1,
+			expected:        true,
+			expectedErr:     errors.New("err: internal"),
+		},
+		{
+			desc: "success: is already enabled",
+			feature: &featureproto.Feature{
+				Enabled: true,
+			},
+			updateCallTimes: 0,
+			expected:        true,
+			expectedErr:     nil,
+		},
+		{
+			desc: "success",
+			feature: &featureproto.Feature{
+				Enabled: false,
+			},
+			updateCallTimes: 1,
+			expected:        true,
+			expectedErr:     nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			feature := &ftdomain.Feature{Feature: p.feature}
+
+			if p.expectedErr != nil {
+				storageMock.EXPECT().UpdateFeature(ctx, feature, "env").
+					Return(p.expectedErr).Times(p.updateCallTimes)
+			} else {
+				storageMock.EXPECT().UpdateFeature(ctx, feature, "env").
+					Return(nil).Times(p.updateCallTimes)
+			}
+
+			err := executeAutoOpsRuleOperation(
+				ctx,
+				storageMock,
+				"env",
+				autoopsproto.OpsType_ENABLE_FEATURE,
+				feature,
+				logger,
+				localizer,
+			)
+			assert.Equal(t, p.expected, feature.Enabled)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func TestDisableFeature(t *testing.T) {
+	t.Parallel()
+
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	storageMock := ftmock.NewMockFeatureStorage(mockController)
+
+	ctx := createContextWithTokenRoleOwner(t)
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	logger := zap.NewNop()
+	localizer := locale.NewLocalizer(ctx)
+
+	patterns := []struct {
+		desc            string
+		feature         *featureproto.Feature
+		autoOpsRuleType autoopsproto.OpsType
+		updateCallTimes int
+		expected        bool
+		expectedErr     error
+	}{
+		{
+			desc: "err: internal",
+			feature: &featureproto.Feature{
+				Enabled: true,
+			},
+			updateCallTimes: 1,
+			expected:        false,
+			expectedErr:     errors.New("err: internal"),
+		},
+		{
+			desc: "success: is already disabled",
+			feature: &featureproto.Feature{
+				Enabled: false,
+			},
+			updateCallTimes: 0,
+			expected:        false,
+			expectedErr:     nil,
+		},
+		{
+			desc: "success",
+			feature: &featureproto.Feature{
+				Enabled: true,
+			},
+			updateCallTimes: 1,
+			expected:        false,
+			expectedErr:     nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			feature := &ftdomain.Feature{Feature: p.feature}
+
+			if p.expectedErr != nil {
+				storageMock.EXPECT().UpdateFeature(ctx, feature, "env").
+					Return(p.expectedErr).Times(p.updateCallTimes)
+			} else {
+				storageMock.EXPECT().UpdateFeature(ctx, feature, "env").
+					Return(nil).Times(p.updateCallTimes)
+			}
+
+			err := executeAutoOpsRuleOperation(
+				ctx,
+				storageMock,
+				"env",
+				autoopsproto.OpsType_DISABLE_FEATURE,
+				feature,
+				logger,
+				localizer,
+			)
+			assert.Equal(t, p.expected, feature.Enabled)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/bucketeer-io/bucketeer/issues/913

---

This pull request includes changes in the `pkg/autoops/api` package to improve the handling of feature flag operations and to simplify the codebase. The major changes include refactoring the `ExecuteAutoOps` function and the `executeAutoOpsRuleOperation` function, and adding tests for the `enableFeature` and `disableFeature` functions.

Refactoring of functions:

* [`pkg/autoops/api/api.go`](diffhunk://#diff-13112ed94680ecaec33373531ff5c65e48cecae142657203e04d967a185684d5R1006-R1014): In the `ExecuteAutoOps` function, the `autoOpsRule` parameter has been replaced with `autoOpsRule.OpsType` and `ftStorage` has been added. The error message has been updated to reflect the changes.

* [`pkg/autoops/api/flag_trigger_operation.go`](diffhunk://#diff-5ea327a81db81cfa4ffb7c8c5013e37b1f28799a4285d95589d2716f7cf59be2L23-R43): The `executeAutoOpsRuleOperation` function has been refactored to use `ftStorage` and `autoOpsRuleType` instead of `autoOpsRule`. The `enableFeature` and `disableFeature` functions have been updated to use `ftStorage` and to remove the use of `autoOpsRule`. The `enableFeature` and `disableFeature` functions now return `nil` if the feature is already enabled or disabled, respectively. [[1]](diffhunk://#diff-5ea327a81db81cfa4ffb7c8c5013e37b1f28799a4285d95589d2716f7cf59be2L23-R43) [[2]](diffhunk://#diff-5ea327a81db81cfa4ffb7c8c5013e37b1f28799a4285d95589d2716f7cf59be2R55-L86) [[3]](diffhunk://#diff-5ea327a81db81cfa4ffb7c8c5013e37b1f28799a4285d95589d2716f7cf59be2R101-R103)

Addition of tests:

* [`pkg/autoops/api/flag_trigger_operation_test.go`](diffhunk://#diff-7346aaa8499748e70575b950d4eab4c344a30806d3c2838f01f32299b770c319R1-R185): Tests have been added for the `enableFeature` and `disableFeature` functions. These tests check the behavior of the functions when the feature is already enabled or disabled, and when an internal error occurs.