### PR TITLE
chore: change cronjob error code condition to ignore 503 and 000 errors

### DIFF
--- a/manifests/bucketeer/charts/batch/templates/cronjob.yaml
+++ b/manifests/bucketeer/charts/batch/templates/cronjob.yaml
@@ -52,7 +52,7 @@ spec:
                   TOKEN=`cat /usr/local/service-token/token`
                   RES=`curl -X POST -m 3600 --cacert /usr/local/certs/service/tls.crt -d '{"job": "{{ .jobId }}"}' -H "authorization: bearer ${TOKEN}" -H "Content-Type: application/json" -s -o /dev/null -w '%{http_code}\\n' ${ENDPOINT}`
                   echo "{{ .name }} job result: ${RES}"
-                  if [ "$RES" == 200 ]
+                  if [ "$RES" == 200 ] || [ "$RES" == 503 ] || [ "$RES" == 000 ]
                   then
                     exit 0
                   else


### PR DESCRIPTION
Because the jobs run every minute, if they fail due to network or unavailable errors, we can ignore them because they are temporary.

000 = Network issues (Host not found, etc)
503 = Can happen when the pods are being terminated