### PR TITLE
fix: ops count is unexpectedly greater than evaluation count

### DIFF
--- a/ui/web-v2/src/components/FeatureAutoOpsRulesForm/index.tsx
+++ b/ui/web-v2/src/components/FeatureAutoOpsRulesForm/index.tsx
@@ -1155,7 +1155,10 @@ const EventRateOperation = memo(
       Math.round(step + index * step)
     );
 
-    const barWidth = (currentEventRate / (threadsholdRate * 100)) * 100;
+    const barWidth = Math.min(
+      (currentEventRate / (threadsholdRate * 100)) * 100,
+      100
+    );
 
     return (
       <div>

--- a/ui/web-v2/src/components/FeatureAutoOpsRulesForm/index.tsx
+++ b/ui/web-v2/src/components/FeatureAutoOpsRulesForm/index.tsx
@@ -1133,10 +1133,16 @@ const EventRateOperation = memo(
 
     let currentEventRate = 0;
     if (opsCount && opsCount.opsEventCount >= minCount) {
+      let opsEventCount = opsCount.opsEventCount;
+      // If opsEventCount is unexpectedly greater than evaluationCount,
+      // clamp opsEventCount to evaluationCount so that it never exceeds 100%.
+      // This way, it will avoid a rate above 100%, which breaks the admin console design.
+      if (opsCount.opsEventCount > opsCount.evaluationCount) {
+        opsEventCount = opsCount.evaluationCount;
+      }
       currentEventRate =
-        Math.round(
-          (opsCount.opsEventCount / opsCount.evaluationCount) * 100 * 100
-        ) / 100;
+        Math.round((opsEventCount / opsCount.evaluationCount) * 100 * 100) /
+        100;
     }
 
     const numberOfSteps =


### PR DESCRIPTION
The evaluation and goal events are sent from the client SDK, and for many reasons, those events could get lost in the client.
So, I implemented clamping the computed rate so that it never exceeds 100% (i.e., 1.0). In other words, if you detect that the opsCount is greater than the evaluationCount, it will adjust the opsCount to be equal to the evaluationCount before calculating the rate. This way, you avoid a rate above 1.0, and the downstream logic stays consistent.

Fix https://github.com/bucketeer-io/bucketeer/issues/1607