### PR TITLE
fix: ops event rate not being processed

### DIFF
--- a/pkg/batch/storage/v2/auto_ops_rule.go
+++ b/pkg/batch/storage/v2/auto_ops_rule.go
@@ -28,7 +28,7 @@ var (
 )
 
 type AutoOpsRuleStorage interface {
-	CountNotTriggeredAutoOpsRules(ctx context.Context) (int, error)
+	CountOpsEventRate(ctx context.Context) (int, error)
 }
 
 type autoOpsRuleStorage struct {
@@ -39,7 +39,7 @@ func NewAutoOpsRuleStorage(qe mysql.QueryExecer) AutoOpsRuleStorage {
 	return &autoOpsRuleStorage{qe: qe}
 }
 
-func (s autoOpsRuleStorage) CountNotTriggeredAutoOpsRules(ctx context.Context) (int, error) {
+func (s autoOpsRuleStorage) CountOpsEventRate(ctx context.Context) (int, error) {
 	var count int
 	err := s.qe.QueryRowContext(ctx, countAutoOpsRulesSql).Scan(&count)
 	if err != nil {

--- a/pkg/batch/storage/v2/mock/auto_ops_rule.go
+++ b/pkg/batch/storage/v2/mock/auto_ops_rule.go
@@ -39,17 +39,17 @@ func (m *MockAutoOpsRuleStorage) EXPECT() *MockAutoOpsRuleStorageMockRecorder {
 	return m.recorder
 }
 
-// CountNotTriggeredAutoOpsRules mocks base method.
-func (m *MockAutoOpsRuleStorage) CountNotTriggeredAutoOpsRules(ctx context.Context) (int, error) {
+// CountOpsEventRate mocks base method.
+func (m *MockAutoOpsRuleStorage) CountOpsEventRate(ctx context.Context) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountNotTriggeredAutoOpsRules", ctx)
+	ret := m.ctrl.Call(m, "CountOpsEventRate", ctx)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CountNotTriggeredAutoOpsRules indicates an expected call of CountNotTriggeredAutoOpsRules.
-func (mr *MockAutoOpsRuleStorageMockRecorder) CountNotTriggeredAutoOpsRules(ctx any) *gomock.Call {
+// CountOpsEventRate indicates an expected call of CountOpsEventRate.
+func (mr *MockAutoOpsRuleStorageMockRecorder) CountOpsEventRate(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountNotTriggeredAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).CountNotTriggeredAutoOpsRules), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountOpsEventRate", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).CountOpsEventRate), ctx)
 }

--- a/pkg/batch/storage/v2/sql/count_auto_ops_rules.sql
+++ b/pkg/batch/storage/v2/sql/count_auto_ops_rules.sql
@@ -4,7 +4,7 @@ LEFT JOIN feature
 ON auto_ops_rule.feature_id = feature.id
 AND auto_ops_rule.environment_namespace = feature.environment_namespace
 WHERE feature.archived = 0
-  AND auto_ops_rule.triggered_at = 0
+  AND auto_ops_rule.status IN (0, 1) -- 0: WAITING, 1: RUNNING
   AND auto_ops_rule.deleted = 0
-  AND JSON_EXTRACT(JSON_EXTRACT(auto_ops_rule.clauses, '$[*].clause'), '$[0].type_url') != 'type.googleapis.com/bucketeer.autoops.DatetimeClause'
-  -- Schedule operation is not based on events, so we don't include in the result
+  AND auto_ops_rule.ops_type = 3 -- 3: EVENT_RATE, 2: SCHEDULE
+  -- Schedule operation is not based on events, so we don't include in the count

--- a/pkg/batch/subscriber/processor/events_ops_persister.go
+++ b/pkg/batch/subscriber/processor/events_ops_persister.go
@@ -153,7 +153,7 @@ func (e eventsOPSPersister) Process(ctx context.Context, msgChan <-chan *puller.
 
 func (e eventsOPSPersister) Switch(ctx context.Context) (bool, error) {
 	autoOpsRuleStorage := storage.NewAutoOpsRuleStorage(e.mysqlClient)
-	autoOpsRuleCount, err := autoOpsRuleStorage.CountNotTriggeredAutoOpsRules(ctx)
+	autoOpsRuleCount, err := autoOpsRuleStorage.CountOpsEventRate(ctx)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/autoops/auto_ops_test.go
+++ b/test/e2e/autoops/auto_ops_test.go
@@ -114,7 +114,15 @@ func TestCreateAndListAutoOpsRule(t *testing.T) {
 	feature := getFeature(t, featureClient, featureID)
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -126,8 +134,8 @@ func TestCreateAndListAutoOpsRule(t *testing.T) {
 	if actual.FeatureId != featureID {
 		t.Fatalf("different feature ID, expected: %v, actual: %v", featureID, actual.FeatureId)
 	}
-	if actual.OpsType != autoopsproto.OpsType_DISABLE_FEATURE {
-		t.Fatalf("different ops type, expected: %v, actual: %v", autoopsproto.OpsType_DISABLE_FEATURE, actual.OpsType)
+	if actual.OpsType != autoopsproto.OpsType_EVENT_RATE {
+		t.Fatalf("different ops type, expected: %v, actual: %v", autoopsproto.OpsType_EVENT_RATE, actual.OpsType)
 	}
 	if actual.AutoOpsStatus != autoopsproto.AutoOpsStatus_WAITING {
 		t.Fatalf("different auto ops status, expected: %v, actual: %v", autoopsproto.AutoOpsStatus_WAITING, actual.AutoOpsStatus)
@@ -147,6 +155,9 @@ func TestCreateAndListAutoOpsRule(t *testing.T) {
 	}
 	if oerc.Operator != autoopsproto.OpsEventRateClause_GREATER_OR_EQUAL {
 		t.Fatalf("different goal id, expected: %v, actual: %v", "gid", oerc.GoalId)
+	}
+	if oerc.ActionType != autoopsproto.ActionType_DISABLE {
+		t.Fatalf("different action type, expected: %v, actual: %v", "gid", oerc.ActionType)
 	}
 }
 
@@ -185,18 +196,12 @@ func TestCreateAndListAutoOpsRuleForMultiSchedule(t *testing.T) {
 	}
 
 	actualClause1 := actual.Clauses[0]
-	if actualClause1.ActionType != autoopsproto.ActionType_DISABLE {
-		t.Fatalf("different clause1 action type, expected: %v, actual: %v", autoopsproto.ActionType_DISABLE, actualClause1.ActionType)
-	}
 	oerc1 := unmarshalDatetimeClause(t, actualClause1)
 	if oerc1.ActionType != autoopsproto.ActionType_DISABLE {
 		t.Fatalf("different dateClause1 action type, expected: %v, actual: %v", autoopsproto.ActionType_DISABLE, actualClause1.ActionType)
 	}
 
 	actualClause2 := actual.Clauses[1]
-	if actualClause2.ActionType != autoopsproto.ActionType_ENABLE {
-		t.Fatalf("different clause2 action type, expected: %v, actual: %v", autoopsproto.ActionType_ENABLE, actualClause2.ActionType)
-	}
 	oerc2 := unmarshalDatetimeClause(t, actualClause2)
 	if oerc2.ActionType != autoopsproto.ActionType_ENABLE {
 		t.Fatalf("different dateClause2 action type, expected: %v, actual: %v", autoopsproto.ActionType_ENABLE, actualClause2.ActionType)
@@ -219,7 +224,15 @@ func TestGetAutoOpsRule(t *testing.T) {
 	feature := getFeature(t, featureClient, featureID)
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -231,8 +244,8 @@ func TestGetAutoOpsRule(t *testing.T) {
 	if actual.FeatureId != featureID {
 		t.Fatalf("different feature ID, expected: %v, actual: %v", featureID, actual.FeatureId)
 	}
-	if actual.OpsType != autoopsproto.OpsType_DISABLE_FEATURE {
-		t.Fatalf("different ops type, expected: %v, actual: %v", autoopsproto.OpsType_DISABLE_FEATURE, actual.OpsType)
+	if actual.OpsType != autoopsproto.OpsType_EVENT_RATE {
+		t.Fatalf("different ops type, expected: %v, actual: %v", autoopsproto.OpsType_EVENT_RATE, actual.OpsType)
 	}
 	oerc := unmarshalOpsEventRateClause(t, actual.Clauses[0])
 	if oerc.VariationId != feature.Variations[0].Id {
@@ -249,6 +262,9 @@ func TestGetAutoOpsRule(t *testing.T) {
 	}
 	if oerc.Operator != autoopsproto.OpsEventRateClause_GREATER_OR_EQUAL {
 		t.Fatalf("different goal id, expected: %v, actual: %v", "gid", oerc.GoalId)
+	}
+	if oerc.ActionType != autoopsproto.ActionType_DISABLE {
+		t.Fatalf("different action type, expected: %v, actual: %v", "gid", oerc.ActionType)
 	}
 }
 
@@ -268,7 +284,15 @@ func TestDeleteAutoOpsRule(t *testing.T) {
 	feature := getFeature(t, featureClient, featureID)
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -344,7 +368,15 @@ func TestExecuteAutoOpsRule(t *testing.T) {
 	feature := getFeature(t, featureClient, featureID)
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -426,7 +458,15 @@ func TestOpsEventRateBatchWithoutTag(t *testing.T) {
 	feature := getFeature(t, featureClient, featureID)
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -464,7 +504,16 @@ func TestGrpcOpsEventRateBatch(t *testing.T) {
 	feature := getFeature(t, featureClient, featureID)
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
+
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -525,7 +574,15 @@ func TestOpsEventRateBatch(t *testing.T) {
 
 	goalID := createGoal(ctx, t, experimentClient)
 	clause := createOpsEventRateClause(t, feature.Variations[0].Id, goalID)
-	createAutoOpsRule(ctx, t, autoOpsClient, featureID, autoopsproto.OpsType_DISABLE_FEATURE, []*autoopsproto.OpsEventRateClause{clause}, nil)
+	createAutoOpsRule(
+		ctx,
+		t,
+		autoOpsClient,
+		featureID,
+		autoopsproto.OpsType_EVENT_RATE,
+		[]*autoopsproto.OpsEventRateClause{clause},
+		nil,
+	)
 	autoOpsRules := listAutoOpsRulesByFeatureID(t, autoOpsClient, featureID)
 	if len(autoOpsRules) != 1 {
 		t.Fatal("not enough rules")
@@ -719,6 +776,7 @@ func createGoal(ctx context.Context, t *testing.T, client experimentclient.Clien
 }
 
 func createOpsEventRateClause(t *testing.T, variationID, goalID string) *autoopsproto.OpsEventRateClause {
+	t.Helper()
 	return &autoopsproto.OpsEventRateClause{
 		VariationId:     variationID,
 		GoalId:          goalID,
@@ -737,6 +795,7 @@ func createDatetimeClause(t *testing.T) *autoopsproto.DatetimeClause {
 }
 
 func createDatetimeClausesWithActionType(t *testing.T, createCount int) []*autoopsproto.DatetimeClause {
+	t.Helper()
 	var dcs []*autoopsproto.DatetimeClause
 	for i := 0; i < createCount; i++ {
 		at := autoopsproto.ActionType_DISABLE


### PR DESCRIPTION
### Things done

- Fixed count query
- Updated e2e tests to use the correct `ops_type and` and `action_type` when testing event rate operations.