### PR TITLE
fix: validated the same date for schedule Auto Ops

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -19,6 +19,12 @@ import (
 	"strconv"
 	"time"
 
+	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	accountclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
 	authclient "github.com/bucketeer-io/bucketeer/pkg/auth/client"
 	"github.com/bucketeer-io/bucketeer/pkg/autoops/command"
@@ -38,11 +44,6 @@ import (
 	autoopsproto "github.com/bucketeer-io/bucketeer/proto/autoops"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	experimentproto "github.com/bucketeer-io/bucketeer/proto/experiment"
-	"go.uber.org/zap"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type options struct {

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -747,34 +747,34 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 			for _, deleteClause := range req.DeleteClauseCommands {
 				delete(extractDateTimeClauses, deleteClause.Id)
 			}
+			checkTimes := make(map[int64]bool)
+			for _, c := range extractDateTimeClauses {
+				checkTimes[c.Time] = true
+			}
 
 			// Check if there is a schedule with the same date and time.
 			for _, c := range req.AddDatetimeClauseCommands {
-				for _, extractDateTimeClause := range extractDateTimeClauses {
-					if c.DatetimeClause.Time == extractDateTimeClause.Time {
-						dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
-							Locale:  localizer.GetLocale(),
-							Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),
-						})
-						if err != nil {
-							return statusInternal.Err()
-						}
-						return dt.Err()
+				if checkTimes[c.DatetimeClause.Time] {
+					dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
+						Locale:  localizer.GetLocale(),
+						Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),
+					})
+					if err != nil {
+						return statusInternal.Err()
 					}
+					return dt.Err()
 				}
 			}
 			for _, c := range req.ChangeDatetimeClauseCommands {
-				for _, extractDateTimeClause := range extractDateTimeClauses {
-					if c.DatetimeClause.Time == extractDateTimeClause.Time {
-						dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
-							Locale:  localizer.GetLocale(),
-							Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),
-						})
-						if err != nil {
-							return statusInternal.Err()
-						}
-						return dt.Err()
+				if checkTimes[c.DatetimeClause.Time] {
+					dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
+						Locale:  localizer.GetLocale(),
+						Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),
+					})
+					if err != nil {
+						return statusInternal.Err()
 					}
+					return dt.Err()
 				}
 			}
 		}

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -411,10 +411,12 @@ func (s *AutoOpsService) validateDatetimeClauses(
 	clauses []*autoopsproto.DatetimeClause,
 	localizer locale.Localizer,
 ) error {
+	var checkClauses []*autoopsproto.DatetimeClause
 	for _, c := range clauses {
-		if err := s.validateDatetimeClause(c, clauses, localizer); err != nil {
+		if err := s.validateDatetimeClause(c, checkClauses, localizer); err != nil {
 			return err
 		}
+		checkClauses = append(checkClauses, c)
 	}
 	return nil
 }
@@ -980,7 +982,7 @@ func (s *AutoOpsService) validateUpdateAutoOpsRuleRequest(
 		}
 	}
 
