### PR TITLE
feat(ui/goal): add archive action tooltip and disable archive action for goals in use

### DIFF
--- a/ui/web-v2/src/assets/lang/ja.json
+++ b/ui/web-v2/src/assets/lang/ja.json
@@ -386,6 +386,7 @@
   "fullStop": "。",
   "generalInformation": "一般情報",
   "goal.action.archive": "アーカイブ",
+  "goal.action.archiveTooltip": "アーカイブする前にゴールの使用を停止してください。",
   "goal.add.header.description": "ゴールを使用することで、エクスペリメントでフィーチャーフラグの影響受けるユーザーの行動を計測できます。",
   "goal.add.header.title": "ゴールの作成",
   "goal.addNewGoal": "ゴールを作成する",

--- a/ui/web-v2/src/components/GoalList/index.tsx
+++ b/ui/web-v2/src/components/GoalList/index.tsx
@@ -61,13 +61,16 @@ export const GoalList: FC<GoalListProps> = memo(
       (state) => state.goals.totalCount,
       shallowEqual
     );
-
-    const createMenuItems = (): Array<MenuItem> => {
+    const createMenuItems = (isInUseStatus: boolean): Array<MenuItem> => {
       const items: Array<MenuItem> = [];
       items.push({
         action: MenuActions.ARCHIVE,
         name: intl.formatMessage(messages.feature.action.archive),
-        iconElement: <MUArchiveIcon />
+        iconElement: <MUArchiveIcon />,
+        disabled: isInUseStatus,
+        tooltipMessage: isInUseStatus
+          ? intl.formatMessage(messages.goal.action.archiveTooltip)
+          : null
       });
       return items;
     };
@@ -181,7 +184,7 @@ export const GoalList: FC<GoalListProps> = memo(
                                   return;
                               }
                             }}
-                            menuItems={createMenuItems()}
+                            menuItems={createMenuItems(goal.isInUseStatus)}
                           />
                         </td>
                       )}

--- a/ui/web-v2/src/lang/messages.ts
+++ b/ui/web-v2/src/lang/messages.ts
@@ -1264,8 +1264,12 @@ export const messages = {
     action: {
       archive: defineMessage({
         id: 'goal.action.archive',
-        defaultMessage: 'Archive'
-      })
+        defaultMessage: 'Archive',
+      }),
+      archiveTooltip: defineMessage({
+        id: 'goal.action.archiveTooltip',
+        defaultMessage:'Please stop using the goal before archiving.'
+      }),
     },
     add: {
       header: {


### PR DESCRIPTION
fix #1157

I have disabled the button so that it cannot be archived when in use, just like the `experiment` UI. 
This is how it looks.

In English
<img width="358" alt="スクリーンショット 2025-03-12 午後7 18 30" src="https://github.com/user-attachments/assets/06bfe5e5-c350-4f4d-b8b9-4b02ec1d066c" />

In Japanese
<img width="438" alt="スクリーンショット 2025-03-12 午後7 18 41" src="https://github.com/user-attachments/assets/7e418c88-1148-4a5c-b1c3-cf3eee85cdba" />


