### PR TITLE
chore: add log for error metrics from sdk client

### DIFF
--- a/pkg/api/api/metrics_event.go
+++ b/pkg/api/api/metrics_event.go
@@ -395,6 +395,16 @@ func (s *grpcGatewayService) saveErrorCount(
 	if labels != nil {
 		tag = labels["tag"]
 	}
+	s.logger.Error("Error metric details",
+		zap.String("projectId", projectID),
+		zap.String("environment", env),
+		zap.String("tag", tag),
+		zap.Any("labels", labels),
+		zap.String("errorType", errorType),
+		zap.String("apiId", apiID.String()),
+		zap.String("sdkVersion", event.SdkVersion),
+		zap.String("sourceId", event.SourceId.String()),
+	)
 	sdkErrorCounter.WithLabelValues(
 		projectID,
 		env,


### PR DESCRIPTION
I'm adding logs to check the labels (key/value map), which contain the error message when an unknown error happens, to improve debugging.