### PR TITLE
fix: account not found when using system admin account

### DIFF
--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -362,8 +362,10 @@ func (s *AccountService) getMyOrganizations(
 		// TODO: Remove this loop after the web console 3.0 is ready
 		// If the account is enabled in any environment in this organization,
 		// we append the organization.
-		// Note: When we disable an account on the web console, we are updating the role to UNASSIGNED.
-		// When the new console is ready, we will use the DisableAccount API instead.
+		// Note: When we disable an account on the web console,
+		// we are updating the role to UNASSIGNED, not the `disabled` column.
+		// When the new console is ready, we will use the DisableAccount API instead,
+		// which will update the `disabled` column in the DB.
 		var enabled bool
 		for _, role := range accWithOrg.AccountV2.EnvironmentRoles {
 			if role.Role != accountproto.AccountV2_Role_Environment_UNASSIGNED {

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -359,6 +359,20 @@ func (s *AccountService) getMyOrganizations(
 		if accWithOrg.AccountV2.Disabled || accWithOrg.Organization.Disabled || accWithOrg.Organization.Archived {
 			continue
 		}
+		// TODO: Remove this loop after the web console 3.0 is ready
+		// If the account is enabled in any environment in this organization,
+		// we append the organization.
+		// Note: When we disable an account on the web console, we are updating the role to UNASSIGNED.
+		// When the new console is ready, we will use the DisableAccount API instead.
+		var enabled bool
+		for _, role := range accWithOrg.AccountV2.EnvironmentRoles {
+			if role.Role != accountproto.AccountV2_Role_Environment_UNASSIGNED {
+				enabled = true
+			}
+		}
+		if !enabled {
+			continue
+		}
 		myOrgs = append(myOrgs, accWithOrg.Organization)
 	}
 	return myOrgs, nil

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -249,6 +249,16 @@ func (s *AccountService) getConsoleAccountEnvironmentRoles(
 		if !ok || project.Disabled {
 			continue
 		}
+		// TODO: Remove this checking after the web console 3.0 is ready
+		// If the account is enabled in any environment in this organization,
+		// we append the organization.
+		// Note: When we disable an account on the web console,
+		// we are updating the role to UNASSIGNED, not the `disabled` column.
+		// When the new console is ready, we will use the DisableAccount API instead,
+		// which will update the `disabled` column in the DB.
+		if r.Role == accountproto.AccountV2_Role_Environment_UNASSIGNED {
+			continue
+		}
 		environmentRoles = append(environmentRoles, &accountproto.ConsoleAccount_EnvironmentRole{
 			Environment: env,
 			Role:        r.Role,


### PR DESCRIPTION
#### Things done

- Fixed system admin account being redirected to the login page on non-system organizations
- Fixed showing organizations where the account is not registered or is disabled
- Fixed showing environments where the account is disabled

---

This pull request includes significant changes to the `AccountService` and its associated test suite in `admin_account.go` and `admin_account_test.go` respectively. The changes are primarily focused on refactoring the `checkAccountStatus` method into `getAccount`, which now also retrieves the account information. This change has a cascading effect on other methods and tests that used `checkAccountStatus`. Additionally, there are changes to handle account disabling and enabling, which are currently managed through the `Role` attribute but will be managed through the `disabled` column in the future.

Refactoring and Simplification:

* [`pkg/account/api/admin_account.go`](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L169-R168): The `checkAccountStatus` method was refactored into `getAccount`, which now also retrieves the account information. This change simplifies the code and reduces redundancy. [[1]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L169-R168) [[2]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L188-R208)

Changes to Error Handling:

* [`pkg/account/api/admin_account.go`](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L66-L72): Error handling in `GetMe` method has been updated to reflect the changes in `getAccount` method. [[1]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L66-L72) [[2]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L153-R146)

Handling of Account Status:

* [`pkg/account/api/admin_account.go`](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95R252-R261): Changes have been made to `getConsoleAccountEnvironmentRoles` and `getMyOrganizations` methods to handle account disabling and enabling through the `Role` attribute. These changes are temporary and will be removed once account status is managed through the `disabled` column. [[1]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95R252-R261) [[2]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95R372-R387)

Changes to Test Suite:

* [`pkg/account/api/admin_account_test.go`](diffhunk://#diff-e56903718b2dfe1cdba4377e98b8bd79e3f96e87891f34e1f4c83886509270ceL86-L154): The test suite has been updated to reflect the changes in `GetMe` and `getAccount` methods. The changes include updates to test descriptions and expected results.