### PR TITLE
perf: update cache across goroutines to speed up caching

### DIFF
--- a/pkg/batch/jobs/cacher/experimentcacher.go
+++ b/pkg/batch/jobs/cacher/experimentcacher.go
@@ -17,6 +17,7 @@ package cacher
 
 import (
 	"context"
+	"sync"
 
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -119,15 +120,25 @@ func (c *experimentCacher) listExperiments(
 // Since the batch runs every minute, we don't handle erros when putting the cache
 func (c *experimentCacher) putCache(experiments *expproto.Experiments, environmentID string) int {
 	var updatedInstances int
+	var mu sync.Mutex     // Mutex to safely update `updatedInstances` across goroutines
+	var wg sync.WaitGroup // Use a WaitGroup to wait for all goroutines to finish
 	for _, cache := range c.caches {
-		if err := cache.Put(experiments, environmentID); err != nil {
-			c.logger.Error("Failed to cache experiments",
-				zap.Error(err),
-				zap.String("environmentId", environmentID),
-			)
-			continue
-		}
-		updatedInstances++
+		wg.Add(1) // Increment the WaitGroup counter
+		go func(cache cachev3.ExperimentsCache) {
+			defer wg.Done()
+			if err := cache.Put(experiments, environmentID); err != nil {
+				// Log the error, but do not stop the other goroutines
+				c.logger.Error("Failed to cache experiments",
+					zap.Error(err),
+					zap.String("environmentId", environmentID),
+				)
+				return
+			}
+			mu.Lock()
+			updatedInstances++
+			mu.Unlock()
+		}(cache)
 	}
+	wg.Wait()
 	return updatedInstances
 }


### PR DESCRIPTION
I'm implementing goroutines while updating the cache because we have many environments and features to update across all regions, which takes time due to the high latency across other regions.