### PR TITLE
fix(ui): subscription not found when updating

### DIFF
--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -799,7 +799,11 @@ func (s *NotificationService) ListSubscriptions(
 		return nil, err
 	}
 	var whereParts []mysql.WherePart
-	if req.EnvironmentId != "" {
+	if req.OrganizationId != "" {
+		// New console
+		whereParts = append(whereParts, mysql.NewFilter("env.organization_id", "=", req.OrganizationId))
+	} else {
+		// Current console
 		whereParts = append(whereParts, mysql.NewFilter("sub.environment_id", "=", req.EnvironmentId))
 	}
 	sourceTypesValues := make([]interface{}, len(req.SourceTypes))
@@ -817,9 +821,6 @@ func (s *NotificationService) ListSubscriptions(
 	}
 	if req.SearchKeyword != "" {
 		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"sub.name"}, req.SearchKeyword))
-	}
-	if req.OrganizationId != "" {
-		whereParts = append(whereParts, mysql.NewFilter("env.organization_id", "=", req.OrganizationId))
 	}
 	orders, err := s.newSubscriptionListOrders(req.OrderBy, req.OrderDirection, localizer)
 	if err != nil {

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -300,7 +300,7 @@ func (s *NotificationService) UpdateSubscription(
 	if err := s.updateSubscription(ctx, commands, req.Id, req.EnvironmentId, editor, localizer); err != nil {
 		if status.Code(err) == codes.Internal {
 			s.logger.Error(
-				"Failed to update feature",
+				"Failed to update subscription",
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.Error(err),
 					zap.String("environmentId", req.EnvironmentId),
@@ -367,7 +367,7 @@ func (s *NotificationService) EnableSubscription(
 	); err != nil {
 		if status.Code(err) == codes.Internal {
 			s.logger.Error(
-				"Failed to enable feature",
+				"Failed to enable subscription",
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.Error(err),
 					zap.String("environmentId", req.EnvironmentId),
@@ -404,7 +404,7 @@ func (s *NotificationService) DisableSubscription(
 	); err != nil {
 		if status.Code(err) == codes.Internal {
 			s.logger.Error(
-				"Failed to disable feature",
+				"Failed to disable subscription",
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.Error(err),
 					zap.String("environmentId", req.EnvironmentId),

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -897,8 +897,8 @@ func (s *NotificationService) ListEnabledSubscriptions(
 	var whereParts []mysql.WherePart
 	whereParts = append(
 		whereParts,
-		mysql.NewFilter("environment_id", "=", req.EnvironmentId),
-		mysql.NewFilter("disabled", "=", false),
+		mysql.NewFilter("sub.environment_id", "=", req.EnvironmentId),
+		mysql.NewFilter("sub.disabled", "=", false),
 	)
 	sourceTypesValues := make([]interface{}, len(req.SourceTypes))
 	for i, st := range req.SourceTypes {
@@ -907,7 +907,7 @@ func (s *NotificationService) ListEnabledSubscriptions(
 	if len(sourceTypesValues) > 0 {
 		whereParts = append(
 			whereParts,
-			mysql.NewJSONFilter("source_types", mysql.JSONContainsNumber, sourceTypesValues),
+			mysql.NewJSONFilter("sub.source_types", mysql.JSONContainsNumber, sourceTypesValues),
 		)
 	}
 	subscriptions, cursor, _, err := s.listSubscriptionsMySQL(

--- a/ui/web-v2/src/modules/notifications.ts
+++ b/ui/web-v2/src/modules/notifications.ts
@@ -61,7 +61,6 @@ interface ListNotificationParams {
   orderDirection?: OrderDirection;
   searchKeyword?: string;
   disabled?: boolean;
-  organizationId: string;
 }
 
 export const listNotification = createAsyncThunk<
@@ -76,7 +75,6 @@ export const listNotification = createAsyncThunk<
   request.setOrderBy(params.orderBy);
   request.setOrderDirection(params.orderDirection);
   request.setSearchKeyword(params.searchKeyword);
-  request.setOrganizationId(params.organizationId);
   params.disabled != null &&
     request.setDisabled(new BoolValue().setValue(params.disabled));
   const result = await subscriptionGrpc.listSubscriptions(request);

--- a/ui/web-v2/src/pages/notification/index.tsx
+++ b/ui/web-v2/src/pages/notification/index.tsx
@@ -51,7 +51,6 @@ import {
 } from '../../utils/search-params';
 
 import { addFormSchema, updateFormSchema } from './formSchema';
-import { getOrganizationId } from '../../storage/organizationId';
 
 interface Sort {
   orderBy: OrderBy;
@@ -126,8 +125,7 @@ export const NotificationIndexPage: FC = memo(() => {
           searchKeyword: options && (options.q as string),
           orderBy: sort.orderBy,
           orderDirection: sort.orderDirection,
-          disabled: disabled,
-          organizationId: getOrganizationId()
+          disabled: disabled
         })
       );
     },


### PR DESCRIPTION
Fix #1420 

The list API listed all subscriptions in the organization, so when we tried to update a subscription that was not in the currently selected environment, it failed because it could not be found.