### PR TITLE
revert: change to save user and event counts in one request

### DIFF
--- a/pkg/redis/v3/redis.go
+++ b/pkg/redis/v3/redis.go
@@ -668,7 +668,7 @@ func (c *client) Pipeline(tx bool) PipeClient {
 		// All commands in the transaction will either all succeed or none will be applied if an error occurs.
 		pipeliner = c.rc.TxPipeline()
 	} else {
-		c.rc.Pipeline()
+		pipeliner = c.rc.Pipeline()
 	}
 	return &pipeClient{
 		ctx:    context.TODO(),

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -240,7 +240,7 @@ func (p *evaluationCountEventPersister) incrementEvaluationCount(
 		if err != nil {
 			return err
 		}
-		pipe := p.evaluationCountCacher.Pipeline(true)
+		pipe := p.evaluationCountCacher.Pipeline(false)
 		// User count (Unique count)
 		ucKey := p.newEvaluationCountkeyV2(userCountKey, e.FeatureId, vID, environmentId, e.Timestamp)
 		pipe.PFAdd(ucKey, e.UserId)


### PR DESCRIPTION
I tried using Pipeline, and indeed, it improves the response time, but it also increases the Pod CPU usage. It's a trade-off.
Since this is a background service and it's not latency-sensitive, I'm reverting it.