### PR TITLE
perf: implement multiple upserting for user persister

### DIFF
--- a/pkg/user/persister/persister.go
+++ b/pkg/user/persister/persister.go
@@ -319,17 +319,14 @@ func (p *persister) upsertMAUs(
 	}
 	err = p.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		s := ustorage.NewMysqlMAUStorage(p.mysqlClient)
-		if err := s.UpsertMAUs(ctx, events, environmentNamespace); err != nil {
-			p.logger.Error("Failed to upsert user events",
-				zap.Error(err),
-				zap.String("environmentNamespace", environmentNamespace),
-				zap.Int("size", len(events)),
-			)
-			return err
-		}
-		return nil
+		return s.UpsertMAUs(ctx, events, environmentNamespace)
 	})
 	if err != nil {
+		p.logger.Error("Failed to upsert user events",
+			zap.Error(err),
+			zap.String("environmentNamespace", environmentNamespace),
+			zap.Int("size", len(events)),
+		)
 		return err
 	}
 	return nil

--- a/pkg/user/persister/persister.go
+++ b/pkg/user/persister/persister.go
@@ -213,42 +213,58 @@ func (p *persister) runWorker() error {
 }
 
 func (p *persister) handleChunk(chunk map[string]*puller.Message) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	events := make(map[string][]*eventproto.UserEvent)
