### PR TITLE
refactor: change the method of specifying query conditions  for AutoOps

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1552,7 +1552,7 @@ func (s *AutoOpsService) listAutoOpsRules(
 		return nil, "", dt.Err()
 
 	}
-	listOptions := &mysql.ListOptions{
+	options := &mysql.ListOptions{
 		Limit:       limit,
 		Offset:      offset,
 		Filters:     filters,
@@ -1562,7 +1562,7 @@ func (s *AutoOpsService) listAutoOpsRules(
 		SearchQuery: nil,
 		Orders:      nil,
 	}
-	autoOpsRules, nextCursor, err := s.autoOpsStorage.ListAutoOpsRulesV2(ctx, listOptions)
+	autoOpsRules, nextCursor, err := s.autoOpsStorage.ListAutoOpsRules(ctx, options)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list autoOpsRules",

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1562,7 +1562,7 @@ func (s *AutoOpsService) listAutoOpsRules(
 		SearchQuery: nil,
 		Orders:      nil,
 	}
-	autoOpsRules, nextCursor, err := s.storage.ListAutoOpsRulesV2(ctx, listOptions)
+	autoOpsRules, nextCursor, err := s.autoOpsStorage.ListAutoOpsRulesV2(ctx, listOptions)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list autoOpsRules",

--- a/pkg/autoops/api/api_test.go
+++ b/pkg/autoops/api/api_test.go
@@ -1477,7 +1477,7 @@ func TestListAutoOpsRulesMySQL(t *testing.T) {
 			desc:    "success",
 			service: createAutoOpsService(mockController),
 			setup: func(s *AutoOpsService) {
-				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRulesV2(
+				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRules(
 					gomock.Any(), gomock.Any(),
 				).Return([]*autoopsproto.AutoOpsRule{}, 0, nil)
 			},
@@ -1495,7 +1495,7 @@ func TestListAutoOpsRulesMySQL(t *testing.T) {
 			desc:    "success with viewer",
 			service: createServiceWithGetAccountByEnvironmentMock(mockController, accountproto.AccountV2_Role_Organization_MEMBER, accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *AutoOpsService) {
-				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRulesV2(
+				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRules(
 					gomock.Any(), gomock.Any(),
 				).Return([]*autoopsproto.AutoOpsRule{}, 0, nil)
 			},

--- a/pkg/autoops/api/api_test.go
+++ b/pkg/autoops/api/api_test.go
@@ -1477,8 +1477,8 @@ func TestListAutoOpsRulesMySQL(t *testing.T) {
 			desc:    "success",
 			service: createAutoOpsService(mockController),
 			setup: func(s *AutoOpsService) {
-				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRules(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRulesV2(
+					gomock.Any(), gomock.Any(),
 				).Return([]*autoopsproto.AutoOpsRule{}, 0, nil)
 			},
 			req:         &autoopsproto.ListAutoOpsRulesRequest{EnvironmentId: "ns0", Cursor: ""},
@@ -1495,8 +1495,8 @@ func TestListAutoOpsRulesMySQL(t *testing.T) {
 			desc:    "success with viewer",
 			service: createServiceWithGetAccountByEnvironmentMock(mockController, accountproto.AccountV2_Role_Organization_MEMBER, accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *AutoOpsService) {
-				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRules(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				s.autoOpsStorage.(*mockAutoOpsStorage.MockAutoOpsRuleStorage).EXPECT().ListAutoOpsRulesV2(
+					gomock.Any(), gomock.Any(),
 				).Return([]*autoopsproto.AutoOpsRule{}, 0, nil)
 			},
 			req:         &autoopsproto.ListAutoOpsRulesRequest{EnvironmentId: "ns0", Cursor: ""},

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -612,7 +612,7 @@ func (s *AutoOpsService) listProgressiveRollouts(
 	}
 
 	storage := v2as.NewProgressiveRolloutStorage(s.mysqlClient)
-	progressiveRollouts, totalCount, nextOffset, err := storage.ListProgressiveRollouts(ctx, listOptions)
+	progressiveRollouts, totalCount, nextOffset, err := storage.ListProgressiveRolloutsV2(ctx, listOptions)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list progressive rollouts",

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -612,7 +612,7 @@ func (s *AutoOpsService) listProgressiveRollouts(
 	}
 
 	storage := v2as.NewProgressiveRolloutStorage(s.mysqlClient)
-	progressiveRollouts, totalCount, nextOffset, err := storage.ListProgressiveRolloutsV2(ctx, listOptions)
+	progressiveRollouts, totalCount, nextOffset, err := storage.ListProgressiveRollouts(ctx, listOptions)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list progressive rollouts",

--- a/pkg/autoops/api/stop_progressive_rollout_operation.go
+++ b/pkg/autoops/api/stop_progressive_rollout_operation.go
@@ -41,7 +41,7 @@ func executeStopProgressiveRolloutOperation(
 		Column: "feature_id",
 		Values: featureIDs,
 	}
-	listOptions := &mysql.ListOptions{
+	options := &mysql.ListOptions{
 		Filters:     filters,
 		Orders:      nil,
 		InFilter:    inFilter,
@@ -51,7 +51,7 @@ func executeStopProgressiveRolloutOperation(
 		Limit:       0,
 		Offset:      0,
 	}
-	list, _, _, err := storage.ListProgressiveRolloutsV2(ctx, listOptions)
+	list, _, _, err := storage.ListProgressiveRollouts(ctx, options)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoops/api/stop_progressive_rollout_operation.go
+++ b/pkg/autoops/api/stop_progressive_rollout_operation.go
@@ -30,11 +30,28 @@ func executeStopProgressiveRolloutOperation(
 	environmentId string,
 	operation autoopsproto.ProgressiveRollout_StoppedBy,
 ) error {
-	whereParts := []mysql.WherePart{
-		mysql.NewFilter("environment_id", "=", environmentId),
-		mysql.NewInFilter("feature_id", featureIDs),
+	filters := []*mysql.FilterV2{
+		{
+			Column:   "environment_id",
+			Operator: mysql.OperatorEqual,
+			Value:    environmentId,
+		},
 	}
-	list, _, _, err := storage.ListProgressiveRollouts(ctx, whereParts, nil, 0, 0)
+	inFilter := &mysql.InFilter{
+		Column: "feature_id",
+		Values: featureIDs,
+	}
+	listOptions := &mysql.ListOptions{
+		Filters:     filters,
+		Orders:      nil,
+		InFilter:    inFilter,
+		NullFilters: nil,
+		JSONFilters: nil,
+		SearchQuery: nil,
+		Limit:       0,
+		Offset:      0,
+	}
+	list, _, _, err := storage.ListProgressiveRollouts(ctx, listOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoops/api/stop_progressive_rollout_operation.go
+++ b/pkg/autoops/api/stop_progressive_rollout_operation.go
@@ -51,7 +51,7 @@ func executeStopProgressiveRolloutOperation(
 		Limit:       0,
 		Offset:      0,
 	}
-	list, _, _, err := storage.ListProgressiveRollouts(ctx, listOptions)
+	list, _, _, err := storage.ListProgressiveRolloutsV2(ctx, listOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/autoops/storage/v2/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule.go
@@ -204,7 +204,6 @@ func (s *autoOpsRuleStorage) ListAutoOpsRulesV2(
 	ctx context.Context,
 	options *mysql.ListOptions,
 ) ([]*proto.AutoOpsRule, int, error) {
-	println("kaki ListAutoOpsRulesV2")
 	var whereParts []mysql.WherePart = []mysql.WherePart{}
 	var orderBySQL string = ""
 	var limitOffsetSQL string = ""

--- a/pkg/autoops/storage/v2/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule.go
@@ -173,6 +173,7 @@ func (s *autoOpsRuleStorage) ListAutoOpsRules(
 			&autoOpsRule.UpdatedAt,
 			&autoOpsRule.Deleted,
 			&autoOpsRule.AutoOpsStatus,
+			&autoOpsRule.FeatureName,
 		)
 		if err != nil {
 			return nil, 0, err

--- a/pkg/autoops/storage/v2/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/autoops/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -204,7 +205,7 @@ func (s *autoOpsRuleStorage) ListAutoOpsRulesV2(
 	options *mysql.ListOptions,
 ) ([]*proto.AutoOpsRule, int, error) {
 	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectAutoOpsRulesSQL, options)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -348,7 +348,7 @@ func TestListAutoOpsRulesV2(t *testing.T) {
 		if p.setup != nil {
 			p.setup(storage)
 		}
-		autoOpsRules, cursor, err := storage.ListAutoOpsRulesV2(
+		autoOpsRules, cursor, err := storage.ListAutoOpsRules(
 			context.Background(),
 			p.listOpts,
 		)

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -214,83 +214,6 @@ func TestListAutoOpsRules(t *testing.T) {
 	defer mockController.Finish()
 	patterns := []struct {
 		setup          func(*autoOpsRuleStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
-		expected       []*proto.AutoOpsRule
-		expectedCursor int
-		expectedErr    error
-	}{
-		{
-			setup: func(s *autoOpsRuleStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
-			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
-			expected:       nil,
-			expectedCursor: 0,
-			expectedErr:    errors.New("error"),
-		},
-		{
-			setup: func(s *autoOpsRuleStorage) {
-				rows := mock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().Return(false)
-				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(rows, nil)
-			},
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("num", ">=", 5),
-			},
-			orders: []*mysql.Order{
-				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-			},
-			limit:          10,
-			offset:         5,
-			expected:       []*proto.AutoOpsRule{},
-			expectedCursor: 5,
-			expectedErr:    nil,
-		},
-	}
-	for _, p := range patterns {
-		storage := newAutoOpsRuleStorageWithMock(t, mockController)
-		if p.setup != nil {
-			p.setup(storage)
-		}
-		autoOpsRules, cursor, err := storage.ListAutoOpsRules(
-			context.Background(),
-			p.whereParts,
-			p.orders,
-			p.limit,
-			p.offset,
-		)
-		assert.Equal(t, p.expected, autoOpsRules)
-		assert.Equal(t, p.expectedCursor, cursor)
-		assert.Equal(t, p.expectedErr, err)
-	}
-}
-
-func TestListAutoOpsRulesV2(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	patterns := []struct {
-		setup          func(*autoOpsRuleStorage)
 		listOpts       *mysql.ListOptions
 		expected       []*proto.AutoOpsRule
 		expectedCursor int
@@ -356,7 +279,7 @@ func TestListAutoOpsRulesV2(t *testing.T) {
 		if p.setup != nil {
 			p.setup(storage)
 		}
-		autoOpsRules, cursor, err := storage.ListAutoOpsRulesV2(
+		autoOpsRules, cursor, err := storage.ListAutoOpsRules(
 			context.Background(),
 			p.listOpts,
 		)

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -298,7 +298,11 @@ func TestListAutoOpsRulesV2(t *testing.T) {
 	}{
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -313,7 +317,11 @@ func TestListAutoOpsRulesV2(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -348,7 +356,7 @@ func TestListAutoOpsRulesV2(t *testing.T) {
 		if p.setup != nil {
 			p.setup(storage)
 		}
-		autoOpsRules, cursor, err := storage.ListAutoOpsRules(
+		autoOpsRules, cursor, err := storage.ListAutoOpsRulesV2(
 			context.Background(),
 			p.listOpts,
 		)

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -314,7 +314,7 @@ func TestListAutoOpsRulesV2(t *testing.T) {
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
 				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
-					gomock.Any(), gomock.Regex(`^SELECT\s+id,\s+feature_id,\s+ops_type,\s+clauses,\s+created_at,\s+updated_at,\s+deleted,\s+status\s+FROM\s+auto_ops_rule\s+WHERE\s+num\s+>=\s+\?\s+ORDER\s+BY\s+id\s+ASC\s+LIMIT\s+10\s+OFFSET\s+5`), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
 			listOpts: &mysql.ListOptions{

--- a/pkg/autoops/storage/v2/mock/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/mock/auto_ops_rule.go
@@ -73,9 +73,9 @@ func (mr *MockAutoOpsRuleStorageMockRecorder) GetAutoOpsRule(ctx, id, environmen
 }
 
 // ListAutoOpsRules mocks base method.
-func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.AutoOpsRule, int, error) {
+func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, options *mysql.ListOptions) ([]*autoops.AutoOpsRule, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAutoOpsRules", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAutoOpsRules", ctx, options)
 	ret0, _ := ret[0].([]*autoops.AutoOpsRule)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -83,9 +83,9 @@ func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, wherePart
 }
 
 // ListAutoOpsRules indicates an expected call of ListAutoOpsRules.
-func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRules(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRules(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRules), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRules), ctx, options)
 }
 
 // UpdateAutoOpsRule mocks base method.

--- a/pkg/autoops/storage/v2/mock/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/mock/auto_ops_rule.go
@@ -73,9 +73,9 @@ func (mr *MockAutoOpsRuleStorageMockRecorder) GetAutoOpsRule(ctx, id, environmen
 }
 
 // ListAutoOpsRules mocks base method.
-func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.AutoOpsRule, int, error) {
+func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, options *mysql.ListOptions) ([]*autoops.AutoOpsRule, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAutoOpsRules", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAutoOpsRules", ctx, options)
 	ret0, _ := ret[0].([]*autoops.AutoOpsRule)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -83,25 +83,9 @@ func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, wherePart
 }
 
 // ListAutoOpsRules indicates an expected call of ListAutoOpsRules.
-func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRules(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRules(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRules), ctx, whereParts, orders, limit, offset)
-}
-
-// ListAutoOpsRulesV2 mocks base method.
-func (m *MockAutoOpsRuleStorage) ListAutoOpsRulesV2(ctx context.Context, options *mysql.ListOptions) ([]*autoops.AutoOpsRule, int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAutoOpsRulesV2", ctx, options)
-	ret0, _ := ret[0].([]*autoops.AutoOpsRule)
-	ret1, _ := ret[1].(int)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ListAutoOpsRulesV2 indicates an expected call of ListAutoOpsRulesV2.
-func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRulesV2(ctx, options any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRulesV2", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRulesV2), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRules), ctx, options)
 }
 
 // UpdateAutoOpsRule mocks base method.

--- a/pkg/autoops/storage/v2/mock/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/mock/auto_ops_rule.go
@@ -73,9 +73,9 @@ func (mr *MockAutoOpsRuleStorageMockRecorder) GetAutoOpsRule(ctx, id, environmen
 }
 
 // ListAutoOpsRules mocks base method.
-func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, options *mysql.ListOptions) ([]*autoops.AutoOpsRule, int, error) {
+func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.AutoOpsRule, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAutoOpsRules", ctx, options)
+	ret := m.ctrl.Call(m, "ListAutoOpsRules", ctx, whereParts, orders, limit, offset)
 	ret0, _ := ret[0].([]*autoops.AutoOpsRule)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -83,9 +83,25 @@ func (m *MockAutoOpsRuleStorage) ListAutoOpsRules(ctx context.Context, options *
 }
 
 // ListAutoOpsRules indicates an expected call of ListAutoOpsRules.
-func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRules(ctx, options any) *gomock.Call {
+func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRules(ctx, whereParts, orders, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRules), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRules", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRules), ctx, whereParts, orders, limit, offset)
+}
+
+// ListAutoOpsRulesV2 mocks base method.
+func (m *MockAutoOpsRuleStorage) ListAutoOpsRulesV2(ctx context.Context, options *mysql.ListOptions) ([]*autoops.AutoOpsRule, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAutoOpsRulesV2", ctx, options)
+	ret0, _ := ret[0].([]*autoops.AutoOpsRule)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListAutoOpsRulesV2 indicates an expected call of ListAutoOpsRulesV2.
+func (mr *MockAutoOpsRuleStorageMockRecorder) ListAutoOpsRulesV2(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAutoOpsRulesV2", reflect.TypeOf((*MockAutoOpsRuleStorage)(nil).ListAutoOpsRulesV2), ctx, options)
 }
 
 // UpdateAutoOpsRule mocks base method.

--- a/pkg/autoops/storage/v2/mock/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/mock/progressive_rollout.go
@@ -87,9 +87,9 @@ func (mr *MockProgressiveRolloutStorageMockRecorder) GetProgressiveRollout(ctx, 
 }
 
 // ListProgressiveRollouts mocks base method.
-func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.ProgressiveRollout, int64, int, error) {
+func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Context, options *mysql.ListOptions) ([]*autoops.ProgressiveRollout, int64, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListProgressiveRollouts", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListProgressiveRollouts", ctx, options)
 	ret0, _ := ret[0].([]*autoops.ProgressiveRollout)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(int)
@@ -98,9 +98,9 @@ func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Cont
 }
 
 // ListProgressiveRollouts indicates an expected call of ListProgressiveRollouts.
-func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRollouts(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRollouts(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRollouts", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRollouts), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRollouts", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRollouts), ctx, options)
 }
 
 // UpdateProgressiveRollout mocks base method.

--- a/pkg/autoops/storage/v2/mock/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/mock/progressive_rollout.go
@@ -87,9 +87,9 @@ func (mr *MockProgressiveRolloutStorageMockRecorder) GetProgressiveRollout(ctx, 
 }
 
 // ListProgressiveRollouts mocks base method.
-func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.ProgressiveRollout, int64, int, error) {
+func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Context, options *mysql.ListOptions) ([]*autoops.ProgressiveRollout, int64, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListProgressiveRollouts", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListProgressiveRollouts", ctx, options)
 	ret0, _ := ret[0].([]*autoops.ProgressiveRollout)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(int)
@@ -98,26 +98,9 @@ func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Cont
 }
 
 // ListProgressiveRollouts indicates an expected call of ListProgressiveRollouts.
-func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRollouts(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRollouts(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRollouts", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRollouts), ctx, whereParts, orders, limit, offset)
-}
-
-// ListProgressiveRolloutsV2 mocks base method.
-func (m *MockProgressiveRolloutStorage) ListProgressiveRolloutsV2(ctx context.Context, options *mysql.ListOptions) ([]*autoops.ProgressiveRollout, int64, int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListProgressiveRolloutsV2", ctx, options)
-	ret0, _ := ret[0].([]*autoops.ProgressiveRollout)
-	ret1, _ := ret[1].(int64)
-	ret2, _ := ret[2].(int)
-	ret3, _ := ret[3].(error)
-	return ret0, ret1, ret2, ret3
-}
-
-// ListProgressiveRolloutsV2 indicates an expected call of ListProgressiveRolloutsV2.
-func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRolloutsV2(ctx, options any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRolloutsV2", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRolloutsV2), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRollouts", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRollouts), ctx, options)
 }
 
 // UpdateProgressiveRollout mocks base method.

--- a/pkg/autoops/storage/v2/mock/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/mock/progressive_rollout.go
@@ -87,9 +87,9 @@ func (mr *MockProgressiveRolloutStorageMockRecorder) GetProgressiveRollout(ctx, 
 }
 
 // ListProgressiveRollouts mocks base method.
-func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Context, options *mysql.ListOptions) ([]*autoops.ProgressiveRollout, int64, int, error) {
+func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.ProgressiveRollout, int64, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListProgressiveRollouts", ctx, options)
+	ret := m.ctrl.Call(m, "ListProgressiveRollouts", ctx, whereParts, orders, limit, offset)
 	ret0, _ := ret[0].([]*autoops.ProgressiveRollout)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(int)
@@ -98,9 +98,26 @@ func (m *MockProgressiveRolloutStorage) ListProgressiveRollouts(ctx context.Cont
 }
 
 // ListProgressiveRollouts indicates an expected call of ListProgressiveRollouts.
-func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRollouts(ctx, options any) *gomock.Call {
+func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRollouts(ctx, whereParts, orders, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRollouts", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRollouts), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRollouts", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRollouts), ctx, whereParts, orders, limit, offset)
+}
+
+// ListProgressiveRolloutsV2 mocks base method.
+func (m *MockProgressiveRolloutStorage) ListProgressiveRolloutsV2(ctx context.Context, options *mysql.ListOptions) ([]*autoops.ProgressiveRollout, int64, int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListProgressiveRolloutsV2", ctx, options)
+	ret0, _ := ret[0].([]*autoops.ProgressiveRollout)
+	ret1, _ := ret[1].(int64)
+	ret2, _ := ret[2].(int)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// ListProgressiveRolloutsV2 indicates an expected call of ListProgressiveRolloutsV2.
+func (mr *MockProgressiveRolloutStorageMockRecorder) ListProgressiveRolloutsV2(ctx, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProgressiveRolloutsV2", reflect.TypeOf((*MockProgressiveRolloutStorage)(nil).ListProgressiveRolloutsV2), ctx, options)
 }
 
 // UpdateProgressiveRollout mocks base method.

--- a/pkg/autoops/storage/v2/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/progressive_rollout.go
@@ -61,12 +61,6 @@ type ProgressiveRolloutStorage interface {
 	DeleteProgressiveRollout(ctx context.Context, id, environmentId string) error
 	ListProgressiveRollouts(
 		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
-	) ([]*autoopsproto.ProgressiveRollout, int64, int, error)
-	ListProgressiveRolloutsV2(
-		ctx context.Context,
 		options *mysql.ListOptions,
 	) ([]*autoopsproto.ProgressiveRollout, int64, int, error)
 	UpdateProgressiveRollout(ctx context.Context,
@@ -211,7 +205,6 @@ func (s *progressiveRolloutStorage) ListProgressiveRolloutsV2(
 	ctx context.Context,
 	options *mysql.ListOptions,
 ) ([]*autoopsproto.ProgressiveRollout, int64, int, error) {
-	println("kaki ListProgressiveRolloutsV2")
 	var whereParts []mysql.WherePart = []mysql.WherePart{}
 	var orderBySQL string = ""
 	var limitOffsetSQL string = ""

--- a/pkg/autoops/storage/v2/progressive_rollout_test.go
+++ b/pkg/autoops/storage/v2/progressive_rollout_test.go
@@ -16,6 +16,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -90,6 +91,159 @@ func TestCreateProgressiveRollout(t *testing.T) {
 			p.setup(storage)
 		}
 		err := storage.CreateProgressiveRollout(context.Background(), p.input, p.environmentId)
+		assert.Equal(t, p.expectedErr, err)
+	}
+}
+
+func TestListProgressiveRollouts(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		setup              func(*progressiveRolloutStorage)
+		whereParts         []mysql.WherePart
+		orders             []*mysql.Order
+		limit              int
+		offset             int
+		expected           []*proto.ProgressiveRollout
+		expectedCursor     int
+		expectedTotalCount int64
+		expectedErr        error
+	}{
+		{
+			setup: func(s *progressiveRolloutStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			whereParts:         nil,
+			orders:             nil,
+			limit:              0,
+			offset:             0,
+			expected:           nil,
+			expectedCursor:     0,
+			expectedTotalCount: 0,
+			expectedErr:        errors.New("error"),
+		},
+		{
+			setup: func(s *progressiveRolloutStorage) {
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().Return(false)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Regex(`^SELECT\s+COUNT\(1\)\s+FROM\s+ops_progressive_rollout\s+WHERE\s+num\s+>=\s+\?`), gomock.Any(),
+				).Return(row)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+			},
+			whereParts: []mysql.WherePart{
+				mysql.NewFilter("num", ">=", 5),
+			},
+			orders: []*mysql.Order{
+				mysql.NewOrder("id", mysql.OrderDirectionAsc),
+			},
+			limit:              10,
+			offset:             5,
+			expected:           []*proto.ProgressiveRollout{},
+			expectedCursor:     5,
+			expectedTotalCount: 0,
+			expectedErr:        nil,
+		},
+	}
+	for _, p := range patterns {
+		storage := newProgressiveRolloutStorageWithMock(t, mockController)
+		if p.setup != nil {
+			p.setup(storage)
+		}
+		pr, totalCount, cursor, err := storage.ListProgressiveRollouts(context.Background(), p.whereParts, p.orders, p.limit, p.offset)
+		assert.Equal(t, p.expected, pr)
+		assert.Equal(t, p.expectedCursor, cursor)
+		assert.Equal(t, p.expectedTotalCount, totalCount)
+		assert.Equal(t, p.expectedErr, err)
+	}
+}
+
+func TestListProgressiveRolloutsV2(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		setup              func(*progressiveRolloutStorage)
+		listOpts           *mysql.ListOptions
+		expected           []*proto.ProgressiveRollout
+		expectedCursor     int
+		expectedTotalCount int64
+		expectedErr        error
+	}{
+		{
+			setup: func(s *progressiveRolloutStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			listOpts:           nil,
+			expected:           nil,
+			expectedCursor:     0,
+			expectedTotalCount: 0,
+			expectedErr:        errors.New("error"),
+		},
+		{
+			setup: func(s *progressiveRolloutStorage) {
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().Return(false)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Regex(`^SELECT\s+COUNT\(1\)\s+FROM\s+ops_progressive_rollout\s+WHERE\s+num\s+>=\s+\?`), gomock.Any(),
+				).Return(row)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+			},
+			listOpts: &mysql.ListOptions{
+				Limit:  10,
+				Offset: 5,
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "num",
+						Operator: mysql.OperatorGreaterThanOrEqual,
+						Value:    5,
+					},
+				},
+				InFilter:    nil,
+				NullFilters: nil,
+				JSONFilters: nil,
+				SearchQuery: nil,
+				Orders: []*mysql.Order{
+					{
+						Column:    "id",
+						Direction: mysql.OrderDirectionAsc,
+					},
+				},
+			},
+			expected:           []*proto.ProgressiveRollout{},
+			expectedCursor:     5,
+			expectedTotalCount: 0,
+			expectedErr:        nil,
+		},
+	}
+	for _, p := range patterns {
+		storage := newProgressiveRolloutStorageWithMock(t, mockController)
+		if p.setup != nil {
+			p.setup(storage)
+		}
+		pr, totalCount, cursor, err := storage.ListProgressiveRolloutsV2(context.Background(), p.listOpts)
+		assert.Equal(t, p.expected, pr)
+		assert.Equal(t, p.expectedCursor, cursor)
+		assert.Equal(t, p.expectedTotalCount, totalCount)
 		assert.Equal(t, p.expectedErr, err)
 	}
 }

--- a/pkg/autoops/storage/v2/progressive_rollout_test.go
+++ b/pkg/autoops/storage/v2/progressive_rollout_test.go
@@ -131,7 +131,7 @@ func TestListProgressiveRollouts(t *testing.T) {
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Regex(`^SELECT\s+COUNT\(1\)\s+FROM\s+ops_progressive_rollout\s+WHERE\s+num\s+>=\s+\?`), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
 			},

--- a/pkg/autoops/storage/v2/progressive_rollout_test.go
+++ b/pkg/autoops/storage/v2/progressive_rollout_test.go
@@ -175,7 +175,7 @@ func TestListProgressiveRollouts(t *testing.T) {
 		if p.setup != nil {
 			p.setup(storage)
 		}
-		pr, totalCount, cursor, err := storage.ListProgressiveRolloutsV2(context.Background(), p.listOpts)
+		pr, totalCount, cursor, err := storage.ListProgressiveRollouts(context.Background(), p.listOpts)
 		assert.Equal(t, p.expected, pr)
 		assert.Equal(t, p.expectedCursor, cursor)
 		assert.Equal(t, p.expectedTotalCount, totalCount)

--- a/pkg/autoops/storage/v2/progressive_rollout_test.go
+++ b/pkg/autoops/storage/v2/progressive_rollout_test.go
@@ -110,7 +110,11 @@ func TestListProgressiveRollouts(t *testing.T) {
 	}{
 		{
 			setup: func(s *progressiveRolloutStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -126,11 +130,15 @@ func TestListProgressiveRollouts(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).Times(2)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
@@ -167,7 +175,7 @@ func TestListProgressiveRollouts(t *testing.T) {
 		if p.setup != nil {
 			p.setup(storage)
 		}
-		pr, totalCount, cursor, err := storage.ListProgressiveRollouts(context.Background(), p.listOpts)
+		pr, totalCount, cursor, err := storage.ListProgressiveRolloutsV2(context.Background(), p.listOpts)
 		assert.Equal(t, p.expected, pr)
 		assert.Equal(t, p.expectedCursor, cursor)
 		assert.Equal(t, p.expectedTotalCount, totalCount)

--- a/pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rules.sql
+++ b/pkg/autoops/storage/v2/sql/auto_ops_rule/select_auto_ops_rules.sql
@@ -13,4 +13,3 @@ FROM
 JOIN feature ft ON
     aor.feature_id = ft.id AND
     aor.environment_id = ft.environment_id
-%s %s %s

--- a/pkg/autoops/storage/v2/sql/ops_progressive_rollout/count_ops_progressive_rollouts.sql
+++ b/pkg/autoops/storage/v2/sql/ops_progressive_rollout/count_ops_progressive_rollouts.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     ops_progressive_rollout
-%s

--- a/pkg/autoops/storage/v2/sql/ops_progressive_rollout/select_ops_progressive_rollouts.sql
+++ b/pkg/autoops/storage/v2/sql/ops_progressive_rollout/select_ops_progressive_rollouts.sql
@@ -10,4 +10,3 @@ SELECT
     updated_at
 FROM
     ops_progressive_rollout
-%s %s %s

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1934,7 +1934,7 @@ func (s *FeatureService) stopProgressiveRollout(
 		Offset:      0,
 	}
 
-	list, _, _, err := storage.ListProgressiveRollouts(ctx, listOptions)
+	list, _, _, err := storage.ListProgressiveRolloutsV2(ctx, listOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1912,11 +1912,29 @@ func (s *FeatureService) stopProgressiveRollout(
 	EnvironmentId, featureID string) error {
 	storage := v2ao.NewProgressiveRolloutStorage(s.mysqlClient)
 	ids := convToInterfaceSlice([]string{featureID})
-	whereParts := []mysql.WherePart{
-		mysql.NewFilter("environment_id", "=", EnvironmentId),
-		mysql.NewInFilter("feature_id", ids),
+	filters := []*mysql.FilterV2{
+		{
+			Column:   "environment_id",
+			Operator: mysql.OperatorEqual,
+			Value:    EnvironmentId,
+		},
 	}
-	list, _, _, err := storage.ListProgressiveRollouts(ctx, whereParts, nil, 0, 0)
+	inFilter := &mysql.InFilter{
+		Column: "feature_id",
+		Values: ids,
+	}
+	listOptions := &mysql.ListOptions{
+		Filters:     filters,
+		Orders:      nil,
+		InFilter:    inFilter,
+		NullFilters: nil,
+		JSONFilters: nil,
+		SearchQuery: nil,
+		Limit:       0,
+		Offset:      0,
+	}
+
+	list, _, _, err := storage.ListProgressiveRollouts(ctx, listOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1934,7 +1934,7 @@ func (s *FeatureService) stopProgressiveRollout(
 		Offset:      0,
 	}
 
-	list, _, _, err := storage.ListProgressiveRolloutsV2(ctx, listOptions)
+	list, _, _, err := storage.ListProgressiveRollouts(ctx, listOptions)
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -335,7 +335,8 @@ func ConstructOrderBySQLString(orders []*Order) string {
 		sb.WriteString(" ")
 		sb.WriteString(o.Direction.String())
 	}
-	return sb.String()
+	constructStr := sb.String() + " "
+	return constructStr
 }
 
 func ConstructQueryAndWhereArgs(baseQuery string, options *ListOptions) (query string, whereArgs []interface{}) {

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -23,6 +23,41 @@ import (
 
 const placeHolder = "?"
 
+type Operator int
+
+const (
+	// Operation to find the field is equal to the specified value.
+	OperatorEqual = iota + 1
+	// Operation to find the field isn't equal to the specified value.
+	OperatorNotEqual
+	// Operation to find ones that contain any one of the multiple values.
+	OperatorIn
+	// Operation to find ones that do not contain any of the specified multiple values.
+	OperatorNotIn
+	// Operation to find ones the field is greater than the specified value.
+	OperatorGreaterThan
+	// Operation to find ones the field is greater or equal than the specified value.
+	OperatorGreaterThanOrEqual
+	// Operation to find ones the field is less than the specified value.
+	OperatorLessThan
+	// Operation to find ones the field is less or equal than the specified value.
+	OperatorLessThanOrEqual
+	// Operation to find ones that have a specified value in its array.
+	OperatorContains
+)
+
+var operatorMap = map[Operator]string{
+	OperatorEqual:              "=",
+	OperatorNotEqual:           "!=",
+	OperatorIn:                 "IN",
+	OperatorNotIn:              "NOT IN",
+	OperatorGreaterThan:        ">",
+	OperatorGreaterThanOrEqual: ">=",
+	OperatorLessThan:           "<",
+	OperatorLessThanOrEqual:    "<=",
+	OperatorContains:           "MEMBER OF",
+}
+
 type WherePart interface {
 	SQLString() (sql string, args []interface{})
 }
@@ -50,6 +85,21 @@ func (f *Filter) SQLString() (sql string, args []interface{}) {
 	return
 }
 
+type FilterV2 struct {
+	Column   string
+	Operator Operator
+	Value    interface{}
+}
+
+func (f *FilterV2) SQLString() (sql string, args []interface{}) {
+	if f.Column == "" || f.Operator < OperatorEqual || f.Operator > OperatorContains {
+		return "", nil
+	}
+	sql = fmt.Sprintf("%s %s %s", f.Column, operatorMap[f.Operator], placeHolder)
+	args = append(args, f.Value)
+	return
+}
+
 type InFilter struct {
 	Column string
 	Values []interface{}
@@ -63,7 +113,7 @@ func NewInFilter(column string, values []interface{}) WherePart {
 }
 
 func (f *InFilter) SQLString() (sql string, args []interface{}) {
-	if f.Column == "" {
+	if f.Column == "" || len(f.Values) == 0 {
 		return "", nil
 	}
 	var sb strings.Builder
@@ -288,6 +338,27 @@ func ConstructOrderBySQLString(orders []*Order) string {
 	return sb.String()
 }
 
+type Orders struct {
+	Orders []*Order
+}
+
+func (o *Orders) SQLString() (sql string, args []interface{}) {
+	if len(o.Orders) == 0 {
+		return "", nil
+	}
+	var sb strings.Builder
+	sb.WriteString("ORDER BY ")
+	for i, o := range o.Orders {
+		if i != 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(o.Column)
+		sb.WriteString(" ")
+		sb.WriteString(o.Direction.String())
+	}
+	return sb.String(), nil
+}
+
 const (
 	QueryNoLimit  = 0
 	QueryNoOffset = 0
@@ -308,4 +379,41 @@ func ConstructLimitOffsetSQLString(limit, offset int) string {
 		return fmt.Sprintf("LIMIT %d", limit)
 	}
 	return fmt.Sprintf("LIMIT %d OFFSET %d", limit, offset)
+}
+
+type ListOptions struct {
+	Limit       int
+	Filters     []*FilterV2
+	InFilter    *InFilter
+	NullFilters []*NullFilter
+	JSONFilters []*JSONFilter
+	SearchQuery *SearchQuery
+	Orders      []*Order
+	Offset      int
+}
+
+func (lo *ListOptions) CreateWhereParts() []WherePart {
+	var whereParts []WherePart
+	if lo.Filters != nil {
+		for _, f := range lo.Filters {
+			whereParts = append(whereParts, f)
+		}
+	}
+	if lo.InFilter != nil {
+		whereParts = append(whereParts, lo.InFilter)
+	}
+	if lo.NullFilters != nil {
+		for _, f := range lo.NullFilters {
+			whereParts = append(whereParts, f)
+		}
+	}
+	if lo.JSONFilters != nil {
+		for _, f := range lo.JSONFilters {
+			whereParts = append(whereParts, f)
+		}
+	}
+	if lo.SearchQuery != nil {
+		whereParts = append(whereParts, lo.SearchQuery)
+	}
+	return whereParts
 }

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -286,7 +286,7 @@ func ConstructWhereSQLString(wps []WherePart) (sql string, args []interface{}) {
 		sb.WriteString(wpSQL)
 		args = append(args, wpArgs...)
 	}
-	sql = sb.String()
+	sql = sb.String() + " "
 	return
 }
 
@@ -336,6 +336,21 @@ func ConstructOrderBySQLString(orders []*Order) string {
 		sb.WriteString(o.Direction.String())
 	}
 	return sb.String()
+}
+
+func ConstructQueryAndWhereArgs(baseQuery string, options *ListOptions) (query string, whereArgs []interface{}) {
+	if options != nil {
+		var whereQuery string
+		whereParts := options.CreateWhereParts()
+		whereQuery, whereArgs = ConstructWhereSQLString(whereParts)
+		orderByQuery := ConstructOrderBySQLString(options.Orders)
+		limitOffsetQuery := ConstructLimitOffsetSQLString(options.Limit, options.Offset)
+		query = baseQuery + whereQuery + orderByQuery + limitOffsetQuery
+	} else {
+		query = baseQuery
+		whereArgs = []interface{}{}
+	}
+	return
 }
 
 type Orders struct {

--- a/pkg/storage/v2/mysql/query_test.go
+++ b/pkg/storage/v2/mysql/query_test.go
@@ -276,7 +276,7 @@ func TestConstructWhereSQLString(t *testing.T) {
 				NewFilter("name", "=", "feature"),
 				NewJSONFilter("enums", JSONContainsNumber, []interface{}{1, 3}),
 			},
-			expectedSQL:  "WHERE name = ? AND JSON_CONTAINS(enums, ?)",
+			expectedSQL:  "WHERE name = ? AND JSON_CONTAINS(enums, ?) ",
 			expectedArgs: []interface{}{"feature", "[1, 3]"},
 		},
 	}

--- a/pkg/storage/v2/mysql/query_test.go
+++ b/pkg/storage/v2/mysql/query_test.go
@@ -307,7 +307,7 @@ func TestConstructOrderBySQLString(t *testing.T) {
 				NewOrder("created_at", OrderDirectionDesc),
 				NewOrder("id", OrderDirectionAsc),
 			},
-			expectedSQL: "ORDER BY created_at DESC, id ASC",
+			expectedSQL: "ORDER BY created_at DESC, id ASC ",
 		},
 	}
 	for _, p := range patterns {


### PR DESCRIPTION
This pull request includes significant refactoring to improve the handling of query filters and options in the `AutoOpsService` and related storage components. The changes focus on replacing the existing `WherePart` and `Order` structures with a more flexible `ListOptions` structure, which encapsulates various filter types and query options.

Part of https://github.com/bucketeer-io/bucketeer/issues/1475