### PR TITLE
chore: ignore configuration not found error

### DIFF
--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -79,13 +79,13 @@ spec:
               value: "{{ .Values.env.experimentCalculatorService }}"
             - name: BUCKETEER_BATCH_BATCH_SERVICE
               value: "{{ .Values.env.batchService }}"
-            - name: BUCKETEER_OPS_EVENT_SCHEDULE_COUNT_WATCHER
+            - name: BUCKETEER_BATCH_EVENT_SCHEDULE_COUNT_WATCHER
               value: "{{ .Values.env.scheduleCountWatcher }}"
-            - name: BUCKETEER_OPS_EVENT_SCHEDULE_DATETIME_WATCHER
+            - name: BUCKETEER_BATCH_EVENT_SCHEDULE_DATETIME_WATCHER
               value: "{{ .Values.env.scheduleDatetimeWatcher }}"
-            - name: BUCKETEER_OPS_EVENT_SCHEDULE_PROGRESSIVE_ROLLOUT_WATCHER
+            - name: BUCKETEER_BATCH_EVENT_SCHEDULE_PROGRESSIVE_ROLLOUT_WATCHER
               value: "{{ .Values.env.scheduleProgressiveRolloutWatcher }}"
-            - name: BUCKETEER_OPS_EVENT_REFRESH_INTERVAL
+            - name: BUCKETEER_BATCH_EVENT_REFRESH_INTERVAL
               value: "{{ .Values.env.refreshInterval }}"
             - name: BUCKETEER_BATCH_MYSQL_USER
               value: "{{ .Values.env.mysqlUser }}"


### PR DESCRIPTION
This PR will ignore the batch subscriber json config not found error rather than crash batch service while user is not configure subscriber json config.