### PR TITLE
fix(ui): add error message when trying to delete a variation in use

### DIFF
--- a/ui/web-v2/src/assets/lang/en.json
+++ b/ui/web-v2/src/assets/lang/en.json
@@ -383,6 +383,7 @@
   "feature.variationSettings.bothVariations": "This variation cannot be deleted because it is used in the default and the off-variation settings.",
   "feature.variationSettings.defaultStrategy": "This variation cannot be deleted because it is used in the default variation settings.",
   "feature.variationSettings.offVariation": "This variation cannot be deleted because it is used in the off-variation settings.",
+  "feature.variationSettings.targetingRule": "This variation cannot be deleted because it is used in the targeting rules.",
   "feature.variationType": "Flag type",
   "fileUpload.browseFiles": "Browse files",
   "fileUpload.fileFormat": "Accepted file type: .json",

--- a/ui/web-v2/src/assets/lang/ja.json
+++ b/ui/web-v2/src/assets/lang/ja.json
@@ -383,6 +383,7 @@
   "feature.variationSettings.bothVariations": "このバリエーションは、デフォルトおよびオフバリエーション設定で使用されているため、削除できません。",
   "feature.variationSettings.defaultStrategy": "このバリエーションはデフォルトバリエーション設定で使用されているため、削除できません。",
   "feature.variationSettings.offVariation": "このバリエーションはオフバリエーション設定で使用されているため、削除できません。",
+  "feature.variationSettings.targetingRule": "このバリエーションはターゲティングルールで使用されているため、削除できません。",
   "feature.variationType": "フラグの型",
   "fileUpload.browseFiles": "ファイルを選択",
   "fileUpload.fileFormat": "ファイルタイプ: .json",

--- a/ui/web-v2/src/lang/messages.ts
+++ b/ui/web-v2/src/lang/messages.ts
@@ -1967,6 +1967,11 @@ export const messages = {
         id: 'feature.variationSettings.bothVariations',
         defaultMessage:
           'This variation cannot be deleted because it is used in the default and the off-variation settings.'
+      }),
+      targetingRule: defineMessage({
+        id: 'feature.variationSettings.targetingRule',
+        defaultMessage:
+          'This variation cannot be deleted because it is used in the targeting rules.'
       })
     },
     evaluation: {


### PR DESCRIPTION
fix #1257 

- Added support for validation of variations used in targeting rules.

When the rule in use,
![スクリーンショット 2025-03-17 午後2 08 20](https://github.com/user-attachments/assets/cbf63382-f28e-4d31-9f81-906912cbc3b4)

In English
![スクリーンショット 2025-03-17 午後2 08 07](https://github.com/user-attachments/assets/43e50e81-51b7-4df0-8780-9d65136e2e9a)

In Japanese
![スクリーンショット 2025-03-17 午後2 07 33](https://github.com/user-attachments/assets/da29fb2f-4caf-43c7-a808-2bde509a8d7d)
