### PR TITLE
chore: change to use redis to cache environment api key

### DIFF
--- a/pkg/cache/v3/environment_api_key.go
+++ b/pkg/cache/v3/environment_api_key.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	environmentAPIKeyKind             = "environment_apikey"
-	environmentAPIKeyTTL              = 1 * time.Minute
-	EnvironmentAPIKeyEvictionInterval = 10 * time.Second
+	environmentAPIKeyKind = "environment_apikey"
+	environmentAPIKeyTTL  = time.Duration(0)
 )
 
 type EnvironmentAPIKeyCache interface {

--- a/pkg/gateway/api/api.go
+++ b/pkg/gateway/api/api.go
@@ -71,7 +71,6 @@ func NewGatewayService(
 	up publisher.Publisher,
 	mp publisher.Publisher,
 	redisV3Cache cache.MultiGetCache,
-	inMemoryCache cache.Cache,
 	opts ...Option,
 ) *gatewayService {
 	options := defaultOptions
@@ -90,7 +89,7 @@ func NewGatewayService(
 		metricsPublisher:       mp,
 		featuresCache:          cachev3.NewFeaturesCache(redisV3Cache),
 		segmentUsersCache:      cachev3.NewSegmentUsersCache(redisV3Cache),
-		environmentAPIKeyCache: cachev3.NewEnvironmentAPIKeyCache(inMemoryCache),
+		environmentAPIKeyCache: cachev3.NewEnvironmentAPIKeyCache(redisV3Cache),
 		opts:                   &options,
 		logger:                 options.logger.Named("api"),
 	}

--- a/pkg/gateway/api/api_grpc_test.go
+++ b/pkg/gateway/api/api_grpc_test.go
@@ -91,7 +91,7 @@ func TestWithLogger(t *testing.T) {
 
 func TestNewGrpcGatewayService(t *testing.T) {
 	t.Parallel()
-	g := NewGrpcGatewayService(nil, nil, nil, nil, nil, nil, nil)
+	g := NewGrpcGatewayService(nil, nil, nil, nil, nil, nil)
 	assert.IsType(t, &grpcGatewayService{}, g)
 }
 
@@ -209,7 +209,6 @@ func TestGrpcGetEnvironmentAPIKey(t *testing.T) {
 						Environment: &environmentproto.EnvironmentV2{Id: "ns0"},
 						ApiKey:      &accountproto.APIKey{Id: "id-0"},
 					}}, nil)
-				gs.environmentAPIKeyCache.(*cachev3mock.MockEnvironmentAPIKeyCache).EXPECT().Put(gomock.Any()).Return(nil)
 			},
 			ctx: metadata.NewIncomingContext(context.TODO(), metadata.MD{
 				"authorization": []string{"test-key"},

--- a/pkg/gateway/api/api_test.go
+++ b/pkg/gateway/api/api_test.go
@@ -51,7 +51,7 @@ const dummyURL = "http://example.com"
 
 func TestNewGatewayService(t *testing.T) {
 	t.Parallel()
-	g := NewGatewayService(nil, nil, nil, nil, nil, nil, nil, nil)
+	g := NewGatewayService(nil, nil, nil, nil, nil, nil, nil)
 	assert.IsType(t, &gatewayService{}, g)
 }
 

--- a/pkg/gateway/cmd/server.go
+++ b/pkg/gateway/cmd/server.go
@@ -238,8 +238,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	defer redisV3Client.Close()
 	redisV3Cache := cachev3.NewRedisCache(redisV3Client)
 
-	inMemoryCache := cachev3.NewInMemoryCache(cachev3.WithEvictionInterval(cachev3.EnvironmentAPIKeyEvictionInterval))
-
 	service := api.NewGrpcGatewayService(
 		featureClient,
 		accountClient,
@@ -247,7 +245,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		evaluationPublisher,
 		userPublisher,
 		redisV3Cache,
-		inMemoryCache,
 		api.WithOldestEventTimestamp(*s.oldestEventTimestamp),
 		api.WithFurthestEventTimestamp(*s.furthestEventTimestamp),
 		api.WithMetrics(registerer),
@@ -288,7 +285,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		userPublisher,
 		metricsPublisher,
 		redisV3Cache,
-		inMemoryCache,
 		api.WithOldestEventTimestamp(*s.oldestEventTimestamp),
 		api.WithFurthestEventTimestamp(*s.furthestEventTimestamp),
 		api.WithMetrics(registerer),


### PR DESCRIPTION
Fixes https://github.com/bucketeer-io/bucketeer/issues/935

We have been experiencing instability issues when the in-memory cache is gone and trying to get the environment API from MySQL. Since the Memorystore has a higher SLA than CloudSQL, I have changed it to Redis.
The batch service already updates the environment API key cache every minute.

This will increase the response latency by a few milliseconds, but it will bring more stability.