### PR TITLE
ci: fix expression injection in action workflow

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -61,7 +61,9 @@ jobs:
         run: echo "value=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
       - name: Store the first line of commit message
         id: commit_message
-        run: echo "value=$(echo "${{ github.event.head_commit.message }}" | head -n 1)" >> $GITHUB_OUTPUT
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: echo "value=$(echo "$COMMIT_MESSAGE" | head -n 1)" >> $GITHUB_OUTPUT
       - name: Store the migration_required value to output
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: changes


### PR DESCRIPTION
Fixes [https://github.com/bucketeer-io/bucketeer/security/code-scanning/1](https://github.com/bucketeer-io/bucketeer/security/code-scanning/1)

To fix the problem, we need to avoid using the user-controlled input directly in the shell command. Instead, we should set the untrusted input value to an intermediate environment variable and then use the environment variable in the shell command using the native shell syntax. This approach will prevent command injection vulnerabilities.

Specifically, we will:
1. Set the commit message to an environment variable.
2. Use the environment variable in the shell command to safely extract the first line of the commit message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
