### PR TITLE
test: fix flaky feature e2e test when using case-sensitive strings

### DIFF
--- a/test/e2e/feature/feature_test.go
+++ b/test/e2e/feature/feature_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -534,7 +535,9 @@ func TestListFeaturesOrderByName(t *testing.T) {
 		}
 		names := make([]string, 0, len(response.Features))
 		for _, f := range response.Features {
-			names = append(names, f.Name)
+			// Custom reverse sort with case-insensitive comparison.
+			// We convert the strings to lower-case before comparing.
+			names = append(names, strings.ToLower(f.Name))
 		}
 		if !tc.checkSortedFunc(names) {
 			t.Fatalf("Features aren't sorted by Name %s. Features: %v", tc.orderDirection, response.Features)


### PR DESCRIPTION
The TestListFeaturesOrderByName test started failing because the ordering in MySQL is case-insensitive, but the `sort.Reverse` is case-sensitive. There is an archived flag in the e2e environment (Test JSON Flag 3), which was created today and caused the issue.

