### PR TITLE
chore: add mysql open connection configuration to batch server

### DIFF
--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -97,6 +97,8 @@ spec:
               value: "{{ .Values.env.mysqlPort }}"
             - name: BUCKETEER_BATCH_MYSQL_DB_NAME
               value: "{{ .Values.env.mysqlDbName }}"
+            - name: BUCKETEER_BATCH_MYSQL_DB_OPEN_CONNS
+              value: "{{ .Values.env.mysqlDBOpenConns }}"
             - name: BUCKETEER_BATCH_WEB_URL
               value: "{{ .Values.env.webURL }}"
             - name: BUCKETEER_BATCH_LOG_LEVEL

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -15,6 +15,7 @@ env:
   mysqlHost:
   mysqlPort:
   mysqlDbName:
+  mysqlDBOpenConns: 50
   pubsubEmulatorHost:
   accountService: localhost:9001
   notificationService: localhost:9001

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -80,11 +80,12 @@ type server struct {
 	oauthClientID      *string
 	oauthIssuer        *string
 	// MySQL
-	mysqlUser   *string
-	mysqlPass   *string
-	mysqlHost   *string
-	mysqlPort   *int
-	mysqlDBName *string
+	mysqlUser        *string
+	mysqlPass        *string
+	mysqlHost        *string
+	mysqlPort        *int
+	mysqlDBName      *string
+	mysqlDBOpenConns *int
 	// gRPC service
 	accountService              *string
 	environmentService          *string
@@ -133,12 +134,13 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"oauth-client-id",
 			"The oauth clientID registered at dex.",
 		).Required().String(),
-		oauthIssuer: cmd.Flag("oauth-issuer", "The url of dex issuer.").Required().String(),
-		mysqlUser:   cmd.Flag("mysql-user", "MySQL user.").Required().String(),
-		mysqlPass:   cmd.Flag("mysql-pass", "MySQL password.").Required().String(),
-		mysqlHost:   cmd.Flag("mysql-host", "MySQL host.").Required().String(),
-		mysqlPort:   cmd.Flag("mysql-port", "MySQL port.").Required().Int(),
-		mysqlDBName: cmd.Flag("mysql-db-name", "MySQL database name.").Required().String(),
+		oauthIssuer:      cmd.Flag("oauth-issuer", "The url of dex issuer.").Required().String(),
+		mysqlUser:        cmd.Flag("mysql-user", "MySQL user.").Required().String(),
+		mysqlPass:        cmd.Flag("mysql-pass", "MySQL password.").Required().String(),
+		mysqlHost:        cmd.Flag("mysql-host", "MySQL host.").Required().String(),
+		mysqlPort:        cmd.Flag("mysql-port", "MySQL port.").Required().Int(),
+		mysqlDBName:      cmd.Flag("mysql-db-name", "MySQL database name.").Required().String(),
+		mysqlDBOpenConns: cmd.Flag("mysql-open-conns", "MySQL open connections.").Required().Int(),
 		accountService: cmd.Flag(
 			"account-service",
 			"bucketeer-account-service address.",
@@ -581,6 +583,7 @@ func (s *server) createMySQLClient(
 		*s.mysqlDBName,
 		mysql.WithLogger(logger),
 		mysql.WithMetrics(registerer),
+		mysql.WithMaxOpenConns(*s.mysqlDBOpenConns),
 	)
 }
 


### PR DESCRIPTION
After we moved the user persister to the batch service, many requests got stuck when upserting the values in the DB. It was getting context deadline errors.
The reason was the MySQL client, by default, uses 10 connections, and the user persister uses 10 workers.
Also, there are other services that use the same client instance, which causes delays in the operations in MySQL, causing errors.

For now, I'm setting the default value to 50 connections. But we should be careful when moving or adding new services that use MySQL in the future.