### PR TITLE
refactor: change the Notification storage scope to QueryExecer

### DIFF
--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -59,15 +59,15 @@ type AdminSubscriptionStorage interface {
 }
 
 type adminSubscriptionStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewAdminSubscriptionStorage(client mysql.Client) AdminSubscriptionStorage {
-	return &adminSubscriptionStorage{client}
+func NewAdminSubscriptionStorage(qe mysql.QueryExecer) AdminSubscriptionStorage {
+	return &adminSubscriptionStorage{qe}
 }
 
 func (s *adminSubscriptionStorage) CreateAdminSubscription(ctx context.Context, e *domain.Subscription) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertAdminSubscriptionV2SQLQuery,
 		e.Id,
@@ -88,7 +88,7 @@ func (s *adminSubscriptionStorage) CreateAdminSubscription(ctx context.Context, 
 }
 
 func (s *adminSubscriptionStorage) UpdateAdminSubscription(ctx context.Context, e *domain.Subscription) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateAdminSubscriptionV2SQLQuery,
 		e.UpdatedAt,
@@ -112,7 +112,7 @@ func (s *adminSubscriptionStorage) UpdateAdminSubscription(ctx context.Context, 
 }
 
 func (s *adminSubscriptionStorage) DeleteAdminSubscription(ctx context.Context, id string) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		deleteAdminSubscriptionV2SQLQuery,
 		id,
@@ -132,7 +132,7 @@ func (s *adminSubscriptionStorage) DeleteAdminSubscription(ctx context.Context, 
 
 func (s *adminSubscriptionStorage) GetAdminSubscription(ctx context.Context, id string) (*domain.Subscription, error) {
 	subscription := proto.Subscription{}
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectAdminSubscriptionV2SQLQuery,
 		id,
@@ -164,7 +164,7 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectAdminSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 
 	if err != nil {
 		return nil, 0, 0, err
@@ -194,7 +194,7 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	var totalCount int64
 	countQuery := fmt.Sprintf(selectAdminSubscriptionV2CountSQLQuery, whereSQL)
 
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/admin_subscription_test.go
+++ b/pkg/notification/storage/v2/admin_subscription_test.go
@@ -54,12 +54,7 @@ func TestCreateAdminSubscription(t *testing.T) {
 		{
 			desc: "ErrAdminSubscriptionAlreadyExists",
 			setup: func(s *adminSubscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -71,12 +66,7 @@ func TestCreateAdminSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -89,12 +79,7 @@ func TestCreateAdminSubscription(t *testing.T) {
 		{
 			desc: "Success",
 			setup: func(s *adminSubscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					id, int64(1), int64(2), false, mysql.JSONObject{Val: sourceTypes}, mysql.JSONObject{Val: recipient}, name,
@@ -138,12 +123,7 @@ func TestUpdateAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -155,12 +135,7 @@ func TestUpdateAdminSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -175,12 +150,7 @@ func TestUpdateAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					int64(2), false, mysql.JSONObject{Val: sourceTypes}, mysql.JSONObject{Val: recipient}, name, id,
@@ -219,12 +189,7 @@ func TestDeleteAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -234,12 +199,7 @@ func TestDeleteAdminSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -252,12 +212,7 @@ func TestDeleteAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					"id-0",
@@ -294,12 +249,7 @@ func TestGetAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -311,12 +261,7 @@ func TestGetAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 
@@ -329,12 +274,7 @@ func TestGetAdminSubscription(t *testing.T) {
 			setup: func(s *adminSubscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					"id-0",
@@ -385,12 +325,7 @@ func TestListAdminSubscriptions(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *adminSubscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -414,19 +349,14 @@ func TestListAdminSubscriptions(t *testing.T) {
 				}).Times(getSize + 1)
 				rows.EXPECT().Err().Return(nil)
 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(),
 					gomock.Any(),
 					updatedAt, disable,
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					updatedAt, disable,
@@ -453,19 +383,15 @@ func TestListAdminSubscriptions(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
 
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(),
 					gomock.Any(),
 					[]interface{}{},
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					[]interface{}{},
@@ -505,5 +431,5 @@ func TestListAdminSubscriptions(t *testing.T) {
 
 func newAdminSubscriptionStorageWithMock(t *testing.T, mockController *gomock.Controller) *adminSubscriptionStorage {
 	t.Helper()
-	return &adminSubscriptionStorage{mock.NewMockClient(mockController)}
+	return &adminSubscriptionStorage{mock.NewMockQueryExecer(mockController)}
 }

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -59,11 +59,11 @@ type SubscriptionStorage interface {
 }
 
 type subscriptionStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewSubscriptionStorage(client mysql.Client) SubscriptionStorage {
-	return &subscriptionStorage{client}
+func NewSubscriptionStorage(qe mysql.QueryExecer) SubscriptionStorage {
+	return &subscriptionStorage{qe}
 }
 
 func (s *subscriptionStorage) CreateSubscription(
@@ -71,7 +71,7 @@ func (s *subscriptionStorage) CreateSubscription(
 	e *domain.Subscription,
 	environmentId string,
 ) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertSubscriptionV2SQLQuery,
 		e.Id,
@@ -98,7 +98,7 @@ func (s *subscriptionStorage) UpdateSubscription(
 	e *domain.Subscription,
 	environmentId string,
 ) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateSubscriptionV2SQLQuery,
 		e.UpdatedAt,
@@ -127,7 +127,7 @@ func (s *subscriptionStorage) DeleteSubscription(
 	ctx context.Context,
 	id, environmentId string,
 ) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		deleteSubscriptionV2SQLQuery,
 		id,
@@ -151,7 +151,7 @@ func (s *subscriptionStorage) GetSubscription(
 	id, environmentId string,
 ) (*domain.Subscription, error) {
 	subscription := proto.Subscription{}
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectSubscriptionV2SQLQuery,
 		id,
@@ -187,7 +187,7 @@ func (s *subscriptionStorage) ListSubscriptions(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -218,7 +218,7 @@ func (s *subscriptionStorage) ListSubscriptions(
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
 	countQuery := fmt.Sprintf(selectSubscriptionV2CountSQLQuery, whereSQL)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/subscription_test.go
+++ b/pkg/notification/storage/v2/subscription_test.go
@@ -58,11 +58,7 @@ func TestCreateSubscription(t *testing.T) {
 		{
 			desc: "ErrSubscriptionAlreadyExists",
 			setup: func(s *subscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 
@@ -76,11 +72,7 @@ func TestCreateSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *subscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -94,11 +86,7 @@ func TestCreateSubscription(t *testing.T) {
 		{
 			desc: "Success",
 			setup: func(s *subscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					id, int64(1), int64(2), false, mysql.JSONObject{Val: sourceTypes}, mysql.JSONObject{Val: recipient}, name, mysql.JSONObject{Val: featureFlagTags}, envNamespace,
@@ -154,12 +142,7 @@ func TestUpdateSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -172,15 +155,9 @@ func TestUpdateSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *subscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
-
 			},
 			input: &domain.Subscription{
 				Subscription: &proto.Subscription{Id: id},
@@ -193,11 +170,7 @@ func TestUpdateSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					int64(2), false, mysql.JSONObject{Val: sourceTypes}, mysql.JSONObject{Val: recipient}, name, mysql.JSONObject{Val: featureFlagTags}, id, envNamespace,
@@ -250,11 +223,7 @@ func TestDeleteSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -265,12 +234,7 @@ func TestDeleteSubscription(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *subscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -284,13 +248,7 @@ func TestDeleteSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
 					id, envNamespace,
@@ -332,12 +290,7 @@ func TestGetSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -350,11 +303,7 @@ func TestGetSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 
@@ -368,11 +317,7 @@ func TestGetSubscription(t *testing.T) {
 			setup: func(s *subscriptionStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					id, envNamespace,
@@ -419,12 +364,7 @@ func TestListSubscriptions(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *subscriptionStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -448,17 +388,13 @@ func TestListSubscriptions(t *testing.T) {
 				}).Times(getSize + 1)
 				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(getSize)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(),
 					gomock.Any(),
 					updatedAt, disable,
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					updatedAt, disable,
@@ -486,18 +422,14 @@ func TestListSubscriptions(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(),
 					gomock.Any(),
 					[]interface{}{},
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(),
 					gomock.Any(),
 					[]interface{}{},
@@ -537,5 +469,5 @@ func TestListSubscriptions(t *testing.T) {
 
 func newsubscriptionStorageWithMock(t *testing.T, mockController *gomock.Controller) *subscriptionStorage {
 	t.Helper()
-	return &subscriptionStorage{mock.NewMockClient(mockController)}
+	return &subscriptionStorage{mock.NewMockQueryExecer(mockController)}
 }


### PR DESCRIPTION
This pull request includes significant refactoring of the `admin_subscription` and `subscription` storage interfaces to replace the `mysql.Client` with `mysql.QueryExecer`. This change affects various methods and their corresponding tests.

This PR is a refactor to the deprecation of `Qe()` in the PR below.
https://github.com/bucketeer-io/bucketeer/pull/1549