### PR TITLE
fix: sql argument when getting account

### DIFF
--- a/pkg/account/storage/v2/admin_account.go
+++ b/pkg/account/storage/v2/admin_account.go
@@ -50,6 +50,7 @@ func (s *accountStorage) GetSystemAdminAccountV2(ctx context.Context, email stri
 		&account.Disabled,
 		&account.CreatedAt,
 		&account.UpdatedAt,
+		&mysql.JSONObject{Val: &account.SearchFilters},
 	)
 	if err != nil {
 		if errors.Is(err, mysql.ErrNoRows) {

--- a/pkg/account/storage/v2/sql/account_v2/select_accounts_with_organization.sql
+++ b/pkg/account/storage/v2/sql/account_v2/select_accounts_with_organization.sql
@@ -8,6 +8,7 @@ SELECT
     a.disabled,
     a.created_at,
     a.updated_at,
+    a.search_filters,
     o.id,
     o.name,
     o.url_code,

--- a/pkg/account/storage/v2/sql/account_v2/select_system_admin_account_v2.sql
+++ b/pkg/account/storage/v2/sql/account_v2/select_system_admin_account_v2.sql
@@ -7,7 +7,8 @@ SELECT
     a.environment_roles,
     a.disabled,
     a.created_at,
-    a.updated_at
+    a.updated_at,
+    a.search_filters
 FROM
     account_v2 AS a
 INNER JOIN


### PR DESCRIPTION
Fix the error `sql: expected 19 destination arguments in Scan, not 20"` when getting the user account.