### PR TITLE
refactor: changed transaction handling related to Notification package

### DIFF
--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -66,8 +66,7 @@ func (s *NotificationService) CreateAdminSubscription(
 	}
 	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
-		adminSubscriptionStorage := v2ss.NewAdminSubscriptionStorage(s.mysqlClient)
-		if err := adminSubscriptionStorage.CreateAdminSubscription(contextWithTx, subscription); err != nil {
+		if err := s.adminSubscriptionStorage.CreateAdminSubscription(contextWithTx, subscription); err != nil {
 			return err
 		}
 		handler, err = command.NewAdminSubscriptionCommandHandler(editor, subscription)
@@ -372,8 +371,7 @@ func (s *NotificationService) updateAdminSubscription(
 ) error {
 	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
-		adminSubscriptionStorage := v2ss.NewAdminSubscriptionStorage(s.mysqlClient)
-		subscription, err := adminSubscriptionStorage.GetAdminSubscription(contextWithTx, id)
+		subscription, err := s.adminSubscriptionStorage.GetAdminSubscription(contextWithTx, id)
 		if err != nil {
 			return err
 		}
@@ -386,7 +384,7 @@ func (s *NotificationService) updateAdminSubscription(
 				return err
 			}
 		}
-		if err = adminSubscriptionStorage.UpdateAdminSubscription(contextWithTx, subscription); err != nil {
+		if err = s.adminSubscriptionStorage.UpdateAdminSubscription(contextWithTx, subscription); err != nil {
 			return err
 		}
 		return nil
@@ -452,8 +450,7 @@ func (s *NotificationService) DeleteAdminSubscription(
 	}
 	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
-		adminSubscriptionStorage := v2ss.NewAdminSubscriptionStorage(s.mysqlClient)
-		subscription, err := adminSubscriptionStorage.GetAdminSubscription(contextWithTx, req.Id)
+		subscription, err := s.adminSubscriptionStorage.GetAdminSubscription(contextWithTx, req.Id)
 		if err != nil {
 			return err
 		}
@@ -464,7 +461,7 @@ func (s *NotificationService) DeleteAdminSubscription(
 		if err := handler.Handle(ctx, req.Command); err != nil {
 			return err
 		}
-		if err = adminSubscriptionStorage.DeleteAdminSubscription(contextWithTx, req.Id); err != nil {
+		if err = s.adminSubscriptionStorage.DeleteAdminSubscription(contextWithTx, req.Id); err != nil {
 			return err
 		}
 		return nil
@@ -571,8 +568,7 @@ func (s *NotificationService) GetAdminSubscription(
 	if err := validateGetAdminSubscriptionRequest(req, localizer); err != nil {
 		return nil, err
 	}
-	adminSubscriptionStorage := v2ss.NewAdminSubscriptionStorage(s.mysqlClient)
-	subscription, err := adminSubscriptionStorage.GetAdminSubscription(ctx, req.Id)
+	subscription, err := s.adminSubscriptionStorage.GetAdminSubscription(ctx, req.Id)
 	if err != nil {
 		if err == v2ss.ErrAdminSubscriptionNotFound {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
@@ -764,8 +760,7 @@ func (s *NotificationService) listAdminSubscriptionsMySQL(
 		}
 		return nil, "", 0, dt.Err()
 	}
-	adminSubscriptionStorage := v2ss.NewAdminSubscriptionStorage(s.mysqlClient)
-	subscriptions, nextCursor, totalCount, err := adminSubscriptionStorage.ListAdminSubscriptions(
+	subscriptions, nextCursor, totalCount, err := s.adminSubscriptionStorage.ListAdminSubscriptions(
 		ctx,
 		whereParts,
 		orders,

--- a/pkg/notification/api/admin_subscription_test.go
+++ b/pkg/notification/api/admin_subscription_test.go
@@ -33,7 +33,6 @@ import (
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/token"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
@@ -729,15 +728,13 @@ func TestGetAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				row := mysqlmock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+				s.adminSubscriptionStorage.(*staragemock.MockAdminSubscriptionStorage).EXPECT().GetAdminSubscription(
+					gomock.Any(), gomock.Any(),
+				).Return(&domain.Subscription{
+					Subscription: &proto.Subscription{
+						Id: "key-0",
+					},
+				}, nil)
 			},
 			isSystemAdmin: true,
 			input:         &proto.GetAdminSubscriptionRequest{Id: "key-0"},
@@ -798,22 +795,10 @@ func TestListAdminSubscriptionsMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				rows := mysqlmock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().Return(false)
-				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(rows, nil)
-				row := mysqlmock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+				s.adminSubscriptionStorage.(*staragemock.MockAdminSubscriptionStorage).EXPECT().ListAdminSubscriptions(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return([]*proto.Subscription{}, 0, int64(0), nil)
+
 			},
 			isSystemAdmin: true,
 			input: &proto.ListAdminSubscriptionsRequest{
@@ -880,22 +865,9 @@ func TestListEnabledAdminSubscriptionsMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				rows := mysqlmock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().Return(false)
-				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(rows, nil)
-				row := mysqlmock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+				s.adminSubscriptionStorage.(*staragemock.MockAdminSubscriptionStorage).EXPECT().ListAdminSubscriptions(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return([]*proto.Subscription{}, 1, int64(1), nil)
 			},
 			isSystemAdmin: true,
 			input: &proto.ListEnabledAdminSubscriptionsRequest{

--- a/pkg/notification/api/admin_subscription_test.go
+++ b/pkg/notification/api/admin_subscription_test.go
@@ -30,6 +30,7 @@ import (
 	v2ss "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2"
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/token"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
@@ -163,9 +164,8 @@ func TestCreateAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -272,9 +272,8 @@ func TestUpdateAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "err: ErrNotFound",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ss.ErrAdminSubscriptionNotFound)
 			},
 			isSystemAdmin: true,
@@ -292,9 +291,8 @@ func TestUpdateAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success: addSourceTypes",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -314,9 +312,8 @@ func TestUpdateAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success: deleteSourceTypes",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -336,9 +333,8 @@ func TestUpdateAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success: all commands",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -426,9 +422,8 @@ func TestEnableAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -499,9 +494,8 @@ func TestDisableAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -571,9 +565,8 @@ func TestDeleteAdminSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -643,7 +636,11 @@ func TestGetAdminSubscriptionMySQL(t *testing.T) {
 			setup: func(s *NotificationService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -710,12 +707,16 @@ func TestListAdminSubscriptionsMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -788,12 +789,16 @@ func TestListEnabledAdminSubscriptionsMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},

--- a/pkg/notification/api/api.go
+++ b/pkg/notification/api/api.go
@@ -26,6 +26,7 @@ import (
 	accountclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
+	v2 "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher"
 	"github.com/bucketeer-io/bucketeer/pkg/role"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -47,11 +48,13 @@ func WithLogger(l *zap.Logger) Option {
 }
 
 type NotificationService struct {
-	mysqlClient          mysql.Client
-	accountClient        accountclient.Client
-	domainEventPublisher publisher.Publisher
-	opts                 *options
-	logger               *zap.Logger
+	mysqlClient              mysql.Client
+	adminSubscriptionStorage v2.AdminSubscriptionStorage
+	subscriptionStorage      v2.SubscriptionStorage
+	accountClient            accountclient.Client
+	domainEventPublisher     publisher.Publisher
+	opts                     *options
+	logger                   *zap.Logger
 }
 
 func NewNotificationService(
@@ -67,11 +70,13 @@ func NewNotificationService(
 		opt(dopts)
 	}
 	return &NotificationService{
-		mysqlClient:          mysqlClient,
-		accountClient:        accountClient,
-		domainEventPublisher: domainEventPublisher,
-		opts:                 dopts,
-		logger:               dopts.logger.Named("api"),
+		mysqlClient:              mysqlClient,
+		adminSubscriptionStorage: v2.NewAdminSubscriptionStorage(mysqlClient),
+		subscriptionStorage:      v2.NewSubscriptionStorage(mysqlClient),
+		accountClient:            accountClient,
+		domainEventPublisher:     domainEventPublisher,
+		opts:                     dopts,
+		logger:                   dopts.logger.Named("api"),
 	}
 }
 

--- a/pkg/notification/api/api_test.go
+++ b/pkg/notification/api/api_test.go
@@ -29,6 +29,7 @@ import (
 
 	accountclientmock "github.com/bucketeer-io/bucketeer/pkg/account/client/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"
+	v2mock "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher"
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
@@ -61,10 +62,12 @@ func newNotificationServiceWithMock(
 ) *NotificationService {
 	t.Helper()
 	return &NotificationService{
-		mysqlClient:          mysqlmock.NewMockClient(c),
-		accountClient:        accountclientmock.NewMockClient(c),
-		domainEventPublisher: publishermock.NewMockPublisher(c),
-		logger:               zap.NewNop(),
+		mysqlClient:              mysqlmock.NewMockClient(c),
+		adminSubscriptionStorage: v2mock.NewMockAdminSubscriptionStorage(c),
+		subscriptionStorage:      v2mock.NewMockSubscriptionStorage(c),
+		accountClient:            accountclientmock.NewMockClient(c),
+		domainEventPublisher:     publishermock.NewMockPublisher(c),
+		logger:                   zap.NewNop(),
 	}
 }
 

--- a/pkg/notification/api/api_test.go
+++ b/pkg/notification/api/api_test.go
@@ -109,10 +109,12 @@ func newNotificationService(c *gomock.Controller, specifiedEnvironmentId *string
 	p := publishermock.NewMockPublisher(c)
 	p.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	return &NotificationService{
-		mysqlClient:          mysqlClient,
-		accountClient:        accountClientMock,
-		domainEventPublisher: publishermock.NewMockPublisher(c),
-		logger:               zap.NewNop(),
+		mysqlClient:              mysqlClient,
+		adminSubscriptionStorage: v2mock.NewMockAdminSubscriptionStorage(c),
+		subscriptionStorage:      v2mock.NewMockSubscriptionStorage(c),
+		accountClient:            accountClientMock,
+		domainEventPublisher:     publishermock.NewMockPublisher(c),
+		logger:                   zap.NewNop(),
 	}
 }
 

--- a/pkg/notification/api/subscription_test.go
+++ b/pkg/notification/api/subscription_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	v2ss "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2"
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
@@ -138,9 +139,8 @@ func TestCreateSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -269,9 +269,8 @@ func TestCreateSubscriptionNoCommandMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().Publish(
 					gomock.Any(), gomock.Any(),
@@ -354,9 +353,8 @@ func TestUpdateSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "err: ErrNotFound",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ss.ErrSubscriptionNotFound)
 			},
 			input: &proto.UpdateSubscriptionRequest{
@@ -373,9 +371,8 @@ func TestUpdateSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success: addSourceTypes",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -394,9 +391,8 @@ func TestUpdateSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success: deleteSourceTypes",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -415,9 +411,8 @@ func TestUpdateSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success: all commands",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -489,9 +484,8 @@ func TestUpdateSubscriptionMySQLNoCommand(t *testing.T) {
 		{
 			desc: "err: ErrNotFound",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ss.ErrSubscriptionNotFound)
 			},
 			input: &proto.UpdateSubscriptionRequest{
@@ -506,9 +500,8 @@ func TestUpdateSubscriptionMySQLNoCommand(t *testing.T) {
 		{
 			desc: "success: update SourceTypes",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().Publish(
 					gomock.Any(), gomock.Any(),
@@ -526,9 +519,8 @@ func TestUpdateSubscriptionMySQLNoCommand(t *testing.T) {
 		{
 			desc: "success: rename",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().Publish(
 					gomock.Any(), gomock.Any(),
@@ -547,9 +539,8 @@ func TestUpdateSubscriptionMySQLNoCommand(t *testing.T) {
 		{
 			desc: "success: disable",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().Publish(
 					gomock.Any(), gomock.Any(),
@@ -615,9 +606,8 @@ func TestEnableSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -683,9 +673,8 @@ func TestDisableSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(
 					gomock.Any(), gomock.Any(),
@@ -744,9 +733,8 @@ func TestDeleteSubscriptionMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *NotificationService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				s.domainEventPublisher.(*publishermock.MockPublisher).EXPECT().Publish(
 					gomock.Any(), gomock.Any(),
@@ -821,7 +809,11 @@ func TestGetSubscriptionMySQL(t *testing.T) {
 			setup: func(s *NotificationService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -903,12 +895,16 @@ func TestListSubscriptionsMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -997,12 +993,16 @@ func TestListEnabledSubscriptionsMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},

--- a/pkg/notification/api/subscription_test.go
+++ b/pkg/notification/api/subscription_test.go
@@ -32,7 +32,6 @@ import (
 	storagemock "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2/mock"
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
@@ -964,15 +963,13 @@ func TestGetSubscriptionMySQL(t *testing.T) {
 			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
 			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
-				row := mysqlmock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.subscriptionStorage.(*storagemock.MockSubscriptionStorage).EXPECT().GetSubscription(
 					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+				).Return(&domain.Subscription{
+					Subscription: &proto.Subscription{
+						Id: "key-0",
+					},
+				}, nil)
 			},
 			input:       &proto.GetSubscriptionRequest{Id: "key-0", EnvironmentId: "ns0"},
 			expectedErr: nil,
@@ -1048,22 +1045,9 @@ func TestListSubscriptionsMySQL(t *testing.T) {
 			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
 			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
-				rows := mysqlmock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().Return(false)
-				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(rows, nil)
-				row := mysqlmock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+				s.subscriptionStorage.(*storagemock.MockSubscriptionStorage).EXPECT().ListSubscriptions(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return([]*proto.Subscription{}, 0, int64(0), nil)
 			},
 			input: &proto.ListSubscriptionsRequest{
 				PageSize: 2,
@@ -1146,22 +1130,9 @@ func TestListEnabledSubscriptionsMySQL(t *testing.T) {
 			orgRole:       toPtr(accountproto.AccountV2_Role_Organization_MEMBER),
 			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
-				rows := mysqlmock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().Return(false)
-				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.mysqlClient.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(rows, nil)
-				row := mysqlmock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+				s.subscriptionStorage.(*storagemock.MockSubscriptionStorage).EXPECT().ListSubscriptions(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return([]*proto.Subscription{}, 1, int64(1), nil)
 			},
 			input: &proto.ListEnabledSubscriptionsRequest{
 				PageSize: 2,

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -59,15 +59,15 @@ type AdminSubscriptionStorage interface {
 }
 
 type adminSubscriptionStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewAdminSubscriptionStorage(qe mysql.QueryExecer) AdminSubscriptionStorage {
-	return &adminSubscriptionStorage{qe}
+func NewAdminSubscriptionStorage(client mysql.Client) AdminSubscriptionStorage {
+	return &adminSubscriptionStorage{client}
 }
 
 func (s *adminSubscriptionStorage) CreateAdminSubscription(ctx context.Context, e *domain.Subscription) error {
-	_, err := s.qe.ExecContext(
+	_, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		insertAdminSubscriptionV2SQLQuery,
 		e.Id,
@@ -88,7 +88,7 @@ func (s *adminSubscriptionStorage) CreateAdminSubscription(ctx context.Context, 
 }
 
 func (s *adminSubscriptionStorage) UpdateAdminSubscription(ctx context.Context, e *domain.Subscription) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		updateAdminSubscriptionV2SQLQuery,
 		e.UpdatedAt,
@@ -112,7 +112,7 @@ func (s *adminSubscriptionStorage) UpdateAdminSubscription(ctx context.Context, 
 }
 
 func (s *adminSubscriptionStorage) DeleteAdminSubscription(ctx context.Context, id string) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		deleteAdminSubscriptionV2SQLQuery,
 		id,
@@ -132,7 +132,7 @@ func (s *adminSubscriptionStorage) DeleteAdminSubscription(ctx context.Context, 
 
 func (s *adminSubscriptionStorage) GetAdminSubscription(ctx context.Context, id string) (*domain.Subscription, error) {
 	subscription := proto.Subscription{}
-	err := s.qe.QueryRowContext(
+	err := s.client.Qe(ctx).QueryRowContext(
 		ctx,
 		selectAdminSubscriptionV2SQLQuery,
 		id,
@@ -164,7 +164,7 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectAdminSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
 
 	if err != nil {
 		return nil, 0, 0, err
@@ -194,7 +194,7 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	var totalCount int64
 	countQuery := fmt.Sprintf(selectAdminSubscriptionV2CountSQLQuery, whereSQL)
 
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/admin_subscription_test.go
+++ b/pkg/notification/storage/v2/admin_subscription_test.go
@@ -19,20 +19,19 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNewAdminSubscriptionStorage(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
-	storage := NewAdminSubscriptionStorage(mock.NewMockQueryExecer(mockController))
+	storage := NewAdminSubscriptionStorage(mock.NewMockClient(mockController))
 	assert.IsType(t, &adminSubscriptionStorage{}, storage)
 }
 
@@ -54,7 +53,12 @@ func TestCreateAdminSubscription(t *testing.T) {
 		{
 			desc: "ErrAdminSubscriptionAlreadyExists",
 			setup: func(s *adminSubscriptionStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -66,7 +70,12 @@ func TestCreateAdminSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -79,7 +88,12 @@ func TestCreateAdminSubscription(t *testing.T) {
 		{
 			desc: "Success",
 			setup: func(s *adminSubscriptionStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					id, int64(1), int64(2), false, mysql.JSONObject{Val: sourceTypes}, mysql.JSONObject{Val: recipient}, name,
@@ -123,7 +137,12 @@ func TestUpdateAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -135,7 +154,12 @@ func TestUpdateAdminSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -150,7 +174,12 @@ func TestUpdateAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					int64(2), false, mysql.JSONObject{Val: sourceTypes}, mysql.JSONObject{Val: recipient}, name, id,
@@ -189,7 +218,12 @@ func TestDeleteAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -199,7 +233,12 @@ func TestDeleteAdminSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -212,7 +251,12 @@ func TestDeleteAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					"id-0",
@@ -249,7 +293,12 @@ func TestGetAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -261,7 +310,12 @@ func TestGetAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 
@@ -274,7 +328,12 @@ func TestGetAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					"id-0",
@@ -325,7 +384,12 @@ func TestListAdminSubscriptions(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -349,14 +413,19 @@ func TestListAdminSubscriptions(t *testing.T) {
 				}).Times(getSize + 1)
 				rows.EXPECT().Err().Return(nil)
 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+
+				qe.EXPECT().QueryContext(
 					gomock.Any(),
 					gomock.Any(),
 					updatedAt, disable,
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					updatedAt, disable,
@@ -383,14 +452,19 @@ func TestListAdminSubscriptions(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+
+				qe.EXPECT().QueryContext(
 					gomock.Any(),
 					gomock.Any(),
 					[]interface{}{},
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					[]interface{}{},
@@ -430,5 +504,5 @@ func TestListAdminSubscriptions(t *testing.T) {
 
 func newAdminSubscriptionStorageWithMock(t *testing.T, mockController *gomock.Controller) *adminSubscriptionStorage {
 	t.Helper()
-	return &adminSubscriptionStorage{mock.NewMockQueryExecer(mockController)}
+	return &adminSubscriptionStorage{mock.NewMockClient(mockController)}
 }

--- a/pkg/notification/storage/v2/admin_subscription_test.go
+++ b/pkg/notification/storage/v2/admin_subscription_test.go
@@ -19,12 +19,13 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
 )
 
 func TestNewAdminSubscriptionStorage(t *testing.T) {

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -59,11 +59,11 @@ type SubscriptionStorage interface {
 }
 
 type subscriptionStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewSubscriptionStorage(qe mysql.QueryExecer) SubscriptionStorage {
-	return &subscriptionStorage{qe}
+func NewSubscriptionStorage(client mysql.Client) SubscriptionStorage {
+	return &subscriptionStorage{client}
 }
 
 func (s *subscriptionStorage) CreateSubscription(
@@ -71,7 +71,7 @@ func (s *subscriptionStorage) CreateSubscription(
 	e *domain.Subscription,
 	environmentId string,
 ) error {
-	_, err := s.qe.ExecContext(
+	_, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		insertSubscriptionV2SQLQuery,
 		e.Id,
@@ -97,7 +97,7 @@ func (s *subscriptionStorage) UpdateSubscription(
 	e *domain.Subscription,
 	environmentId string,
 ) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		updateSubscriptionV2SQLQuery,
 		e.UpdatedAt,
@@ -125,7 +125,7 @@ func (s *subscriptionStorage) DeleteSubscription(
 	ctx context.Context,
 	id, environmentId string,
 ) error {
-	result, err := s.qe.ExecContext(
+	result, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		deleteSubscriptionV2SQLQuery,
 		id,
@@ -149,7 +149,7 @@ func (s *subscriptionStorage) GetSubscription(
 	id, environmentId string,
 ) (*domain.Subscription, error) {
 	subscription := proto.Subscription{}
-	err := s.qe.QueryRowContext(
+	err := s.client.Qe(ctx).QueryRowContext(
 		ctx,
 		selectSubscriptionV2SQLQuery,
 		id,
@@ -184,7 +184,7 @@ func (s *subscriptionStorage) ListSubscriptions(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -214,7 +214,7 @@ func (s *subscriptionStorage) ListSubscriptions(
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
 	countQuery := fmt.Sprintf(selectSubscriptionV2CountSQLQuery, whereSQL)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}


### PR DESCRIPTION
This pull request includes significant updates to the `NotificationService` in the `pkg/notification/api/admin_subscription.go` file, focusing on improving transaction handling and refactoring storage interactions. Additionally, corresponding changes have been made to the test files to align with these updates.

Improvements to transaction handling:

* [`pkg/notification/api/admin_subscription.go`](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L68-R69): Replaced `BeginTx` and `RunInTransaction` with `RunInTransactionV2` to streamline transaction management and error handling. [[1]](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L68-R69) [[2]](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L391-R374) [[3]](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L488-R453)

Refactoring storage interactions:

* [`pkg/notification/api/admin_subscription.go`](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L625-R571): Updated methods to use `s.adminSubscriptionStorage` directly instead of creating new instances of `AdminSubscriptionStorage`. [[1]](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L625-R571) [[2]](diffhunk://#diff-c5d32f9d198e39c37106414c33b9e77ae9bcfe363249aeebd24a68f3d6c229e8L818-R763)

Part of https://github.com/bucketeer-io/bucketeer/issues/1252