-	var tmpDatetimeClauses []*autoopsproto.DatetimeClause
+	var checkDatetimeClauses []*autoopsproto.DatetimeClause
 	for _, c := range req.AddDatetimeClauseCommands {
 		if c.DatetimeClause == nil {
 			dt, err := statusDatetimeClauseRequired.WithDetails(&errdetails.LocalizedMessage{
@@ -992,13 +994,12 @@ func (s *AutoOpsService) validateUpdateAutoOpsRuleRequest(
 			}
 			return dt.Err()
 		}
-		tmpDatetimeClauses = append(tmpDatetimeClauses, c.DatetimeClause)
-		if err := s.validateDatetimeClause(c.DatetimeClause, tmpDatetimeClauses, localizer); err != nil {
+		if err := s.validateDatetimeClause(c.DatetimeClause, checkDatetimeClauses, localizer); err != nil {
 			return err
 		}
+		checkDatetimeClauses = append(checkDatetimeClauses, c.DatetimeClause)
 	}
 
-	tmpDatetimeClauses = []*autoopsproto.DatetimeClause{}
 	for _, c := range req.ChangeDatetimeClauseCommands {
 		if c.Id == "" {
 			dt, err := statusClauseIDRequired.WithDetails(&errdetails.LocalizedMessage{
@@ -1020,10 +1021,10 @@ func (s *AutoOpsService) validateUpdateAutoOpsRuleRequest(
 			}
 			return dt.Err()
 		}
-		tmpDatetimeClauses = append(tmpDatetimeClauses, c.DatetimeClause)
-		if err := s.validateDatetimeClause(c.DatetimeClause, tmpDatetimeClauses, localizer); err != nil {
+		if err := s.validateDatetimeClause(c.DatetimeClause, checkDatetimeClauses, localizer); err != nil {
 			return err
 		}
+		checkDatetimeClauses = append(checkDatetimeClauses, c.DatetimeClause)
 	}
 	return nil
 }

--- a/pkg/autoops/api/error.go
+++ b/pkg/autoops/api/error.go
@@ -82,6 +82,10 @@ var (
 		codes.InvalidArgument,
 		"autoops: datetime clause time must be after now timestamp",
 	)
+	statusDatetimeClauseDuplicateTime = gstatus.New(
+		codes.InvalidArgument,
+		"autoops: datetime clause time must be unique",
+	)
 	statusNotFound                       = gstatus.New(codes.NotFound, "autoops: not found")
 	statusAlreadyDeleted                 = gstatus.New(codes.NotFound, "autoops: already deleted")
 	statusOpsEventRateClauseGoalNotFound = gstatus.New(

--- a/pkg/autoops/domain/auto_ops_rule.go
+++ b/pkg/autoops/domain/auto_ops_rule.go
@@ -337,6 +337,21 @@ func (a *AutoOpsRule) ExtractDatetimeClauses() (map[string]*proto.DatetimeClause
 	return datetimeClauses, nil
 }
 
+func (a *AutoOpsRule) ExtractDatetimeClause(clauseId string) (*proto.DatetimeClause, error) {
+	datetimeClauses, err := a.ExtractDatetimeClauses()
+	var datetimeClause *proto.DatetimeClause = nil
+	if err != nil {
+		return nil, err
+	}
+	for id, c := range datetimeClauses {
+		if id == clauseId {
+			datetimeClause = c
+			break
+		}
+	}
+	return datetimeClause, nil
+}
+
 func (a *AutoOpsRule) unmarshalDatetimeClause(clause *proto.Clause) (*proto.DatetimeClause, error) {
 	if ptypes.Is(clause.Clause, DatetimeClause) {
 		c := &proto.DatetimeClause{}

--- a/pkg/autoops/domain/auto_ops_rule.go
+++ b/pkg/autoops/domain/auto_ops_rule.go
@@ -337,21 +337,6 @@ func (a *AutoOpsRule) ExtractDatetimeClauses() (map[string]*proto.DatetimeClause
 	return datetimeClauses, nil
 }
 
-func (a *AutoOpsRule) ExtractDatetimeClause(clauseId string) (*proto.DatetimeClause, error) {
-	datetimeClauses, err := a.ExtractDatetimeClauses()
-	var datetimeClause *proto.DatetimeClause = nil
-	if err != nil {
-		return nil, err
-	}
-	for id, c := range datetimeClauses {
-		if id == clauseId {
-			datetimeClause = c
-			break
-		}
-	}
-	return datetimeClause, nil
-}
-
 func (a *AutoOpsRule) unmarshalDatetimeClause(clause *proto.Clause) (*proto.DatetimeClause, error) {
 	if ptypes.Is(clause.Clause, DatetimeClause) {
 		c := &proto.DatetimeClause{}


### PR DESCRIPTION
Fixed to reject requests that have the same date or already have the same date when scheduling AutoOps.