### PR TITLE
fix: use file io encoded_descriptor when replace encoded descriptor

### DIFF
--- a/tools/gen/descriptor.sh
+++ b/tools/gen/descriptor.sh
@@ -30,7 +30,9 @@ descriptor_file="proto_descriptor.pb"
 # api-gateway
 api_gateway_values_path="./manifests/bucketeer/charts/api/values.yaml"
 encoded_descriptor=$(cat ${DESCRIPTOR_PATH}/gateway/${descriptor_file} | base64 | tr -d \\n)
-yq eval ".envoy.descriptor = \"${encoded_descriptor}\"" -i ${api_gateway_values_path}
+echo $encoded_descriptor > encoded_descriptor.txt
+yq eval ".envoy.descriptor = load(\"encoded_descriptor.txt\")" -i ${api_gateway_values_path}
+rm encoded_descriptor.txt
 
 # web-gateway
 web_gateway_values_path="./manifests/bucketeer/charts/web/values.yaml"


### PR DESCRIPTION
Resolve issue https://github.com/bucketeer-io/bucketeer/issues/1328

- At one point when we specify new API or develop new feature in *.proto files, the proto_descriptor.pb (in /proto sub packages) will expand.
- **For some machines**, the input argument when we run bash commands will reach that machine max arg limitation, so when we run make go-descriptor or make generate-all, the error "Argument list too long" can appear in line 33 in tools/descriptor.sh, hence we can not replace the encoded-descriptor in manifest.envoy descriptor yaml config and block the rest.
```bash
/workspaces/bucketeer/tools/gen/descriptor.sh: line 33: /go/bin/yq: Argument list too long
make[1]: *** [Makefile:89: go-descriptor] Error 126
make[1]: Leaving directory '/workspaces/bucketeer/proto'
make: *** [Makefile:100: proto-go-descriptor] Error 2
```

- This pr fix the problem by replace std input to file input so limit arg max won't happen