### PR TITLE
fix: publish domain event fails due to message being nil

### DIFF
--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -558,22 +558,24 @@ func (s *AutoOpsService) ExecuteProgressiveRollout(
 		}
 		return nil, dt.Err()
 	}
-	if errs := s.publisher.PublishMulti(ctx, []publisher.Message{event}); len(errs) > 0 {
-		s.logger.Error(
-			"Failed to publish events",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Any("errors", errs),
-				zap.String("environmentId", req.EnvironmentNamespace),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
+	if event != nil {
+		if errs := s.publisher.PublishMulti(ctx, []publisher.Message{event}); len(errs) > 0 {
+			s.logger.Error(
+				"Failed to publish events",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.Any("errors", errs),
+					zap.String("environmentId", req.EnvironmentNamespace),
+				)...,
+			)
+			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+				Locale:  localizer.GetLocale(),
+				Message: localizer.MustLocalize(locale.InternalServerError),
+			})
+			if err != nil {
+				return nil, statusInternal.Err()
+			}
+			return nil, dt.Err()
 		}
-		return nil, dt.Err()
 	}
 	return &autoopsproto.ExecuteProgressiveRolloutResponse{}, nil
 }

--- a/pkg/autoops/api/progressive_rollout_test.go
+++ b/pkg/autoops/api/progressive_rollout_test.go
@@ -30,7 +30,6 @@ import (
 	experimentclientmock "github.com/bucketeer-io/bucketeer/pkg/experiment/client/mock"
 	featureclientmock "github.com/bucketeer-io/bucketeer/pkg/feature/client/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
-	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	autoopsproto "github.com/bucketeer-io/bucketeer/proto/autoops"
@@ -1333,34 +1332,11 @@ func TestExecuteProgressiveRolloutMySQL(t *testing.T) {
 			expectedErr: createError(statusProgressiveRolloutInternal, localizer.MustLocalize(locale.InternalServerError)),
 		},
 		{
-			desc: "err: publish an event fails",
-			setup: func(s *AutoOpsService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil)
-				s.publisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
-					gomock.Any(), gomock.Any(),
-				).Return(map[string]error{"key": errors.New("internal")})
-			},
-			req: &autoopsproto.ExecuteProgressiveRolloutRequest{
-				Id:                   "aid1",
-				EnvironmentNamespace: "ns0",
-				ChangeProgressiveRolloutTriggeredAtCommand: &autoopsproto.ChangeProgressiveRolloutScheduleTriggeredAtCommand{
-					ScheduleId: "sid1",
-				},
-			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
-		},
-		{
 			desc: "success",
 			setup: func(s *AutoOpsService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
 					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil)
-				s.publisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
-					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.ExecuteProgressiveRolloutRequest{


### PR DESCRIPTION
```
stacktrace: "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher.(*publisher).PublishMulti
	/home/runner/work/bucketeer/bucketeer/pkg/pubsub/publisher/publisher.go:134
github.com/bucketeer-io/bucketeer/pkg/autoops/api.(*AutoOpsService).ExecuteProgressiveRollout
	/home/runner/work/bucketeer/bucketeer/pkg/autoops/api/progressive_rollout.go:561
github.com/bucketeer-io/bucketeer/proto/autoops._AutoOpsService_ExecuteProgressiveRollout_Handler.func1
	/home/runner/work/bucketeer/bucketeer/proto/autoops/service.pb.go:3108
github.com/bucketeer-io/bucketeer/pkg/rpc.(*Server).setupRPC.AuthUnaryServerInterceptor.func3
	/home/runner/work/bucketeer/bucketeer/pkg/rpc/auth.go:66
google.golang.org/grpc.getChainUnaryHandler.func1
	/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1196
github.com/bucketeer-io/bucketeer/pkg/rpc.(*Server).setupRPC.MetricsUnaryServerInterceptor.func2
	/home/runner/work/bucketeer/bucketeer/pkg/rpc/metrics.go:81
google.golang.org/grpc.getChainUnaryHandler.func1
	/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1196
github.com/bucketeer-io/bucketeer/pkg/rpc.(*Server).setupRPC.LogUnaryServerInterceptor.func1
	/home/runner/work/bucketeer/bucketeer/pkg/rpc/log.go:45
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1
	/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1187
github.com/bucketeer-io/bucketeer/proto/autoops._AutoOpsService_ExecuteProgressiveRollout_Handler
	/home/runner/work/bucketeer/bucketeer/proto/autoops/service.pb.go:3110
google.golang.org/grpc.(*Server).processUnaryRPC
	/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1379
google.golang.org/grpc.(*Server).handleStream
	/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1790
google.golang.org/grpc.(*Server).serveStreams.func2.1
	/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1029"
```