### PR TITLE
chore: improve security in the sign-in api

### DIFF
--- a/pkg/auth/api/signin.go
+++ b/pkg/auth/api/signin.go
@@ -35,10 +35,12 @@ func (s *authService) SignIn(
 		return nil, err
 	}
 	config := s.config.DemoSignIn
-	if request.Email != config.Email ||
+	if !config.Enabled ||
+		request.Email != config.Email ||
 		request.Password != config.Password {
 		s.logger.Error(
 			"Sign in failed",
+			zap.Bool("enabled", config.Enabled),
 			zap.String("email", request.Email),
 			zap.String("password", request.Password),
 		)


### PR DESCRIPTION
If we disabled the demo sign-in but the demo account is still enabled, someone could get the access token by calling the SignIn API directly.
So, I changed it to check the config file to ensure we won't access it if it is disabled.