### PR TITLE
chore: update storage for multi-schedule

### DIFF
--- a/pkg/autoops/storage/v2/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule.go
@@ -79,6 +79,7 @@ func (s *autoOpsRuleStorage) CreateAutoOpsRule(
 		e.CreatedAt,
 		e.UpdatedAt,
 		e.Deleted,
+		int32(e.AutoOpsStatus),
 		environmentNamespace,
 	)
 	if err != nil {
@@ -105,6 +106,7 @@ func (s *autoOpsRuleStorage) UpdateAutoOpsRule(
 		e.CreatedAt,
 		e.UpdatedAt,
 		e.Deleted,
+		int32(e.AutoOpsStatus),
 		e.Id,
 		environmentNamespace,
 	)
@@ -141,6 +143,7 @@ func (s *autoOpsRuleStorage) GetAutoOpsRule(
 		&autoOpsRule.CreatedAt,
 		&autoOpsRule.UpdatedAt,
 		&autoOpsRule.Deleted,
+		&autoOpsRule.AutoOpsStatus,
 	)
 	if err != nil {
 		if err == mysql.ErrNoRows {
@@ -180,6 +183,7 @@ func (s *autoOpsRuleStorage) ListAutoOpsRules(
 			&autoOpsRule.CreatedAt,
 			&autoOpsRule.UpdatedAt,
 			&autoOpsRule.Deleted,
+			&autoOpsRule.AutoOpsStatus,
 		)
 		if err != nil {
 			return nil, 0, err

--- a/pkg/autoops/storage/v2/sql/auto_ops_rule/insert_auto_ops_rule.sql
+++ b/pkg/autoops/storage/v2/sql/auto_ops_rule/insert_auto_ops_rule.sql
@@ -7,7 +7,8 @@ INSERT INTO auto_ops_rule (
     created_at,
     updated_at,
     deleted,
+    status,
     environment_namespace
 ) VALUES (
-    ?, ?, ?, ?, ?, ?, ?, ?, ?
+    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
 )

--- a/pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rule.sql
+++ b/pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rule.sql
@@ -6,7 +6,8 @@ SELECT
     triggered_at,
     created_at,
     updated_at,
-    deleted
+    deleted,
+    status
 FROM
     auto_ops_rule
 WHERE

--- a/pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rules.sql
+++ b/pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rules.sql
@@ -6,7 +6,8 @@ SELECT
     triggered_at,
     created_at,
     updated_at,
-    deleted
+    deleted,
+    status
 FROM
     auto_ops_rule
 %s %s %s

--- a/pkg/autoops/storage/v2/sql/auto_ops_rule/update_auto_ops_rule.sql
+++ b/pkg/autoops/storage/v2/sql/auto_ops_rule/update_auto_ops_rule.sql
@@ -7,7 +7,8 @@ SET
     triggered_at = ?,
     created_at = ?,
     updated_at = ?,
-    deleted = ?
+    deleted = ?,
+    status = ?
 WHERE
     id = ? AND
     environment_namespace = ?


### PR DESCRIPTION
This pull request includes Storage layer support needed in the process of supporting multiple schedules for automated operations.

The related RFC is https://github.com/bucketeer-io/bucketeer/pull/937.
Part of https://github.com/bucketeer-io/bucketeer/issues/885.

As a result of this PR, we need to add a column of `status` to the `auto_ops_rule` table.
```
ALTER TABLE auto_ops_rule
ADD `status` int NOT NULL default 0;
```

Changes to SQL queries:

* [`pkg/autoops/storage/v2/sql/auto_ops_rule/insert_auto_ops_rule.sql`](diffhunk://#diff-49b2f47566150a206e986802da795ae502851cf3296d080db4ee50cd653c0008R10-R13): Added a new `status` field to the `INSERT INTO auto_ops_rule` SQL command.
* [`pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rule.sql`](diffhunk://#diff-a4ff36c09f4785224443ae20c1790ce9ea55a5f4272be34b4847d2d83f9fe695L9-R10): Modified the `SELECT` command to include the new `status` field in the fetched columns.
* [`pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rules.sql`](diffhunk://#diff-98bcdaadf4de404d92d4dd30d4bd6bf0e95fb49d3bf31603640d0b8924784bd7L9-R10): Modified the `SELECT` command to include the new `status` field in the fetched columns.
* [`pkg/autoops/storage/v2/sql/auto_ops_rule/update_auto_ops_rule.sql`](diffhunk://#diff-e7eb10fc5d2f94587eace01516cef35e1e1094bf5ea2ca0d35bc5a9aae0a6a63L10-R11): Added the new `status` field to the `SET` clause of the `UPDATE` command.

Changes to Go functions:

* [`pkg/autoops/storage/v2/auto_ops_rule.go`](diffhunk://#diff-12ff7cd117e3c2198ed20104c463641620d9f6c13bc67c0434d5f84b7c512f0dR82): Updated the `CreateAutoOpsRule`, `UpdateAutoOpsRule`, `GetAutoOpsRule`, and `ListAutoOpsRules` functions to include the new `AutoOpsStatus` field. [[1]](diffhunk://#diff-12ff7cd117e3c2198ed20104c463641620d9f6c13bc67c0434d5f84b7c512f0dR82) [[2]](diffhunk://#diff-12ff7cd117e3c2198ed20104c463641620d9f6c13bc67c0434d5f84b7c512f0dR109) [[3]](diffhunk://#diff-12ff7cd117e3c2198ed20104c463641620d9f6c13bc67c0434d5f84b7c512f0dR146) [[4]](diffhunk://#diff-12ff7cd117e3c2198ed20104c463641620d9f6c13bc67c0434d5f84b7c512f0dR186)