### PR TITLE
chore: change the default time range when getting evaluation count to 7 days

### DIFF
--- a/ui/web-v2/src/pages/feature/evaluation.tsx
+++ b/ui/web-v2/src/pages/feature/evaluation.tsx
@@ -24,7 +24,7 @@ export const FeatureEvaluationPage: FC<FeatureEvaluationPageProps> = memo(
       shallowEqual
     );
     const [selectedTimeRange, setSelectedTimeRange] = useState(
-      timeRangeOptions[0]
+      timeRangeOptions[2]
     );
 
     useEffect(() => {
@@ -32,7 +32,7 @@ export const FeatureEvaluationPage: FC<FeatureEvaluationPageProps> = memo(
         getEvaluationTimeseriesCount({
           featureId: featureId,
           environmentNamespace: currentEnvironment.id,
-          timeRange: TimeRange.LAST_THIRTY_DAYS
+          timeRange: TimeRange.SEVEN_DAYS
         })
       );
     }, [dispatch, featureId, currentEnvironment]);


### PR DESCRIPTION
When using Redis Cluster, merging the time-series data takes more time than a single instance. Because the user usually checks a 7-day or 24-hour range more often, so I'm changing the default request to 7 days.