### PR TITLE
fix: audit log pubg message not being acknowledged

### DIFF
--- a/pkg/auditlog/storage/v2/admin_audit_log_test.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log_test.go
@@ -110,6 +110,78 @@ func TestCreateAdminAuditLogs(t *testing.T) {
 	}
 }
 
+func TestCreateAdminAuditLog(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	id0 := "id-0"
+	patterns := []struct {
+		desc        string
+		setup       func(*adminAuditLogStorage)
+		input       *domain.AuditLog
+		expectedErr error
+	}{
+		{
+			desc: "ErrAdminAuditLogAlreadyExists",
+			setup: func(s *adminAuditLogStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, mysql.ErrDuplicateEntry)
+			},
+			input: &domain.AuditLog{
+				AuditLog: &proto.AuditLog{Id: "id-0"},
+			},
+			expectedErr: ErrAdminAuditLogAlreadyExists,
+		},
+		{
+			desc: "Error",
+			setup: func(s *adminAuditLogStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			input: &domain.AuditLog{
+				AuditLog: &proto.AuditLog{Id: "id-0"},
+			},
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "success",
+			setup: func(s *adminAuditLogStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					id0, int64(1), int32(2), "e0", int32(3), gomock.Any(), gomock.Any(), gomock.Any(), "ed", "ped",
+				).Return(nil, nil)
+			},
+			input: &domain.AuditLog{
+				AuditLog: &proto.AuditLog{
+					Id:                 id0,
+					Timestamp:          1,
+					EntityType:         2,
+					EntityId:           "e0",
+					Type:               3,
+					EntityData:         "ed",
+					PreviousEntityData: "ped",
+				},
+				EnvironmentNamespace: "ns0",
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAdminAuditLogStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.CreateAdminAuditLog(context.Background(), p.input)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
 func TestListAdminAuditLogs(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)

--- a/pkg/auditlog/storage/v2/mock/admin_audit_log.go
+++ b/pkg/auditlog/storage/v2/mock/admin_audit_log.go
@@ -43,6 +43,20 @@ func (m *MockAdminAuditLogStorage) EXPECT() *MockAdminAuditLogStorageMockRecorde
 	return m.recorder
 }
 
+// CreateAdminAuditLog mocks base method.
+func (m *MockAdminAuditLogStorage) CreateAdminAuditLog(ctx context.Context, auditLog *domain.AuditLog) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAdminAuditLog", ctx, auditLog)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateAdminAuditLog indicates an expected call of CreateAdminAuditLog.
+func (mr *MockAdminAuditLogStorageMockRecorder) CreateAdminAuditLog(ctx, auditLog any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAdminAuditLog", reflect.TypeOf((*MockAdminAuditLogStorage)(nil).CreateAdminAuditLog), ctx, auditLog)
+}
+
 // CreateAdminAuditLogs mocks base method.
 func (m *MockAdminAuditLogStorage) CreateAdminAuditLogs(ctx context.Context, auditLogs []*domain.AuditLog) error {
 	m.ctrl.T.Helper()

--- a/pkg/auditlog/storage/v2/mock/audit_log.go
+++ b/pkg/auditlog/storage/v2/mock/audit_log.go
@@ -43,6 +43,20 @@ func (m *MockAuditLogStorage) EXPECT() *MockAuditLogStorageMockRecorder {
 	return m.recorder
 }
 
+// CreateAuditLog mocks base method.
+func (m *MockAuditLogStorage) CreateAuditLog(ctx context.Context, auditLog *domain.AuditLog) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAuditLog", ctx, auditLog)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateAuditLog indicates an expected call of CreateAuditLog.
+func (mr *MockAuditLogStorageMockRecorder) CreateAuditLog(ctx, auditLog any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAuditLog", reflect.TypeOf((*MockAuditLogStorage)(nil).CreateAuditLog), ctx, auditLog)
+}
+
 // CreateAuditLogs mocks base method.
 func (m *MockAuditLogStorage) CreateAuditLogs(ctx context.Context, auditLogs []*domain.AuditLog) error {
 	m.ctrl.T.Helper()

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/insert_admin_audit_logs_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/insert_admin_audit_logs_v2.sql
@@ -9,4 +9,4 @@ INSERT INTO admin_audit_log (
     options,
     entity_data,
     previous_entity_data
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES

--- a/pkg/auditlog/storage/v2/sql/auditlog/insert_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/insert_audit_log_v2.sql
@@ -10,4 +10,4 @@ INSERT INTO audit_log (
     environment_namespace,
     entity_data,
     previous_entity_data
-) VALUES
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/pkg/auditlog/storage/v2/sql/auditlog/insert_audit_logs_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/insert_audit_logs_v2.sql
@@ -1,4 +1,4 @@
-INSERT INTO admin_audit_log (
+INSERT INTO audit_log (
     id,
     timestamp,
     entity_type,
@@ -7,6 +7,7 @@ INSERT INTO admin_audit_log (
     event,
     editor,
     options,
+    environment_namespace,
     entity_data,
     previous_entity_data
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES


### PR DESCRIPTION
When the subscriber tries to insert an audit log that already exists in the DB, it doesn't acknowledge the PubSub message and keeps trying in an infinite loop until the message expires in PubSub.

I'm changing it to insert a single audit log so we can acknowledge the correct message when it happens and not all the messages in the chunk, which could lead to data loss.