### PR TITLE
chore: ensure that all kubectl commands for the dev container run in the minikube only

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ modify-hosts:
 
 # enable vault transit secret engine
 enable-vault-transit:
+	kubectl config use-context minikube
 	kubectl exec localenv-vault-0 -- vault secrets enable transit
 
 # create bigquery-emulator tables
@@ -334,6 +335,7 @@ create-bigquery-emulator-tables:
 		--no-profile
 
 setup-bigquery-vault:
+	kubectl config use-context minikube
 	while [ "$$(kubectl get pods | grep localenv-bq | awk '{print $$3}')" != "Running" ] || [ "$$(kubectl get pods | grep localenv-vault-0 | awk '{print $$3}')" != "Running" ]; \
 	do \
 		sleep 5; \

--- a/tools/dev/Makefile
+++ b/tools/dev/Makefile
@@ -14,24 +14,29 @@ generate-oauth:
 	openssl rsa -in ${CURDIR}/cert/oauth-private.pem -pubout -out ${CURDIR}/cert/oauth-public.pem
 
 service-cert-secret:
+	kubectl config use-context minikube
 	kubectl delete secret bucketeer-service-cert --namespace $(NAMESPACE) --ignore-not-found
 	kubectl create secret tls bucketeer-service-cert --key ${CURDIR}/cert/tls.key --cert ${CURDIR}/cert/tls.crt --namespace $(NAMESPACE)
 
 service-token-secret:
+	kubectl config use-context minikube
 	kubectl delete secret bucketeer-service-token --namespace $(NAMESPACE) --ignore-not-found
 	kubectl create secret generic bucketeer-service-token --from-file token=${CURDIR}/cert/service-token --namespace $(NAMESPACE)
 
 oauth-key-secret:
+	kubectl config use-context minikube
 	kubectl delete secret bucketeer-oauth-key --namespace $(NAMESPACE) --ignore-not-found
 	kubectl create secret generic bucketeer-oauth-key --from-file public.pem=${CURDIR}/cert/oauth-public.pem --from-file private.pem=${CURDIR}/cert/oauth-private.pem --namespace $(NAMESPACE)
 
 setup-minikube:
 	minikube start --memory max --cpus max
 	minikube addons enable ingress
+	kubectl config use-context minikube
 	kubectl patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'
 	helm install localenv ../../manifests/localenv
 
 start-minikube: 
 	minikube start
 	# used to enable ssl-passthrough for nginx ingress container
+	kubectl config use-context minikube
 	kubectl patch deployment -n ingress-nginx ingress-nginx-controller --type='json' -p='[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value":"--enable-ssl-passthrough"}]'


### PR DESCRIPTION
To avoid the kubectl commands for the dev container being executed on the host by accident, I changed to always executing it in the `minikube` context.