### PR TITLE
fix: update refresh token TTL to 7 days

### DIFF
--- a/pkg/auth/api/api.go
+++ b/pkg/auth/api/api.go
@@ -60,7 +60,7 @@ type options struct {
 }
 
 var defaultOptions = options{
-	refreshTokenTTL: 30 * 24 * time.Hour,
+	refreshTokenTTL: 7 * 24 * time.Hour,
 	logger:          zap.NewNop(),
 }
 

--- a/pkg/auth/api/api.go
+++ b/pkg/auth/api/api.go
@@ -60,7 +60,7 @@ type options struct {
 }
 
 var defaultOptions = options{
-	refreshTokenTTL: time.Hour,
+	refreshTokenTTL: 30 * 24 * time.Hour,
 	logger:          zap.NewNop(),
 }
 

--- a/pkg/web/cmd/server/server.go
+++ b/pkg/web/cmd/server/server.go
@@ -126,6 +126,7 @@ type server struct {
 	autoOpsService       *string
 	codeReferenceService *string
 	// auth
+	refreshTokenTTL     *time.Duration
 	emailFilter         *string
 	oauthConfigPath     *string
 	oauthPublicKeyPath  *string
@@ -287,6 +288,10 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"Path to public key used to verify oauth token.",
 		).Required().String(),
 		// auth
+		refreshTokenTTL: cmd.Flag(
+			"refresh-token-ttl",
+			"TTL for refresh token.",
+		).Default("168h").Duration(),
 		emailFilter:     cmd.Flag("email-filter", "Regexp pattern for filtering email.").String(),
 		oauthConfigPath: cmd.Flag("oauth-config-path", "Path to oauth config.").Required().String(),
 		oauthPrivateKeyPath: cmd.Flag(
@@ -825,7 +830,7 @@ func (s *server) createAuthService(
 	}
 	serviceOptions := []authapi.Option{
 		authapi.WithLogger(logger),
-		authapi.WithRefreshTokenTTL(30 * 24 * time.Hour),
+		authapi.WithRefreshTokenTTL(*s.refreshTokenTTL),
 	}
 	if *s.emailFilter != "" {
 		filter, err := regexp.Compile(*s.emailFilter)

--- a/pkg/web/cmd/server/server.go
+++ b/pkg/web/cmd/server/server.go
@@ -825,6 +825,7 @@ func (s *server) createAuthService(
 	}
 	serviceOptions := []authapi.Option{
 		authapi.WithLogger(logger),
+		authapi.WithRefreshTokenTTL(30 * 24 * time.Hour),
 	}
 	if *s.emailFilter != "" {
 		filter, err := regexp.Compile(*s.emailFilter)


### PR DESCRIPTION
fix #1579

- Changed default refresh token TTL  from 1 hour to 7 days
- Added explicit WithRefreshTokenTTL() in service initialization

In the `generateToken` function, there was logic to set a default 30-day TTL but override it with the options value if present:

```go
refreshTokenTTL := 30 * day
if s.opts.refreshTokenTTL > 0 {
    refreshTokenTTL = s.opts.refreshTokenTTL
}
```

However, the `defaultOptions` had the refresh token TTL set to just 1 hour:
```go
var defaultOptions = options{
    refreshTokenTTL: time.Hour,
    logger:          zap.NewNop(),
}
```

And the service initialization did not explicitly specify the WithRefreshTokenTTL option, so the default 1-hour value was used.

The condition `if s.opts.refreshTokenTTL > 0` was always true, causing the default 30-day setting to always be overridden with the 1-hour value.