### PR TITLE
chore: make the `ttlSecondsAfterFinished` optional in the migration job

### DIFF
--- a/manifests/bucketeer-migration/templates/atlas-migration.yaml
+++ b/manifests/bucketeer-migration/templates/atlas-migration.yaml
@@ -5,7 +5,9 @@ metadata:
   annotations: {{ toYaml .Values.annotations | nindent 4 }}
 spec:
   backoffLimit: {{ .Values.backoffLimit }}
-  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+  {{- with .Values.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
   template:
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/manifests/bucketeer-migration/values.yaml
+++ b/manifests/bucketeer-migration/values.yaml
@@ -10,7 +10,7 @@ image:
 imagePullSecrets: []
 
 backoffLimit: 0
-ttlSecondsAfterFinished: 86400
+ttlSecondsAfterFinished:
 
 # URL to access the DB to do the migration
 # E.g. mysql://user:password@host:port/db_name

--- a/manifests/bucketeer/templates/atlas-migration.yaml
+++ b/manifests/bucketeer/templates/atlas-migration.yaml
@@ -8,8 +8,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
 
 spec:
-  backoffLimit: {{ .Values.backoffLimit }}
-  ttlSecondsAfterFinished: {{ .Values.ttlSecondsAfterFinished }}
+  backoffLimit: {{ .Values.migration.backoffLimit }}
+  {{- with .Values.migration.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
   template:
     spec:
       {{- with .Values.migration.imagePullSecrets }}

--- a/manifests/bucketeer/values.yaml
+++ b/manifests/bucketeer/values.yaml
@@ -11,7 +11,7 @@ migration:
   imagePullSecrets: []
 
   backoffLimit: 0
-  ttlSecondsAfterFinished: 86400
+  ttlSecondsAfterFinished:
 
   # URL to access the DB to do the migration
   # E.g. mysql://user:password@host:port/db_name


### PR DESCRIPTION
The current setting is 24 hours. After the Job is deleted, PipeCD keeps showing an out-of-sync warning because the job is no longer there. So, I'm changing the `ttlSecondsAfterFinished` to be optional so we can keep the job after completion and avoid warnings.