### PR TITLE
refactor: change the Push storage scope to QueryExecer

### DIFF
--- a/pkg/push/storage/v2/push.go
+++ b/pkg/push/storage/v2/push.go
@@ -56,15 +56,15 @@ type PushStorage interface {
 }
 
 type pushStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewPushStorage(client mysql.Client) PushStorage {
-	return &pushStorage{client: client}
+func NewPushStorage(qe mysql.QueryExecer) PushStorage {
+	return &pushStorage{qe: qe}
 }
 
 func (s *pushStorage) CreatePush(ctx context.Context, e *domain.Push, environmentId string) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertPushSQL,
 		e.Id,
@@ -87,7 +87,7 @@ func (s *pushStorage) CreatePush(ctx context.Context, e *domain.Push, environmen
 }
 
 func (s *pushStorage) UpdatePush(ctx context.Context, e *domain.Push, environmentId string) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updatePushSQL,
 		e.FcmServiceAccount,
@@ -115,7 +115,7 @@ func (s *pushStorage) UpdatePush(ctx context.Context, e *domain.Push, environmen
 
 func (s *pushStorage) GetPush(ctx context.Context, id, environmentId string) (*domain.Push, error) {
 	push := proto.Push{}
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectPushSQL,
 		id,
@@ -151,7 +151,7 @@ func (s *pushStorage) ListPushes(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(listPushesSQL, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -182,7 +182,7 @@ func (s *pushStorage) ListPushes(
 	nextOffset := offset + len(pushes)
 	var totalCount int64
 	countQuery := fmt.Sprintf(countPushesSQL, whereSQL)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/push/storage/v2/push_test.go
+++ b/pkg/push/storage/v2/push_test.go
@@ -50,11 +50,7 @@ func TestCreatePush(t *testing.T) {
 		{
 			desc: "ErrPushAlreadyExists",
 			setup: func(s *pushStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -67,11 +63,7 @@ func TestCreatePush(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *pushStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -85,11 +77,7 @@ func TestCreatePush(t *testing.T) {
 		{
 			desc: "Success",
 			setup: func(s *pushStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -128,11 +116,7 @@ func TestUpdatePush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -145,11 +129,7 @@ func TestUpdatePush(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *pushStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 
@@ -165,11 +145,7 @@ func TestUpdatePush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -208,11 +184,7 @@ func TestGetPush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -225,11 +197,7 @@ func TestGetPush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 
@@ -243,11 +211,7 @@ func TestGetPush(t *testing.T) {
 			setup: func(s *pushStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -286,11 +250,7 @@ func TestListPushs(t *testing.T) {
 		{
 			desc: "Error",
 			setup: func(s *pushStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -309,16 +269,12 @@ func TestListPushs(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -357,5 +313,5 @@ func TestListPushs(t *testing.T) {
 
 func newpushStorageWithMock(t *testing.T, mockController *gomock.Controller) *pushStorage {
 	t.Helper()
-	return &pushStorage{mock.NewMockClient(mockController)}
+	return &pushStorage{mock.NewMockQueryExecer(mockController)}
 }


### PR DESCRIPTION
This pull request includes changes to the `pkg/push/storage/v2/push.go` and `pkg/push/storage/v2/push_test.go` files to replace the `mysql.Client` with `mysql.QueryExecer` in the `pushStorage` struct and its associated methods. The most important changes include updating the `pushStorage` struct, modifying the methods to use the new `qe` field, and adjusting the tests accordingly.

This PR is a refactor to the deprecation of `Qe()` in the PR below.
https://github.com/bucketeer-io/bucketeer/pull/1549