### PR TITLE
fix:  service.proto syntax error

### DIFF
--- a/proto/gateway/service.proto
+++ b/proto/gateway/service.proto
@@ -220,8 +220,7 @@ message UpdatePushRequest {
   string id = 1;
   repeated string tags = 2;
   google.protobuf.StringValue name = 3;
-  google.protobuf.BoolValue deleted = 4 [(grpc.gateway.protoc_gen_openapiv2
-                                              .options.openapiv2_field) = {
+  google.protobuf.BoolValue deleted = 4 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {
     title: "deleted"
     description: "if true, the push notification will be deleted and other fields will be ignored."
   }];


### PR DESCRIPTION
I found a syntax error in service.proto when trying to test the gateway API. This is causing errors when using the proto files.

<img width="594" alt="Screenshot 2024-11-25 at 11 16 56" src="https://github.com/user-attachments/assets/5bb3ef3c-98f1-43cc-8c3c-e35f975375ff">
