### PR TITLE
fix: add unknown api id error handling

### DIFF
--- a/pkg/subscriber/processor/metrics_event_persister.go
+++ b/pkg/subscriber/processor/metrics_event_persister.go
@@ -16,6 +16,7 @@ package processor
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/golang/protobuf/ptypes"
@@ -102,6 +103,10 @@ func (m metricsEventPersister) handle(message *puller.Message) error {
 	}
 	err = m.saveMetrics(metricsEvents)
 	if err != nil {
+		// This is an expected case, so we don't need to log an error
+		if errors.Is(err, ErrUnknownApiId) {
+			return nil
+		}
 		m.logger.Error("could not store data to prometheus client", zap.Error(err))
 		return err
 	}


### PR DESCRIPTION
fix #1317

Fix unnecessary error logging for unknown API ID(issue #1317) by preventing unnecessary error logging when "unknown api id" errors occur during metrics event processing. This error is actually part of the normal flow and should not be treated as actual errors in the logs.

