### PR TITLE
refactor: changed transaction handling related to OpsEvent package

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -60,6 +60,7 @@ func WithLogger(l *zap.Logger) Option {
 
 type AutoOpsService struct {
 	mysqlClient      mysql.Client
+	opsCountStorage  v2os.OpsCountStorage
 	featureClient    featureclient.Client
 	experimentClient experimentclient.Client
 	accountClient    accountclient.Client
@@ -86,6 +87,7 @@ func NewAutoOpsService(
 	}
 	return &AutoOpsService{
 		mysqlClient:      mysqlClient,
+		opsCountStorage:  v2os.NewOpsCountStorage(mysqlClient),
 		featureClient:    featureClient,
 		experimentClient: experimentClient,
 		accountClient:    accountClient,
@@ -1481,8 +1483,7 @@ func (s *AutoOpsService) listOpsCounts(
 		return nil, "", dt.Err()
 
 	}
-	opsCountStorage := v2os.NewOpsCountStorage(s.mysqlClient)
-	opsCounts, nextCursor, err := opsCountStorage.ListOpsCounts(
+	opsCounts, nextCursor, err := s.opsCountStorage.ListOpsCounts(
 		ctx,
 		whereParts,
 		nil,

--- a/pkg/autoops/api/progressive_rollout_test.go
+++ b/pkg/autoops/api/progressive_rollout_test.go
@@ -831,7 +831,7 @@ func TestCreateProgressiveRolloutMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := createAutoOpsService(mockController, nil)
+			s := createAutoOpsService(mockController)
 			if p.setup != nil {
 				p.setup(s)
 			}
@@ -910,7 +910,7 @@ func TestGetProgressiveRolloutMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := createAutoOpsService(mockController, nil)
+			s := createAutoOpsService(mockController)
 			if p.setup != nil {
 				p.setup(s)
 			}
@@ -1022,7 +1022,7 @@ func TestStopProgressiveRolloutMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := createAutoOpsService(mockController, nil)
+			s := createAutoOpsService(mockController)
 			if p.setup != nil {
 				p.setup(s)
 			}
@@ -1115,7 +1115,7 @@ func TestDeleteProgressiveRolloutMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := createAutoOpsService(mockController, nil)
+			s := createAutoOpsService(mockController)
 			if p.setup != nil {
 				p.setup(s)
 			}
@@ -1209,7 +1209,7 @@ func TestListProgressiveRolloutsMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			service := createAutoOpsService(mockController, nil)
+			service := createAutoOpsService(mockController)
 			if p.setup != nil {
 				p.setup(service)
 			}
@@ -1287,7 +1287,7 @@ func TestExecuteProgressiveRolloutMySQL(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s := createAutoOpsService(mockController, nil)
+			s := createAutoOpsService(mockController)
 			if p.setup != nil {
 				p.setup(s)
 			}

--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -74,6 +74,7 @@ type setupMockFunc func(
 	mysqlMockClient *mysqlmock.MockClient,
 	mysqlMockRows *mysqlmock.MockRows,
 	redisMockClient *redismock.MockMultiGetCache,
+	qe *mysqlmock.MockQueryExecer,
 )
 
 func TestExperimentStatusUpdater(t *testing.T) {
@@ -91,6 +92,7 @@ func TestExperimentStatusUpdater(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -144,6 +146,7 @@ func TestExperimentRunningWatcher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -187,6 +190,7 @@ func TestFeatureStaleWatcher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -230,6 +234,7 @@ func TestMAUCountWatcher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListProjects(gomock.Any(), gomock.Any()).
@@ -283,6 +288,7 @@ func TestDatetimeWatcher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -334,6 +340,7 @@ func TestEventCountWatcher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -404,12 +411,13 @@ func TestEventCountWatcher(t *testing.T) {
 				},
 				nil,
 			)
-		mysqlMockClient.EXPECT().
-			ExecContext(
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-			Times(2).
-			Return(nil, nil)
+		mysqlMockClient.EXPECT().Qe(
+			gomock.Any(),
+		).AnyTimes().Return(qe)
+		qe.EXPECT().ExecContext(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		).AnyTimes().Return(nil, nil)
 		mockAutoOpsExecutor.EXPECT().
 			Execute(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(2).
@@ -436,6 +444,7 @@ func TestProgressiveRolloutWatcher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -502,6 +511,7 @@ func TestFeatureFlagCacher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		mysqlMockRows.EXPECT().Close().Return(nil)
 		mysqlMockRows.EXPECT().Next().Return(false)
@@ -531,6 +541,7 @@ func TestSegmentUserCacher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -590,6 +601,7 @@ func TestAPIKeyCacher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		mysqlMockRows.EXPECT().Close().Return(nil)
 		mysqlMockRows.EXPECT().Next().Return(false)
@@ -619,6 +631,7 @@ func TestExperimentCacher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -665,6 +678,7 @@ func TestAutoOpsRulesCacher(t *testing.T) {
 		mysqlMockClient *mysqlmock.MockClient,
 		mysqlMockRows *mysqlmock.MockRows,
 		redisMockClient *redismock.MockMultiGetCache,
+		qe *mysqlmock.MockQueryExecer,
 	) {
 		environmentMockClient.EXPECT().
 			ListEnvironmentsV2(gomock.Any(), gomock.Any()).
@@ -727,6 +741,7 @@ func newBatchService(t *testing.T,
 	mysqlMockClient := mysqlmock.NewMockClient(mockController)
 	mysqlMockRows := mysqlmock.NewMockRows(mockController)
 	redisMockClient := redismock.NewMockMultiGetCache(mockController)
+	qe := mysqlmock.NewMockQueryExecer(mockController)
 
 	setupMock(
 		accountMockClient,
@@ -741,6 +756,7 @@ func newBatchService(t *testing.T,
 		mysqlMockClient,
 		mysqlMockRows,
 		redisMockClient,
+		qe,
 	)
 
 	service := NewBatchService(

--- a/pkg/batch/jobs/opsevent/event_count_watcher_test.go
+++ b/pkg/batch/jobs/opsevent/event_count_watcher_test.go
@@ -292,7 +292,11 @@ func TestRunCountWatcher(t *testing.T) {
 						},
 					}, nil)
 
-				w.mysqlClient.(*mysqlmock.MockClient).EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				qe := mysqlmock.NewMockQueryExecer(mockController)
+				w.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
+					gomock.Any(),
+				).Return(qe)
+				qe.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil, nil,
 				)
 

--- a/pkg/opsevent/storage/v2/ops_count.go
+++ b/pkg/opsevent/storage/v2/ops_count.go
@@ -35,11 +35,11 @@ type OpsCountStorage interface {
 }
 
 type opsCountStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewOpsCountStorage(qe mysql.QueryExecer) OpsCountStorage {
-	return &opsCountStorage{qe: qe}
+func NewOpsCountStorage(client mysql.Client) OpsCountStorage {
+	return &opsCountStorage{client: client}
 }
 
 func (s *opsCountStorage) UpsertOpsCount(ctx context.Context, environmentId string, oc *domain.OpsCount) error {
@@ -63,7 +63,7 @@ func (s *opsCountStorage) UpsertOpsCount(ctx context.Context, environmentId stri
 			evaluation_count = VALUES(evaluation_count),
 			feature_id = VALUES(feature_id)
 	`
-	_, err := s.qe.ExecContext(
+	_, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		query,
 		oc.Id,
@@ -104,7 +104,7 @@ func (s *opsCountStorage) ListOpsCounts(
 		%s %s %s
 		`, whereSQL, orderBySQL, limitOffsetSQL,
 	)
-	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
+	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, err
 	}


### PR DESCRIPTION
I Changed the transaction instance of `OpsCountStorage` to be controlled via `mysqlClient.Qe()`.

Also, this pull request introduces significant updates to the `AutoOpsService` in the `pkg/autoops/api/api.go` file, focusing on the refactoring of storage dependencies. The main changes involve replacing inline storage initializations with pre-initialized storage fields within the `AutoOpsService` struct. Additionally, corresponding test updates have been made to accommodate these changes.
By doing so, you can mock Storage in your test code, resulting in more meaningful test code.

Part of #1252