+	messages := make(map[string][]*puller.Message)
 	for _, msg := range chunk {
-		event, err := p.unmarshalMessage(msg)
-		if err != nil {
-			handledCounter.WithLabelValues(codes.BadMessage.String()).Inc()
+		// Extract the user event
+		event := p.extractUserEvent(msg)
+		if event == nil {
 			continue
 		}
-		if !p.validateEvent(event) {
-			handledCounter.WithLabelValues(codes.BadMessage.String()).Inc()
-			continue
+		// Append events per environment
+		listEvents, ok := events[event.EnvironmentNamespace]
+		if ok {
+			events[event.EnvironmentNamespace] = append(listEvents, event)
+		} else {
+			events[event.EnvironmentNamespace] = []*eventproto.UserEvent{event}
 		}
-		ok, repeatable := p.upsert(event)
-		if !ok {
-			if repeatable {
-				msg.Nack()
-				handledCounter.WithLabelValues(codes.RepeatableError.String()).Inc()
+		// Append PubSub messages per environment
+		listMessages, ok := messages[event.EnvironmentNamespace]
+		if ok {
+			messages[event.EnvironmentNamespace] = append(listMessages, msg)
+		} else {
+			messages[event.EnvironmentNamespace] = []*puller.Message{msg}
+		}
+	}
+	// Upsert events
+	if len(events) > 0 {
+		for environmentNamespace, events := range events {
+			// Upsert events per environment
+			err := p.upsertMAUs(ctx, events, environmentNamespace)
+			if err != nil {
+				p.nackMessages(messages[environmentNamespace])
 			} else {
-				msg.Ack()
-				handledCounter.WithLabelValues(codes.NonRepeatableError.String()).Inc()
+				p.ackMessages(messages[environmentNamespace])
 			}
-			continue
 		}
-		msg.Ack()
-		handledCounter.WithLabelValues(codes.OK.String()).Inc()
 	}
 }
 
-func (p *persister) validateEvent(event *eventproto.UserEvent) bool {
-	if event.UserId == "" {
-		p.logger.Warn("Message contains an empty User Id", zap.Any("event", event))
-		return false
+func (p *persister) extractUserEvent(message *puller.Message) *eventproto.UserEvent {
+	event, err := p.unmarshalMessage(message)
+	if err != nil {
+		message.Nack()
+		handledCounter.WithLabelValues(codes.BadMessage.String()).Inc()
+		return nil
 	}
-	if event.LastSeen == 0 {
-		p.logger.Warn("Message's LastSeen is zero", zap.Any("event", event))
-		return false
+	if !p.validateEvent(event) {
+		message.Nack()
+		handledCounter.WithLabelValues(codes.BadMessage.String()).Inc()
+		return nil
 	}
-	return true
+	return event
 }
 
 func (p *persister) unmarshalMessage(msg *puller.Message) (*eventproto.UserEvent, error) {
@@ -265,21 +281,56 @@ func (p *persister) unmarshalMessage(msg *puller.Message) (*eventproto.UserEvent
 	return &userEvent, err
 }
 
-func (p *persister) upsert(event *eventproto.UserEvent) (ok, repeatable bool) {
-	if err := p.upsertMAU(event); err != nil {
-		p.logger.Error(
-			"Failed to store the mau",
-			zap.Error(err),
-			zap.String("environmentNamespace", event.EnvironmentNamespace),
-			zap.String("userId", event.UserId),
-			zap.String("tag", event.Tag),
-		)
-		return false, true
+func (p *persister) validateEvent(event *eventproto.UserEvent) bool {
+	if event.UserId == "" {
+		p.logger.Warn("Message contains an empty User Id", zap.Any("event", event))
+		return false
 	}
-	return true, false
+	if event.LastSeen == 0 {
+		p.logger.Warn("Message's LastSeen is zero", zap.Any("event", event))
+		return false
+	}
+	return true
 }
 
-func (p *persister) upsertMAU(event *eventproto.UserEvent) error {
-	s := ustorage.NewMysqlMAUStorage(p.mysqlClient)
-	return s.UpsertMAU(p.ctx, event, event.EnvironmentNamespace)
+func (p *persister) nackMessages(messages []*puller.Message) {
+	for _, msg := range messages {
+		msg.Nack()
+		handledCounter.WithLabelValues(codes.RepeatableError.String()).Inc()
+	}
+}
+
+func (p *persister) ackMessages(messages []*puller.Message) {
+	for _, msg := range messages {
+		msg.Ack()
+		handledCounter.WithLabelValues(codes.OK.String()).Inc()
+	}
+}
+
+func (p *persister) upsertMAUs(
+	ctx context.Context,
+	events []*eventproto.UserEvent,
+	environmentNamespace string,
+) error {
+	tx, err := p.mysqlClient.BeginTx(ctx)
+	if err != nil {
+		p.logger.Error("Failed to begin transaction", zap.Error(err))
+		return err
+	}
+	err = p.mysqlClient.RunInTransaction(ctx, tx, func() error {
+		s := ustorage.NewMysqlMAUStorage(p.mysqlClient)
+		if err := s.UpsertMAUs(ctx, events, environmentNamespace); err != nil {
+			p.logger.Error("Failed to upsert user events",
+				zap.Error(err),
+				zap.String("environmentNamespace", environmentNamespace),
+				zap.Int("size", len(events)),
+			)
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/pkg/user/persister/persister_test.go
+++ b/pkg/user/persister/persister_test.go
@@ -17,16 +17,21 @@ package persister
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/bucketeer-io/bucketeer/pkg/log"
+	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
+	ecproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/service"
 )
 
@@ -149,4 +154,120 @@ func newPersisterWithMock(
 		opts:        defaultOptions,
 		logger:      logger,
 	}
+}
+
+func TestHandleChunk(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	now := time.Now()
+	uuid, err := uuid.NewUUID()
+	require.NoError(t, err)
+	aMap := generatePullerMessages(t, 2, "env-1")
+	bMap := generatePullerMessages(t, 3, "env-2")
+
+	patterns := []struct {
+		desc, environmentNamespace string
+		setup                      func(*persister)
+		input                      map[string]*puller.Message
+		expected                   error
+	}{
+		{
+			desc:                 "upsert mau error",
+			environmentNamespace: "env1",
+			setup: func(p *persister) {
+				p.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil).Times(2)
+				p.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(errors.New("internal")).Times(2)
+			},
+			input:    mergeMap(t, aMap, bMap),
+			expected: errors.New("internal"),
+		},
+		{
+			desc:                 "upsert success",
+			environmentNamespace: "env1",
+			setup: func(p *persister) {
+				p.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil).Times(2)
+				p.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil).Times(2)
+			},
+			input:    mergeMap(t, aMap, bMap),
+			expected: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			pst := newPersisterWithMock(t, mockController, now, uuid)
+			if p.setup != nil {
+				p.setup(pst)
+			}
+			pst.handleChunk(p.input)
+		})
+	}
+}
+
+func generatePullerMessages(
+	t *testing.T,
+	size int,
+	environmentNamespace string,
+) map[string]*puller.Message {
+	t.Helper()
+	messages := make(map[string]*puller.Message)
+	for i := 0; i < size; i++ {
+		userEvent := generateUserEvent(t, environmentNamespace)
+		msg := generatePullerMessage(t, userEvent)
+		messages[msg.ID] = msg
+	}
+	return messages
+}
+
+func generatePullerMessage(t *testing.T, userEvent *eventproto.UserEvent) *puller.Message {
+	t.Helper()
+	ue, err := ptypes.MarshalAny(userEvent)
+	if err != nil {
+		t.Fatalf("Failed to marshal any user event: %v", err)
+	}
+	id, err := uuid.NewUUID()
+	if err != nil {
+		t.Fatalf("Failed to generate UUID: %v", err)
+	}
+	ev := &ecproto.Event{
+		Id:                   id.String(),
+		Event:                ue,
+		EnvironmentNamespace: userEvent.EnvironmentNamespace,
+	}
+	data, err := proto.Marshal(ev)
+	if err != nil {
+		t.Fatalf("Failed to marshal message: %v", err)
+	}
+	msg := &puller.Message{
+		ID:   fmt.Sprintf("message-id-%s", id.String()),
+		Data: data,
+		Nack: func() {},
+		Ack:  func() {},
+	}
+	return msg
+}
+
+func generateUserEvent(t *testing.T, environmentNamespace string) *eventproto.UserEvent {
+	t.Helper()
+	id, err := uuid.NewUUID()
+	if err != nil {
+		t.Fatalf("Failed to generate UUID: %v", err)
+	}
+	return &eventproto.UserEvent{
+		EnvironmentNamespace: environmentNamespace,
+		UserId:               fmt.Sprintf("user-id-%s", id),
+		LastSeen:             time.Now().Unix(),
+	}
+}
+
+func mergeMap(t *testing.T, a, b map[string]*puller.Message) map[string]*puller.Message {
+	t.Helper()
+	for k, v := range b {
+		a[k] = v
+	}
+	return a
 }

--- a/pkg/user/storage/v2/mock/mau.go
+++ b/pkg/user/storage/v2/mock/mau.go
@@ -49,3 +49,17 @@ func (mr *MockMAUStorageMockRecorder) UpsertMAU(ctx, event, environmentNamespace
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMAU", reflect.TypeOf((*MockMAUStorage)(nil).UpsertMAU), ctx, event, environmentNamespace)
 }
+
+// UpsertMAUs mocks base method.
+func (m *MockMAUStorage) UpsertMAUs(ctx context.Context, events []*service.UserEvent, environmentNamespace string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpsertMAUs", ctx, events, environmentNamespace)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpsertMAUs indicates an expected call of UpsertMAUs.
+func (mr *MockMAUStorageMockRecorder) UpsertMAUs(ctx, events, environmentNamespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertMAUs", reflect.TypeOf((*MockMAUStorage)(nil).UpsertMAUs), ctx, events, environmentNamespace)
+}


### PR DESCRIPTION
The current implementation is too slow when upserting the same row into the DB.
Instead of upserting a single value, I have changed to upserting multiple values in a single query, which is far faster.

The multiple values in a single query logic, is the same logic being used in the [segment user persister](https://github.com/bucketeer-io/bucketeer/blob/main/pkg/feature/storage/v2/segment_user.go#L78).

Before: 9k messages per second
After 40k messages per second

---

This pull request modifies the `persister.go` and `persister_test.go` files in the `pkg/user/persister` package, and the `mau.go` file in the `pkg/user/storage/v2` package. The changes primarily focus on improving the handling of user events and messages, and upserting multiple user events in batches. 

Here are the most important changes:

Modifications to `persister.go`:

* The `handleChunk` function now creates a context with a timeout, and extracts and appends user events and PubSub messages per environment. It also upserts events if the length of events is greater than zero.
* The `unmarshalMessage` function has been modified to validate events and nack messages if they are not valid.
* New functions `validateEvent`, `nackMessages`, `ackMessages`, and `upsertMAUs` have been added to validate user events, nack messages, ack messages, and upsert multiple active users (MAUs) respectively.

Modifications to `persister_test.go`:

* The `TestUpsert` function now creates a context with cancel, and has been modified to test the `upsertMAUs` function. [[1]](diffhunk://#diff-925ce2bd6b81d87865a057ddf6174ad585a15a23fbac86848b6ed0eab3b920cdR18) [[2]](diffhunk://#diff-925ce2bd6b81d87865a057ddf6174ad585a15a23fbac86848b6ed0eab3b920cdL30) [[3]](diffhunk://#diff-925ce2bd6b81d87865a057ddf6174ad585a15a23fbac86848b6ed0eab3b920cdL80-R122) [[4]](diffhunk://#diff-925ce2bd6b81d87865a057ddf6174ad585a15a23fbac86848b6ed0eab3b920cdL134-R132)

Modifications to `mau.go`:

* New functions `UpsertMAUs` and `upsertMAUs` have been added to upsert multiple MAUs in batches. [[1]](diffhunk://#diff-d3d5e2508d4558aa4f46b9508f67e4f8aeb757dfb158e43ecb53c62d64e51b99R21-R34) [[2]](diffhunk://#diff-d3d5e2508d4558aa4f46b9508f67e4f8aeb757dfb158e43ecb53c62d64e51b99R81-R154)