### PR TITLE
fix: validate unknown action type

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -395,8 +395,7 @@ func (s *AutoOpsService) validateOpsEventRateClause(
 		}
 		return dt.Err()
 	}
-	// ToDo: After the web console supports ActionType, it returns an error when ActionType_UNKNOWN
-	if clause.ActionType == autoopsproto.ActionType_ENABLE {
+	if clause.ActionType == autoopsproto.ActionType_UNKNOWN || clause.ActionType == autoopsproto.ActionType_ENABLE {
 		dt, err := statusIncompatibleOpsType.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "action_type"),
@@ -432,7 +431,16 @@ func (s *AutoOpsService) validateDatetimeClause(clause *autoopsproto.DatetimeCla
 		}
 		return dt.Err()
 	}
-	// ToDo: After the web console supports ActionType, it returns an error when ActionType_UNKNOWN
+	if clause.ActionType == autoopsproto.ActionType_UNKNOWN {
+		dt, err := statusIncompatibleOpsType.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "action_type"),
+		})
+		if err != nil {
+			return statusInternal.Err()
+		}
+		return dt.Err()
+	}
 	return nil
 }
 

--- a/pkg/autoops/api/api_test.go
+++ b/pkg/autoops/api/api_test.go
@@ -340,10 +340,14 @@ func TestCreateAutoOpsRuleMySQL(t *testing.T) {
 							MinCount:        10,
 							ThreadsholdRate: 0.5,
 							Operator:        autoopsproto.OpsEventRateClause_GREATER_OR_EQUAL,
+							ActionType:      autoopsproto.ActionType_DISABLE,
 						},
 					},
 					DatetimeClauses: []*autoopsproto.DatetimeClause{
-						{Time: time.Now().AddDate(0, 0, 1).Unix()},
+						{
+							Time:       time.Now().AddDate(0, 0, 1).Unix(),
+							ActionType: autoopsproto.ActionType_ENABLE,
+						},
 					},
 				},
 			},
@@ -371,10 +375,14 @@ func TestCreateAutoOpsRuleMySQL(t *testing.T) {
 							MinCount:        10,
 							ThreadsholdRate: 0.5,
 							Operator:        autoopsproto.OpsEventRateClause_GREATER_OR_EQUAL,
+							ActionType:      autoopsproto.ActionType_DISABLE,
 						},
 					},
 					DatetimeClauses: []*autoopsproto.DatetimeClause{
-						{Time: time.Now().AddDate(0, 0, 1).Unix()},
+						{
+							Time:       time.Now().AddDate(0, 0, 1).Unix(),
+							ActionType: autoopsproto.ActionType_ENABLE,
+						},
 					},
 				},
 			},
@@ -514,6 +522,7 @@ func TestUpdateAutoOpsRuleMySQL(t *testing.T) {
 						MinCount:        10,
 						ThreadsholdRate: 0.5,
 						Operator:        autoopsproto.OpsEventRateClause_GREATER_OR_EQUAL,
+						ActionType:      autoopsproto.ActionType_DISABLE,
 					},
 				}},
 				DeleteClauseCommands: []*autoopsproto.DeleteClauseCommand{{
@@ -521,7 +530,8 @@ func TestUpdateAutoOpsRuleMySQL(t *testing.T) {
 				}},
 				AddDatetimeClauseCommands: []*autoopsproto.AddDatetimeClauseCommand{{
 					DatetimeClause: &autoopsproto.DatetimeClause{
-						Time: time.Now().AddDate(0, 0, 1).Unix(),
+						ActionType: autoopsproto.ActionType_ENABLE,
+						Time:       time.Now().AddDate(0, 0, 1).Unix(),
 					},
 				}},
 			},

--- a/test/e2e/autoops/auto_ops_test.go
+++ b/test/e2e/autoops/auto_ops_test.go
@@ -725,12 +725,14 @@ func createOpsEventRateClause(t *testing.T, variationID, goalID string) *autoops
 		MinCount:        int64(5),
 		ThreadsholdRate: float64(0.5),
 		Operator:        autoopsproto.OpsEventRateClause_GREATER_OR_EQUAL,
+		ActionType:      autoopsproto.ActionType_DISABLE,
 	}
 }
 
 func createDatetimeClause(t *testing.T) *autoopsproto.DatetimeClause {
 	return &autoopsproto.DatetimeClause{
-		Time: time.Now().Add(5 * time.Second).Unix(),
+		Time:       time.Now().Add(5 * time.Second).Unix(),
+		ActionType: autoopsproto.ActionType_DISABLE,
 	}
 }
 


### PR DESCRIPTION
Now that the UI multi-scheduling support has been merged, it should validate Unknown Action Type.