### PR TITLE
fix: nil pointer when logging

### DIFF
--- a/pkg/batch/subscriber/processor/user_event_persister.go
+++ b/pkg/batch/subscriber/processor/user_event_persister.go
@@ -72,6 +72,7 @@ func NewUserEventPersister(
 		mysqlClient:              mysqlClient,
 		timeNow:                  time.Now,
 		newUUID:                  uuid.NewUUID,
+		logger:                   logger,
 	}, nil
 }
 


### PR DESCRIPTION
This pull request will fix the issue of the `logger` field not being set, which has caused the user event persister to stop subscription.