### PR TITLE
chore: change bigquery emulator image to bucketeer

### DIFF
--- a/manifests/localenv/values.yaml
+++ b/manifests/localenv/values.yaml
@@ -38,7 +38,7 @@ bq:
     type: NodePort
     httpNodePort: 31000
   image:
-    repository: ghcr.io/ubisoft-potato/bigquery-emulator
+    repository: ghcr.io/bucketeer-io/bigquery-emulator
     
 pubsub: 
   image: 


### PR DESCRIPTION
We will manage the bigquery emulator in Bucketeer: https://github.com/bucketeer-io/bigquery-emulator/pkgs/container/bigquery-emulator