### PR TITLE
fix(evaluation): race condition when removing the variation description

### DIFF
--- a/evaluation/evaluation.go
+++ b/evaluation/evaluation.go
@@ -141,10 +141,6 @@ func (e *evaluator) evaluate(
 		if targetTag != "" && !tagExist(feature.Tags, targetTag) {
 			continue
 		}
-		// FIXME: Remove the next line when the Variation
-		// no longer is being used
-		// For security reasons, it removes the variation description
-		variation.Description = ""
 		evaluationID := EvaluationID(feature.Id, feature.Version, user.Id)
 		evaluation := &ftproto.Evaluation{
 			Id:             evaluationID,
@@ -154,8 +150,17 @@ func (e *evaluator) evaluate(
 			VariationId:    variation.Id,
 			VariationName:  variation.Name,
 			VariationValue: variation.Value,
-			Variation:      variation, // deprecated
-			Reason:         reason,
+			// Deprecated
+			// FIXME: Remove the Variation when is no longer being used.
+			// For security reasons, we should remove the variation description.
+			// We copy the variation object to avoid race conditions when removing
+			// the description directly from the `variation`
+			Variation: &ftproto.Variation{
+				Id:    variation.Id,
+				Name:  variation.Name,
+				Value: variation.Value,
+			},
+			Reason: reason,
 		}
 		evaluations = append(evaluations, evaluation)
 	}


### PR DESCRIPTION
There is a [race condition](https://github.com/bucketeer-io/go-server-sdk/actions/runs/10036619540/job/27736550399?pr=136) in the Go SDK when the variation description is removed when evaluating the user.
The evaluation module shouldn't change the data in memory.
To avoid other issues, I changed it to copy the Variation object with no description instead of changing the in-memory data.

Go SDK coverage and unit test results.

```
make test
.....
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user	(cached)
=== RUN   TestNewV4
=== PAUSE TestNewV4
=== CONT  TestNewV4
--- PASS: TestNewV4 (0.00s)
PASS
ok  
```

```
make coverage 
go test -race -covermode=atomic -coverprofile=coverage.out -coverpkg=./pkg/... ./pkg/...
?   	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/cache/mock	[no test files]
?   	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/version	[no test files]
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer	1.895s	coverage: 30.0% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/api	1.667s	coverage: 8.9% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/cache	2.380s	coverage: 33.3% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/cache/processor	22.489s	coverage: 39.3% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/evaluator	2.066s	coverage: 18.4% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/event	3.116s	coverage: 54.3% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/log	3.230s	coverage: 44.4% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/model	2.645s	coverage: 81.6% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/user	2.795s	coverage: 100.0% of statements in ./pkg/...
ok  	github.com/bucketeer-io/go-server-sdk/pkg/bucketeer/uuid	3.515s	coverage: 88.9% of statements in ./pkg/...
```