### PR TITLE
fix: cannot create an account

### DIFF
--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -136,6 +136,7 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 						Email:            "bucketeer@example.com",
 						FirstName:        "Test",
 						LastName:         "User",
+						Language:         "en",
 						OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
 					},
 				}, nil)
@@ -147,9 +148,6 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 			req: &accountproto.CreateAccountV2Request{
 				Command: &accountproto.CreateAccountV2Command{
 					Email:            "bucketeer_environment@example.com",
-					FirstName:        "Test",
-					LastName:         "User",
-					Language:         "en",
 					OrganizationRole: accountproto.AccountV2_Role_Organization_MEMBER,
 				},
 				OrganizationId: "org0",
@@ -178,9 +176,6 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 			req: &accountproto.CreateAccountV2Request{
 				Command: &accountproto.CreateAccountV2Command{
 					Email:            "bucketeer@example.com",
-					FirstName:        "Test",
-					LastName:         "User",
-					Language:         "en",
 					OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
 				},
 				OrganizationId: "org0",
@@ -209,9 +204,6 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 			req: &accountproto.CreateAccountV2Request{
 				Command: &accountproto.CreateAccountV2Command{
 					Email:            "bucketeer@example.com",
-					FirstName:        "Test",
-					LastName:         "User",
-					Language:         "en",
 					OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
 				},
 				OrganizationId: "org0",

--- a/pkg/account/api/validation.go
+++ b/pkg/account/api/validation.go
@@ -173,56 +173,6 @@ func validateCreateAccountV2Request(req *accountproto.CreateAccountV2Request, lo
 		}
 		return dt.Err()
 	}
-	if req.Command.FirstName == "" {
-		dt, err := statusFirstNameIsEmpty.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "first_name"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if len(req.Command.FirstName) > maxAccountNameLength {
-		dt, err := statusInvalidFirstName.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "first_name"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if req.Command.LastName == "" {
-		dt, err := statusLastNameIsEmpty.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "last_name"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if len(req.Command.LastName) > maxAccountNameLength {
-		dt, err := statusInvalidLastName.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "last_name"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
-	if req.Command.Language == "" {
-		dt, err := statusLanguageIsEmpty.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "language"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
-	}
 	if req.Command.OrganizationRole == accountproto.AccountV2_Role_Organization_UNASSIGNED {
 		dt, err := statusInvalidOrganizationRole.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),


### PR DESCRIPTION
When creating a new account, we only know the email, so the other fields must be optional. When the user logs into the console for the first time, we save his first and last name when updating his account.