### PR TITLE
fix(evaluation/typescript): missing proto import when build release lib

### DIFF
--- a/evaluation/typescript/CHANGELOG.md
+++ b/evaluation/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.3] (2025-03-07)
+
+### Fix
+
+- fix(evaluation/typescript): missing proto import when build release lib (#1567)[https://github.com/bucketeer-io/bucketeer/pull/1567]
+
 ## [0.0.2] (2025-03-04)
 
 ### Miscellaneous

--- a/evaluation/typescript/Makefile
+++ b/evaluation/typescript/Makefile
@@ -104,7 +104,7 @@ gen_proto: clean_proto gen_proto_external_api
 	-I $(PROTOBUF_INCLUDE_DIR) \
 	-I $(GOOGLEAPIS) \
 	-I $(OPENAPI) \
-	$(shell find $(ROOT_DIR)/proto -type f -name "*.proto" -not -path "**/external/*.proto" -not -path "**/auth/*.proto" -not -path "**/experiment/*.proto" -not -path "**/test/*.proto" -not -path "**/push/*.proto" -not -path "**/notification/*.proto"  -not -path "**/eventpersisterdwh/*.proto" -not -path "**/eventcounter/*.proto" -not -path "**/environment/*.proto" -not -path "**/batch/*.proto" -not -path "**/autoops/*.proto" -not -path "**/auditlog/*.proto" -not -path "**/account/*.proto" -not -path "**/openapi/web_default_settings.proto"  -not -path "**/google/protobuf/*.proto" -not -path "**/google/api/*.proto" -not -path "**/protoc-gen-openapiv2/options/*.proto")
+	$(shell find $(ROOT_DIR)/proto -type f -name "*.proto" -not -path "**/external/*.proto" -not -path "**/auth/*.proto" -not -path "**/test/*.proto" -not -path "**/eventpersisterdwh/*.proto" -not -path "**/eventcounter/*.proto" -not -path "**/batch/*.proto" -not -path "**/auditlog/*.proto" -not -path "**/openapi/web_default_settings.proto"  -not -path "**/google/protobuf/*.proto" -not -path "**/google/api/*.proto" -not -path "**/protoc-gen-openapiv2/options/*.proto")
 
 
 .PHONY: gen_proto_external_api

--- a/evaluation/typescript/package.json
+++ b/evaluation/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketeer/evaluation",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/evaluation/typescript/tsconfig.json
+++ b/evaluation/typescript/tsconfig.json
@@ -25,7 +25,7 @@
 		"noEmitOnError": true,
 		"useDefineForClassFields": true,
 		"forceConsistentCasingInFileNames": true,
-		"skipLibCheck": true,
+		"skipLibCheck": false,
     "outDir": "./__lib/",
     "types": [
       "node"


### PR DESCRIPTION
This pull request includes several changes to enhance the build process and ensure stricter type checking on the generated code

### Build Process Improvements:
* [`evaluation/typescript/Makefile`](diffhunk://#diff-955290520a7032b83d1a07ab890a0248dbc3732261fb21ae36d66af8418586b9L107-R107): Add import experiment.proto, account.proto, push.proto, notification.proto...

### Package Version Update:
* [`evaluation/typescript/package.json`](diffhunk://#diff-4e552c36cddb498024f82e0b6a55d75319b249ba56b576a447ad0541aba84e8fL3-R3): Updated the package version from `0.0.2` to `0.0.3`.

### TypeScript Configuration:
* [`evaluation/typescript/tsconfig.json`](diffhunk://#diff-e5ec89107a2e4807496305971d410256be6a5f4e7302a0e33041508f457b0065L28-R28): Changed the `skipLibCheck` option from `true` to `false` to enforce stricter type checking.