### PR TITLE
refactor: changes to storage-related transaction handling within AutoOps packages

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -182,25 +182,9 @@ func (s *AutoOpsService) CreateAutoOpsRule(
 			return nil, dt.Err()
 		}
 	}
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(tx)
+
+	err = s.mysqlClient.RunInTransactionV2(&ctx, func(_ mysql.Transaction) error {
+		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(s.mysqlClient)
 		handler, err := command.NewAutoOpsCommandHandler(editor, autoOpsRule, s.publisher, req.EnvironmentId)
 		if err != nil {
 			return err
@@ -473,26 +457,9 @@ func (s *AutoOpsService) StopAutoOpsRule(
 	if err := validateStopAutoOpsRuleRequest(req, localizer); err != nil {
 		return nil, err
 	}
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
 
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(tx)
+	err = s.mysqlClient.RunInTransactionV2(&ctx, func(_ mysql.Transaction) error {
+		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(s.mysqlClient)
 		autoOpsRule, err := autoOpsRuleStorage.GetAutoOpsRule(ctx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
@@ -561,25 +528,9 @@ func (s *AutoOpsService) DeleteAutoOpsRule(
 	if err := validateDeleteAutoOpsRuleRequest(req, localizer); err != nil {
 		return nil, err
 	}
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(tx)
+
+	err = s.mysqlClient.RunInTransactionV2(&ctx, func(_ mysql.Transaction) error {
+		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(s.mysqlClient)
 		autoOpsRule, err := autoOpsRuleStorage.GetAutoOpsRule(ctx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
@@ -696,25 +647,9 @@ func (s *AutoOpsService) UpdateAutoOpsRule(
 		}
 	}
 	commands := s.createUpdateAutoOpsRuleCommands(req)
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(tx)
+
+	err = s.mysqlClient.RunInTransactionV2(&ctx, func(_ mysql.Transaction) error {
+		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(s.mysqlClient)
 		autoOpsRule, err := autoOpsRuleStorage.GetAutoOpsRule(ctx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
@@ -1187,25 +1122,9 @@ func (s *AutoOpsService) ExecuteAutoOps(
 	if triggered {
 		return &autoopsproto.ExecuteAutoOpsResponse{AlreadyTriggered: true}, nil
 	}
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(tx)
+
+	err = s.mysqlClient.RunInTransactionV2(&ctx, func(tx mysql.Transaction) error {
+		autoOpsRuleStorage := v2as.NewAutoOpsRuleStorage(s.mysqlClient)
 		autoOpsRule, err := autoOpsRuleStorage.GetAutoOpsRule(ctx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1154,7 +1154,7 @@ func (s *AutoOpsService) ExecuteAutoOps(
 		if err != nil {
 			return err
 		}
-		prStorage := v2as.NewProgressiveRolloutStorage(tx)
+		prStorage := v2as.NewProgressiveRolloutStorage(s.mysqlClient)
 		// Stop the running progressive rollout if the operation type is disable
 		if executeClause.ActionType == autoopsproto.ActionType_DISABLE {
 			if err := s.stopProgressiveRollout(

--- a/pkg/autoops/api/api_test.go
+++ b/pkg/autoops/api/api_test.go
@@ -367,9 +367,8 @@ func TestCreateAutoOpsRuleMySQL(t *testing.T) {
 				s.experimentClient.(*experimentclientmock.MockClient).EXPECT().GetGoal(
 					gomock.Any(), gomock.Any(),
 				).Return(&experimentproto.GetGoalResponse{}, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.CreateAutoOpsRuleRequest{
@@ -393,9 +392,8 @@ func TestCreateAutoOpsRuleMySQL(t *testing.T) {
 		{
 			desc: "success schedule",
 			setup: func(s *AutoOpsService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.CreateAutoOpsRuleRequest{
@@ -590,9 +588,8 @@ func TestUpdateAutoOpsRuleMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AutoOpsService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.UpdateAutoOpsRuleRequest{
@@ -673,9 +670,8 @@ func TestStopAutoOpsRuleMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AutoOpsService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.StopAutoOpsRuleRequest{
@@ -738,9 +734,8 @@ func TestDeleteAutoOpsRuleMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *AutoOpsService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.DeleteAutoOpsRuleRequest{
@@ -801,7 +796,11 @@ func TestGetAutoOpsRuleMySQL(t *testing.T) {
 			setup: func(s *AutoOpsService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -821,7 +820,11 @@ func TestGetAutoOpsRuleMySQL(t *testing.T) {
 			setup: func(s *AutoOpsService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -834,7 +837,11 @@ func TestGetAutoOpsRuleMySQL(t *testing.T) {
 			setup: func(s *AutoOpsService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -888,7 +895,11 @@ func TestListAutoOpsRulesMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -910,7 +921,12 @@ func TestListAutoOpsRulesMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -1058,7 +1074,11 @@ func TestExecuteAutoOpsRuleMySQL(t *testing.T) {
 			setup: func(s *AutoOpsService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -1076,12 +1096,15 @@ func TestExecuteAutoOpsRuleMySQL(t *testing.T) {
 			setup: func(s *AutoOpsService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil).AnyTimes()
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &autoopsproto.ExecuteAutoOpsRequest{

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -58,7 +58,7 @@ func (s *AutoOpsService) CreateProgressiveRollout(
 		return nil, err
 	}
 
-	err = s.mysqlClient.RunInTransactionV2(&ctx, func(tx mysql.Transaction) error {
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, tx mysql.Transaction) error {
 		progressiveRollout, err := domain.NewProgressiveRollout(
 			req.Command.FeatureId,
 			req.Command.ProgressiveRolloutManualScheduleClause,
@@ -80,7 +80,7 @@ func (s *AutoOpsService) CreateProgressiveRollout(
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
-		return storage.CreateProgressiveRollout(ctx, progressiveRollout, req.EnvironmentId)
+		return storage.CreateProgressiveRollout(contextWithTx, progressiveRollout, req.EnvironmentId)
 	})
 	if err != nil {
 		switch err {
@@ -197,9 +197,9 @@ func (s *AutoOpsService) updateProgressiveRollout(
 	editor *eventproto.Editor,
 	localizer locale.Localizer,
 ) error {
-	err := s.mysqlClient.RunInTransactionV2(&ctx, func(tx mysql.Transaction) error {
+	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, tx mysql.Transaction) error {
 		storage := v2as.NewProgressiveRolloutStorage(s.mysqlClient)
-		progressiveRollout, err := storage.GetProgressiveRollout(ctx, progressiveRolloutID, environmentId)
+		progressiveRollout, err := storage.GetProgressiveRollout(contextWithTx, progressiveRolloutID, environmentId)
 		if err != nil {
 			return err
 		}
@@ -215,7 +215,7 @@ func (s *AutoOpsService) updateProgressiveRollout(
 		if err := handler.Handle(ctx, cmd); err != nil {
 			return err
 		}
-		return storage.UpdateProgressiveRollout(ctx, progressiveRollout, environmentId)
+		return storage.UpdateProgressiveRollout(contextWithTx, progressiveRollout, environmentId)
 	})
 	if err != nil {
 		s.logger.Error(
@@ -263,9 +263,9 @@ func (s *AutoOpsService) DeleteProgressiveRollout(
 		return nil, err
 	}
 
-	err = s.mysqlClient.RunInTransactionV2(&ctx, func(tx mysql.Transaction) error {
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, tx mysql.Transaction) error {
 		storage := v2as.NewProgressiveRolloutStorage(s.mysqlClient)
-		progressiveRollout, err := storage.GetProgressiveRollout(ctx, req.Id, req.EnvironmentId)
+		progressiveRollout, err := storage.GetProgressiveRollout(contextWithTx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
 		}
@@ -281,7 +281,7 @@ func (s *AutoOpsService) DeleteProgressiveRollout(
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
-		return storage.DeleteProgressiveRollout(ctx, req.Id, req.EnvironmentId)
+		return storage.DeleteProgressiveRollout(contextWithTx, req.Id, req.EnvironmentId)
 	})
 	if err != nil {
 		s.logger.Error(
@@ -355,7 +355,7 @@ func (s *AutoOpsService) ExecuteProgressiveRollout(
 	}
 
 	var event *eventproto.Event
-	err = s.mysqlClient.RunInTransactionV2(&ctx, func(tx mysql.Transaction) error {
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, tx mysql.Transaction) error {
 		storage := v2as.NewProgressiveRolloutStorage(s.mysqlClient)
 		progressiveRollout, err := storage.GetProgressiveRollout(ctx, req.Id, req.EnvironmentId)
 		if err != nil {

--- a/pkg/autoops/storage/v2/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule.go
@@ -56,11 +56,11 @@ type AutoOpsRuleStorage interface {
 }
 
 type autoOpsRuleStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewAutoOpsRuleStorage(qe mysql.QueryExecer) AutoOpsRuleStorage {
-	return &autoOpsRuleStorage{qe: qe}
+func NewAutoOpsRuleStorage(client mysql.Client) AutoOpsRuleStorage {
+	return &autoOpsRuleStorage{client: client}
 }
 
 func (s *autoOpsRuleStorage) CreateAutoOpsRule(
@@ -68,7 +68,7 @@ func (s *autoOpsRuleStorage) CreateAutoOpsRule(
 	e *domain.AutoOpsRule,
 	environmentId string,
 ) error {
-	_, err := s.qe.ExecContext(
+	_, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		insertAutoOpsRuleSQL,
 		e.Id,
@@ -95,7 +95,7 @@ func (s *autoOpsRuleStorage) UpdateAutoOpsRule(
 	e *domain.AutoOpsRule,
 	environmentId string,
 ) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		updateAutoOpsRuleSQL,
 		e.FeatureId,
@@ -127,7 +127,7 @@ func (s *autoOpsRuleStorage) GetAutoOpsRule(
 ) (*domain.AutoOpsRule, error) {
 	autoOpsRule := proto.AutoOpsRule{}
 	var opsType int32
-	err := s.qe.QueryRowContext(
+	err := s.client.Qe(ctx).QueryRowContext(
 		ctx,
 		selectAutoOpsRuleSQL,
 		id,
@@ -162,7 +162,7 @@ func (s *autoOpsRuleStorage) ListAutoOpsRules(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectAutoOpsRulesSQL, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -32,7 +32,8 @@ func TestNewAutoOpsRuleStorage(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
-	db := NewAutoOpsRuleStorage(mock.NewMockQueryExecer(mockController))
+	client := mock.NewMockClient(mockController)
+	db := NewAutoOpsRuleStorage(client)
 	assert.IsType(t, &autoOpsRuleStorage{}, db)
 }
 
@@ -49,7 +50,11 @@ func TestCreateAutoOpsRule(t *testing.T) {
 	}{
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -61,7 +66,11 @@ func TestCreateAutoOpsRule(t *testing.T) {
 		},
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -97,7 +106,11 @@ func TestUpdateAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -111,7 +124,11 @@ func TestUpdateAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -148,7 +165,11 @@ func TestGetAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -161,7 +182,11 @@ func TestGetAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -199,7 +224,11 @@ func TestListAutoOpsRules(t *testing.T) {
 	}{
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -217,7 +246,11 @@ func TestListAutoOpsRules(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -254,5 +287,5 @@ func TestListAutoOpsRules(t *testing.T) {
 
 func newAutoOpsRuleStorageWithMock(t *testing.T, mockController *gomock.Controller) *autoOpsRuleStorage {
 	t.Helper()
-	return &autoOpsRuleStorage{mock.NewMockQueryExecer(mockController)}
+	return &autoOpsRuleStorage{mock.NewMockClient(mockController)}
 }

--- a/pkg/autoops/storage/v2/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/progressive_rollout.go
@@ -48,7 +48,7 @@ var (
 )
 
 type progressiveRolloutStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
 type ProgressiveRolloutStorage interface {
@@ -71,8 +71,8 @@ type ProgressiveRolloutStorage interface {
 	) error
 }
 
-func NewProgressiveRolloutStorage(qe mysql.QueryExecer) ProgressiveRolloutStorage {
-	return &progressiveRolloutStorage{qe: qe}
+func NewProgressiveRolloutStorage(client mysql.Client) ProgressiveRolloutStorage {
+	return &progressiveRolloutStorage{client: client}
 }
 
 func (s *progressiveRolloutStorage) CreateProgressiveRollout(
@@ -80,7 +80,7 @@ func (s *progressiveRolloutStorage) CreateProgressiveRollout(
 	progressiveRollout *domain.ProgressiveRollout,
 	environmentId string,
 ) error {
-	_, err := s.qe.ExecContext(
+	_, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		insertOpsProgressiveRolloutSQL,
 		progressiveRollout.Id,
@@ -108,7 +108,7 @@ func (s *progressiveRolloutStorage) GetProgressiveRollout(
 	id, environmentId string,
 ) (*domain.ProgressiveRollout, error) {
 	progressiveRollout := autoopsproto.ProgressiveRollout{}
-	err := s.qe.QueryRowContext(
+	err := s.client.Qe(ctx).QueryRowContext(
 		ctx,
 		selectOpsProgressiveRolloutSQL,
 		id,
@@ -137,7 +137,7 @@ func (s *progressiveRolloutStorage) DeleteProgressiveRollout(
 	ctx context.Context,
 	id, environmentId string,
 ) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		deleteOpsProgressiveRolloutSQL,
 		id,
@@ -166,7 +166,7 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectOpsProgressiveRolloutsSQL, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -196,7 +196,7 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	nextOffset := offset + len(progressiveRollouts)
 	var totalCount int64
 	countQuery := fmt.Sprintf(countOpsProgressiveRolloutsSQL, whereSQL)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -208,7 +208,7 @@ func (s *progressiveRolloutStorage) UpdateProgressiveRollout(
 	progressiveRollout *domain.ProgressiveRollout,
 	environmentId string,
 ) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		updateOpsProgressiveRolloutSQL,
 		&progressiveRollout.FeatureId,

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1921,7 +1921,7 @@ func (s *FeatureService) stopProgressiveRollout(
 	ctx context.Context,
 	tx mysql.Transaction,
 	EnvironmentId, featureID string) error {
-	storage := v2ao.NewProgressiveRolloutStorage(tx)
+	storage := v2ao.NewProgressiveRolloutStorage(s.mysqlClient)
 	ids := convToInterfaceSlice([]string{featureID})
 	whereParts := []mysql.WherePart{
 		mysql.NewFilter("environment_id", "=", EnvironmentId),

--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -1760,9 +1760,8 @@ func TestEnableFeatureMySQL(t *testing.T) {
 		{
 			desc: "error: statusNotFound",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2fs.ErrFeatureNotFound)
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(gomock.Any(), gomock.Any()).Return(
 					&envproto.GetEnvironmentV2Response{
@@ -1781,9 +1780,8 @@ func TestEnableFeatureMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.batchClient.(*btclientmock.MockClient).EXPECT().ExecuteBatchJob(gomock.Any(), gomock.Any())
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(
@@ -1866,9 +1864,8 @@ func TestDisableFeatureMySQL(t *testing.T) {
 		{
 			desc: "error: statusNotFound",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2fs.ErrFeatureNotFound)
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(gomock.Any(), gomock.Any()).Return(
 					&envproto.GetEnvironmentV2Response{
@@ -1887,9 +1884,8 @@ func TestDisableFeatureMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.batchClient.(*btclientmock.MockClient).EXPECT().ExecuteBatchJob(gomock.Any(), gomock.Any())
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(
@@ -2021,9 +2017,8 @@ func TestUnarchiveFeatureMySQL(t *testing.T) {
 		{
 			desc: "error: statusNotFound",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2fs.ErrFeatureNotFound)
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(gomock.Any(), gomock.Any()).Return(
 					&envproto.GetEnvironmentV2Response{
@@ -2042,9 +2037,8 @@ func TestUnarchiveFeatureMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.batchClient.(*btclientmock.MockClient).EXPECT().ExecuteBatchJob(gomock.Any(), gomock.Any())
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(
@@ -2127,9 +2121,8 @@ func TestDeleteFeatureMySQL(t *testing.T) {
 		{
 			desc: "error: statusNotFound",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2fs.ErrFeatureNotFound)
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(gomock.Any(), gomock.Any()).Return(
 					&envproto.GetEnvironmentV2Response{
@@ -2148,9 +2141,8 @@ func TestDeleteFeatureMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *FeatureService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.batchClient.(*btclientmock.MockClient).EXPECT().ExecuteBatchJob(gomock.Any(), gomock.Any())
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(

--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -1761,7 +1761,7 @@ func TestEnableFeatureMySQL(t *testing.T) {
 			desc: "error: statusNotFound",
 			setup: func(s *FeatureService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
-					gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(v2fs.ErrFeatureNotFound)
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(gomock.Any(), gomock.Any()).Return(
 					&envproto.GetEnvironmentV2Response{

--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -1761,7 +1761,7 @@ func TestEnableFeatureMySQL(t *testing.T) {
 			desc: "error: statusNotFound",
 			setup: func(s *FeatureService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(v2fs.ErrFeatureNotFound)
 				s.environmentClient.(*envclientmock.MockClient).EXPECT().GetEnvironmentV2(gomock.Any(), gomock.Any()).Return(
 					&envproto.GetEnvironmentV2Response{

--- a/pkg/storage/v2/mysql/client.go
+++ b/pkg/storage/v2/mysql/client.go
@@ -107,7 +107,8 @@ type Client interface {
 	// Deprecated
 	BeginTx(ctx context.Context) (Transaction, error)
 	RunInTransaction(ctx context.Context, tx Transaction, f func() error) error
-	// ToDo: Transaction is passed because it is required for storage that does not support storage architecture refactoring,
+	// ToDo:
+	// Transaction is passed because it is required for storage that does not support storage architecture refactoring,
 	// but we plan to remove it once the refactoring is complete.
 	RunInTransactionV2(ctx *context.Context, f func(tx Transaction) error) error
 	Qe(ctx context.Context) QueryExecer
@@ -185,6 +186,7 @@ func (c *client) QueryRowContext(ctx context.Context, query string, args ...inte
 	return r
 }
 
+// Deprecated
 func (c *client) BeginTx(ctx context.Context) (Transaction, error) {
 	var err error
 	defer record()(operationBeginTx, &err)

--- a/pkg/storage/v2/mysql/client.go
+++ b/pkg/storage/v2/mysql/client.go
@@ -28,6 +28,7 @@ import (
 )
 
 const dsnParams = "collation=utf8mb4_bin"
+const transactionKey = "transaction"
 
 type options struct {
 	connMaxLifetime time.Duration
@@ -103,8 +104,13 @@ type QueryExecer interface {
 type Client interface {
 	QueryExecer
 	Close() error
+	// Deprecated
 	BeginTx(ctx context.Context) (Transaction, error)
 	RunInTransaction(ctx context.Context, tx Transaction, f func() error) error
+	// ToDo: Transaction is passed because it is required for storage that does not support storage architecture refactoring,
+	// but we plan to remove it once the refactoring is complete.
+	RunInTransactionV2(ctx *context.Context, f func(tx Transaction) error) error
+	Qe(ctx context.Context) QueryExecer
 }
 
 type client struct {
@@ -198,4 +204,30 @@ func (c *client) RunInTransaction(ctx context.Context, tx Transaction, f func() 
 		err = tx.Commit()
 	}
 	return err
+}
+
+func (c *client) RunInTransactionV2(ctx *context.Context, f func(tx Transaction) error) error {
+	tx, err := c.BeginTx(*ctx)
+	if err != nil {
+		return fmt.Errorf("account: begin tx: %w", err)
+	}
+	*ctx = context.WithValue(*ctx, transactionKey, tx)
+	defer record()(operationRunInTransaction, &err)
+	defer func() {
+		if err != nil {
+			tx.Rollback() // nolint:errcheck
+		}
+	}()
+	if err = f(tx); err == nil {
+		err = tx.Commit()
+	}
+	return err
+}
+
+func (c *client) Qe(ctx context.Context) QueryExecer {
+	tx, ok := ctx.Value(transactionKey).(Transaction)
+	if ok {
+		return tx
+	}
+	return c
 }

--- a/pkg/storage/v2/mysql/mock/client.go
+++ b/pkg/storage/v2/mysql/mock/client.go
@@ -345,7 +345,7 @@ func (mr *MockClientMockRecorder) RunInTransaction(ctx, tx, f any) *gomock.Call 
 }
 
 // RunInTransactionV2 mocks base method.
-func (m *MockClient) RunInTransactionV2(ctx *context.Context, f func(mysql.Transaction) error) error {
+func (m *MockClient) RunInTransactionV2(ctx context.Context, f func(context.Context, mysql.Transaction) error) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunInTransactionV2", ctx, f)
 	ret0, _ := ret[0].(error)

--- a/pkg/storage/v2/mysql/mock/client.go
+++ b/pkg/storage/v2/mysql/mock/client.go
@@ -277,6 +277,20 @@ func (mr *MockClientMockRecorder) ExecContext(ctx, query any, args ...any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContext", reflect.TypeOf((*MockClient)(nil).ExecContext), varargs...)
 }
 
+// Qe mocks base method.
+func (m *MockClient) Qe(ctx context.Context) mysql.QueryExecer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Qe", ctx)
+	ret0, _ := ret[0].(mysql.QueryExecer)
+	return ret0
+}
+
+// Qe indicates an expected call of Qe.
+func (mr *MockClientMockRecorder) Qe(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Qe", reflect.TypeOf((*MockClient)(nil).Qe), ctx)
+}
+
 // QueryContext mocks base method.
 func (m *MockClient) QueryContext(ctx context.Context, query string, args ...any) (mysql.Rows, error) {
 	m.ctrl.T.Helper()
@@ -328,4 +342,18 @@ func (m *MockClient) RunInTransaction(ctx context.Context, tx mysql.Transaction,
 func (mr *MockClientMockRecorder) RunInTransaction(ctx, tx, f any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInTransaction", reflect.TypeOf((*MockClient)(nil).RunInTransaction), ctx, tx, f)
+}
+
+// RunInTransactionV2 mocks base method.
+func (m *MockClient) RunInTransactionV2(ctx *context.Context, f func(mysql.Transaction) error) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunInTransactionV2", ctx, f)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RunInTransactionV2 indicates an expected call of RunInTransactionV2.
+func (mr *MockClientMockRecorder) RunInTransactionV2(ctx, f any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunInTransactionV2", reflect.TypeOf((*MockClient)(nil).RunInTransactionV2), ctx, f)
 }


### PR DESCRIPTION
This pull request includes significant changes to the `AutoOpsService` and `ProgressiveRollout` functionalities, focusing on refactoring the transaction handling mechanism. The primary change is the transition from using `RunInTransaction` to `RunInTransactionV2`, which simplifies the transaction management and improves code maintainability.

Part of https://github.com/bucketeer-io/bucketeer/issues/1252