### PR TITLE
chore: create sync api key maintainer migration

### DIFF
--- a/migration/mysql/20241206094413_sync_maintainer_api_key_table.sql
+++ b/migration/mysql/20241206094413_sync_maintainer_api_key_table.sql
@@ -1,0 +1,5 @@
+-- Get creator of api_key from audit_log and update api_key maintainer
+update api_key
+    join audit_log on api_key.id = audit_log.entity_id
+    set api_key.maintainer = (JSON_UNQUOTE(json_extract(editor, '$.email')))
+where audit_log.type = 400;

--- a/migration/mysql/20241206094413_sync_maintainer_api_key_table.sql
+++ b/migration/mysql/20241206094413_sync_maintainer_api_key_table.sql
@@ -1,5 +1,5 @@
 -- Get creator of api_key from audit_log and update api_key maintainer
-update api_key
-    join audit_log on api_key.id = audit_log.entity_id
-    set api_key.maintainer = (JSON_UNQUOTE(json_extract(editor, '$.email')))
-where audit_log.type = 400;
+UPDATE api_key
+    JOIN audit_log ON api_key.id = audit_log.entity_id
+    SET api_key.maintainer = (JSON_UNQUOTE(JSON_EXTRACT(editor, '$.email')))
+WHERE audit_log.type = 400;

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:7KE3wDUXF04Of2tQ8+KyG/imEI0sB6N1MCuKiHBXQ74=
+h1:OJd5uwhvbvMeVFWy5ettpaTn5NB8nxKILdgAaaukyRE=
 20240626022133_initialization.sql h1:u9qmPkwWX7PN92qEcDDfR92lrMpwadQSMxUJgv6LjQ0=
 20240708065726_update_audit_log_table.sql h1:k7gK8Njv1yHMsYXAQtSgMaSbXy4lxyZ9MPzbJyMyyoM=
 20240815043128_update_auto_ops_rule_table.sql h1:6ib+XfS1uu9AUO3qESvkpUfOu3qUsLwHm9KHcrGEz0E=
@@ -14,4 +14,4 @@ h1:7KE3wDUXF04Of2tQ8+KyG/imEI0sB6N1MCuKiHBXQ74=
 20241113142932_update_environment_id_table.sql h1:MufoP4KqI2pl8lCV5OHhyITYC+VQcYJc3jSwDpqK0Ks=
 20241122042909_add_api_key_maintainer_table.sql h1:srtthACDj2dyr8oFKRcPPIYsEsI/Ivzj3VClwY2x0Cs=
 20241122095236_sync_api_key_table.sql h1:nl53c3tgJTOEqxP34ayddS/iYyk03rwerDC7ABuJmmA=
-20241206094413_sync_maintainer_api_key_table.sql h1:1zrYmlzGpQ/sz7BFbw41hsPuMy7ZeIIbrWVW8D7Z3a4=
+20241206094413_sync_maintainer_api_key_table.sql h1:M1Ui8fGVyg7E+w/21cFnBXdP7Qgwr+x0PGEKA7u6jeg=

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:etbgl9IBPjae1gOaGHGD2vKzVsUwfmkRO55ID1LL3H0=
+h1:7KE3wDUXF04Of2tQ8+KyG/imEI0sB6N1MCuKiHBXQ74=
 20240626022133_initialization.sql h1:u9qmPkwWX7PN92qEcDDfR92lrMpwadQSMxUJgv6LjQ0=
 20240708065726_update_audit_log_table.sql h1:k7gK8Njv1yHMsYXAQtSgMaSbXy4lxyZ9MPzbJyMyyoM=
 20240815043128_update_auto_ops_rule_table.sql h1:6ib+XfS1uu9AUO3qESvkpUfOu3qUsLwHm9KHcrGEz0E=
@@ -14,3 +14,4 @@ h1:etbgl9IBPjae1gOaGHGD2vKzVsUwfmkRO55ID1LL3H0=
 20241113142932_update_environment_id_table.sql h1:MufoP4KqI2pl8lCV5OHhyITYC+VQcYJc3jSwDpqK0Ks=
 20241122042909_add_api_key_maintainer_table.sql h1:srtthACDj2dyr8oFKRcPPIYsEsI/Ivzj3VClwY2x0Cs=
 20241122095236_sync_api_key_table.sql h1:nl53c3tgJTOEqxP34ayddS/iYyk03rwerDC7ABuJmmA=
+20241206094413_sync_maintainer_api_key_table.sql h1:1zrYmlzGpQ/sz7BFbw41hsPuMy7ZeIIbrWVW8D7Z3a4=


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1331

- Get creator of api key from audit_log table and update api_key.maintainer so audit log issue can also be resolved for old api keys