### PR TITLE
refactor: changed transaction handling related to Push package

### DIFF
--- a/pkg/push/api/api.go
+++ b/pkg/push/api/api.go
@@ -183,26 +183,9 @@ func (s *PushService) CreatePush(
 		}
 		return nil, dt.Err()
 	}
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		pushStorage := v2ps.NewPushStorage(tx)
-		if err := pushStorage.CreatePush(ctx, push, req.EnvironmentId); err != nil {
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
+		pushStorage := v2ps.NewPushStorage(s.mysqlClient)
+		if err := pushStorage.CreatePush(contextWithTx, push, req.EnvironmentId); err != nil {
 			return err
 		}
 		handler, err := command.NewPushCommandHandler(editor, push, s.publisher, req.EnvironmentId)
@@ -330,26 +313,9 @@ func (s *PushService) createPushNoCommand(
 	}
 
 	var event *eventproto.Event
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		pushStorage := v2ps.NewPushStorage(tx)
-		if err := pushStorage.CreatePush(ctx, push, req.EnvironmentId); err != nil {
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
+		pushStorage := v2ps.NewPushStorage(s.mysqlClient)
+		if err := pushStorage.CreatePush(contextWithTx, push, req.EnvironmentId); err != nil {
 			return err
 		}
 		prev := &domain.Push{}
@@ -506,26 +472,9 @@ func (s *PushService) UpdatePush(
 
 	var updatedPushPb *pushproto.Push
 	commands := s.createUpdatePushCommands(req)
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		pushStorage := v2ps.NewPushStorage(tx)
-		push, err := pushStorage.GetPush(ctx, req.Id, req.EnvironmentId)
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
+		pushStorage := v2ps.NewPushStorage(s.mysqlClient)
+		push, err := pushStorage.GetPush(contextWithTx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
 		}
@@ -539,7 +488,7 @@ func (s *PushService) UpdatePush(
 			}
 		}
 		updatedPushPb = push.Push
-		return pushStorage.UpdatePush(ctx, push, req.EnvironmentId)
+		return pushStorage.UpdatePush(contextWithTx, push, req.EnvironmentId)
 	})
 	if err != nil {
 		switch {
@@ -599,26 +548,9 @@ func (s *PushService) updatePushNoCommand(
 	}
 	var updatedPushPb *pushproto.Push
 	var updatePushEvent *eventproto.Event
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		pushStorage := v2ps.NewPushStorage(tx)
-		push, err := pushStorage.GetPush(ctx, req.Id, req.EnvironmentId)
+	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
+		pushStorage := v2ps.NewPushStorage(s.mysqlClient)
+		push, err := pushStorage.GetPush(contextWithTx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
 		}
@@ -648,7 +580,7 @@ func (s *PushService) updatePushNoCommand(
 		}
 		updatedPushPb = updated.Push
 
-		return pushStorage.UpdatePush(ctx, updated, req.EnvironmentId)
+		return pushStorage.UpdatePush(contextWithTx, updated, req.EnvironmentId)
 	})
 	if err != nil {
 		switch {
@@ -842,26 +774,9 @@ func (s *PushService) DeletePush(
 	}
 
 	var event *eventproto.Event
-	tx, err := s.mysqlClient.BeginTx(ctx)
-	if err != nil {
-		s.logger.Error(
-			"Failed to begin transaction",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.Error(err),
-			)...,
-		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
-	}
-	err = s.mysqlClient.RunInTransaction(ctx, tx, func() error {
-		pushStorage := v2ps.NewPushStorage(tx)
-		push, err := pushStorage.GetPush(ctx, req.Id, req.EnvironmentId)
+	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
+		pushStorage := v2ps.NewPushStorage(s.mysqlClient)
+		push, err := pushStorage.GetPush(contextWithTx, req.Id, req.EnvironmentId)
 		if err != nil {
 			return err
 		}
@@ -890,7 +805,7 @@ func (s *PushService) DeletePush(
 		if err = s.publisher.Publish(ctx, event); err != nil {
 			return err
 		}
-		return pushStorage.UpdatePush(ctx, push, req.EnvironmentId)
+		return pushStorage.UpdatePush(contextWithTx, push, req.EnvironmentId)
 	})
 	if err != nil {
 		switch {

--- a/pkg/push/api/api_test.go
+++ b/pkg/push/api/api_test.go
@@ -38,6 +38,7 @@ import (
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	v2ps "github.com/bucketeer-io/bucketeer/pkg/push/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/token"
 	pushproto "github.com/bucketeer-io/bucketeer/proto/push"
@@ -151,17 +152,20 @@ func TestCreatePushMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ps.ErrPushAlreadyExists)
 			},
 			req: &pushproto.CreatePushRequest{
@@ -181,17 +185,20 @@ func TestCreatePushMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.CreatePushRequest{
@@ -274,17 +281,20 @@ func TestCreatePushNoCommandMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ps.ErrPushAlreadyExists)
 			},
 			req: &pushproto.CreatePushRequest{
@@ -302,17 +312,20 @@ func TestCreatePushNoCommandMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.CreatePushRequest{
@@ -408,17 +421,20 @@ func TestUpdatePushMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ps.ErrPushNotFound)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -430,9 +446,8 @@ func TestUpdatePushMySQL(t *testing.T) {
 		{
 			desc: "success: rename",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -445,9 +460,8 @@ func TestUpdatePushMySQL(t *testing.T) {
 		{
 			desc: "success: deletePushTags",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -464,17 +478,20 @@ func TestUpdatePushMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -491,17 +508,20 @@ func TestUpdatePushMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.All(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -559,9 +579,8 @@ func TestUpdatePushNoCommandMySQL(t *testing.T) {
 		{
 			desc: "err: ErrNotFound",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ps.ErrPushNotFound)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -574,9 +593,8 @@ func TestUpdatePushNoCommandMySQL(t *testing.T) {
 		{
 			desc: "success update name",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -588,9 +606,8 @@ func TestUpdatePushNoCommandMySQL(t *testing.T) {
 		{
 			desc: "success update tags",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -602,9 +619,8 @@ func TestUpdatePushNoCommandMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.UpdatePushRequest{
@@ -746,9 +762,8 @@ func TestDeletePushMySQL(t *testing.T) {
 		{
 			desc: "err: ErrNotFound",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(v2ps.ErrPushNotFound)
 			},
 			req: &pushproto.DeletePushRequest{
@@ -761,9 +776,8 @@ func TestDeletePushMySQL(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().BeginTx(gomock.Any()).Return(nil, nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransaction(
-					gomock.Any(), gomock.Any(), gomock.Any(),
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},
 			req: &pushproto.DeletePushRequest{
@@ -826,7 +840,11 @@ func TestListPushesMySQL(t *testing.T) {
 		{
 			desc: "err: ErrInternal",
 			setup: func(s *PushService) {
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -851,12 +869,16 @@ func TestListPushesMySQL(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -914,7 +936,11 @@ func TestGetPushMySQL(t *testing.T) {
 			setup: func(s *PushService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(v2ps.ErrPushNotFound)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -929,7 +955,11 @@ func TestGetPushMySQL(t *testing.T) {
 			setup: func(s *PushService) {
 				row := mysqlmock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},

--- a/pkg/push/api/api_test.go
+++ b/pkg/push/api/api_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 	"time"
 
-	proto "github.com/bucketeer-io/bucketeer/proto/push"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
@@ -29,6 +28,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	gstatus "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	proto "github.com/bucketeer-io/bucketeer/proto/push"
 
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 

--- a/pkg/push/storage/v2/push_test.go
+++ b/pkg/push/storage/v2/push_test.go
@@ -32,7 +32,7 @@ func TestNewPushStorage(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
-	storage := NewPushStorage(mock.NewMockQueryExecer(mockController))
+	storage := NewPushStorage(mock.NewMockClient(mockController))
 	assert.IsType(t, &pushStorage{}, storage)
 }
 
@@ -50,7 +50,11 @@ func TestCreatePush(t *testing.T) {
 		{
 			desc: "ErrPushAlreadyExists",
 			setup: func(s *pushStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -63,7 +67,11 @@ func TestCreatePush(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *pushStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -77,7 +85,11 @@ func TestCreatePush(t *testing.T) {
 		{
 			desc: "Success",
 			setup: func(s *pushStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -116,7 +128,11 @@ func TestUpdatePush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -129,7 +145,11 @@ func TestUpdatePush(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *pushStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -145,7 +165,11 @@ func TestUpdatePush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -184,7 +208,11 @@ func TestGetPush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -197,7 +225,11 @@ func TestGetPush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 
@@ -211,7 +243,11 @@ func TestGetPush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -250,7 +286,11 @@ func TestListPushs(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *pushStorage) {
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -269,12 +309,16 @@ func TestListPushs(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe).AnyTimes()
+				qe.EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -313,5 +357,5 @@ func TestListPushs(t *testing.T) {
 
 func newpushStorageWithMock(t *testing.T, mockController *gomock.Controller) *pushStorage {
 	t.Helper()
-	return &pushStorage{mock.NewMockQueryExecer(mockController)}
+	return &pushStorage{mock.NewMockClient(mockController)}
 }


### PR DESCRIPTION
This pull request includes significant changes to the `pkg/push/api/api.go` file to refactor transaction handling and improve the push storage mechanism. The main changes involve replacing the old transaction methods with a new version and updating the push storage usage across various functions. Additionally, the test cases in `pkg/push/api/api_test.go` have been updated to reflect these changes.

Refactoring transaction handling and push storage:

* [`pkg/push/api/api.go`](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L186-R189): Replaced the old transaction handling methods with `RunInTransactionV2` and updated the usage of `pushStorage` across multiple functions such as `CreatePush`, `UpdatePush`, `DeletePush`, and `GetPush`. [[1]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L186-R189) [[2]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L333-R318) [[3]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L509-R476) [[4]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L602-R551) [[5]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L845-R776) [[6]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L938-R850) [[7]](diffhunk://#diff-927c02bd692b9ee775cb3720ede88aa16612d46cf46213f45274a0ddd792c782L1269-R1180)

Updating test cases:

* [`pkg/push/api/api_test.go`](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faR32-R45): Modified the test cases to use the mock `pushStorage` and the new transaction handling method `RunInTransactionV2`. This includes changes in functions like `TestCreatePushMySQL`, `TestCreatePushNoCommandMySQL`, and `TestUpdatePushMySQL`. [[1]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faR32-R45) [[2]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL150-R163) [[3]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL180-R191) [[4]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL273-R277) [[5]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL301-R303) [[6]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL407-R404) [[7]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL433-R428) [[8]](diffhunk://#diff-352a5994812a6b055d4e5e49ad7d19108692a5232ade0fdc9fa15315c221d2faL448-R458)

Part of #1474