### PR TITLE
fix(ui): auto operation action type not being set

### DIFF
--- a/ui/web-v2/src/components/EventRateAddUpdateForm/index.tsx
+++ b/ui/web-v2/src/components/EventRateAddUpdateForm/index.tsx
@@ -29,7 +29,7 @@ import { classNames } from '../../utils/css';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { addFormSchema } from '../../pages/goal/formSchema';
 import { Dialog, Transition } from '@headlessui/react';
-import { OpsEventRateClause } from '../../proto/autoops/clause_pb';
+import { OpsEventRateClause, ActionType } from '../../proto/autoops/clause_pb';
 import ReactSelect, { components } from 'react-select';
 import {
   CreateAutoOpsRuleCommand,
@@ -702,6 +702,7 @@ export function createOpsEventRateClause(
   clause.setMinCount(oerc.minCount);
   clause.setThreadsholdRate(oerc.threadsholdRate / 100);
   clause.setOperator(createOpsEventRateOperator(oerc.operator));
+  clause.setActionType(ActionType.DISABLE);
   return clause;
 }
 

--- a/ui/web-v2/src/components/FeatureConfirmDialog/index.tsx
+++ b/ui/web-v2/src/components/FeatureConfirmDialog/index.tsx
@@ -16,7 +16,7 @@ import {
 } from '../../modules/porgressiveRollout';
 import { addToast } from '../../modules/toasts';
 import { OpsType } from '../../proto/autoops/auto_ops_rule_pb';
-import { DatetimeClause } from '../../proto/autoops/clause_pb';
+import { ActionType, DatetimeClause } from '../../proto/autoops/clause_pb';
 import { CreateAutoOpsRuleCommand } from '../../proto/autoops/command_pb';
 import { ProgressiveRollout } from '../../proto/autoops/progressive_rollout_pb';
 import { Feature } from '../../proto/feature/feature_pb';
@@ -205,12 +205,13 @@ export const FeatureConfirmDialog: FC<FeatureConfirmDialogProps> = ({
   const handleScheduleSubmit = () => {
     const command = new CreateAutoOpsRuleCommand();
     command.setFeatureId(featureId);
-    if (isEnabled) {
-      command.setOpsType(OpsType.DISABLE_FEATURE);
-    } else {
-      command.setOpsType(OpsType.ENABLE_FEATURE);
-    }
     const clause = new DatetimeClause();
+    command.setOpsType(OpsType.SCHEDULE);
+    if (isEnabled) {
+      clause.setActionType(ActionType.DISABLE);
+    } else {
+      clause.setActionType(ActionType.ENABLE);
+    }
     clause.setTime(Math.round(datetime.getTime() / 1000));
     command.setDatetimeClausesList([clause]);
     dispatch(


### PR DESCRIPTION
The action type wasn't set when creating an event rate operation. Also, it wasn't set when creating a schedule operation on the feature flags list page.