### PR TITLE
test: increase request timeout for eventcounter tests to improve flaky tests

### DIFF
--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -54,7 +54,7 @@ import (
 
 const (
 	prefixTestName = "e2e-test"
-	timeout        = 60 * time.Second
+	timeout        = 2 * time.Minute
 	retryTimes     = 50
 )
 


### PR DESCRIPTION
For some reason, the E2E test requests are failing due to timeout when running them on GitHub Actions.
It seems it works better when setting the timeout to 2 minutes.