### PR TITLE
chore: add evaluation event count metrics to subscriber

### DIFF
--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -255,6 +255,7 @@ func (p *evaluationCountEventPersister) incrementEvaluationCount(
 		if err := p.countEvent(eckv2); err != nil {
 			return err
 		}
+		evaluationEventCounter.WithLabelValues(e.FeatureId, e.Tag, e.Metadata[appVersion]).Inc()
 	}
 	return nil
 }

--- a/pkg/subscriber/processor/metrics.go
+++ b/pkg/subscriber/processor/metrics.go
@@ -52,6 +52,7 @@ const (
 	codeFailedToAppendEvaluationEvents      = "FailedToAppendEvaluationEvents"
 	codeFailedToAppendGoalEvents            = "FailedToAppendGoalEvents"
 	codeLinked                              = "Linked"
+	appVersion                              = "app_version"
 )
 
 var (
@@ -79,6 +80,14 @@ var (
 			Help:      "Histogram of message handling duration (seconds)",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"subscriber", "code"})
+
+	evaluationEventCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "bucketeer",
+			Subsystem: "subscriber",
+			Name:      "evaluation_event_total",
+			Help:      "Total number of evaluation events",
+		}, []string{"tag", "feature_id", "app_version"})
 )
 
 func registerMetrics(r metrics.Registerer) {


### PR DESCRIPTION
This pull request includes changes to improve the metrics collection for evaluation events in the subscriber processor. The most important changes include adding a new counter for evaluation events and updating the `incrementEvaluationCount` method to increment this new counter.

Metrics collection improvements:

* [`pkg/subscriber/processor/metrics.go`](diffhunk://#diff-097770a75bd6749152b599e44f98b7dca77d92b833fecbfea9c2ce40291607ffR55): Added a new constant `appVersion` to be used as a label in the new counter.
* [`pkg/subscriber/processor/metrics.go`](diffhunk://#diff-097770a75bd6749152b599e44f98b7dca77d92b833fecbfea9c2ce40291607ffR83-R90): Introduced a new `evaluationEventCounter` using `prometheus.NewCounterVec` to count evaluation events with labels for `tag`, `feature_id`, and `app_version`.
* [`pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go`](diffhunk://#diff-ce8f25bdc00abed88c31fe33f370739972f110b61246643d20d74286ad81799aR258): Updated the `incrementEvaluationCount` method to increment the `evaluationEventCounter` with appropriate label values.