### PR TITLE
chore: change update segment cache timeout to 1 minute

### DIFF
--- a/pkg/subscriber/processor/push_sender.go
+++ b/pkg/subscriber/processor/push_sender.go
@@ -43,6 +43,7 @@ import (
 
 const (
 	topicPrefix = "bucketeer-"
+	timeout     = time.Minute
 )
 
 type pushSender struct {
@@ -130,7 +131,7 @@ func (p pushSender) handle(msg *puller.Message) {
 }
 
 func (p pushSender) send(featureID, environmentId string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	resp, err := p.featureClient.GetFeature(ctx, &featureproto.GetFeatureRequest{
 		Id:            featureID,


### PR DESCRIPTION
I see a `Failed to update segment user cache` error due to `context deadline exceeded` while trying to send the FCM notification.
Since this process involves many internal requests and could take more than 30 seconds, depending on some cases, I'm changing it to 1 minute to see how it goes.

