### PR TITLE
feat: add entity data to auditlog

### DIFF
--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -68,7 +68,10 @@ func (s *AccountService) CreateAccountV2(
 			return err
 		}
 		if exist != nil {
-			handler := command.NewAccountV2CommandHandler(editor, exist, s.publisher, req.OrganizationId)
+			handler, err := command.NewAccountV2CommandHandler(editor, exist, s.publisher, req.OrganizationId)
+			if err != nil {
+				return err
+			}
 			cmd := &accountproto.ChangeAccountV2EnvironmentRolesCommand{
 				Roles:     account.EnvironmentRoles,
 				WriteType: accountproto.ChangeAccountV2EnvironmentRolesCommand_WriteType_PATCH,
@@ -79,7 +82,10 @@ func (s *AccountService) CreateAccountV2(
 			return s.accountStorage.UpdateAccountV2(ctx, exist)
 		}
 		// TODO: temporary implementation end ---
-		handler := command.NewAccountV2CommandHandler(editor, account, s.publisher, req.OrganizationId)
+		handler, err := command.NewAccountV2CommandHandler(editor, account, s.publisher, req.OrganizationId)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -326,7 +332,10 @@ func (s *AccountService) updateAccountV2MySQL(
 		if err != nil {
 			return err
 		}
-		handler := command.NewAccountV2CommandHandler(editor, account, s.publisher, organizationID)
+		handler, err := command.NewAccountV2CommandHandler(editor, account, s.publisher, organizationID)
+		if err != nil {
+			return err
+		}
 		for _, c := range commands {
 			if err := handler.Handle(ctx, c); err != nil {
 				return err
@@ -366,7 +375,10 @@ func (s *AccountService) DeleteAccountV2(
 		if err != nil {
 			return err
 		}
-		handler := command.NewAccountV2CommandHandler(editor, account, s.publisher, req.OrganizationId)
+		handler, err := command.NewAccountV2CommandHandler(editor, account, s.publisher, req.OrganizationId)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}

--- a/pkg/account/api/api_key.go
+++ b/pkg/account/api/api_key.go
@@ -67,7 +67,10 @@ func (s *AccountService) CreateAPIKey(
 		return nil, dt.Err()
 	}
 	err = s.accountStorage.RunInTransaction(ctx, func() error {
-		handler := command.NewAPIKeyCommandHandler(editor, key, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewAPIKeyCommandHandler(editor, key, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -282,7 +285,10 @@ func (s *AccountService) updateAPIKeyMySQL(
 		if err != nil {
 			return err
 		}
-		handler := command.NewAPIKeyCommandHandler(editor, apiKey, s.publisher, environmentNamespace)
+		handler, err := command.NewAPIKeyCommandHandler(editor, apiKey, s.publisher, environmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			return err
 		}

--- a/pkg/account/command/account_v2_test.go
+++ b/pkg/account/command/account_v2_test.go
@@ -18,7 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/bucketeer-io/bucketeer/pkg/account/domain"
@@ -28,8 +30,9 @@ import (
 
 func TestNewAccountV2CommandHandler(t *testing.T) {
 	t.Parallel()
-	a := NewAccountV2CommandHandler(nil, nil, nil, "")
+	a, err := NewAccountV2CommandHandler(nil, &domain.AccountV2{}, nil, "")
 	assert.IsType(t, &accountV2CommandHandler{}, a)
+	assert.NoError(t, err)
 }
 
 func TestHandleV2(t *testing.T) {
@@ -55,6 +58,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.CreateAccountV2Command{},
@@ -72,6 +79,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.ChangeAccountV2NameCommand{},
@@ -89,6 +100,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.ChangeAccountV2AvatarImageUrlCommand{},
@@ -106,6 +121,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.ChangeAccountV2OrganizationRoleCommand{},
@@ -128,6 +147,10 @@ func TestHandleV2(t *testing.T) {
 					},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input: &accountproto.ChangeAccountV2EnvironmentRolesCommand{
@@ -158,6 +181,10 @@ func TestHandleV2(t *testing.T) {
 					},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input: &accountproto.ChangeAccountV2EnvironmentRolesCommand{
@@ -183,6 +210,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.ChangeAccountV2NameCommand{},
@@ -200,6 +231,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.EnableAccountV2Command{},
@@ -217,6 +252,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.DisableAccountV2Command{},
@@ -234,6 +273,10 @@ func TestHandleV2(t *testing.T) {
 					[]*accountproto.AccountV2_EnvironmentRole{},
 				)
 				h.account = a
+				prev := &domain.AccountV2{}
+				err := copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAccount = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.DeleteAccountV2Command{},

--- a/pkg/account/command/api_key_test.go
+++ b/pkg/account/command/api_key_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/jinzhu/copier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -29,8 +30,9 @@ import (
 
 func TestNewAPIKeyCommandHandler(t *testing.T) {
 	t.Parallel()
-	a := NewAPIKeyCommandHandler(nil, nil, nil, "")
+	a, err := NewAPIKeyCommandHandler(nil, &domain.APIKey{}, nil, "")
 	assert.IsType(t, &apiKeyCommandHandler{}, a)
+	assert.NoError(t, err)
 }
 
 func newAPIKeyCommandHandlerWithMock(t *testing.T, mockController *gomock.Controller) *apiKeyCommandHandler {
@@ -56,6 +58,10 @@ func TestAPIKeyHandle(t *testing.T) {
 				a, err := domain.NewAPIKey("email", accountproto.APIKey_SDK_CLIENT)
 				require.NoError(t, err)
 				h.apiKey = a
+				prev := &domain.APIKey{}
+				err = copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAPIKey = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.CreateAPIKeyCommand{},
@@ -67,6 +73,10 @@ func TestAPIKeyHandle(t *testing.T) {
 				a, err := domain.NewAPIKey("email", accountproto.APIKey_SDK_CLIENT)
 				require.NoError(t, err)
 				h.apiKey = a
+				prev := &domain.APIKey{}
+				err = copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAPIKey = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.ChangeAPIKeyNameCommand{},
@@ -78,6 +88,10 @@ func TestAPIKeyHandle(t *testing.T) {
 				a, err := domain.NewAPIKey("email", accountproto.APIKey_SDK_CLIENT)
 				require.NoError(t, err)
 				h.apiKey = a
+				prev := &domain.APIKey{}
+				err = copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAPIKey = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.EnableAPIKeyCommand{},
@@ -89,6 +103,10 @@ func TestAPIKeyHandle(t *testing.T) {
 				a, err := domain.NewAPIKey("email", accountproto.APIKey_SDK_CLIENT)
 				require.NoError(t, err)
 				h.apiKey = a
+				prev := &domain.APIKey{}
+				err = copier.Copy(prev, a)
+				require.NoError(t, err)
+				h.previousAPIKey = prev
 				h.publisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			input:       &accountproto.DisableAPIKeyCommand{},

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -201,7 +201,10 @@ func (s *AutoOpsService) CreateAutoOpsRule(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(tx)
-		handler := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -480,7 +483,10 @@ func (s *AutoOpsService) StopAutoOpsRule(
 			}
 			return dt.Err()
 		}
-		handler := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -554,7 +560,10 @@ func (s *AutoOpsService) DeleteAutoOpsRule(
 		if err != nil {
 			return err
 		}
-		handler := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -708,7 +717,10 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 			}
 			return dt.Err()
 		}
-		handler := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		for _, command := range commands {
 			if err := handler.Handle(ctx, command); err != nil {
 				return err
@@ -1168,7 +1180,10 @@ func (s *AutoOpsService) ExecuteAutoOps(
 		if autoOpsRule.Clauses[len(autoOpsRule.Clauses)-1].Id == req.ExecuteAutoOpsRuleCommand.ClauseId {
 			opsStatus = autoopsproto.AutoOpsStatus_FINISHED
 		}
-		handler := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, &autoopsproto.ChangeAutoOpsStatusCommand{Status: opsStatus}); err != nil {
 			return err
 		}

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -81,12 +81,15 @@ func (s *AutoOpsService) CreateProgressiveRollout(
 			return err
 		}
 		storage := v2as.NewProgressiveRolloutStorage(tx)
-		handler := command.NewProgressiveRolloutCommandHandler(
+		handler, err := command.NewProgressiveRolloutCommandHandler(
 			editor,
 			progressiveRollout,
 			s.publisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -230,12 +233,15 @@ func (s *AutoOpsService) updateProgressiveRollout(
 		if err != nil {
 			return err
 		}
-		handler := command.NewProgressiveRolloutCommandHandler(
+		handler, err := command.NewProgressiveRolloutCommandHandler(
 			editor,
 			progressiveRollout,
 			s.publisher,
 			environmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			return err
 		}
@@ -309,12 +315,15 @@ func (s *AutoOpsService) DeleteProgressiveRollout(
 		if err != nil {
 			return err
 		}
-		handler := command.NewProgressiveRolloutCommandHandler(
+		handler, err := command.NewProgressiveRolloutCommandHandler(
 			editor,
 			progressiveRollout,
 			s.publisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -454,12 +463,15 @@ func (s *AutoOpsService) ExecuteProgressiveRollout(
 				return err
 			}
 		}
-		handler := command.NewProgressiveRolloutCommandHandler(
+		handler, err := command.NewProgressiveRolloutCommandHandler(
 			editor,
 			progressiveRollout,
 			s.publisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.ChangeProgressiveRolloutTriggeredAtCommand); err != nil {
 			return err
 		}

--- a/pkg/autoops/command/auto_ops_rule_test.go
+++ b/pkg/autoops/command/auto_ops_rule_test.go
@@ -44,7 +44,7 @@ func TestChangeOpsType(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -68,7 +68,7 @@ func TestDelete(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -91,7 +91,7 @@ func TestChangeTriggeredAt(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -114,7 +114,7 @@ func TestChangeAutoOpsStatus(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -142,7 +142,7 @@ func TestAddOpsEventRateClause(t *testing.T) {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
 		l := len(a.Clauses)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -168,7 +168,7 @@ func TestChangeOpsEventRateClause(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -192,7 +192,7 @@ func TestDeleteClause(t *testing.T) {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
 		l := len(a.Clauses)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -219,7 +219,7 @@ func TestAddDatetimeClause(t *testing.T) {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
 		l := len(a.Clauses)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -245,7 +245,7 @@ func TestChangeDatetimeClause(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := newAutoOpsRule(t)
-		h := newAutoOpsRuleCommandHandler(m, a)
+		h := newAutoOpsRuleCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -279,8 +279,9 @@ func newAutoOpsRule(t *testing.T) *domain.AutoOpsRule {
 	return aor
 }
 
-func newAutoOpsRuleCommandHandler(publisher publisher.Publisher, autoOpsRule *domain.AutoOpsRule) Handler {
-	return NewAutoOpsCommandHandler(
+func newAutoOpsRuleCommandHandler(t *testing.T, publisher publisher.Publisher, autoOpsRule *domain.AutoOpsRule) Handler {
+	t.Helper()
+	h, err := NewAutoOpsCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
@@ -288,4 +289,8 @@ func newAutoOpsRuleCommandHandler(publisher publisher.Publisher, autoOpsRule *do
 		publisher,
 		"ns0",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/autoops/command/progressive_rollout_test.go
+++ b/pkg/autoops/command/progressive_rollout_test.go
@@ -43,7 +43,7 @@ func TestProgressiveRolloutDelete(t *testing.T) {
 	for _, p := range patterns {
 		m := publishermock.NewMockPublisher(mockController)
 		a := createProgressiveRollout(t)
-		h := newProgressiveRolloutCommandHandler(m, a)
+		h := newProgressiveRolloutCommandHandler(t, m, a)
 		if p.expected == nil {
 			m.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 		}
@@ -99,8 +99,9 @@ func createProgressiveRollout(t *testing.T) *domain.ProgressiveRollout {
 	return p
 }
 
-func newProgressiveRolloutCommandHandler(publisher publisher.Publisher, progressiveRollout *domain.ProgressiveRollout) Handler {
-	return NewProgressiveRolloutCommandHandler(
+func newProgressiveRolloutCommandHandler(t *testing.T, publisher publisher.Publisher, progressiveRollout *domain.ProgressiveRollout) Handler {
+	t.Helper()
+	h, err := NewProgressiveRolloutCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
@@ -108,4 +109,8 @@ func newProgressiveRolloutCommandHandler(publisher publisher.Publisher, progress
 		publisher,
 		"ns0",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/batch/subscriber/processor/auditlog_persister_test.go
+++ b/pkg/batch/subscriber/processor/auditlog_persister_test.go
@@ -42,6 +42,8 @@ func TestExtractAuditLogs(t *testing.T) {
 		eventproto.Event_FEATURE_CREATED,
 		&eventproto.FeatureCreatedEvent{Id: "fId-0"},
 		"ns0",
+		"{\"id\": \"curr\"}",
+		"{\"id\": \"prev\"}",
 	)
 	assert.NoError(t, err)
 	event1, err := domainevent.NewEvent(
@@ -51,6 +53,8 @@ func TestExtractAuditLogs(t *testing.T) {
 		eventproto.Event_FEATURE_CREATED,
 		&eventproto.FeatureCreatedEvent{Id: "fId-1"},
 		"ns0",
+		"{\"id\": \"curr\"}",
+		"{\"id\": \"prev\"}",
 	)
 	assert.NoError(t, err)
 	adninEvent0, err := domainevent.NewAdminEvent(
@@ -59,6 +63,8 @@ func TestExtractAuditLogs(t *testing.T) {
 		"fId-2",
 		eventproto.Event_FEATURE_CREATED,
 		&eventproto.FeatureCreatedEvent{Id: "fId-2"},
+		"{\"id\": \"curr\"}",
+		"{\"id\": \"prev\"}",
 	)
 	assert.NoError(t, err)
 	chunk := createChunk(t, []*domain.Event{event0, event1, adninEvent0})

--- a/pkg/batch/subscriber/processor/segment_user_persister.go
+++ b/pkg/batch/subscriber/processor/segment_user_persister.go
@@ -382,7 +382,10 @@ func (p *segmentUserPersister) updateSegmentStatus(
 			State:  state,
 			Count:  cnt,
 		}
-		handler := command.NewSegmentCommandHandler(editor, segment, p.domainPublisher, environmentNamespace)
+		handler, err := command.NewSegmentCommandHandler(editor, segment, p.domainPublisher, environmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, changeCmd); err != nil {
 			return err
 		}

--- a/pkg/environment/api/environment_v2.go
+++ b/pkg/environment/api/environment_v2.go
@@ -346,7 +346,10 @@ func (s *EnvironmentService) createEnvironmentV2(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		environmentStorage := v2es.NewEnvironmentStorage(tx)
-		handler := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		handler, err := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			return err
 		}
@@ -428,7 +431,10 @@ func (s *EnvironmentService) updateEnvironmentV2(
 		if err != nil {
 			return err
 		}
-		handler := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		handler, err := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		if err != nil {
+			return err
+		}
 		for _, c := range commands {
 			if err := handler.Handle(ctx, c); err != nil {
 				return err
@@ -552,7 +558,10 @@ func (s *EnvironmentService) ArchiveEnvironmentV2(
 		if err != nil {
 			return err
 		}
-		handler := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		handler, err := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -638,7 +647,10 @@ func (s *EnvironmentService) UnarchiveEnvironmentV2(
 		if err != nil {
 			return err
 		}
-		handler := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		handler, err := command.NewEnvironmentV2CommandHandler(editor, environment, s.publisher)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}

--- a/pkg/environment/api/organization.go
+++ b/pkg/environment/api/organization.go
@@ -340,7 +340,10 @@ func (s *EnvironmentService) createOrganization(
 				return v2es.ErrOrganizationAlreadyExists
 			}
 		}
-		handler := command.NewOrganizationCommandHandler(editor, organization, s.publisher)
+		handler, err := command.NewOrganizationCommandHandler(editor, organization, s.publisher)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			return err
 		}
@@ -490,7 +493,10 @@ func (s *EnvironmentService) updateOrganization(
 		if err != nil {
 			return err
 		}
-		handler := command.NewOrganizationCommandHandler(editor, organization, s.publisher)
+		handler, err := command.NewOrganizationCommandHandler(editor, organization, s.publisher)
+		if err != nil {
+			return err
+		}
 		for _, c := range commands {
 			if err := handler.Handle(ctx, c); err != nil {
 				return err

--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -373,7 +373,10 @@ func (s *EnvironmentService) createProject(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		projectStorage := v2es.NewProjectStorage(tx)
-		handler := command.NewProjectCommandHandler(editor, project, s.publisher)
+		handler, err := command.NewProjectCommandHandler(editor, project, s.publisher)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			return err
 		}
@@ -752,7 +755,10 @@ func (s *EnvironmentService) updateProject(
 		if err != nil {
 			return err
 		}
-		handler := command.NewProjectCommandHandler(editor, project, s.publisher)
+		handler, err := command.NewProjectCommandHandler(editor, project, s.publisher)
+		if err != nil {
+			return err
+		}
 		for _, command := range commands {
 			if err := handler.Handle(ctx, command); err != nil {
 				return err

--- a/pkg/environment/command/environment_v2_test.go
+++ b/pkg/environment/command/environment_v2_test.go
@@ -153,11 +153,15 @@ func TestHandleArchiveAndUnarchiveEnvironmentV2Command(t *testing.T) {
 
 func newEnvironmentV2CommandHandler(t *testing.T, publisher publisher.Publisher, env *domain.EnvironmentV2) Handler {
 	t.Helper()
-	return NewEnvironmentV2CommandHandler(
+	h, err := NewEnvironmentV2CommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
 		env,
 		publisher,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/environment/command/organization_test.go
+++ b/pkg/environment/command/organization_test.go
@@ -147,11 +147,15 @@ func TestHandleConvertTrialOrganizationCommand(t *testing.T) {
 
 func newOrganizationCommandHandler(t *testing.T, publisher publisher.Publisher, organization *domain.Organization) Handler {
 	t.Helper()
-	return NewOrganizationCommandHandler(
+	h, err := NewOrganizationCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
 		organization,
 		publisher,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/environment/command/project_test.go
+++ b/pkg/environment/command/project_test.go
@@ -189,11 +189,15 @@ func TestHandleConvertTrialProjectCommand(t *testing.T) {
 
 func newProjectCommandHandler(t *testing.T, publisher publisher.Publisher, project *domain.Project) Handler {
 	t.Helper()
-	return NewProjectCommandHandler(
+	h, err := NewProjectCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
 		project,
 		publisher,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/experiment/api/experiment.go
+++ b/pkg/experiment/api/experiment.go
@@ -343,12 +343,15 @@ func (s *experimentService) CreateExperiment(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		experimentStorage := v2es.NewExperimentStorage(tx)
-		handler := command.NewExperimentCommandHandler(
+		handler, err := command.NewExperimentCommandHandler(
 			editor,
 			experiment,
 			s.publisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -488,12 +491,15 @@ func (s *experimentService) UpdateExperiment(
 		if err != nil {
 			return err
 		}
-		handler := command.NewExperimentCommandHandler(
+		handler, err := command.NewExperimentCommandHandler(
 			editor,
 			experiment,
 			s.publisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if req.ChangeExperimentPeriodCommand != nil {
 			if err = handler.Handle(ctx, req.ChangeExperimentPeriodCommand); err != nil {
 				s.logger.Error(
@@ -851,7 +857,10 @@ func (s *experimentService) updateExperiment(
 			)
 			return err
 		}
-		handler := command.NewExperimentCommandHandler(editor, experiment, s.publisher, environmentNamespace)
+		handler, err := command.NewExperimentCommandHandler(editor, experiment, s.publisher, environmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			s.logger.Error(
 				"Failed to handle command",

--- a/pkg/experiment/api/goal.go
+++ b/pkg/experiment/api/goal.go
@@ -261,7 +261,10 @@ func (s *experimentService) CreateGoal(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		goalStorage := v2es.NewGoalStorage(tx)
-		handler := command.NewGoalCommandHandler(editor, goal, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewGoalCommandHandler(editor, goal, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -534,7 +537,10 @@ func (s *experimentService) updateGoal(
 		if err != nil {
 			return err
 		}
-		handler := command.NewGoalCommandHandler(editor, goal, s.publisher, environmentNamespace)
+		handler, err := command.NewGoalCommandHandler(editor, goal, s.publisher, environmentNamespace)
+		if err != nil {
+			return err
+		}
 		for _, command := range commands {
 			if err := handler.Handle(ctx, command); err != nil {
 				return err

--- a/pkg/experiment/command/experiment_test.go
+++ b/pkg/experiment/command/experiment_test.go
@@ -165,7 +165,7 @@ func newExperiment(startAt int64, stopAt int64) *experimentdomain.Experiment {
 
 func newExperimentCommandHandler(t *testing.T, publisher publisher.Publisher, experiment *experimentdomain.Experiment) Handler {
 	t.Helper()
-	return NewExperimentCommandHandler(
+	h, err := NewExperimentCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
@@ -173,4 +173,8 @@ func newExperimentCommandHandler(t *testing.T, publisher publisher.Publisher, ex
 		publisher,
 		"ns0",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/experiment/command/goal_test.go
+++ b/pkg/experiment/command/goal_test.go
@@ -96,7 +96,7 @@ func TestHandleDeleteGoalCommand(t *testing.T) {
 
 func newGoalCommandHandler(t *testing.T, publisher publisher.Publisher, goal *domain.Goal) Handler {
 	t.Helper()
-	return NewGoalCommandHandler(
+	h, err := NewGoalCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
@@ -104,4 +104,8 @@ func newGoalCommandHandler(t *testing.T, publisher publisher.Publisher, goal *do
 		publisher,
 		"ns0",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -94,12 +94,15 @@ func (s *FeatureService) CreateFlagTrigger(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		storage := v2fs.NewFlagTriggerStorage(tx)
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			flagTrigger,
 			s.domainPublisher,
 			request.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, request.CreateFlagTriggerCommand); err != nil {
 			s.logger.Error(
 				"Failed to create flag trigger",
@@ -198,12 +201,15 @@ func (s *FeatureService) UpdateFlagTrigger(
 			)
 			return err
 		}
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			flagTrigger,
 			s.domainPublisher,
 			request.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, request.ChangeFlagTriggerDescriptionCommand); err != nil {
 			s.logger.Error(
 				"Failed to update flag trigger",
@@ -300,12 +306,15 @@ func (s *FeatureService) EnableFlagTrigger(
 			)
 			return err
 		}
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			flagTrigger,
 			s.domainPublisher,
 			request.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, request.EnableFlagTriggerCommand); err != nil {
 			s.logger.Error(
 				"Failed to enable flag trigger",
@@ -402,12 +411,15 @@ func (s *FeatureService) DisableFlagTrigger(
 			)
 			return err
 		}
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			flagTrigger,
 			s.domainPublisher,
 			request.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, request.DisableFlagTriggerCommand); err != nil {
 			s.logger.Error(
 				"Failed to enable flag trigger",
@@ -498,12 +510,15 @@ func (s *FeatureService) ResetFlagTrigger(
 		return nil, err
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			trigger,
 			s.domainPublisher,
 			request.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, request.ResetFlagTriggerCommand); err != nil {
 			s.logger.Error(
 				"Failed to reset flag trigger",
@@ -511,7 +526,7 @@ func (s *FeatureService) ResetFlagTrigger(
 			)
 			return err
 		}
-		err := v2fs.NewFlagTriggerStorage(tx).UpdateFlagTrigger(ctx, trigger)
+		err = v2fs.NewFlagTriggerStorage(tx).UpdateFlagTrigger(ctx, trigger)
 		if err != nil {
 			s.logger.Error(
 				"Failed to reset flag trigger",
@@ -598,12 +613,15 @@ func (s *FeatureService) DeleteFlagTrigger(
 			)
 			return err
 		}
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			flagTrigger,
 			s.domainPublisher,
 			request.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, request.DeleteFlagTriggerCommand); err != nil {
 			s.logger.Error(
 				"Failed to delete flag trigger",
@@ -951,13 +969,16 @@ func (s *FeatureService) updateTriggerUsageInfo(
 	}
 	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
 		storage := v2fs.NewFlagTriggerStorage(tx)
-		handler := command.NewFlagTriggerCommandHandler(
+		handler, err := command.NewFlagTriggerCommandHandler(
 			editor,
 			flagTrigger,
 			s.domainPublisher,
 			flagTrigger.EnvironmentNamespace,
 		)
-		err := handler.Handle(ctx, &featureproto.UpdateFlagTriggerUsageCommand{})
+		if err != nil {
+			return err
+		}
+		err = handler.Handle(ctx, &featureproto.UpdateFlagTriggerUsageCommand{})
 		if err != nil {
 			s.logger.Error(
 				"Failed to update flag trigger usage",

--- a/pkg/feature/api/segment.go
+++ b/pkg/feature/api/segment.go
@@ -106,12 +106,15 @@ func (s *FeatureService) CreateSegment(
 			)
 			return err
 		}
-		handler := command.NewSegmentCommandHandler(
+		handler, err := command.NewSegmentCommandHandler(
 			editor,
 			segment,
 			s.domainPublisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			s.logger.Error(
 				"Failed to handle command",
@@ -357,12 +360,15 @@ func (s *FeatureService) updateSegment(
 			)
 			return err
 		}
-		handler := command.NewSegmentCommandHandler(
+		handler, err := command.NewSegmentCommandHandler(
 			editor,
 			segment,
 			s.domainPublisher,
 			environmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		for _, cmd := range commands {
 			if err := handler.Handle(ctx, cmd); err != nil {
 				s.logger.Error(

--- a/pkg/feature/api/segment_user.go
+++ b/pkg/feature/api/segment_user.go
@@ -190,12 +190,15 @@ func (s *FeatureService) updateSegmentUser(
 			)
 			return err
 		}
-		handler := command.NewSegmentCommandHandler(
+		handler, err := command.NewSegmentCommandHandler(
 			editor,
 			segment,
 			s.domainPublisher,
 			environmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, cmd); err != nil {
 			s.logger.Error(
 				"Failed to handle command",
@@ -450,12 +453,15 @@ func (s *FeatureService) BulkUploadSegmentUsers(
 			}
 			return dt.Err()
 		}
-		handler := command.NewSegmentCommandHandler(
+		handler, err := command.NewSegmentCommandHandler(
 			editor,
 			segment,
 			s.domainPublisher,
 			req.EnvironmentNamespace,
 		)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			s.logger.Error(
 				"Failed to handle command",

--- a/pkg/feature/command/eventfactory.go
+++ b/pkg/feature/command/eventfactory.go
@@ -21,11 +21,13 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
 	domainproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
+	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
 type FeatureEventFactory struct {
 	editor               *eventproto.Editor
 	feature              *domain.Feature
+	previousFeature      *domain.Feature
 	environmentNamespace string
 	comment              string
 }
@@ -34,6 +36,10 @@ func (s *FeatureEventFactory) CreateEvent(
 	eventType eventproto.Event_Type,
 	event proto.Message,
 ) (*domainproto.Event, error) {
+	var prev *featureproto.Feature
+	if s.previousFeature != nil && s.previousFeature.Feature != nil {
+		prev = s.previousFeature.Feature
+	}
 	return domainevent.NewEvent(
 		s.editor,
 		eventproto.Event_FEATURE,
@@ -41,6 +47,8 @@ func (s *FeatureEventFactory) CreateEvent(
 		eventType,
 		event,
 		s.environmentNamespace,
+		s.feature.Feature,
+		prev,
 		domainevent.WithComment(s.comment),
 		domainevent.WithNewVersion(s.feature.Version),
 	)

--- a/pkg/feature/command/feature.go
+++ b/pkg/feature/command/feature.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"strings"
 
+	"github.com/jinzhu/copier"
+
 	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
@@ -35,17 +37,22 @@ func NewFeatureCommandHandler(
 	feature *domain.Feature,
 	environmentNamespace string,
 	comment string,
-) *FeatureCommandHandler {
+) (*FeatureCommandHandler, error) {
+	prev := &domain.Feature{}
+	if err := copier.Copy(prev, feature); err != nil {
+		return nil, err
+	}
 	return &FeatureCommandHandler{
 		feature: feature,
 		eventFactory: &FeatureEventFactory{
 			editor:               editor,
 			feature:              feature,
+			previousFeature:      prev,
 			environmentNamespace: environmentNamespace,
 			comment:              comment,
 		},
 		Events: []*eventproto.Event{},
-	}
+	}, nil
 }
 
 // for unit test

--- a/pkg/feature/command/segment_test.go
+++ b/pkg/feature/command/segment_test.go
@@ -74,12 +74,16 @@ func TestChangeBulkUploadSegmentUsersStatus(t *testing.T) {
 
 func newMockSegmentCommandHandler(t *testing.T, mockController *gomock.Controller, segment *domain.Segment) *segmentCommandHandler {
 	t.Helper()
-	return &segmentCommandHandler{
+	h, err := NewSegmentCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
 		segment,
 		publishermock.NewMockPublisher(mockController),
 		"bucketeer-environment-space",
+	)
+	if err != nil {
+		t.Fatal(err)
 	}
+	return h.(*segmentCommandHandler)
 }

--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -87,7 +87,10 @@ func (s *NotificationService) CreateAdminSubscription(
 		if err := adminSubscriptionStorage.CreateAdminSubscription(ctx, subscription); err != nil {
 			return err
 		}
-		handler = command.NewAdminSubscriptionCommandHandler(editor, subscription)
+		handler, err = command.NewAdminSubscriptionCommandHandler(editor, subscription)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -408,7 +411,10 @@ func (s *NotificationService) updateAdminSubscription(
 		if err != nil {
 			return err
 		}
-		handler = command.NewAdminSubscriptionCommandHandler(editor, subscription)
+		handler, err = command.NewAdminSubscriptionCommandHandler(editor, subscription)
+		if err != nil {
+			return err
+		}
 		for _, command := range commands {
 			if err := handler.Handle(ctx, command); err != nil {
 				return err
@@ -502,7 +508,10 @@ func (s *NotificationService) DeleteAdminSubscription(
 		if err != nil {
 			return err
 		}
-		handler = command.NewAdminSubscriptionCommandHandler(editor, subscription)
+		handler, err = command.NewAdminSubscriptionCommandHandler(editor, subscription)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -92,7 +92,10 @@ func (s *NotificationService) CreateSubscription(
 		if err := subscriptionStorage.CreateSubscription(ctx, subscription, req.EnvironmentNamespace); err != nil {
 			return err
 		}
-		handler = command.NewSubscriptionCommandHandler(editor, subscription, req.EnvironmentNamespace)
+		handler, err = command.NewSubscriptionCommandHandler(editor, subscription, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -430,7 +433,10 @@ func (s *NotificationService) updateSubscription(
 		if err != nil {
 			return err
 		}
-		handler = command.NewSubscriptionCommandHandler(editor, subscription, environmentNamespace)
+		handler, err = command.NewSubscriptionCommandHandler(editor, subscription, environmentNamespace)
+		if err != nil {
+			return err
+		}
 		for _, command := range commands {
 			if err := handler.Handle(ctx, command); err != nil {
 				return err
@@ -591,7 +597,10 @@ func (s *NotificationService) DeleteSubscription(
 		if err != nil {
 			return err
 		}
-		handler = command.NewSubscriptionCommandHandler(editor, subscription, req.EnvironmentNamespace)
+		handler, err = command.NewSubscriptionCommandHandler(editor, subscription, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}

--- a/pkg/notification/command/admin_subscription_test.go
+++ b/pkg/notification/command/admin_subscription_test.go
@@ -181,11 +181,15 @@ func TestAdminRename(t *testing.T) {
 
 func newAdminSubscriptionCommandHandler(t *testing.T, subscription *domain.Subscription) Handler {
 	t.Helper()
-	return NewAdminSubscriptionCommandHandler(
+	h, err := NewAdminSubscriptionCommandHandler(
 		&eventproto.Editor{
 			Email:   "email",
 			IsAdmin: true,
 		},
 		subscription,
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/notification/command/subscription_test.go
+++ b/pkg/notification/command/subscription_test.go
@@ -197,11 +197,15 @@ func newSubscription(t *testing.T, disabled bool) *domain.Subscription {
 
 func newSubscriptionCommandHandler(t *testing.T, subscription *domain.Subscription) Handler {
 	t.Helper()
-	return NewSubscriptionCommandHandler(
+	h, err := NewSubscriptionCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
 		subscription,
 		"ns0",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }

--- a/pkg/push/api/api.go
+++ b/pkg/push/api/api.go
@@ -203,7 +203,10 @@ func (s *PushService) CreatePush(
 		if err := pushStorage.CreatePush(ctx, push, req.EnvironmentNamespace); err != nil {
 			return err
 		}
-		handler := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
@@ -322,7 +325,10 @@ func (s *PushService) UpdatePush(
 		if err != nil {
 			return err
 		}
-		handler := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		for _, command := range commands {
 			if err := handler.Handle(ctx, command); err != nil {
 				return err
@@ -517,7 +523,10 @@ func (s *PushService) DeletePush(
 		if err != nil {
 			return err
 		}
-		handler := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentNamespace)
+		handler, err := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentNamespace)
+		if err != nil {
+			return err
+		}
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}

--- a/pkg/push/command/push_test.go
+++ b/pkg/push/command/push_test.go
@@ -152,7 +152,7 @@ func newPush(t *testing.T) *domain.Push {
 
 func newPushCommandHandler(t *testing.T, publisher publisher.Publisher, push *domain.Push) Handler {
 	t.Helper()
-	return NewPushCommandHandler(
+	h, err := NewPushCommandHandler(
 		&eventproto.Editor{
 			Email: "email",
 		},
@@ -160,4 +160,8 @@ func newPushCommandHandler(t *testing.T, publisher publisher.Publisher, push *do
 		publisher,
 		"ns0",
 	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
 }


### PR DESCRIPTION
part of https://github.com/bucketeer-io/bucketeer/pull/1103

---

This pull request mainly addresses error handling and data copying in the `account` and `autoops` packages. The most significant changes include adding error checks when creating new command handlers, copying the current state of an account or API key before modifications, and updating the tests to reflect these changes.

Error handling improvements:

* [`pkg/account/api/account.go`](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L71-R74): Added error checks when creating new `AccountV2CommandHandler` instances in multiple methods. [[1]](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L71-R74) [[2]](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L82-R88) [[3]](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L329-R338) [[4]](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L369-R381)
* [`pkg/account/api/api_key.go`](diffhunk://#diff-1236610833a324b8af6d6273437bdeb2fb35012b5ae3b3374760927a8427c204L70-R73): Added error checks when creating new `APIKeyCommandHandler` instances in multiple methods. [[1]](diffhunk://#diff-1236610833a324b8af6d6273437bdeb2fb35012b5ae3b3374760927a8427c204L70-R73) [[2]](diffhunk://#diff-1236610833a324b8af6d6273437bdeb2fb35012b5ae3b3374760927a8427c204L285-R291)
* [`pkg/autoops/api/api.go`](diffhunk://#diff-13112ed94680ecaec33373531ff5c65e48cecae142657203e04d967a185684d5L204-R207): Added an error check when creating a new `AutoOpsCommandHandler` instance.

Data copying and testing updates:

* [`pkg/account/command/account_v2.go`](diffhunk://#diff-5994f3567bf3c0a6b4bbb1640f159c2ea9d4a28369a4bf71661520c4b0337b8bR33): Added a copy of the current state of an account before modifications and returned an error if the copying process fails. [[1]](diffhunk://#diff-5994f3567bf3c0a6b4bbb1640f159c2ea9d4a28369a4bf71661520c4b0337b8bR33) [[2]](diffhunk://#diff-5994f3567bf3c0a6b4bbb1640f159c2ea9d4a28369a4bf71661520c4b0337b8bL41-R54)
* [`pkg/account/command/account_v2_test.go`](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273L31-R35): Updated tests to copy the current state of an account before modifications and added error checks for the copying process. [[1]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273L31-R35) [[2]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R61-R64) [[3]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R82-R85) [[4]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R103-R106) [[5]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R124-R127) [[6]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R150-R153) [[7]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R184-R187) [[8]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R213-R216) [[9]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R234-R237) [[10]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R255-R258) [[11]](diffhunk://#diff-1a3705e6442d5793be6834be5a8c8acbfa0fd33dbc338de83d5eb373ff57c273R276-R279)
* [`pkg/account/command/api_key.go`](diffhunk://#diff-a8126e6ac9a438dfe3f19ea9e568ac502b8edc7e98d412d963a7b62b06169571R33): Added a copy of the current state of an API key before modifications and returned an error if the copying process fails. [[1]](diffhunk://#diff-a8126e6ac9a438dfe3f19ea9e568ac502b8edc7e98d412d963a7b62b06169571R33) [[2]](diffhunk://#diff-a8126e6ac9a438dfe3f19ea9e568ac502b8edc7e98d412d963a7b62b06169571L41-R54)
* [`pkg/account/command/api_key_test.go`](diffhunk://#diff-10925193b59c3c0f3cf41a85ed00b48de2b10b5c041ccf5f2786e17235d4d523L32-R35): Updated tests to copy the current state of an API key before modifications and added error checks for the copying process. [[1]](diffhunk://#diff-10925193b59c3c0f3cf41a85ed00b48de2b10b5c041ccf5f2786e17235d4d523L32-R35) [[2]](diffhunk://#diff-10925193b59c3c0f3cf41a85ed00b48de2b10b5c041ccf5f2786e17235d4d523R61-R64) [[3]](diffhunk://#diff-10925193b59c3c0f3cf41a85ed00b48de2b10b5c041ccf5f2786e17235d4d523R76-R79) [[4]](diffhunk://#diff-10925193b59c3c0f3cf41a85ed00b48de2b10b5c041ccf5f2786e17235d4d523R91-R94) [[5]](diffhunk://#diff-10925193b59c3c0f3cf41a85ed00b48de2b10b5c041ccf5f2786e17235d4d523R106-R109)