### PR TITLE
test: fix non-constant format string in Fatalf

### DIFF
--- a/test/e2e/experiment/experiment_test.go
+++ b/test/e2e/experiment/experiment_test.go
@@ -537,7 +537,7 @@ func TestStatusUpdateFromWaitingToRunning(t *testing.T) {
 			break
 		}
 		if i == retryTimes-1 {
-			t.Fatalf("retry timeout")
+			t.Fatalf("retry timeout: %s", resp.Experiment.Name)
 		}
 		time.Sleep(time.Second)
 	}
@@ -594,7 +594,7 @@ func TestStatusUpdateFromRunningToStopped(t *testing.T) {
 			break
 		}
 		if i == retryTimes-1 {
-			t.Fatalf(fmt.Sprintf("retry timeout: %s", resp.Experiment.Name))
+			t.Fatalf("retry timeout: %s", resp.Experiment.Name)
 		}
 		time.Sleep(time.Second)
 	}
@@ -653,7 +653,7 @@ func TestStatusUpdateFromRunningToStoppedNoCommand(t *testing.T) {
 			break
 		}
 		if i == retryTimes-1 {
-			t.Fatalf(fmt.Sprintf("retry timeout: %s", resp.Experiment.Name))
+			t.Fatalf("retry timeout: %s", resp.Experiment.Name)
 		}
 		time.Sleep(time.Second)
 	}
@@ -705,7 +705,7 @@ func TestStatusUpdateFromWaitingToStopped(t *testing.T) {
 			break
 		}
 		if i == retryTimes-1 {
-			t.Fatalf(fmt.Sprintf("retry timeout: %s", resp.Experiment.Name))
+			t.Fatalf("retry timeout: %s", resp.Experiment.Name)
 		}
 		time.Sleep(time.Second)
 	}


### PR DESCRIPTION
Fix e2e test error when upgrading Go1.24 :
```
# [github.com/bucketeer-io/bucketeer/test/e2e/experiment]
Error: test/e2e/experiment/experiment_test.go:597:13: non-constant format string in call to (*testing.common).Fatalf
Error: test/e2e/experiment/experiment_test.go:656:13: non-constant format string in call to (*testing.common).Fatalf
Error: test/e2e/experiment/experiment_test.go:708:13: non-constant format string in call to (*testing.common).Fatalf
```