### PR TITLE
refactor: change the AutoOps storage scope to QueryExecer

### DIFF
--- a/pkg/autoops/storage/v2/auto_ops_rule.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule.go
@@ -53,11 +53,11 @@ type AutoOpsRuleStorage interface {
 }
 
 type autoOpsRuleStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewAutoOpsRuleStorage(client mysql.Client) AutoOpsRuleStorage {
-	return &autoOpsRuleStorage{client: client}
+func NewAutoOpsRuleStorage(qe mysql.QueryExecer) AutoOpsRuleStorage {
+	return &autoOpsRuleStorage{qe: qe}
 }
 
 func (s *autoOpsRuleStorage) CreateAutoOpsRule(
@@ -65,7 +65,7 @@ func (s *autoOpsRuleStorage) CreateAutoOpsRule(
 	e *domain.AutoOpsRule,
 	environmentId string,
 ) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertAutoOpsRuleSQL,
 		e.Id,
@@ -92,7 +92,7 @@ func (s *autoOpsRuleStorage) UpdateAutoOpsRule(
 	e *domain.AutoOpsRule,
 	environmentId string,
 ) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateAutoOpsRuleSQL,
 		e.FeatureId,
@@ -124,7 +124,7 @@ func (s *autoOpsRuleStorage) GetAutoOpsRule(
 ) (*domain.AutoOpsRule, error) {
 	autoOpsRule := proto.AutoOpsRule{}
 	var opsType int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectAutoOpsRuleSQL,
 		id,
@@ -155,7 +155,7 @@ func (s *autoOpsRuleStorage) ListAutoOpsRules(
 	options *mysql.ListOptions,
 ) ([]*proto.AutoOpsRule, int, error) {
 	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectAutoOpsRulesSQL, options)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -50,11 +50,7 @@ func TestCreateAutoOpsRule(t *testing.T) {
 	}{
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -66,11 +62,7 @@ func TestCreateAutoOpsRule(t *testing.T) {
 		},
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -106,11 +98,7 @@ func TestUpdateAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -124,11 +112,7 @@ func TestUpdateAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -165,11 +149,7 @@ func TestGetAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -182,11 +162,7 @@ func TestGetAutoOpsRule(t *testing.T) {
 			setup: func(s *autoOpsRuleStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -221,11 +197,7 @@ func TestListAutoOpsRules(t *testing.T) {
 	}{
 		{
 			setup: func(s *autoOpsRuleStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -240,11 +212,7 @@ func TestListAutoOpsRules(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -291,5 +259,5 @@ func TestListAutoOpsRules(t *testing.T) {
 
 func newAutoOpsRuleStorageWithMock(t *testing.T, mockController *gomock.Controller) *autoOpsRuleStorage {
 	t.Helper()
-	return &autoOpsRuleStorage{mock.NewMockClient(mockController)}
+	return &autoOpsRuleStorage{mock.NewMockQueryExecer(mockController)}
 }

--- a/pkg/autoops/storage/v2/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/progressive_rollout.go
@@ -47,7 +47,7 @@ var (
 )
 
 type progressiveRolloutStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
 type ProgressiveRolloutStorage interface {
@@ -68,8 +68,8 @@ type ProgressiveRolloutStorage interface {
 	) error
 }
 
-func NewProgressiveRolloutStorage(client mysql.Client) ProgressiveRolloutStorage {
-	return &progressiveRolloutStorage{client: client}
+func NewProgressiveRolloutStorage(qe mysql.QueryExecer) ProgressiveRolloutStorage {
+	return &progressiveRolloutStorage{qe: qe}
 }
 
 func (s *progressiveRolloutStorage) CreateProgressiveRollout(
@@ -77,7 +77,7 @@ func (s *progressiveRolloutStorage) CreateProgressiveRollout(
 	progressiveRollout *domain.ProgressiveRollout,
 	environmentId string,
 ) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertOpsProgressiveRolloutSQL,
 		progressiveRollout.Id,
@@ -105,7 +105,7 @@ func (s *progressiveRolloutStorage) GetProgressiveRollout(
 	id, environmentId string,
 ) (*domain.ProgressiveRollout, error) {
 	progressiveRollout := autoopsproto.ProgressiveRollout{}
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectOpsProgressiveRolloutSQL,
 		id,
@@ -134,7 +134,7 @@ func (s *progressiveRolloutStorage) DeleteProgressiveRollout(
 	ctx context.Context,
 	id, environmentId string,
 ) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		deleteOpsProgressiveRolloutSQL,
 		id,
@@ -158,7 +158,7 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	options *mysql.ListOptions,
 ) ([]*autoopsproto.ProgressiveRollout, int64, int, error) {
 	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectOpsProgressiveRolloutsSQL, options)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -192,7 +192,7 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	nextOffset := offset + len(progressiveRollouts)
 	var totalCount int64
 	countQuery, whereArgs := mysql.ConstructQueryAndWhereArgs(countOpsProgressiveRolloutsSQL, options)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -204,7 +204,7 @@ func (s *progressiveRolloutStorage) UpdateProgressiveRollout(
 	progressiveRollout *domain.ProgressiveRollout,
 	environmentId string,
 ) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateOpsProgressiveRolloutSQL,
 		&progressiveRollout.FeatureId,

--- a/pkg/autoops/storage/v2/progressive_rollout_test.go
+++ b/pkg/autoops/storage/v2/progressive_rollout_test.go
@@ -51,12 +51,7 @@ func TestCreateProgressiveRollout(t *testing.T) {
 		{
 			desc: "error",
 			setup: func(s *progressiveRolloutStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -69,12 +64,7 @@ func TestCreateProgressiveRollout(t *testing.T) {
 		{
 			desc: "success",
 			setup: func(s *progressiveRolloutStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -110,11 +100,7 @@ func TestListProgressiveRollouts(t *testing.T) {
 	}{
 		{
 			setup: func(s *progressiveRolloutStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -130,15 +116,11 @@ func TestListProgressiveRollouts(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).Times(2)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
@@ -185,5 +167,5 @@ func TestListProgressiveRollouts(t *testing.T) {
 
 func newProgressiveRolloutStorageWithMock(t *testing.T, mockController *gomock.Controller) *progressiveRolloutStorage {
 	t.Helper()
-	return &progressiveRolloutStorage{mock.NewMockClient(mockController)}
+	return &progressiveRolloutStorage{mock.NewMockQueryExecer(mockController)}
 }


### PR DESCRIPTION
This pull request focuses on refactoring the `AutoOpsService` and related storage classes to simplify the codebase and improve maintainability. The primary changes involve replacing direct instantiations of `ProgressiveRolloutStorage` and `AutoOpsRuleStorage` with dependency injections, thus improving the code's flexibility and testability.

This PR is a refactor to the deprecation of `Qe()` in the PR below.
#1549