### PR TITLE
fix: update evaluation event counter metrics to include variation ID

### DIFF
--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -255,7 +255,7 @@ func (p *evaluationCountEventPersister) incrementEvaluationCount(
 		if err := p.countEvent(eckv2); err != nil {
 			return err
 		}
-		evaluationEventCounter.WithLabelValues(e.SdkVersion, e.Tag, e.FeatureId, e.Metadata[appVersion]).Inc()
+		evaluationEventCounter.WithLabelValues(e.SdkVersion, e.FeatureId, e.Metadata[appVersion], e.VariationId).Inc()
 	}
 	return nil
 }

--- a/pkg/subscriber/processor/metrics.go
+++ b/pkg/subscriber/processor/metrics.go
@@ -87,7 +87,7 @@ var (
 			Subsystem: "subscriber",
 			Name:      "evaluation_event_total",
 			Help:      "Total number of evaluation events",
-		}, []string{"sdk_version", "tag", "feature_id", "app_version"})
+		}, []string{"sdk_version", "feature_id", "app_version", "variation_id"})
 )
 
 func registerMetrics(r metrics.Registerer) {


### PR DESCRIPTION
This pull request includes changes to the evaluation event metrics in the `pkg/subscriber/processor` package to improve the tracking of variation IDs. The most important changes are:

Metrics update:

* [`pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go`](diffhunk://#diff-ce8f25bdc00abed88c31fe33f370739972f110b61246643d20d74286ad81799aL258-R258): Modified the `incrementEvaluationCount` function to include `VariationId` in the `evaluationEventCounter` labels.
* [`pkg/subscriber/processor/metrics.go`](diffhunk://#diff-097770a75bd6749152b599e44f98b7dca77d92b833fecbfea9c2ce40291607ffL90-R90): Updated the `evaluation_event_total` metric definition to include `variation_id` as a label.