### PR TITLE
refactor: changed transaction handling related to EventCounter package

### DIFF
--- a/pkg/eventcounter/storage/v2/experiment_result.go
+++ b/pkg/eventcounter/storage/v2/experiment_result.go
@@ -31,11 +31,11 @@ type ExperimentResultStorage interface {
 }
 
 type experimentResultStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewExperimentResultStorage(qe mysql.QueryExecer) ExperimentResultStorage {
-	return &experimentResultStorage{qe}
+func NewExperimentResultStorage(client mysql.Client) ExperimentResultStorage {
+	return &experimentResultStorage{client}
 }
 
 func (s *experimentResultStorage) GetExperimentResult(
@@ -56,7 +56,7 @@ func (s *experimentResultStorage) GetExperimentResult(
 			id = ? AND
 			environment_id = ?
 	`
-	err := s.qe.QueryRowContext(
+	err := s.client.Qe(ctx).QueryRowContext(
 		ctx,
 		query,
 		id,

--- a/pkg/eventcounter/storage/v2/experiment_result_test.go
+++ b/pkg/eventcounter/storage/v2/experiment_result_test.go
@@ -30,7 +30,7 @@ func TestNewExperimentResultStorage(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
-	storage := NewExperimentResultStorage(mock.NewMockQueryExecer(mockController))
+	storage := NewExperimentResultStorage(mock.NewMockClient(mockController))
 	assert.IsType(t, &experimentResultStorage{}, storage)
 }
 
@@ -50,7 +50,9 @@ func TestGetExperimentResult(t *testing.T) {
 			setup: func(s *experimentResultStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -63,7 +65,9 @@ func TestGetExperimentResult(t *testing.T) {
 			setup: func(s *experimentResultStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 
@@ -77,7 +81,9 @@ func TestGetExperimentResult(t *testing.T) {
 			setup: func(s *experimentResultStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+				qe := mock.NewMockQueryExecer(mockController)
+				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
+				qe.EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -100,5 +106,5 @@ func TestGetExperimentResult(t *testing.T) {
 
 func newExperimentResultStorageWithMock(t *testing.T, mockController *gomock.Controller) *experimentResultStorage {
 	t.Helper()
-	return &experimentResultStorage{mock.NewMockQueryExecer(mockController)}
+	return &experimentResultStorage{mock.NewMockClient(mockController)}
 }

--- a/pkg/eventcounter/storage/v2/mau_summary.go
+++ b/pkg/eventcounter/storage/v2/mau_summary.go
@@ -30,11 +30,11 @@ type MAUSummaryStorage interface {
 }
 
 type mauSummaryStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewMAUSummaryStorage(qe mysql.QueryExecer) MAUSummaryStorage {
-	return &mauSummaryStorage{qe: qe}
+func NewMAUSummaryStorage(client mysql.Client) MAUSummaryStorage {
+	return &mauSummaryStorage{client: client}
 }
 
 func (s *mauSummaryStorage) UpsertMAUSummary(
@@ -64,7 +64,7 @@ func (s *mauSummaryStorage) UpsertMAUSummary(
 			is_finished = VALUES(is_finished),
 			updated_at = VALUES(updated_at)
 	`
-	_, err := s.qe.ExecContext(
+	_, err := s.client.Qe(ctx).ExecContext(
 		ctx,
 		query,
 		m.Yearmonth,

--- a/pkg/eventcounter/storage/v2/user_count.go
+++ b/pkg/eventcounter/storage/v2/user_count.go
@@ -39,11 +39,11 @@ type UserCountStorage interface {
 }
 
 type userCountStorage struct {
-	qe mysql.QueryExecer
+	client mysql.Client
 }
 
-func NewUserCountStorage(qe mysql.QueryExecer) UserCountStorage {
-	return &userCountStorage{qe: qe}
+func NewUserCountStorage(client mysql.Client) UserCountStorage {
+	return &userCountStorage{client: client}
 }
 
 func (s *userCountStorage) GetMAUCount(
@@ -61,7 +61,7 @@ func (s *userCountStorage) GetMAUCount(
 			yearmonth = ?
 	`
 	var userCount, eventCount int64
-	err := s.qe.QueryRowContext(
+	err := s.client.Qe(ctx).QueryRowContext(
 		ctx,
 		query,
 		environmentId,
@@ -93,7 +93,7 @@ func (s *userCountStorage) GetMAUCounts(
 		GROUP BY
 			environment_id
 	`
-	rows, err := s.qe.QueryContext(
+	rows, err := s.client.Qe(ctx).QueryContext(
 		ctx,
 		query,
 		yearMonth,
@@ -141,7 +141,7 @@ func (s *userCountStorage) GetMAUCountsGroupBySourceID(
 			environment_id,
 			source_id
 	`
-	rows, err := s.qe.QueryContext(
+	rows, err := s.client.Qe(ctx).QueryContext(
 		ctx,
 		query,
 		yearMonth,


### PR DESCRIPTION
This pull request includes changes to replace the use of `mysql.QueryExecer` with `mysql.Client` across multiple storage files and their corresponding test files. This refactoring aims to standardize the client interface used for database operations.

Part of https://github.com/bucketeer-io/bucketeer/issues/1474