### PR TITLE
fix: clear-text logging of sensitive information

### DIFF
--- a/pkg/auth/api/signin.go
+++ b/pkg/auth/api/signin.go
@@ -42,7 +42,6 @@ func (s *authService) SignIn(
 			"Sign in failed",
 			zap.Bool("enabled", config.Enabled),
 			zap.String("email", request.Email),
-			zap.String("password", request.Password),
 		)
 		dt, err := auth.StatusAccessDenied.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),


### PR DESCRIPTION
Fixes [https://github.com/bucketeer-io/bucketeer/security/code-scanning/7](https://github.com/bucketeer-io/bucketeer/security/code-scanning/7)

To fix the problem, we should avoid logging the password entirely. Instead, we can log other non-sensitive information that can help in debugging or monitoring without exposing sensitive data. In this case, we can remove the logging of the password and retain the logging of other relevant information such as the email and whether the sign-in feature is enabled.

- Remove the line that logs the password.
- Ensure that the functionality remains unchanged by only modifying the logging statement.
- The changes will be made in the file `pkg/auth/api/signin.go` on line 45.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
