### PR TITLE
chore: populate api_key with values from id

### DIFF
--- a/migration/README.md
+++ b/migration/README.md
@@ -24,6 +24,7 @@ Once you are logged in, you can make your changes in the Database.
 
 ## 2- Creating Migration File
 
+### 2.1 - Generate Migration File
 To create the migration file, you must port-forward the `localenv-mysql` service before creating it.
 
 ```shell
@@ -43,6 +44,20 @@ For the migration file name, please use one of the following prefixes.
 - **drop:** Used when you drop a table. E.g. `drop_xxx_table`
 
 After creating it, ensure you see the new file in the `migration/mysql` directory.
+
+### 2.2 - Create Migration File manually
+In case no structure changes are executed, you can create the migration file manually.
+
+Create a new migration file
+```shell
+atlas migrate new <file_name> --dir "file://migration/mysql"
+```
+
+Edit the migration file then update atlas migration files hash
+```shell
+atlas migrate hash --dir "file://migration/mysql"
+```
+If the migration sql statement changed again, rerun the above command to update the hash.
 
 ## 3- Pushing Migration File
 

--- a/migration/mysql/20241122095236_sync_api_key_table.sql
+++ b/migration/mysql/20241122095236_sync_api_key_table.sql
@@ -1,0 +1,2 @@
+-- Populate api_key with values from id
+UPDATE api_key SET api_key = id;

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:EVG3EaGFLShs1tnbc4xlhnrMNKEHCo5h/zJTE8Ns20M=
+h1:etbgl9IBPjae1gOaGHGD2vKzVsUwfmkRO55ID1LL3H0=
 20240626022133_initialization.sql h1:u9qmPkwWX7PN92qEcDDfR92lrMpwadQSMxUJgv6LjQ0=
 20240708065726_update_audit_log_table.sql h1:k7gK8Njv1yHMsYXAQtSgMaSbXy4lxyZ9MPzbJyMyyoM=
 20240815043128_update_auto_ops_rule_table.sql h1:6ib+XfS1uu9AUO3qESvkpUfOu3qUsLwHm9KHcrGEz0E=
@@ -13,3 +13,4 @@ h1:EVG3EaGFLShs1tnbc4xlhnrMNKEHCo5h/zJTE8Ns20M=
 20241113125451_update_environment_namespace.sql h1:dqTCT/L3QtjMIsM788jAisRiDU0ItEx4m3xgOiuXU1k=
 20241113142932_update_environment_id_table.sql h1:MufoP4KqI2pl8lCV5OHhyITYC+VQcYJc3jSwDpqK0Ks=
 20241122042909_add_api_key_maintainer_table.sql h1:srtthACDj2dyr8oFKRcPPIYsEsI/Ivzj3VClwY2x0Cs=
+20241122095236_sync_api_key_table.sql h1:nl53c3tgJTOEqxP34ayddS/iYyk03rwerDC7ABuJmmA=


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1331
- Add doc for manual atlas migration
- Populate api_key with values from id