### PR TITLE
ci: update npm packages with dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -28,3 +28,17 @@ updates:
       dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "10:00"
+      timezone: "Asia/Tokyo"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+


### PR DESCRIPTION
The UI's packages were recently cleaned up (https://github.com/bucketeer-io/bucketeer/pull/1031, https://github.com/bucketeer-io/bucketeer/pull/1039), so I suppose they're ready to be updated with Dependabot.