### PR TITLE
revert: default vars for dev container

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,15 +74,35 @@ Please note that you only need to create them once.
 ### Create API keys
 
 ```shell
-make create-api-key API_KEY_ROLE=SDK_CLIENT API_KEY_PATH=/workspaces/bucketeer/tools/dev/cert/api_key_client
+WEB_GATEWAY_URL=web-gateway.bucketeer.io \
+WEB_GATEWAY_CERT_PATH=/workspaces/bucketeer/tools/dev/cert/tls.crt \
+SERVICE_TOKEN_PATH=/workspaces/bucketeer/tools/dev/cert/service-token \
+API_KEY_PATH=/workspaces/bucketeer/tools/dev/cert/api_key_client \
+API_KEY_ROLE=SDK_CLIENT \
+ENVIRONMENT_NAMESPACE=e2e \
+make create-api-key
 ```
 
 ```shell
-make create-api-key API_KEY_ROLE=SDK_SERVER API_KEY_PATH=/workspaces/bucketeer/tools/dev/cert/api_key_server
+WEB_GATEWAY_URL=web-gateway.bucketeer.io \
+WEB_GATEWAY_CERT_PATH=/workspaces/bucketeer/tools/dev/cert/tls.crt \
+SERVICE_TOKEN_PATH=/workspaces/bucketeer/tools/dev/cert/service-token \
+API_KEY_PATH=/workspaces/bucketeer/tools/dev/cert/api_key_server \
+API_KEY_ROLE=SDK_SERVER \
+ENVIRONMENT_NAMESPACE=e2e \
+make create-api-key
 ```
 
 ### Run E2E tests
 
 ```shell
+WEB_GATEWAY_URL=web-gateway.bucketeer.io \
+GATEWAY_URL=api-gateway.bucketeer.io \
+WEB_GATEWAY_CERT_PATH=/workspaces/bucketeer/tools/dev/cert/tls.crt \
+GATEWAY_CERT_PATH=/workspaces/bucketeer/tools/dev/cert/tls.crt \
+SERVICE_TOKEN_PATH=/workspaces/bucketeer/tools/dev/cert/service-token \
+API_KEY_PATH=/workspaces/bucketeer/tools/dev/cert/api_key_client \
+API_KEY_SERVER_PATH=/workspaces/bucketeer/tools/dev/cert/api_key_server \
+ENVIRONMENT_NAMESPACE=e2e \
 make e2e
 ```

--- a/Makefile
+++ b/Makefile
@@ -21,16 +21,6 @@ LDFLAGS_VERSION := $(LDFLAGS_PACKAGE).Version
 LDFLAGS_HASH := $(LDFLAGS_PACKAGE).Hash
 LDFLAGS_BUILDDATE := $(LDFLAGS_PACKAGE).BuildDate
 
-# Default variables for dev container
-WEB_GATEWAY_URL := web-gateway.bucketeer.io
-GATEWAY_URL := api-gateway.bucketeer.io
-WEB_GATEWAY_CERT_PATH := /workspaces/bucketeer/tools/dev/cert/tls.crt
-GATEWAY_CERT_PATH := /workspaces/bucketeer/tools/dev/cert/tls.crt
-SERVICE_TOKEN_PATH := /workspaces/bucketeer/tools/dev/cert/service-token
-API_KEY_PATH := /workspaces/bucketeer/tools/dev/cert/api_key_client
-API_KEY_SERVER_PATH := /workspaces/bucketeer/tools/dev/cert/api_key_server
-ENVIRONMENT_NAMESPACE := e2e
-
 #############################
 # Run make commands on docker container
 #############################


### PR DESCRIPTION
For now, I'm reverting this because the e2e test fails in the CI due to incorrect file paths.
I'll think of a better of doing this.