### PR TITLE
fix: update AutoOps rule URL template path

### DIFF
--- a/pkg/domainevent/domain/url.go
+++ b/pkg/domainevent/domain/url.go
@@ -29,7 +29,7 @@ const (
 	urlTemplateAccount      = "%s/%s/accounts/%s"
 	urlTemplateAPIKey       = "%s/%s/apikeys/%s"
 	urlTemplateSegment      = "%s/%s/segments/%s"
-	urlTemplateAutoOpsRule  = "%s/%s/features/%s/settings"
+	urlTemplateAutoOpsRule  = "%s/%s/features/%s/autoops"
 	urlTemplatePush         = "%s/%s/settings/pushes/%s"
 	urlTemplateSubscription = "%s/%s/settings/notifications/%s"
 	urlTemplateTag          = "%s/%s/tags/%s"


### PR DESCRIPTION
fix #1192

- URL of autoops page is `https://ENDPOINT/production/features/hoge/autoops`