### PR TITLE
fix: proto clone changs empty slice to nil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/googleapis/gax-go/v2 v2.12.5
 	github.com/hashicorp/vault/api v1.14.0
+	github.com/jinzhu/copier v0.4.0
 	github.com/lib/pq v1.10.9
 	github.com/mna/redisc v1.4.0
 	github.com/nicksnyder/go-i18n/v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -799,6 +799,8 @@ github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/j-keck/arping v1.0.2/go.mod h1:aJbELhR92bSk7tp79AWM/ftfc90EfEi2bQJrbBFOsPw=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20160803190731-bd40a432e4c7/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -20,11 +20,11 @@ import (
 	"strconv"
 	"time"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	"github.com/bucketeer-io/bucketeer/proto/feature"
+	"github.com/jinzhu/copier"
 )
 
 const (
@@ -949,7 +949,8 @@ func (f *Feature) Update(
 	enabled *wrapperspb.BoolValue,
 	archived *wrapperspb.BoolValue,
 ) (*Feature, error) {
-	updated := &Feature{Feature: proto.Clone(f.Feature).(*feature.Feature)}
+	updated := &Feature{}
+	copier.Copy(updated, f)
 	incVersion := false
 	if name != nil {
 		if err := updated.UpdateName(name.Value); err != nil {

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -22,9 +22,10 @@ import (
 
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/jinzhu/copier"
+
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	"github.com/bucketeer-io/bucketeer/proto/feature"
-	"github.com/jinzhu/copier"
 )
 
 const (
@@ -950,7 +951,9 @@ func (f *Feature) Update(
 	archived *wrapperspb.BoolValue,
 ) (*Feature, error) {
 	updated := &Feature{}
-	copier.Copy(updated, f)
+	if err := copier.Copy(updated, f); err != nil {
+		return nil, err
+	}
 	incVersion := false
 	if name != nil {
 		if err := updated.UpdateName(name.Value); err != nil {

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -1835,7 +1835,9 @@ func TestUpdate(t *testing.T) {
 		{
 			desc: "success",
 			feature: &Feature{
-				Feature: &proto.Feature{},
+				Feature: &proto.Feature{
+					Prerequisites: []*proto.Prerequisite{},
+				},
 			},
 			name:        &wrapperspb.StringValue{Value: "name"},
 			description: &wrapperspb.StringValue{Value: "description"},
@@ -1844,10 +1846,11 @@ func TestUpdate(t *testing.T) {
 			tags:        []string{"tag1", "tag2"},
 			expected: &Feature{
 				Feature: &proto.Feature{
-					Name:        "name",
-					Description: "description",
-					UpdatedAt:   time.Now().Unix(),
-					Version:     1,
+					Name:          "name",
+					Description:   "description",
+					UpdatedAt:     time.Now().Unix(),
+					Version:       1,
+					Prerequisites: []*proto.Prerequisite{},
 				},
 			},
 			expectedErr: nil,
@@ -1875,10 +1878,11 @@ func TestUpdate(t *testing.T) {
 				p.name, p.description,
 				p.tags, p.enabled, p.archived,
 			)
-			if p.expectedErr != nil && actual != nil {
+			if p.expected != nil || actual != nil {
 				assert.Equal(t, p.expected.Name, actual.Name, p.desc)
 				assert.Equal(t, p.expected.Description, actual.Description, p.desc)
 				assert.Equal(t, p.expected.Version, actual.Version, p.desc)
+				assert.Equal(t, p.expected.Prerequisites, actual.Prerequisites, p.desc)
 				assert.LessOrEqual(t, p.expected.UpdatedAt, actual.UpdatedAt)
 			}
 			assert.Equal(t, p.expectedErr, err)


### PR DESCRIPTION
proto built-in Clone() changes an empty slice to nil, which creates unexpected diffs.

<img width="351" alt="Screenshot 2024-06-29 at 13 12 20" src="https://github.com/bucketeer-io/bucketeer/assets/16733673/568238d3-7710-442e-9301-922eba65d9fb">
