### PR TITLE
chore: remove github token

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,7 +54,7 @@ Additionally, this command will:
 The following command will deploy all the Bucketeer services at once.
 
 ```shell
-GITHUB_TOKEN=token make deploy-bucketeer
+make deploy-bucketeer
 ```
 
 If you need to deploy a single service, you can do as follows.

--- a/Makefile
+++ b/Makefile
@@ -369,8 +369,6 @@ deploy-bucketeer: delete-all-services-from-minikube
 	make -C tools/dev service-cert-secret
 	make -C tools/dev service-token-secret
 	make -C tools/dev oauth-key-secret
-	GITHUB_TOKEN=$(GITHUB_TOKEN) make -C tools/dev generate-github-token
-
 	make -C ./ build-go
 	TAG=localenv make -C ./ build-docker-images
 	TAG=localenv make -C ./ minikube-load-images

--- a/manifests/bucketeer/charts/backend/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/backend/templates/deployment.yaml
@@ -44,9 +44,6 @@ spec:
         - name: oauth-key-secret
           secret:
             secretName: {{ template "oauth-key-secret" . }}
-        - name: github-access-token-secret
-          secret:
-            secretName: github-token
       {{- if .Values.serviceAccount.annotations }}
       serviceAccountName: {{ template "backend.fullname" . }}
       {{- end }}
@@ -122,8 +119,6 @@ spec:
               value: "{{ .Values.env.experimentServicePort }}"
             - name: BUCKETEER_BACKEND_FEATURE_SERVICE_PORT
               value: "{{ .Values.env.featureServicePort }}"
-            - name: BUCKETEER_BACKEND_MIGRATE_MYSQL_SERVICE_PORT
-              value: "{{ .Values.env.migrateMysqlServicePort }}"
             - name: BUCKETEER_BACKEND_NOTIFICATION_SERVICE_PORT
               value: "{{ .Values.env.notificationServicePort }}"
             - name: BUCKETEER_BACKEND_PUSH_SERVICE_PORT
@@ -174,16 +169,6 @@ spec:
               value: "{{ .Values.webhook.baseURL }}"
             - name: BUCKETEER_BACKEND_WEBHOOK_KMS_RESOURCE_NAME
               value: "{{ .Values.webhook.kmsResourceName }}"
-            - name: BUCKETEER_BACKEND_GITHUB_USER
-              value: "{{ .Values.env.githubUser }}"
-            - name: BUCKETEER_BACKEND_GITHUB_ACCESS_TOKEN_PATH
-              value: /usr/local/github-access-token/bucketeer-bot-access-token
-            - name: BUCKETEER_BACKEND_GITHUB_MIGRATION_SOURCE_PATH
-              value: "{{ .Values.env.githubMigrationSourcePath }}"
-            - name: BUCKETEER_BACKEND_MYSQL_MIGRATION_USER
-              value: "{{ .Values.env.mysqlMigrationUser }}"
-            - name: BUCKETEER_BACKEND_MYSQL_MIGRATION_PASS
-              value: "{{ .Values.env.mysqlMigrationPass }}"
           volumeMounts:
             - name: issuer-cert-secret
               mountPath: /usr/local/certs/issuer
@@ -196,9 +181,6 @@ spec:
               readOnly: true
             - name: oauth-key-secret
               mountPath: /usr/local/oauth-key
-              readOnly: true
-            - name: github-access-token-secret
-              mountPath: /usr/local/github-access-token
               readOnly: true
           ports:
             - name: health-check

--- a/manifests/bucketeer/charts/backend/values.dev.yaml
+++ b/manifests/bucketeer/charts/backend/values.dev.yaml
@@ -10,8 +10,6 @@ env:
   bucketeerTestEnabled: true
   bigqueryEmulatorHost: http://localenv-bq.default.svc.cluster.local:9050
   pubsubEmulatorHost: localenv-pubsub.default.svc.cluster.local:8089
-  mysqlMigrationUser: bucketeer
-  mysqlMigrationPass: bucketeer
   project: bucketeer-test
   mysqlUser: bucketeer
   mysqlPass: bucketeer
@@ -33,8 +31,6 @@ env:
   domainTopic: domain
   bulkSegmentUsersReceivedTopic: bulk-segment-users-received
   timezone: UTC
-  githubUser: bucketeer
-  githubMigrationSourcePath: /tmp/migration
   logLevel: info
 tls:
   service:

--- a/manifests/bucketeer/charts/backend/values.yaml
+++ b/manifests/bucketeer/charts/backend/values.yaml
@@ -12,8 +12,6 @@ env:
   bucketeerTestEnabled:
   gcpEnabled: true
   bigqueryEmulatorHost:
