### PR TITLE
ci: remove dependabot ignoring release please

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,8 +6,6 @@ updates:
       interval: "monthly"
       time: "10:00"
       timezone: "Asia/Tokyo"
-    ignore:
-      - dependency-name: "google-github-actions/release-please-action"
     commit-message:
       prefix: "build"
       include: "scope"


### PR DESCRIPTION
release please can be the target now (https://github.com/bucketeer-io/bucketeer/pull/987)