### PR TITLE
chore: remove grpc logging

### DIFF
--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -136,7 +136,6 @@ func (s *Server) setupRPC() {
 		s.logger.Fatal("Failed to read credentials: %v", zap.Error(err))
 	}
 	interceptors := []grpc.UnaryServerInterceptor{
-		LogUnaryServerInterceptor(s.logger),
 		MetricsUnaryServerInterceptor(),
 	}
 	if s.verifier != nil {


### PR DESCRIPTION
The application level is already logging the most important warning and error logs; I'm removing this from the RPC layer because there are too many duplicate logs, unnecessarily increasing the log costs in GCP.