### PR TITLE
fix: feature not found error on evaluation

### DIFF
--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -2309,9 +2309,10 @@ func (s *FeatureService) getTargetFeatures(
 	if err != nil {
 		return nil, err
 	}
-	if len(feature.Prerequisites) > 0 {
-		// If we select only the prerequisite feature flags, we have to get them recursively.
-		// Thus, we evaluate all features here to avoid complex logic.
+	// Check if the flag depends on other flags.
+	// Thus, we evaluate all features here to avoid complex logic.
+	df := &domain.Feature{Feature: feature}
+	if len(df.FeatureIDsDependsOn()) > 0 {
 		return fs, nil
 	}
 	return []*featureproto.Feature{feature}, nil


### PR DESCRIPTION
This pull request includes a change to the `getTargetFeatures` function in the `pkg/feature/api/feature.go` file. The main modification involves how the code checks for dependencies on other feature flags. The most important change is:

* Simplified the logic for checking if a feature flag depends on other flags by using the `FeatureIDsDependsOn` method from the `domain.Feature` struct. This avoids the need for recursive logic when evaluating feature flags. (`[pkg/feature/api/feature.goL2312-R2315](diffhunk://#diff-2d0a2c8153246509abb80eca89b6ca25f95f7ea8e75640dae22408489b8b0eafL2312-R2315)`)