### PR TITLE
chore(evaluation/typescript): export function getFeatureIDsDependsOn

### DIFF
--- a/evaluation/typescript/package.json
+++ b/evaluation/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketeer/evaluation",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/evaluation/typescript/src/evaluation.ts
+++ b/evaluation/typescript/src/evaluation.ts
@@ -286,7 +286,7 @@ enum Mark {
 }
 
 // FeatureIDsDependsOn returns the ids of the features that this feature depends on.
-function featureIDsDependsOn(feature: Feature): Array<string> {
+function getFeatureIDsDependsOn(feature: Feature): Array<string> {
   const ids: Array<string> = [];
 
   // Iterate over prerequisites and add their FeatureId
@@ -341,7 +341,7 @@ function topologicalSort(features: Array<Feature>): Array<Feature> {
 
     marks[fId] = Mark.Temporary;
 
-    const dependentFeatureIds = featureIDsDependsOn(f);
+    const dependentFeatureIds = getFeatureIDsDependsOn(f);
     for (const fid of dependentFeatureIds) {
       const pf = mapFeatures[fid];
       if (!pf) {
@@ -381,7 +381,7 @@ function getFeaturesDependedOnTargets(
     evals[f.getId()] = f;
 
     // Get dependent features recursively
-    const featureDependencies = featureIDsDependsOn(f);
+    const featureDependencies = getFeatureIDsDependsOn(f);
     featureDependencies.forEach((fid) => {
       const target = all.get(fid);
       if (target !== undefined) {
@@ -415,7 +415,7 @@ function getFeaturesDependsOnTargets(
       return true;
     }
 
-    const featureDependencies = featureIDsDependsOn(f);
+    const featureDependencies = getFeatureIDsDependsOn(f);
     for (const fid of featureDependencies) {
       const dependentFeature = all.get(fid);
       if (dependentFeature && dfs(dependentFeature)) {
@@ -445,4 +445,4 @@ function arrayToRecord(arr: Array<[string, string]>): Record<string, string> {
   );
 }
 
-export { Evaluator };
+export { Evaluator, getFeatureIDsDependsOn };

--- a/evaluation/typescript/src/index.ts
+++ b/evaluation/typescript/src/index.ts
@@ -1,4 +1,4 @@
-import { Evaluator } from './evaluation';
+import { Evaluator, getFeatureIDsDependsOn } from './evaluation';
 import { SegmentUser, SegmentUsers } from './proto/feature/segment_pb';
 import { Feature } from './proto/feature/feature_pb';
 import { NewUserEvaluations } from './userEvaluation';
@@ -31,7 +31,7 @@ import {
 import { SourceId } from './proto/event/client/event_pb';
 import { GatewayClient, ServiceError } from './proto/gateway/service_pb_service';
 
-export { Evaluator, NewUserEvaluations, Evaluation, UserEvaluations };
+export { Evaluator, NewUserEvaluations, Evaluation, UserEvaluations, getFeatureIDsDependsOn };
 export { User, SegmentUser, SegmentUsers, Feature };
 export { Strategy, Clause, Reason };
 export {


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1552

This pull request includes changes to update the version of the `@bucketeer/evaluation` package and refactor a function name for clarity in the `evaluation/typescript` module. The most important changes include updating the package version and renaming the `featureIDsDependsOn` function to `getFeatureIDsDependsOn`.

Version update:

* [`evaluation/typescript/package.json`](diffhunk://#diff-4e552c36cddb498024f82e0b6a55d75319b249ba56b576a447ad0541aba84e8fL3-R3): Updated the package version from `0.0.1` to `0.0.2`.

Function refactoring:

* [`evaluation/typescript/src/evaluation.ts`](diffhunk://#diff-9066692683b621001ceee806082359c858e133563baba9d06b0aeb44966ddd09L289-R289): Renamed the function `featureIDsDependsOn` to `getFeatureIDsDependsOn` in multiple places for better readability and consistency. [[1]](diffhunk://#diff-9066692683b621001ceee806082359c858e133563baba9d06b0aeb44966ddd09L289-R289) [[2]](diffhunk://#diff-9066692683b621001ceee806082359c858e133563baba9d06b0aeb44966ddd09L344-R344) [[3]](diffhunk://#diff-9066692683b621001ceee806082359c858e133563baba9d06b0aeb44966ddd09L384-R384) [[4]](diffhunk://#diff-9066692683b621001ceee806082359c858e133563baba9d06b0aeb44966ddd09L418-R418) [[5]](diffhunk://#diff-9066692683b621001ceee806082359c858e133563baba9d06b0aeb44966ddd09L448-R448)
* [`evaluation/typescript/src/index.ts`](diffhunk://#diff-e08865689de19eff4dab27526347538479450c775be6f9aa116bfe5dfccdde1fL1-R1): Updated imports and exports to reflect the renamed function `getFeatureIDsDependsOn`. [[1]](diffhunk://#diff-e08865689de19eff4dab27526347538479450c775be6f9aa116bfe5dfccdde1fL1-R1) [[2]](diffhunk://#diff-e08865689de19eff4dab27526347538479450c775be6f9aa116bfe5dfccdde1fL34-R34)