### PR TITLE
chore: fix devcontainer for development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,5 +32,5 @@
     "memory": "8gb",
     "storage": "32gb"
   },
-  "postAttachCommand": "make local-deps && make vendor && (cd ui/web-v2 && yarn)"
+  "postAttachCommand": "make local-deps && make update-repos && (cd ui/web-v2 && yarn)"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,12 @@
       "settings": {
         "go.toolsManagement.checkForUpdates": "local",
         "go.useLanguageServer": true,
-        "go.gopath": "/go"
+        "go.gopath": "/go",
+        "go.lintTool": "golangci-lint",
+        "go.lintFlags": [
+          "--config=${workspaceFolder}/.golangci.yml",
+          "--fast"
+        ]
       },
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
@@ -26,5 +31,6 @@
     "cpus": 4,
     "memory": "8gb",
     "storage": "32gb"
-  }
+  },
+  "postAttachCommand": "make local-deps && make vendor && (cd ui/web-v2 && yarn)"
 }

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 COPY first-run-notice.txt /tmp/scripts/
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     # Restore man command
-    && yes | unminimize 2>&1 
+    && yes | unminimize 2>&1
 
 ENV LANG="C.UTF-8"
 
@@ -29,15 +29,13 @@ RUN apt-get update \
         zip \
         libgdiplus \
         jq \
-        # By default pip is not available in the buildpacks image
-        python-pip-whl \
         python3-pip \
         #.NET Core related pre-requisites
         libc6 \
         libgcc1 \
         libgssapi-krb5-2 \
         libncurses5 \
-        liblttng-ust0 \
+        liblttng-ust1 \
         libssl-dev \
         libstdc++6 \
         zlib1g \
@@ -59,7 +57,7 @@ RUN apt-get update \
 
 # Verify expected build and debug tools are present
 RUN apt-get update \
-    && apt-get -y install build-essential cmake cppcheck valgrind clang lldb llvm gdb python3-dev \
+    && apt-get -y install build-essential cmake cppcheck valgrind clang clang-format lldb llvm gdb python3-dev \
     # Install tools and shells not in common script
     && apt-get install -yq vim vim-doc xtail software-properties-common libsecret-1-dev \
     # Install additional tools (useful for 'puppeteer' project)
@@ -78,7 +76,7 @@ ENV SHELL=/bin/bash \
 # Remove scripts now that we're done with them
 RUN apt-get clean -y && rm -rf /tmp/scripts
 
-# Mount for docker-in-docker 
+# Mount for docker-in-docker
 VOLUME [ "/var/lib/docker" ]
 
 # Fire Docker/Moby script if needed
@@ -88,7 +86,7 @@ CMD [ "sleep", "infinity" ]
 # [Optional] Install debugger for development of Codespaces - Not in resulting image by default
 ARG DeveloperBuild
 RUN if [ -z $DeveloperBuild ]; then \
-        echo "not including debugger" ; \
+    echo "not including debugger" ; \
     else \
-        curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg ; \
+    curl -sSL https://aka.ms/getvsdbgsh | bash /dev/stdin -v latest -l /vsdbg ; \
     fi

--- a/.github/.devcontainer/devcontainer-lock.json
+++ b/.github/.devcontainer/devcontainer-lock.json
@@ -40,6 +40,11 @@
       "resolved": "ghcr.io/devcontainers/features/kubectl-helm-minikube@sha256:23aca9dfe058b498b4d7fa2d5592c75b1ff06e581b950419a56e19568d8ecaf7",
       "integrity": "sha256:23aca9dfe058b498b4d7fa2d5592c75b1ff06e581b950419a56e19568d8ecaf7"
     },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.4.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:6c4f444d8e3eb68594d60ec128bce76a80647edc2b9a94960ca377895855145f",
+      "integrity": "sha256:6c4f444d8e3eb68594d60ec128bce76a80647edc2b9a94960ca377895855145f"
+    },
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "1.0.9",
       "resolved": "ghcr.io/devcontainers/features/sshd@sha256:7f6467f25d23c47371ba59f6f3350c9de3439a4d4cdf7497ae50e8aca40bc0e0",

--- a/.github/.devcontainer/devcontainer.json
+++ b/.github/.devcontainer/devcontainer.json
@@ -37,6 +37,9 @@
     "ghcr.io/devcontainers/features/go:1": {
       "version": "latest"
     },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "latest"
+    },
     "./local-features/setup-user": "latest"
   },
   "overrideFeatureInstallOrder": [

--- a/Makefile
+++ b/Makefile
@@ -265,8 +265,12 @@ update-copyright:
 # dev container
 #############################
 
+# build devcontainer locally
+build-devcontainer:
+	devcontainer build --workspace-folder=.github --push=false --image-name="ghcr.io/bucketeer-io/bucketeer-devcontainer:latest"
+
 # start minikube
-start-minikube: 
+start-minikube:
 	if [ $$(minikube status | grep -c "minikube start") -eq 1 ]; then \
 		make -C tools/dev setup-minikube; \
 	elif [ $$(minikube status | grep -c "Stopped") -gt 1 ]; then \


### PR DESCRIPTION
This PR
- Enables to development of Bucketeer inside devcontainers.
  - Update dependencies
  - Add tools
    - clang-format
  - Install tools after the container starts
- Add make command
   - `build-devcontainer` builds devcontainer locally. This command is for development of devcontainer.