### PR TITLE
chore: delete docker building cache when open dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,5 +42,5 @@
     "memory": "8gb",
     "storage": "32gb"
   },
-  "postAttachCommand": "make local-deps && make update-repos && (cd ui/web-v2 && yarn)"
+  "postAttachCommand": "docker system prune -f && make local-deps && make update-repos && (cd ui/web-v2 && yarn)"
 }


### PR DESCRIPTION
When building many times a day, it will increase the storage usage and fail with no space left.
So, I added the `docker system prune -f` command to delete the docker building cache to avoid that error.