-  mysqlMigrationUser:
-  mysqlMigrationPass:
   pubsubEmulatorHost:
   project:
   mysqlUser:
@@ -51,14 +49,11 @@ env:
   eventCounterServicePort: 9096
   experimentServicePort: 9097
   featureServicePort: 9098
-  migrateMysqlServicePort: 9099
   notificationServicePort: 9100
   pushServicePort: 9101
   metricsPort: 9002
   timezone: UTC
   emailFilter:
-  githubUser:
-  githubMigrationSourcePath:
   logLevel: info
 
 affinity: {}

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -29,8 +29,6 @@ backend:
     bucketeerTestEnabled: true
     bigqueryEmulatorHost: http://localenv-bq.default.svc.cluster.local:9050
     pubsubEmulatorHost: localenv-pubsub.default.svc.cluster.local:8089
-    mysqlMigrationUser: bucketeer
-    mysqlMigrationPass: bucketeer
     project: bucketeer-test
     mysqlUser: bucketeer
     mysqlPass: bucketeer
@@ -52,8 +50,6 @@ backend:
     domainTopic: domain
     bulkSegmentUsersReceivedTopic: bulk-segment-users-received
     timezone: UTC
-    githubUser: bucketeer
-    githubMigrationSourcePath: /tmp/migration
     logLevel: info
   tls:
     service:

--- a/pkg/backend/cmd/server/server.go
+++ b/pkg/backend/cmd/server/server.go
@@ -84,9 +84,6 @@ type server struct {
 	mysqlHost   *string
 	mysqlPort   *int
 	mysqlDBName *string
-	// MySQL for Migration
-	mysqlMigrationUser *string
-	mysqlMigrationPass *string
 	// Persistent Redis
 	persistentRedisServerName    *string
 	persistentRedisAddr          *string
@@ -112,7 +109,6 @@ type server struct {
 	eventCounterServicePort *int
 	experimentServicePort   *int
 	featureServicePort      *int
-	migrateMySQLServicePort *int
 	notificationServicePort *int
 	pushServicePort         *int
 	// Service
@@ -133,10 +129,6 @@ type server struct {
 	webhookBaseURL         *string
 	webhookKMSResourceName *string
 	cloudService           *string
-	// migration-mysql
-	githubUser                *string
-	githubAccessTokenPath     *string
-	githubMigrationSourcePath *string
 }
 
 func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
@@ -223,10 +215,6 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"feature-service-port",
 			"Port to bind to feature service.",
 		).Default("9098").Int(),
-		migrateMySQLServicePort: cmd.Flag(
-			"migrate-mysql-service-port",
-			"Port to bind to migrate mysql service.",
-		).Default("9099").Int(),
 		notificationServicePort: cmd.Flag(
 			"notification-service-port",
 			"Port to bind to notification service.",
@@ -295,15 +283,6 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"Cloud KMS resource name to encrypt and decrypt webhook credentials.",
 		).Required().String(),
 		cloudService: cmd.Flag("cloud-service", "Cloud Service info").Default(gcp).String(),
-		// migration-mysql
-		githubUser:            cmd.Flag("github-user", "GitHub user.").Required().String(),
-		githubAccessTokenPath: cmd.Flag("github-access-token-path", "Path to GitHub access token.").Required().String(),
-		githubMigrationSourcePath: cmd.Flag(
-			"github-migration-source-path",
-			"Path to migration file in GitHub. (e.g. owner/repo/path#ref)",
-		).Required().String(),
-		mysqlMigrationUser: cmd.Flag("mysql-migration-user", "MySQL user for migration.").Required().String(),
-		mysqlMigrationPass: cmd.Flag("mysql-migration-pass", "MySQL password for migration.").Required().String(),
 	}
 	r.RegisterCommand(server)
 	return server

--- a/tools/dev/Makefile
+++ b/tools/dev/Makefile
@@ -25,10 +25,6 @@ oauth-key-secret:
 	kubectl delete secret bucketeer-oauth-key --namespace $(NAMESPACE) --ignore-not-found
 	kubectl create secret generic bucketeer-oauth-key --from-file public.pem=${CURDIR}/cert/oauth-public.pem --from-file private.pem=${CURDIR}/cert/oauth-private.pem --namespace $(NAMESPACE)
 
-generate-github-token:
-	kubectl delete secret github-token --namespace ${NAMESPACE} --ignore-not-found
-	kubectl create secret generic github-token --from-literal bucketeer-bot-access-token=${GITHUB_TOKEN}
-
 setup-minikube:
 	minikube start --memory 6g
 	minikube addons enable ingress


### PR DESCRIPTION
Since we already merged new database migration, we can remove the github token dependency of old migration.