### PR TITLE
refactor: change the OpsEvent storage scope to QueryExecer

### DIFF
--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -411,6 +411,12 @@ func TestEventCountWatcher(t *testing.T) {
 				},
 				nil,
 			)
+		mysqlMockClient.EXPECT().
+			ExecContext(
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Times(2).
+			Return(nil, nil)
 		mysqlMockClient.EXPECT().Qe(
 			gomock.Any(),
 		).AnyTimes().Return(mysqlMockQueryExecer)

--- a/pkg/batch/jobs/opsevent/event_count_watcher_test.go
+++ b/pkg/batch/jobs/opsevent/event_count_watcher_test.go
@@ -292,11 +292,7 @@ func TestRunCountWatcher(t *testing.T) {
 						},
 					}, nil)
 
-				qe := mysqlmock.NewMockQueryExecer(mockController)
-				w.mysqlClient.(*mysqlmock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
+				w.mysqlClient.(*mysqlmock.MockClient).EXPECT().ExecContext(gomock.Any(), gomock.Any(), gomock.Any()).Return(
 					nil, nil,
 				)
 

--- a/pkg/opsevent/storage/v2/ops_count.go
+++ b/pkg/opsevent/storage/v2/ops_count.go
@@ -35,11 +35,11 @@ type OpsCountStorage interface {
 }
 
 type opsCountStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewOpsCountStorage(client mysql.Client) OpsCountStorage {
-	return &opsCountStorage{client: client}
+func NewOpsCountStorage(qe mysql.QueryExecer) OpsCountStorage {
+	return &opsCountStorage{qe: qe}
 }
 
 func (s *opsCountStorage) UpsertOpsCount(ctx context.Context, environmentId string, oc *domain.OpsCount) error {
@@ -63,7 +63,7 @@ func (s *opsCountStorage) UpsertOpsCount(ctx context.Context, environmentId stri
 			evaluation_count = VALUES(evaluation_count),
 			feature_id = VALUES(feature_id)
 	`
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		query,
 		oc.Id,
@@ -104,7 +104,7 @@ func (s *opsCountStorage) ListOpsCounts(
 		%s %s %s
 		`, whereSQL, orderBySQL, limitOffsetSQL,
 	)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/opsevent/storage/v2/ops_count_test.go
+++ b/pkg/opsevent/storage/v2/ops_count_test.go
@@ -49,11 +49,7 @@ func TestUpsertOpsCount(t *testing.T) {
 	}{
 		{
 			setup: func(s *opsCountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -88,11 +84,7 @@ func TestListOpsCounts(t *testing.T) {
 	}{
 		{
 			setup: func(s *opsCountStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -110,11 +102,7 @@ func TestListOpsCounts(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
@@ -151,5 +139,5 @@ func TestListOpsCounts(t *testing.T) {
 
 func newOpsCountStorageWithMock(t *testing.T, mockController *gomock.Controller) *opsCountStorage {
 	t.Helper()
-	return &opsCountStorage{mock.NewMockClient(mockController)}
+	return &opsCountStorage{mock.NewMockQueryExecer(mockController)}
 }


### PR DESCRIPTION
This pull request includes changes to the `pkg/opsevent/storage/v2/ops_count.go` file and its associated test file to replace the `mysql.Client` dependency with `mysql.QueryExecer`. This change simplifies the interface and improves the code's flexibility.

This PR is a refactor to the deprecation of Qe() in the PR below.
https://github.com/bucketeer-io/bucketeer/pull/1549