### PR TITLE
fix: fixed to also check ActionType when validating the same date

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -747,14 +747,14 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 			for _, deleteClause := range req.DeleteClauseCommands {
 				delete(extractDateTimeClauses, deleteClause.Id)
 			}
-			checkTimes := make(map[int64]bool)
+			checkTimes := make(map[int64]autoopsproto.ActionType)
 			for _, c := range extractDateTimeClauses {
-				checkTimes[c.Time] = true
+				checkTimes[c.Time] = c.ActionType
 			}
 
 			// Check if there is a schedule with the same date and time.
 			for _, c := range req.AddDatetimeClauseCommands {
-				if checkTimes[c.DatetimeClause.Time] {
+				if actionType, hasSameTime := checkTimes[c.DatetimeClause.Time]; hasSameTime && actionType == c.DatetimeClause.ActionType {
 					dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
 						Locale:  localizer.GetLocale(),
 						Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),
@@ -766,7 +766,7 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 				}
 			}
 			for _, c := range req.ChangeDatetimeClauseCommands {
-				if checkTimes[c.DatetimeClause.Time] {
+				if actionType, hasSameTime := checkTimes[c.DatetimeClause.Time]; hasSameTime && actionType == c.DatetimeClause.ActionType {
 					dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
 						Locale:  localizer.GetLocale(),
 						Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -754,7 +754,8 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 
 			// Check if there is a schedule with the same date and time.
 			for _, c := range req.AddDatetimeClauseCommands {
-				if actionType, hasSameTime := checkTimes[c.DatetimeClause.Time]; hasSameTime && actionType == c.DatetimeClause.ActionType {
+				actionType, hasSameTime := checkTimes[c.DatetimeClause.Time]
+				if hasSameTime && actionType == c.DatetimeClause.ActionType {
 					dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
 						Locale:  localizer.GetLocale(),
 						Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),
@@ -766,7 +767,8 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 				}
 			}
 			for _, c := range req.ChangeDatetimeClauseCommands {
-				if actionType, hasSameTime := checkTimes[c.DatetimeClause.Time]; hasSameTime && actionType == c.DatetimeClause.ActionType {
+				actionType, hasSameTime := checkTimes[c.DatetimeClause.Time]
+				if hasSameTime && actionType == c.DatetimeClause.ActionType {
 					dt, err := statusDatetimeClauseDuplicateTime.WithDetails(&errdetails.LocalizedMessage{
 						Locale:  localizer.GetLocale(),
 						Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "time"),


### PR DESCRIPTION
When updating an AutoOps schedule, updating to a different ActionType while keeping the same date caused an error.