### PR TITLE
ci: set clang-format version

### DIFF
--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -100,8 +100,14 @@ jobs:
         with:
           version: ${{ env.PROTOC_VERSION }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Check proto files
-        run: make proto-check
+      - name:  Check proto format
+        uses: jidicula/clang-format-action@c74383674bf5f7c69f60ce562019c1c94bc1421a # v4.13.0
+        with:
+          clang-format-version: '18'
+          check-path: 'proto'
+          exclude-regex: 'external' # googleapis proto files
+      - name: Check proto lock
+        run: make proto-lock-check
 
   proto-descriptor-check:
     runs-on: ubuntu-latest

--- a/proto/.clang-format
+++ b/proto/.clang-format
@@ -1,1 +1,4 @@
 BasedOnStyle: Google
+---
+Language: Proto
+ColumnLimit: 80

--- a/proto/notification/recipient.proto
+++ b/proto/notification/recipient.proto
@@ -18,7 +18,9 @@ package bucketeer.notification;
 option go_package = "github.com/bucketeer-io/bucketeer/proto/notification";
 
 message Recipient {
-  enum Type { SlackChannel = 0; }
+  enum Type {
+    SlackChannel = 0;
+  }
   enum Language {
     ENGLISH = 0;
     JAPANESE = 1;


### PR DESCRIPTION
The `ubuntu-latest` uses clang-format 14, which is very old. 
Sometimes, it fails due to a newer version running on the local machine when developing.
To avoid this, I'm setting a specific version to avoid errors.