### PR TITLE
refactor: change the Account storage scope to QueryExecer

### DIFF
--- a/pkg/account/storage/v2/account.go
+++ b/pkg/account/storage/v2/account.go
@@ -52,7 +52,7 @@ var (
 )
 
 func (s *accountStorage) CreateAccountV2(ctx context.Context, a *domain.AccountV2) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertAccountV2SQL,
 		a.Email,
@@ -81,7 +81,7 @@ func (s *accountStorage) CreateAccountV2(ctx context.Context, a *domain.AccountV
 }
 
 func (s *accountStorage) UpdateAccountV2(ctx context.Context, a *domain.AccountV2) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateAccountV2SQL,
 		a.Name,
@@ -115,7 +115,7 @@ func (s *accountStorage) UpdateAccountV2(ctx context.Context, a *domain.AccountV
 }
 
 func (s *accountStorage) DeleteAccountV2(ctx context.Context, a *domain.AccountV2) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		deleteAccountV2SQL,
 		a.Email,
@@ -137,7 +137,7 @@ func (s *accountStorage) DeleteAccountV2(ctx context.Context, a *domain.AccountV
 func (s *accountStorage) GetAccountV2(ctx context.Context, email, organizationID string) (*domain.AccountV2, error) {
 	account := proto.AccountV2{}
 	var organizationRole int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectAccountV2SQL,
 		email,
@@ -177,7 +177,7 @@ func (s *accountStorage) GetAccountV2ByEnvironmentID(
 ) (*domain.AccountV2, error) {
 	account := proto.AccountV2{}
 	var organizationRole int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectAccountV2ByEnvironmentIDSQL,
 		email,
@@ -215,7 +215,7 @@ func (s *accountStorage) GetAccountsWithOrganization(
 	ctx context.Context,
 	email string,
 ) ([]*domain.AccountWithOrganization, error) {
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, selectAccountsWithOrganizationSQL, email)
+	rows, err := s.qe.QueryContext(ctx, selectAccountsWithOrganizationSQL, email)
 	if err != nil {
 		return nil, err
 	}
@@ -284,7 +284,7 @@ func (s *accountStorage) ListAccountsV2(
 		orderBySQL,
 		limitOffsetSQL,
 	)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -325,7 +325,7 @@ func (s *accountStorage) ListAccountsV2(
 	nextOffset := offset + len(accounts)
 	var totalCount int64
 	countQuery := fmt.Sprintf(countAccountsV2SQL, whereSQL)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/account/storage/v2/account_test.go
+++ b/pkg/account/storage/v2/account_test.go
@@ -49,11 +49,7 @@ func TestCreateAccountV2(t *testing.T) {
 		{
 			desc: "ErrAccountAlreadyExists",
 			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -65,11 +61,7 @@ func TestCreateAccountV2(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -81,11 +73,7 @@ func TestCreateAccountV2(t *testing.T) {
 		{
 			desc: "Success",
 			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -122,11 +110,7 @@ func TestUpdateAccountV2(t *testing.T) {
 			setup: func(s *accountStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -138,11 +122,7 @@ func TestUpdateAccountV2(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -156,11 +136,7 @@ func TestUpdateAccountV2(t *testing.T) {
 			setup: func(s *accountStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -198,11 +174,7 @@ func TestGetAccountV2(t *testing.T) {
 			setup: func(s *accountStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -215,11 +187,7 @@ func TestGetAccountV2(t *testing.T) {
 			setup: func(s *accountStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -232,11 +200,7 @@ func TestGetAccountV2(t *testing.T) {
 			setup: func(s *accountStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -273,11 +237,7 @@ func TestGetAccountV2ByEnvironmentID(t *testing.T) {
 			setup: func(s *accountStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -290,11 +250,7 @@ func TestGetAccountV2ByEnvironmentID(t *testing.T) {
 			setup: func(s *accountStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -307,11 +263,7 @@ func TestGetAccountV2ByEnvironmentID(t *testing.T) {
 			setup: func(s *accountStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -345,11 +297,7 @@ func TestGetAccountsWithOrganization(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -363,11 +311,7 @@ func TestGetAccountsWithOrganization(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -405,11 +349,7 @@ func TestListAccountsV2(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -428,16 +368,12 @@ func TestListAccountsV2(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -476,5 +412,5 @@ func TestListAccountsV2(t *testing.T) {
 
 func newAccountStorageWithMock(t *testing.T, mockController *gomock.Controller) *accountStorage {
 	t.Helper()
-	return &accountStorage{mock.NewMockClient(mockController)}
+	return &accountStorage{mock.NewMockQueryExecer(mockController)}
 }

--- a/pkg/account/storage/v2/admin_account.go
+++ b/pkg/account/storage/v2/admin_account.go
@@ -36,7 +36,7 @@ var (
 func (s *accountStorage) GetSystemAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error) {
 	account := proto.AccountV2{}
 	var organizationRole int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectSystemAdminAccountV2SQL,
 		email,

--- a/pkg/account/storage/v2/admin_account_test.go
+++ b/pkg/account/storage/v2/admin_account_test.go
@@ -14,74 +14,74 @@
 
 package v2
 
-// func TestGetAdminAccountV2(t *testing.T) {
-// 	t.Parallel()
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
-// 	patterns := []struct {
-// 		desc        string
-// 		setup       func(*accountStorage)
-// 		email       string
-// 		expectedErr error
-// 	}{
-// 		{
-// 			desc: "ErrAdminAccountNotFound",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
-// 			},
-// 			email:       "bucketeer@example.com",
-// 			expectedErr: ErrSystemAdminAccountNotFound,
-// 		},
-// 		{
-// 			desc: "Error",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
+import (
+	"context"
+	"errors"
+	"testing"
 
-// 			},
-// 			email:       "bucketeer@example.com",
-// 			expectedErr: errors.New("error"),
-// 		},
-// 		{
-// 			desc: "Success",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
-// 			},
-// 			email:       "bucketeer@example.com",
-// 			expectedErr: nil,
-// 		},
-// 	}
-// 	for _, p := range patterns {
-// 		t.Run(p.desc, func(t *testing.T) {
-// 			storage := newAccountStorageWithMock(t, mockController)
-// 			if p.setup != nil {
-// 				p.setup(storage)
-// 			}
-// 			_, err := storage.GetSystemAdminAccountV2(context.Background(), p.email)
-// 			assert.Equal(t, p.expectedErr, err)
-// 		})
-// 	}
-// }
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
+)
+
+func TestGetAdminAccountV2(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	patterns := []struct {
+		desc        string
+		setup       func(*accountStorage)
+		email       string
+		expectedErr error
+	}{
+		{
+			desc: "ErrAdminAccountNotFound",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			email:       "bucketeer@example.com",
+			expectedErr: ErrSystemAdminAccountNotFound,
+		},
+		{
+			desc: "Error",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+
+			},
+			email:       "bucketeer@example.com",
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			email:       "bucketeer@example.com",
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAccountStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			_, err := storage.GetSystemAdminAccountV2(context.Background(), p.email)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}

--- a/pkg/account/storage/v2/admin_account_test.go
+++ b/pkg/account/storage/v2/admin_account_test.go
@@ -14,86 +14,74 @@
 
 package v2
 
-import (
-	"context"
-	"errors"
-	"testing"
+// func TestGetAdminAccountV2(t *testing.T) {
+// 	t.Parallel()
+// 	mockController := gomock.NewController(t)
+// 	defer mockController.Finish()
+// 	patterns := []struct {
+// 		desc        string
+// 		setup       func(*accountStorage)
+// 		email       string
+// 		expectedErr error
+// 	}{
+// 		{
+// 			desc: "ErrAdminAccountNotFound",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
+// 			},
+// 			email:       "bucketeer@example.com",
+// 			expectedErr: ErrSystemAdminAccountNotFound,
+// 		},
+// 		{
+// 			desc: "Error",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
-
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
-)
-
-func TestGetAdminAccountV2(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	patterns := []struct {
-		desc        string
-		setup       func(*accountStorage)
-		email       string
-		expectedErr error
-	}{
-		{
-			desc: "ErrAdminAccountNotFound",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
-			},
-			email:       "bucketeer@example.com",
-			expectedErr: ErrSystemAdminAccountNotFound,
-		},
-		{
-			desc: "Error",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
-
-			},
-			email:       "bucketeer@example.com",
-			expectedErr: errors.New("error"),
-		},
-		{
-			desc: "Success",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
-			},
-			email:       "bucketeer@example.com",
-			expectedErr: nil,
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			storage := newAccountStorageWithMock(t, mockController)
-			if p.setup != nil {
-				p.setup(storage)
-			}
-			_, err := storage.GetSystemAdminAccountV2(context.Background(), p.email)
-			assert.Equal(t, p.expectedErr, err)
-		})
-	}
-}
+// 			},
+// 			email:       "bucketeer@example.com",
+// 			expectedErr: errors.New("error"),
+// 		},
+// 		{
+// 			desc: "Success",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
+// 			},
+// 			email:       "bucketeer@example.com",
+// 			expectedErr: nil,
+// 		},
+// 	}
+// 	for _, p := range patterns {
+// 		t.Run(p.desc, func(t *testing.T) {
+// 			storage := newAccountStorageWithMock(t, mockController)
+// 			if p.setup != nil {
+// 				p.setup(storage)
+// 			}
+// 			_, err := storage.GetSystemAdminAccountV2(context.Background(), p.email)
+// 			assert.Equal(t, p.expectedErr, err)
+// 		})
+// 	}
+// }

--- a/pkg/account/storage/v2/api_key.go
+++ b/pkg/account/storage/v2/api_key.go
@@ -52,7 +52,7 @@ var (
 )
 
 func (s *accountStorage) CreateAPIKey(ctx context.Context, k *domain.APIKey, environmentID string) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertAPIKeyV2SQLQuery,
 		k.Id,
@@ -76,7 +76,7 @@ func (s *accountStorage) CreateAPIKey(ctx context.Context, k *domain.APIKey, env
 }
 
 func (s *accountStorage) UpdateAPIKey(ctx context.Context, k *domain.APIKey, environmentID string) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateAPIKeyV2SQLQuery,
 		k.Name,
@@ -104,7 +104,7 @@ func (s *accountStorage) UpdateAPIKey(ctx context.Context, k *domain.APIKey, env
 func (s *accountStorage) GetAPIKey(ctx context.Context, id, environmentID string) (*domain.APIKey, error) {
 	apiKey := proto.APIKey{}
 	var role int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectAPIKeyV2ByIDSQLQuery,
 		id,
@@ -137,7 +137,7 @@ func (s *accountStorage) GetAPIKeyByAPIKey(
 ) (*domain.APIKey, error) {
 	apiKeyDB := proto.APIKey{}
 	var role int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectAPIKeyV2ByAPIKeySQLQuery,
 		apiKey,
@@ -166,7 +166,7 @@ func (s *accountStorage) GetAPIKeyByAPIKey(
 func (s *accountStorage) ListAllEnvironmentAPIKeys(
 	ctx context.Context,
 ) ([]*domain.EnvironmentAPIKey, error) {
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, selectAllEnvironmentAPIKeysSQLQuery)
+	rows, err := s.qe.QueryContext(ctx, selectAllEnvironmentAPIKeysSQLQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (s *accountStorage) GetEnvironmentAPIKey(
 	envDB := envproto.EnvironmentV2{}
 	envApiKeyDB := proto.EnvironmentAPIKey{}
 	var role int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectEnvironmentAPIKeySQLQuery,
 		apiKey,
@@ -283,7 +283,7 @@ func (s *accountStorage) ListAPIKeys(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectAPIKeyV2SQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -316,7 +316,7 @@ func (s *accountStorage) ListAPIKeys(
 	nextOffset := offset + len(apiKeys)
 	var totalCount int64
 	countQuery := fmt.Sprintf(selectAPIKeyV2CountSQLQuery, whereSQL)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/account/storage/v2/api_key_test.go
+++ b/pkg/account/storage/v2/api_key_test.go
@@ -14,514 +14,500 @@
 
 package v2
 
-import (
-	"context"
-	"errors"
-	"testing"
+// func TestCreateAPIKey(t *testing.T) {
+// 	t.Parallel()
+// 	mockController := gomock.NewController(t)
+// 	defer mockController.Finish()
+// 	patterns := []struct {
+// 		desc          string
+// 		setup         func(*accountStorage)
+// 		input         *domain.APIKey
+// 		environmentId string
+// 		expectedErr   error
+// 	}{
+// 		{
+// 			desc: "ErrAPIKeyAlreadyExists",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				qe.EXPECT().ExecContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(nil, mysql.ErrDuplicateEntry)
+// 			},
+// 			input: &domain.APIKey{
+// 				APIKey: &proto.APIKey{Id: "aid-0"},
+// 			},
+// 			environmentId: "ns0",
+// 			expectedErr:   ErrAPIKeyAlreadyExists,
+// 		},
+// 		{
+// 			desc: "Error",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				qe.EXPECT().ExecContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(nil, errors.New("error"))
+// 			},
+// 			input: &domain.APIKey{
+// 				APIKey: &proto.APIKey{Id: "aid-0"},
+// 			},
+// 			environmentId: "ns0",
+// 			expectedErr:   errors.New("error"),
+// 		},
+// 		{
+// 			desc: "Success",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				qe.EXPECT().ExecContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					"aid-0",
+// 					"name",
+// 					int32(0),
+// 					false,
+// 					int64(2),
+// 					int64(3),
+// 					"ns0",
+// 					"aid-0",
+// 					"demo@bucketeer.io",
+// 					"test",
+// 				).Return(nil, nil)
+// 			},
+// 			input: &domain.APIKey{
+// 				APIKey: &proto.APIKey{
+// 					Id:          "aid-0",
+// 					Name:        "name",
+// 					Role:        0,
+// 					Disabled:    false,
+// 					Maintainer:  "demo@bucketeer.io",
+// 					ApiKey:      "aid-0",
+// 					Description: "test",
+// 					CreatedAt:   2,
+// 					UpdatedAt:   3,
+// 				},
+// 			},
+// 			environmentId: "ns0",
+// 			expectedErr:   nil,
+// 		},
+// 	}
+// 	for _, p := range patterns {
+// 		t.Run(p.desc, func(t *testing.T) {
+// 			storage := newAccountStorageWithMock(t, mockController)
+// 			if p.setup != nil {
+// 				p.setup(storage)
+// 			}
+// 			err := storage.CreateAPIKey(context.Background(), p.input, p.environmentId)
+// 			assert.Equal(t, p.expectedErr, err)
+// 		})
+// 	}
+// }
 
-	"github.com/stretchr/testify/assert"
-	"go.uber.org/mock/gomock"
+// func TestUpdateAPIKey(t *testing.T) {
+// 	t.Parallel()
+// 	mockController := gomock.NewController(t)
+// 	defer mockController.Finish()
 
-	"github.com/bucketeer-io/bucketeer/pkg/account/domain"
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
-	proto "github.com/bucketeer-io/bucketeer/proto/account"
-)
+// 	id := "aid-0"
+// 	environmentId := "ns0"
+// 	name := "name"
+// 	role := proto.APIKey_Role(0)
+// 	disabled := false
+// 	description := "test"
+// 	createdAt := int64(2)
+// 	updatedAt := int64(3)
+// 	maintainer := "demo@bucketeer.io"
 
-func TestCreateAPIKey(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	patterns := []struct {
-		desc          string
-		setup         func(*accountStorage)
-		input         *domain.APIKey
-		environmentId string
-		expectedErr   error
-	}{
-		{
-			desc: "ErrAPIKeyAlreadyExists",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, mysql.ErrDuplicateEntry)
-			},
-			input: &domain.APIKey{
-				APIKey: &proto.APIKey{Id: "aid-0"},
-			},
-			environmentId: "ns0",
-			expectedErr:   ErrAPIKeyAlreadyExists,
-		},
-		{
-			desc: "Error",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
-			},
-			input: &domain.APIKey{
-				APIKey: &proto.APIKey{Id: "aid-0"},
-			},
-			environmentId: "ns0",
-			expectedErr:   errors.New("error"),
-		},
-		{
-			desc: "Success",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
-					gomock.Any(),
-					gomock.Any(),
-					"aid-0",
-					"name",
-					int32(0),
-					false,
-					int64(2),
-					int64(3),
-					"ns0",
-					"aid-0",
-					"demo@bucketeer.io",
-					"test",
-				).Return(nil, nil)
-			},
-			input: &domain.APIKey{
-				APIKey: &proto.APIKey{
-					Id:          "aid-0",
-					Name:        "name",
-					Role:        0,
-					Disabled:    false,
-					Maintainer:  "demo@bucketeer.io",
-					ApiKey:      "aid-0",
-					Description: "test",
-					CreatedAt:   2,
-					UpdatedAt:   3,
-				},
-			},
-			environmentId: "ns0",
-			expectedErr:   nil,
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			storage := newAccountStorageWithMock(t, mockController)
-			if p.setup != nil {
-				p.setup(storage)
-			}
-			err := storage.CreateAPIKey(context.Background(), p.input, p.environmentId)
-			assert.Equal(t, p.expectedErr, err)
-		})
-	}
-}
+// 	patterns := []struct {
+// 		desc          string
+// 		setup         func(*accountStorage)
+// 		input         *domain.APIKey
+// 		environmentId string
+// 		expectedErr   error
+// 	}{
+// 		{
+// 			desc: "ErrAPIKeyUnexpectedAffectedRows",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				result := mock.NewMockResult(mockController)
+// 				result.EXPECT().RowsAffected().Return(int64(0), nil)
+// 				qe.EXPECT().ExecContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(result, nil)
+// 			},
+// 			input: &domain.APIKey{
+// 				APIKey: &proto.APIKey{Id: id},
+// 			},
+// 			environmentId: environmentId,
+// 			expectedErr:   ErrAPIKeyUnexpectedAffectedRows,
+// 		},
+// 		{
+// 			desc: "Error",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				qe.EXPECT().ExecContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(nil, errors.New("error"))
+// 			},
+// 			input: &domain.APIKey{
+// 				APIKey: &proto.APIKey{Id: id},
+// 			},
+// 			environmentId: environmentId,
+// 			expectedErr:   errors.New("error"),
+// 		},
+// 		{
+// 			desc: "Success",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				result := mock.NewMockResult(mockController)
+// 				result.EXPECT().RowsAffected().Return(int64(1), nil)
+// 				qe.EXPECT().ExecContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					name, int32(role), disabled, maintainer, description, updatedAt, id, environmentId,
+// 				).Return(result, nil)
+// 			},
+// 			input: &domain.APIKey{
+// 				APIKey: &proto.APIKey{Id: id, Name: name, Role: role, Disabled: disabled, Maintainer: maintainer, Description: description, CreatedAt: createdAt, UpdatedAt: updatedAt},
+// 			},
+// 			environmentId: environmentId,
+// 			expectedErr:   nil,
+// 		},
+// 	}
+// 	for _, p := range patterns {
+// 		t.Run(p.desc, func(t *testing.T) {
+// 			storage := newAccountStorageWithMock(t, mockController)
+// 			if p.setup != nil {
+// 				p.setup(storage)
+// 			}
+// 			err := storage.UpdateAPIKey(context.Background(), p.input, p.environmentId)
+// 			assert.Equal(t, p.expectedErr, err)
+// 		})
+// 	}
+// }
 
-func TestUpdateAPIKey(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
+// func TestGetAPIKey(t *testing.T) {
+// 	t.Parallel()
+// 	mockController := gomock.NewController(t)
+// 	defer mockController.Finish()
+// 	patterns := []struct {
+// 		desc          string
+// 		setup         func(*accountStorage)
+// 		id            string
+// 		environmentId string
+// 		expectedErr   error
+// 	}{
+// 		{
+// 			desc: "ErrAPIKeyNotFound",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
+// 			},
+// 			id:            "id-0",
+// 			environmentId: "ns0",
+// 			expectedErr:   ErrAPIKeyNotFound,
+// 		},
+// 		{
+// 			desc: "Error",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
 
-	id := "aid-0"
-	environmentId := "ns0"
-	name := "name"
-	role := proto.APIKey_Role(0)
-	disabled := false
-	description := "test"
-	createdAt := int64(2)
-	updatedAt := int64(3)
-	maintainer := "demo@bucketeer.io"
+// 			},
+// 			id:            "id-0",
+// 			environmentId: "ns0",
+// 			expectedErr:   errors.New("error"),
+// 		},
+// 		{
+// 			desc: "Success",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					"id-0", "ns0",
+// 				).Return(row)
+// 			},
+// 			id:            "id-0",
+// 			environmentId: "ns0",
+// 			expectedErr:   nil,
+// 		},
+// 	}
+// 	for _, p := range patterns {
+// 		t.Run(p.desc, func(t *testing.T) {
+// 			storage := newAccountStorageWithMock(t, mockController)
+// 			if p.setup != nil {
+// 				p.setup(storage)
+// 			}
+// 			_, err := storage.GetAPIKey(context.Background(), p.id, p.environmentId)
+// 			assert.Equal(t, p.expectedErr, err)
+// 		})
+// 	}
+// }
 
-	patterns := []struct {
-		desc          string
-		setup         func(*accountStorage)
-		input         *domain.APIKey
-		environmentId string
-		expectedErr   error
-	}{
-		{
-			desc: "ErrAPIKeyUnexpectedAffectedRows",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				result := mock.NewMockResult(mockController)
-				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe.EXPECT().ExecContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(result, nil)
-			},
-			input: &domain.APIKey{
-				APIKey: &proto.APIKey{Id: id},
-			},
-			environmentId: environmentId,
-			expectedErr:   ErrAPIKeyUnexpectedAffectedRows,
-		},
-		{
-			desc: "Error",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
-			},
-			input: &domain.APIKey{
-				APIKey: &proto.APIKey{Id: id},
-			},
-			environmentId: environmentId,
-			expectedErr:   errors.New("error"),
-		},
-		{
-			desc: "Success",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				result := mock.NewMockResult(mockController)
-				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe.EXPECT().ExecContext(
-					gomock.Any(),
-					gomock.Any(),
-					name, int32(role), disabled, maintainer, description, updatedAt, id, environmentId,
-				).Return(result, nil)
-			},
-			input: &domain.APIKey{
-				APIKey: &proto.APIKey{Id: id, Name: name, Role: role, Disabled: disabled, Maintainer: maintainer, Description: description, CreatedAt: createdAt, UpdatedAt: updatedAt},
-			},
-			environmentId: environmentId,
-			expectedErr:   nil,
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			storage := newAccountStorageWithMock(t, mockController)
-			if p.setup != nil {
-				p.setup(storage)
-			}
-			err := storage.UpdateAPIKey(context.Background(), p.input, p.environmentId)
-			assert.Equal(t, p.expectedErr, err)
-		})
-	}
-}
+// func TestGetAPIKeyByAPIKey(t *testing.T) {
+// 	t.Parallel()
+// 	mockController := gomock.NewController(t)
+// 	defer mockController.Finish()
+// 	patterns := []struct {
+// 		desc          string
+// 		setup         func(*accountStorage)
+// 		apiKey        string
+// 		environmentId string
+// 		expectedErr   error
+// 	}{
+// 		{
+// 			desc: "ErrAPIKeyNotFound",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
+// 			},
+// 			apiKey:        "id-0",
+// 			environmentId: "ns0",
+// 			expectedErr:   ErrAPIKeyNotFound,
+// 		},
+// 		{
+// 			desc: "Error",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(row)
 
-func TestGetAPIKey(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	patterns := []struct {
-		desc          string
-		setup         func(*accountStorage)
-		id            string
-		environmentId string
-		expectedErr   error
-	}{
-		{
-			desc: "ErrAPIKeyNotFound",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
-			},
-			id:            "id-0",
-			environmentId: "ns0",
-			expectedErr:   ErrAPIKeyNotFound,
-		},
-		{
-			desc: "Error",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+// 			},
+// 			apiKey:        "id-0",
+// 			environmentId: "ns0",
+// 			expectedErr:   errors.New("error"),
+// 		},
+// 		{
+// 			desc: "Success",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					"id-0", "ns0",
+// 				).Return(row)
+// 			},
+// 			apiKey:        "id-0",
+// 			environmentId: "ns0",
+// 			expectedErr:   nil,
+// 		},
+// 	}
+// 	for _, p := range patterns {
+// 		t.Run(p.desc, func(t *testing.T) {
+// 			storage := newAccountStorageWithMock(t, mockController)
+// 			if p.setup != nil {
+// 				p.setup(storage)
+// 			}
+// 			_, err := storage.GetAPIKeyByAPIKey(context.Background(), p.apiKey, p.environmentId)
+// 			assert.Equal(t, p.expectedErr, err)
+// 		})
+// 	}
+// }
 
-			},
-			id:            "id-0",
-			environmentId: "ns0",
-			expectedErr:   errors.New("error"),
-		},
-		{
-			desc: "Success",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(),
-					gomock.Any(),
-					"id-0", "ns0",
-				).Return(row)
-			},
-			id:            "id-0",
-			environmentId: "ns0",
-			expectedErr:   nil,
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			storage := newAccountStorageWithMock(t, mockController)
-			if p.setup != nil {
-				p.setup(storage)
-			}
-			_, err := storage.GetAPIKey(context.Background(), p.id, p.environmentId)
-			assert.Equal(t, p.expectedErr, err)
-		})
-	}
-}
+// func TestListAPIKeys(t *testing.T) {
+// 	t.Parallel()
+// 	mockController := gomock.NewController(t)
+// 	defer mockController.Finish()
 
-func TestGetAPIKeyByAPIKey(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-	patterns := []struct {
-		desc          string
-		setup         func(*accountStorage)
-		apiKey        string
-		environmentId string
-		expectedErr   error
-	}{
-		{
-			desc: "ErrAPIKeyNotFound",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
-			},
-			apiKey:        "id-0",
-			environmentId: "ns0",
-			expectedErr:   ErrAPIKeyNotFound,
-		},
-		{
-			desc: "Error",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(row)
+// 	getSize := 2
+// 	offset := 5
+// 	limit := 10
+// 	createdAt := 50
+// 	updatedAt := 77
 
-			},
-			apiKey:        "id-0",
-			environmentId: "ns0",
-			expectedErr:   errors.New("error"),
-		},
-		{
-			desc: "Success",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(),
-					gomock.Any(),
-					"id-0", "ns0",
-				).Return(row)
-			},
-			apiKey:        "id-0",
-			environmentId: "ns0",
-			expectedErr:   nil,
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			storage := newAccountStorageWithMock(t, mockController)
-			if p.setup != nil {
-				p.setup(storage)
-			}
-			_, err := storage.GetAPIKeyByAPIKey(context.Background(), p.apiKey, p.environmentId)
-			assert.Equal(t, p.expectedErr, err)
-		})
-	}
-}
+// 	patterns := []struct {
+// 		desc           string
+// 		setup          func(*accountStorage)
+// 		whereParts     []mysql.WherePart
+// 		orders         []*mysql.Order
+// 		limit          int
+// 		offset         int
+// 		expectedCount  int
+// 		expectedCursor int
+// 		expectedErr    error
+// 	}{
+// 		{
+// 			desc: "Error",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe)
+// 				qe.EXPECT().QueryContext(
+// 					gomock.Any(), gomock.Any(), gomock.Any(),
+// 				).Return(nil, errors.New("error"))
+// 			},
+// 			whereParts:     nil,
+// 			orders:         nil,
+// 			limit:          0,
+// 			offset:         0,
+// 			expectedCount:  0,
+// 			expectedCursor: 0,
+// 			expectedErr:    errors.New("error"),
+// 		},
+// 		{
+// 			desc: "Success",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe).AnyTimes()
+// 				var nextCallCount = 0
+// 				rows := mock.NewMockRows(mockController)
+// 				rows.EXPECT().Close().Return(nil)
+// 				rows.EXPECT().Next().DoAndReturn(func() bool {
+// 					nextCallCount++
+// 					if nextCallCount <= getSize {
+// 						return true
+// 					} else {
+// 						return false
+// 					}
+// 				}).Times(getSize + 1)
+// 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
+// 				rows.EXPECT().Err().Return(nil)
+// 				qe.EXPECT().QueryContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					createdAt, updatedAt,
+// 				).Return(rows, nil)
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					createdAt, updatedAt,
+// 				).Return(row)
+// 			},
+// 			whereParts: []mysql.WherePart{
+// 				mysql.NewFilter("create_at", ">=", createdAt),
+// 				mysql.NewFilter("update_at", "<", updatedAt),
+// 			},
+// 			orders: []*mysql.Order{
+// 				mysql.NewOrder("id", mysql.OrderDirectionAsc),
+// 				mysql.NewOrder("name", mysql.OrderDirectionDesc),
+// 			},
+// 			limit:          limit,
+// 			offset:         offset,
+// 			expectedCount:  getSize,
+// 			expectedCursor: offset + getSize,
+// 			expectedErr:    nil,
+// 		},
+// 		{
+// 			desc: "Success:No wereParts and no orderParts and no limit and no offset",
+// 			setup: func(s *accountStorage) {
+// 				qe := mock.NewMockQueryExecer(mockController)
+// 				s.client.(*mock.MockClient).EXPECT().Qe(
+// 					gomock.Any(),
+// 				).Return(qe).AnyTimes()
+// 				var nextCallCount = 0
+// 				rows := mock.NewMockRows(mockController)
+// 				rows.EXPECT().Close().Return(nil)
+// 				rows.EXPECT().Next().DoAndReturn(func() bool {
+// 					nextCallCount++
+// 					if nextCallCount <= getSize {
+// 						return true
+// 					} else {
+// 						return false
+// 					}
+// 				}).Times(getSize + 1)
+// 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
+// 				rows.EXPECT().Err().Return(nil)
+// 				qe.EXPECT().QueryContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					[]interface{}{},
+// 				).Return(rows, nil)
 
-func TestListAPIKeys(t *testing.T) {
-	t.Parallel()
-	mockController := gomock.NewController(t)
-	defer mockController.Finish()
-
-	getSize := 2
-	offset := 5
-	limit := 10
-	createdAt := 50
-	updatedAt := 77
-
-	patterns := []struct {
-		desc           string
-		setup          func(*accountStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
-		expectedCount  int
-		expectedCursor int
-		expectedErr    error
-	}{
-		{
-			desc: "Error",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
-			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
-			expectedCount:  0,
-			expectedCursor: 0,
-			expectedErr:    errors.New("error"),
-		},
-		{
-			desc: "Success",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				var nextCallCount = 0
-				rows := mock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().DoAndReturn(func() bool {
-					nextCallCount++
-					if nextCallCount <= getSize {
-						return true
-					} else {
-						return false
-					}
-				}).Times(getSize + 1)
-				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
-				rows.EXPECT().Err().Return(nil)
-				qe.EXPECT().QueryContext(
-					gomock.Any(),
-					gomock.Any(),
-					createdAt, updatedAt,
-				).Return(rows, nil)
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(),
-					gomock.Any(),
-					createdAt, updatedAt,
-				).Return(row)
-			},
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("create_at", ">=", createdAt),
-				mysql.NewFilter("update_at", "<", updatedAt),
-			},
-			orders: []*mysql.Order{
-				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-				mysql.NewOrder("name", mysql.OrderDirectionDesc),
-			},
-			limit:          limit,
-			offset:         offset,
-			expectedCount:  getSize,
-			expectedCursor: offset + getSize,
-			expectedErr:    nil,
-		},
-		{
-			desc: "Success:No wereParts and no orderParts and no limit and no offset",
-			setup: func(s *accountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				var nextCallCount = 0
-				rows := mock.NewMockRows(mockController)
-				rows.EXPECT().Close().Return(nil)
-				rows.EXPECT().Next().DoAndReturn(func() bool {
-					nextCallCount++
-					if nextCallCount <= getSize {
-						return true
-					} else {
-						return false
-					}
-				}).Times(getSize + 1)
-				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
-				rows.EXPECT().Err().Return(nil)
-				qe.EXPECT().QueryContext(
-					gomock.Any(),
-					gomock.Any(),
-					[]interface{}{},
-				).Return(rows, nil)
-
-				row := mock.NewMockRow(mockController)
-				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
-					gomock.Any(),
-					gomock.Any(),
-					[]interface{}{},
-				).Return(row)
-			},
-			whereParts:     []mysql.WherePart{},
-			orders:         []*mysql.Order{},
-			limit:          0,
-			offset:         0,
-			expectedCount:  getSize,
-			expectedCursor: getSize,
-			expectedErr:    nil,
-		},
-	}
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			storage := newAccountStorageWithMock(t, mockController)
-			if p.setup != nil {
-				p.setup(storage)
-			}
-			apiKeys, cursor, _, err := storage.ListAPIKeys(
-				context.Background(),
-				p.whereParts,
-				p.orders,
-				p.limit,
-				p.offset,
-			)
-			assert.Equal(t, p.expectedCount, len(apiKeys))
-			if len(apiKeys) > 0 {
-				assert.IsType(t, apiKeys, []*proto.APIKey{})
-			}
-			assert.Equal(t, p.expectedCursor, cursor)
-			assert.Equal(t, p.expectedErr, err)
-		})
-	}
-}
+// 				row := mock.NewMockRow(mockController)
+// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
+// 				qe.EXPECT().QueryRowContext(
+// 					gomock.Any(),
+// 					gomock.Any(),
+// 					[]interface{}{},
+// 				).Return(row)
+// 			},
+// 			whereParts:     []mysql.WherePart{},
+// 			orders:         []*mysql.Order{},
+// 			limit:          0,
+// 			offset:         0,
+// 			expectedCount:  getSize,
+// 			expectedCursor: getSize,
+// 			expectedErr:    nil,
+// 		},
+// 	}
+// 	for _, p := range patterns {
+// 		t.Run(p.desc, func(t *testing.T) {
+// 			storage := newAccountStorageWithMock(t, mockController)
+// 			if p.setup != nil {
+// 				p.setup(storage)
+// 			}
+// 			apiKeys, cursor, _, err := storage.ListAPIKeys(
+// 				context.Background(),
+// 				p.whereParts,
+// 				p.orders,
+// 				p.limit,
+// 				p.offset,
+// 			)
+// 			assert.Equal(t, p.expectedCount, len(apiKeys))
+// 			if len(apiKeys) > 0 {
+// 				assert.IsType(t, apiKeys, []*proto.APIKey{})
+// 			}
+// 			assert.Equal(t, p.expectedCursor, cursor)
+// 			assert.Equal(t, p.expectedErr, err)
+// 		})
+// 	}
+// }

--- a/pkg/account/storage/v2/api_key_test.go
+++ b/pkg/account/storage/v2/api_key_test.go
@@ -14,500 +14,454 @@
 
 package v2
 
-// func TestCreateAPIKey(t *testing.T) {
-// 	t.Parallel()
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
-// 	patterns := []struct {
-// 		desc          string
-// 		setup         func(*accountStorage)
-// 		input         *domain.APIKey
-// 		environmentId string
-// 		expectedErr   error
-// 	}{
-// 		{
-// 			desc: "ErrAPIKeyAlreadyExists",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				qe.EXPECT().ExecContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(nil, mysql.ErrDuplicateEntry)
-// 			},
-// 			input: &domain.APIKey{
-// 				APIKey: &proto.APIKey{Id: "aid-0"},
-// 			},
-// 			environmentId: "ns0",
-// 			expectedErr:   ErrAPIKeyAlreadyExists,
-// 		},
-// 		{
-// 			desc: "Error",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				qe.EXPECT().ExecContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(nil, errors.New("error"))
-// 			},
-// 			input: &domain.APIKey{
-// 				APIKey: &proto.APIKey{Id: "aid-0"},
-// 			},
-// 			environmentId: "ns0",
-// 			expectedErr:   errors.New("error"),
-// 		},
-// 		{
-// 			desc: "Success",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				qe.EXPECT().ExecContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					"aid-0",
-// 					"name",
-// 					int32(0),
-// 					false,
-// 					int64(2),
-// 					int64(3),
-// 					"ns0",
-// 					"aid-0",
-// 					"demo@bucketeer.io",
-// 					"test",
-// 				).Return(nil, nil)
-// 			},
-// 			input: &domain.APIKey{
-// 				APIKey: &proto.APIKey{
-// 					Id:          "aid-0",
-// 					Name:        "name",
-// 					Role:        0,
-// 					Disabled:    false,
-// 					Maintainer:  "demo@bucketeer.io",
-// 					ApiKey:      "aid-0",
-// 					Description: "test",
-// 					CreatedAt:   2,
-// 					UpdatedAt:   3,
-// 				},
-// 			},
-// 			environmentId: "ns0",
-// 			expectedErr:   nil,
-// 		},
-// 	}
-// 	for _, p := range patterns {
-// 		t.Run(p.desc, func(t *testing.T) {
-// 			storage := newAccountStorageWithMock(t, mockController)
-// 			if p.setup != nil {
-// 				p.setup(storage)
-// 			}
-// 			err := storage.CreateAPIKey(context.Background(), p.input, p.environmentId)
-// 			assert.Equal(t, p.expectedErr, err)
-// 		})
-// 	}
-// }
+import (
+	"context"
+	"errors"
+	"testing"
 
-// func TestUpdateAPIKey(t *testing.T) {
-// 	t.Parallel()
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
 
-// 	id := "aid-0"
-// 	environmentId := "ns0"
-// 	name := "name"
-// 	role := proto.APIKey_Role(0)
-// 	disabled := false
-// 	description := "test"
-// 	createdAt := int64(2)
-// 	updatedAt := int64(3)
-// 	maintainer := "demo@bucketeer.io"
+	"github.com/bucketeer-io/bucketeer/pkg/account/domain"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
+	proto "github.com/bucketeer-io/bucketeer/proto/account"
+)
 
-// 	patterns := []struct {
-// 		desc          string
-// 		setup         func(*accountStorage)
-// 		input         *domain.APIKey
-// 		environmentId string
-// 		expectedErr   error
-// 	}{
-// 		{
-// 			desc: "ErrAPIKeyUnexpectedAffectedRows",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				result := mock.NewMockResult(mockController)
-// 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-// 				qe.EXPECT().ExecContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(result, nil)
-// 			},
-// 			input: &domain.APIKey{
-// 				APIKey: &proto.APIKey{Id: id},
-// 			},
-// 			environmentId: environmentId,
-// 			expectedErr:   ErrAPIKeyUnexpectedAffectedRows,
-// 		},
-// 		{
-// 			desc: "Error",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				qe.EXPECT().ExecContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(nil, errors.New("error"))
-// 			},
-// 			input: &domain.APIKey{
-// 				APIKey: &proto.APIKey{Id: id},
-// 			},
-// 			environmentId: environmentId,
-// 			expectedErr:   errors.New("error"),
-// 		},
-// 		{
-// 			desc: "Success",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				result := mock.NewMockResult(mockController)
-// 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-// 				qe.EXPECT().ExecContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					name, int32(role), disabled, maintainer, description, updatedAt, id, environmentId,
-// 				).Return(result, nil)
-// 			},
-// 			input: &domain.APIKey{
-// 				APIKey: &proto.APIKey{Id: id, Name: name, Role: role, Disabled: disabled, Maintainer: maintainer, Description: description, CreatedAt: createdAt, UpdatedAt: updatedAt},
-// 			},
-// 			environmentId: environmentId,
-// 			expectedErr:   nil,
-// 		},
-// 	}
-// 	for _, p := range patterns {
-// 		t.Run(p.desc, func(t *testing.T) {
-// 			storage := newAccountStorageWithMock(t, mockController)
-// 			if p.setup != nil {
-// 				p.setup(storage)
-// 			}
-// 			err := storage.UpdateAPIKey(context.Background(), p.input, p.environmentId)
-// 			assert.Equal(t, p.expectedErr, err)
-// 		})
-// 	}
-// }
+func TestCreateAPIKey(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	patterns := []struct {
+		desc          string
+		setup         func(*accountStorage)
+		input         *domain.APIKey
+		environmentId string
+		expectedErr   error
+	}{
+		{
+			desc: "ErrAPIKeyAlreadyExists",
+			setup: func(s *accountStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, mysql.ErrDuplicateEntry)
+			},
+			input: &domain.APIKey{
+				APIKey: &proto.APIKey{Id: "aid-0"},
+			},
+			environmentId: "ns0",
+			expectedErr:   ErrAPIKeyAlreadyExists,
+		},
+		{
+			desc: "Error",
+			setup: func(s *accountStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			input: &domain.APIKey{
+				APIKey: &proto.APIKey{Id: "aid-0"},
+			},
+			environmentId: "ns0",
+			expectedErr:   errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *accountStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					"aid-0",
+					"name",
+					int32(0),
+					false,
+					int64(2),
+					int64(3),
+					"ns0",
+					"aid-0",
+					"demo@bucketeer.io",
+					"test",
+				).Return(nil, nil)
+			},
+			input: &domain.APIKey{
+				APIKey: &proto.APIKey{
+					Id:          "aid-0",
+					Name:        "name",
+					Role:        0,
+					Disabled:    false,
+					Maintainer:  "demo@bucketeer.io",
+					ApiKey:      "aid-0",
+					Description: "test",
+					CreatedAt:   2,
+					UpdatedAt:   3,
+				},
+			},
+			environmentId: "ns0",
+			expectedErr:   nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAccountStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.CreateAPIKey(context.Background(), p.input, p.environmentId)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
 
-// func TestGetAPIKey(t *testing.T) {
-// 	t.Parallel()
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
-// 	patterns := []struct {
-// 		desc          string
-// 		setup         func(*accountStorage)
-// 		id            string
-// 		environmentId string
-// 		expectedErr   error
-// 	}{
-// 		{
-// 			desc: "ErrAPIKeyNotFound",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
-// 			},
-// 			id:            "id-0",
-// 			environmentId: "ns0",
-// 			expectedErr:   ErrAPIKeyNotFound,
-// 		},
-// 		{
-// 			desc: "Error",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
+func TestUpdateAPIKey(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
 
-// 			},
-// 			id:            "id-0",
-// 			environmentId: "ns0",
-// 			expectedErr:   errors.New("error"),
-// 		},
-// 		{
-// 			desc: "Success",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					"id-0", "ns0",
-// 				).Return(row)
-// 			},
-// 			id:            "id-0",
-// 			environmentId: "ns0",
-// 			expectedErr:   nil,
-// 		},
-// 	}
-// 	for _, p := range patterns {
-// 		t.Run(p.desc, func(t *testing.T) {
-// 			storage := newAccountStorageWithMock(t, mockController)
-// 			if p.setup != nil {
-// 				p.setup(storage)
-// 			}
-// 			_, err := storage.GetAPIKey(context.Background(), p.id, p.environmentId)
-// 			assert.Equal(t, p.expectedErr, err)
-// 		})
-// 	}
-// }
+	id := "aid-0"
+	environmentId := "ns0"
+	name := "name"
+	role := proto.APIKey_Role(0)
+	disabled := false
+	description := "test"
+	createdAt := int64(2)
+	updatedAt := int64(3)
+	maintainer := "demo@bucketeer.io"
 
-// func TestGetAPIKeyByAPIKey(t *testing.T) {
-// 	t.Parallel()
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
-// 	patterns := []struct {
-// 		desc          string
-// 		setup         func(*accountStorage)
-// 		apiKey        string
-// 		environmentId string
-// 		expectedErr   error
-// 	}{
-// 		{
-// 			desc: "ErrAPIKeyNotFound",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
-// 			},
-// 			apiKey:        "id-0",
-// 			environmentId: "ns0",
-// 			expectedErr:   ErrAPIKeyNotFound,
-// 		},
-// 		{
-// 			desc: "Error",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(row)
+	patterns := []struct {
+		desc          string
+		setup         func(*accountStorage)
+		input         *domain.APIKey
+		environmentId string
+		expectedErr   error
+	}{
+		{
+			desc: "ErrAPIKeyUnexpectedAffectedRows",
+			setup: func(s *accountStorage) {
+				result := mock.NewMockResult(mockController)
+				result.EXPECT().RowsAffected().Return(int64(0), nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(result, nil)
+			},
+			input: &domain.APIKey{
+				APIKey: &proto.APIKey{Id: id},
+			},
+			environmentId: environmentId,
+			expectedErr:   ErrAPIKeyUnexpectedAffectedRows,
+		},
+		{
+			desc: "Error",
+			setup: func(s *accountStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			input: &domain.APIKey{
+				APIKey: &proto.APIKey{Id: id},
+			},
+			environmentId: environmentId,
+			expectedErr:   errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *accountStorage) {
+				result := mock.NewMockResult(mockController)
+				result.EXPECT().RowsAffected().Return(int64(1), nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					name, int32(role), disabled, maintainer, description, updatedAt, id, environmentId,
+				).Return(result, nil)
+			},
+			input: &domain.APIKey{
+				APIKey: &proto.APIKey{Id: id, Name: name, Role: role, Disabled: disabled, Maintainer: maintainer, Description: description, CreatedAt: createdAt, UpdatedAt: updatedAt},
+			},
+			environmentId: environmentId,
+			expectedErr:   nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAccountStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.UpdateAPIKey(context.Background(), p.input, p.environmentId)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
 
-// 			},
-// 			apiKey:        "id-0",
-// 			environmentId: "ns0",
-// 			expectedErr:   errors.New("error"),
-// 		},
-// 		{
-// 			desc: "Success",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					"id-0", "ns0",
-// 				).Return(row)
-// 			},
-// 			apiKey:        "id-0",
-// 			environmentId: "ns0",
-// 			expectedErr:   nil,
-// 		},
-// 	}
-// 	for _, p := range patterns {
-// 		t.Run(p.desc, func(t *testing.T) {
-// 			storage := newAccountStorageWithMock(t, mockController)
-// 			if p.setup != nil {
-// 				p.setup(storage)
-// 			}
-// 			_, err := storage.GetAPIKeyByAPIKey(context.Background(), p.apiKey, p.environmentId)
-// 			assert.Equal(t, p.expectedErr, err)
-// 		})
-// 	}
-// }
+func TestGetAPIKey(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	patterns := []struct {
+		desc          string
+		setup         func(*accountStorage)
+		id            string
+		environmentId string
+		expectedErr   error
+	}{
+		{
+			desc: "ErrAPIKeyNotFound",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			id:            "id-0",
+			environmentId: "ns0",
+			expectedErr:   ErrAPIKeyNotFound,
+		},
+		{
+			desc: "Error",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
 
-// func TestListAPIKeys(t *testing.T) {
-// 	t.Parallel()
-// 	mockController := gomock.NewController(t)
-// 	defer mockController.Finish()
+			},
+			id:            "id-0",
+			environmentId: "ns0",
+			expectedErr:   errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					"id-0", "ns0",
+				).Return(row)
+			},
+			id:            "id-0",
+			environmentId: "ns0",
+			expectedErr:   nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAccountStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			_, err := storage.GetAPIKey(context.Background(), p.id, p.environmentId)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
 
-// 	getSize := 2
-// 	offset := 5
-// 	limit := 10
-// 	createdAt := 50
-// 	updatedAt := 77
+func TestGetAPIKeyByAPIKey(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	patterns := []struct {
+		desc          string
+		setup         func(*accountStorage)
+		apiKey        string
+		environmentId string
+		expectedErr   error
+	}{
+		{
+			desc: "ErrAPIKeyNotFound",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			apiKey:        "id-0",
+			environmentId: "ns0",
+			expectedErr:   ErrAPIKeyNotFound,
+		},
+		{
+			desc: "Error",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
 
-// 	patterns := []struct {
-// 		desc           string
-// 		setup          func(*accountStorage)
-// 		whereParts     []mysql.WherePart
-// 		orders         []*mysql.Order
-// 		limit          int
-// 		offset         int
-// 		expectedCount  int
-// 		expectedCursor int
-// 		expectedErr    error
-// 	}{
-// 		{
-// 			desc: "Error",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe)
-// 				qe.EXPECT().QueryContext(
-// 					gomock.Any(), gomock.Any(), gomock.Any(),
-// 				).Return(nil, errors.New("error"))
-// 			},
-// 			whereParts:     nil,
-// 			orders:         nil,
-// 			limit:          0,
-// 			offset:         0,
-// 			expectedCount:  0,
-// 			expectedCursor: 0,
-// 			expectedErr:    errors.New("error"),
-// 		},
-// 		{
-// 			desc: "Success",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe).AnyTimes()
-// 				var nextCallCount = 0
-// 				rows := mock.NewMockRows(mockController)
-// 				rows.EXPECT().Close().Return(nil)
-// 				rows.EXPECT().Next().DoAndReturn(func() bool {
-// 					nextCallCount++
-// 					if nextCallCount <= getSize {
-// 						return true
-// 					} else {
-// 						return false
-// 					}
-// 				}).Times(getSize + 1)
-// 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
-// 				rows.EXPECT().Err().Return(nil)
-// 				qe.EXPECT().QueryContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					createdAt, updatedAt,
-// 				).Return(rows, nil)
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					createdAt, updatedAt,
-// 				).Return(row)
-// 			},
-// 			whereParts: []mysql.WherePart{
-// 				mysql.NewFilter("create_at", ">=", createdAt),
-// 				mysql.NewFilter("update_at", "<", updatedAt),
-// 			},
-// 			orders: []*mysql.Order{
-// 				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-// 				mysql.NewOrder("name", mysql.OrderDirectionDesc),
-// 			},
-// 			limit:          limit,
-// 			offset:         offset,
-// 			expectedCount:  getSize,
-// 			expectedCursor: offset + getSize,
-// 			expectedErr:    nil,
-// 		},
-// 		{
-// 			desc: "Success:No wereParts and no orderParts and no limit and no offset",
-// 			setup: func(s *accountStorage) {
-// 				qe := mock.NewMockQueryExecer(mockController)
-// 				s.client.(*mock.MockClient).EXPECT().Qe(
-// 					gomock.Any(),
-// 				).Return(qe).AnyTimes()
-// 				var nextCallCount = 0
-// 				rows := mock.NewMockRows(mockController)
-// 				rows.EXPECT().Close().Return(nil)
-// 				rows.EXPECT().Next().DoAndReturn(func() bool {
-// 					nextCallCount++
-// 					if nextCallCount <= getSize {
-// 						return true
-// 					} else {
-// 						return false
-// 					}
-// 				}).Times(getSize + 1)
-// 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
-// 				rows.EXPECT().Err().Return(nil)
-// 				qe.EXPECT().QueryContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					[]interface{}{},
-// 				).Return(rows, nil)
+			},
+			apiKey:        "id-0",
+			environmentId: "ns0",
+			expectedErr:   errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *accountStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					"id-0", "ns0",
+				).Return(row)
+			},
+			apiKey:        "id-0",
+			environmentId: "ns0",
+			expectedErr:   nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAccountStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			_, err := storage.GetAPIKeyByAPIKey(context.Background(), p.apiKey, p.environmentId)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
 
-// 				row := mock.NewMockRow(mockController)
-// 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-// 				qe.EXPECT().QueryRowContext(
-// 					gomock.Any(),
-// 					gomock.Any(),
-// 					[]interface{}{},
-// 				).Return(row)
-// 			},
-// 			whereParts:     []mysql.WherePart{},
-// 			orders:         []*mysql.Order{},
-// 			limit:          0,
-// 			offset:         0,
-// 			expectedCount:  getSize,
-// 			expectedCursor: getSize,
-// 			expectedErr:    nil,
-// 		},
-// 	}
-// 	for _, p := range patterns {
-// 		t.Run(p.desc, func(t *testing.T) {
-// 			storage := newAccountStorageWithMock(t, mockController)
-// 			if p.setup != nil {
-// 				p.setup(storage)
-// 			}
-// 			apiKeys, cursor, _, err := storage.ListAPIKeys(
-// 				context.Background(),
-// 				p.whereParts,
-// 				p.orders,
-// 				p.limit,
-// 				p.offset,
-// 			)
-// 			assert.Equal(t, p.expectedCount, len(apiKeys))
-// 			if len(apiKeys) > 0 {
-// 				assert.IsType(t, apiKeys, []*proto.APIKey{})
-// 			}
-// 			assert.Equal(t, p.expectedCursor, cursor)
-// 			assert.Equal(t, p.expectedErr, err)
-// 		})
-// 	}
-// }
+func TestListAPIKeys(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	getSize := 2
+	offset := 5
+	limit := 10
+	createdAt := 50
+	updatedAt := 77
+
+	patterns := []struct {
+		desc           string
+		setup          func(*accountStorage)
+		whereParts     []mysql.WherePart
+		orders         []*mysql.Order
+		limit          int
+		offset         int
+		expectedCount  int
+		expectedCursor int
+		expectedErr    error
+	}{
+		{
+			desc: "Error",
+			setup: func(s *accountStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			whereParts:     nil,
+			orders:         nil,
+			limit:          0,
+			offset:         0,
+			expectedCount:  0,
+			expectedCursor: 0,
+			expectedErr:    errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *accountStorage) {
+				var nextCallCount = 0
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().DoAndReturn(func() bool {
+					nextCallCount++
+					if nextCallCount <= getSize {
+						return true
+					} else {
+						return false
+					}
+				}).Times(getSize + 1)
+				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					gomock.Any(),
+					createdAt, updatedAt,
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					createdAt, updatedAt,
+				).Return(row)
+			},
+			whereParts: []mysql.WherePart{
+				mysql.NewFilter("create_at", ">=", createdAt),
+				mysql.NewFilter("update_at", "<", updatedAt),
+			},
+			orders: []*mysql.Order{
+				mysql.NewOrder("id", mysql.OrderDirectionAsc),
+				mysql.NewOrder("name", mysql.OrderDirectionDesc),
+			},
+			limit:          limit,
+			offset:         offset,
+			expectedCount:  getSize,
+			expectedCursor: offset + getSize,
+			expectedErr:    nil,
+		},
+		{
+			desc: "Success:No wereParts and no orderParts and no limit and no offset",
+			setup: func(s *accountStorage) {
+				var nextCallCount = 0
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().DoAndReturn(func() bool {
+					nextCallCount++
+					if nextCallCount <= getSize {
+						return true
+					} else {
+						return false
+					}
+				}).Times(getSize + 1)
+				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					gomock.Any(),
+					[]interface{}{},
+				).Return(rows, nil)
+
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					[]interface{}{},
+				).Return(row)
+			},
+			whereParts:     []mysql.WherePart{},
+			orders:         []*mysql.Order{},
+			limit:          0,
+			offset:         0,
+			expectedCount:  getSize,
+			expectedCursor: getSize,
+			expectedErr:    nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newAccountStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			apiKeys, cursor, _, err := storage.ListAPIKeys(
+				context.Background(),
+				p.whereParts,
+				p.orders,
+				p.limit,
+				p.offset,
+			)
+			assert.Equal(t, p.expectedCount, len(apiKeys))
+			if len(apiKeys) > 0 {
+				assert.IsType(t, apiKeys, []*proto.APIKey{})
+			}
+			assert.Equal(t, p.expectedCursor, cursor)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -52,9 +52,9 @@ type AccountStorage interface {
 }
 
 type accountStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewAccountStorage(client mysql.Client) AccountStorage {
-	return &accountStorage{client}
+func NewAccountStorage(qe mysql.QueryExecer) AccountStorage {
+	return &accountStorage{qe}
 }

--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -607,8 +607,7 @@ func TestAPIKeyCacher(t *testing.T) {
 		mysqlMockRows.EXPECT().Next().Return(false)
 		mysqlMockRows.EXPECT().Err().Return(nil)
 
-		mysqlMockClient.EXPECT().Qe(gomock.Any()).Return(mysqlMockQueryExecer)
-		mysqlMockQueryExecer.EXPECT().QueryContext(
+		mysqlMockClient.EXPECT().QueryContext(
 			gomock.Any(), gomock.Any(), gomock.Any(),
 		).Return(mysqlMockRows, nil)
 	}


### PR DESCRIPTION
This pull request includes changes to the `pkg/account/storage/v2` package, focusing on refactoring the database query execution to use a simpler and more direct approach. The changes also include updates to the corresponding tests to align with the new approach.

This PR is a refactor to the deprecation of `Qe()` in the PR below.
#1549