### PR TITLE
chore: add transaction support for redis pipeline

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -76,7 +76,7 @@ type Counter interface {
 }
 
 type PipeLiner interface {
-	Pipeline() redis.PipeClient
+	Pipeline(tx bool) redis.PipeClient
 }
 
 type Expirer interface {

--- a/pkg/cache/mock/cache.go
+++ b/pkg/cache/mock/cache.go
@@ -309,17 +309,17 @@ func (mr *MockMultiGetDeleteCountCacheMockRecorder) PFMerge(dest any, keys ...an
 }
 
 // Pipeline mocks base method.
-func (m *MockMultiGetDeleteCountCache) Pipeline() v3.PipeClient {
+func (m *MockMultiGetDeleteCountCache) Pipeline(tx bool) v3.PipeClient {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Pipeline")
+	ret := m.ctrl.Call(m, "Pipeline", tx)
 	ret0, _ := ret[0].(v3.PipeClient)
 	return ret0
 }
 
 // Pipeline indicates an expected call of Pipeline.
-func (mr *MockMultiGetDeleteCountCacheMockRecorder) Pipeline() *gomock.Call {
+func (mr *MockMultiGetDeleteCountCacheMockRecorder) Pipeline(tx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipeline", reflect.TypeOf((*MockMultiGetDeleteCountCache)(nil).Pipeline))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipeline", reflect.TypeOf((*MockMultiGetDeleteCountCache)(nil).Pipeline), tx)
 }
 
 // Put mocks base method.
@@ -642,17 +642,17 @@ func (m *MockPipeLiner) EXPECT() *MockPipeLinerMockRecorder {
 }
 
 // Pipeline mocks base method.
-func (m *MockPipeLiner) Pipeline() v3.PipeClient {
+func (m *MockPipeLiner) Pipeline(tx bool) v3.PipeClient {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Pipeline")
+	ret := m.ctrl.Call(m, "Pipeline", tx)
 	ret0, _ := ret[0].(v3.PipeClient)
 	return ret0
 }
 
 // Pipeline indicates an expected call of Pipeline.
-func (mr *MockPipeLinerMockRecorder) Pipeline() *gomock.Call {
+func (mr *MockPipeLinerMockRecorder) Pipeline(tx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipeline", reflect.TypeOf((*MockPipeLiner)(nil).Pipeline))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipeline", reflect.TypeOf((*MockPipeLiner)(nil).Pipeline), tx)
 }
 
 // MockExpirer is a mock of Expirer interface.

--- a/pkg/cache/testing/cache.go
+++ b/pkg/cache/testing/cache.go
@@ -100,7 +100,7 @@ func (c *inMemoryCache) Expire(key string, expiration time.Duration) (bool, erro
 	return true, nil
 }
 
-func (c *inMemoryCache) Pipeline() redis.PipeClient {
+func (c *inMemoryCache) Pipeline(tx bool) redis.PipeClient {
 	// TODO: implement
 	return nil
 }

--- a/pkg/cache/v3/redis_cache.go
+++ b/pkg/cache/v3/redis_cache.go
@@ -92,8 +92,8 @@ func (r *redisCache) PFAdd(key string, els ...string) (int64, error) {
 	return r.client.PFAdd(key, els...)
 }
 
-func (r *redisCache) Pipeline() redis.PipeClient {
-	return r.client.Pipeline()
+func (r *redisCache) Pipeline(tx bool) redis.PipeClient {
+	return r.client.Pipeline(tx)
 }
 
 func (r *redisCache) Expire(key string, expiration time.Duration) (bool, error) {

--- a/pkg/redis/v3/mock/redis.go
+++ b/pkg/redis/v3/mock/redis.go
@@ -270,17 +270,17 @@ func (mr *MockClientMockRecorder) PFMerge(dest any, keys ...any) *gomock.Call {
 }
 
 // Pipeline mocks base method.
-func (m *MockClient) Pipeline() v3.PipeClient {
+func (m *MockClient) Pipeline(tx bool) v3.PipeClient {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Pipeline")
+	ret := m.ctrl.Call(m, "Pipeline", tx)
 	ret0, _ := ret[0].(v3.PipeClient)
 	return ret0
 }
 
 // Pipeline indicates an expected call of Pipeline.
-func (mr *MockClientMockRecorder) Pipeline() *gomock.Call {
+func (mr *MockClientMockRecorder) Pipeline(tx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipeline", reflect.TypeOf((*MockClient)(nil).Pipeline))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Pipeline", reflect.TypeOf((*MockClient)(nil).Pipeline), tx)
 }
 
 // Restore mocks base method.


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1368

I am adding transaction support so we can ensure that we don't duplicate the counting when an error occurs, saving the counts in the same request in the subscriber svc.