### PR TITLE
chore: change to verify issuer and audience in the access token

### DIFF
--- a/pkg/token/verifier.go
+++ b/pkg/token/verifier.go
@@ -68,13 +68,12 @@ func (v *verifier) VerifyAccessToken(rawAccessToken string) (*AccessToken, error
 	if err := json.Unmarshal(payload, t); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal claims: %v", err)
 	}
-	// TODO: revert
-	// if t.Issuer != v.issuer {
-	// 	return nil, fmt.Errorf("id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
-	// }
-	// if t.Audience != v.audience {
-	// 	return nil, fmt.Errorf("expected audience %q got %q", v.audience, t.Audience)
-	// }
+	if t.Issuer != v.issuer {
+		return nil, fmt.Errorf("id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
+	}
+	if t.Audience != v.audience {
+		return nil, fmt.Errorf("expected audience %q got %q", v.audience, t.Audience)
+	}
 	if t.Expiry.Before(time.Now()) {
 		return nil, fmt.Errorf("token is expired (Token Expiry: %v)", t.Expiry)
 	}


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/pull/1097

Because the issuer was different when using Dex, we had to stop verifying the issuer and audience until we updated the new issuer and audience using the new authenticator.