### PR TITLE
build(ui): add post build script to recreate the file after building web project

### DIFF
--- a/ui/web-v2/package.json
+++ b/ui/web-v2/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "build": "webpack --mode production --config ./webpack.config.js",
+    "postbuild": "touch ./dist/DONT-EDIT-FILES-IN-THIS-DIRECTORY",
     "start": "TAILWIND_MODE=watch webpack-cli serve --mode development --config webpack.dev.js",
     "lint": "yarn tsc:strict && yarn eslint && yarn prettier",
     "lintfix": "yarn eslintfix && yarn prettierfix",


### PR DESCRIPTION
When we build the web project, it deletes the `DONT-EDIT-FILES-IN-THIS-DIRECTORY` in the dist directory.
Because the go embed building needs that file, we must ensure it is not accidentally deleted and pushed to the main branch.
