### PR TITLE
refactor: change the Experiment storage scope to QueryExecer

### DIFF
--- a/pkg/batch/api/api_test.go
+++ b/pkg/batch/api/api_test.go
@@ -417,9 +417,6 @@ func TestEventCountWatcher(t *testing.T) {
 				gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Times(2).
 			Return(nil, nil)
-		mysqlMockClient.EXPECT().Qe(
-			gomock.Any(),
-		).AnyTimes().Return(mysqlMockQueryExecer)
 		mysqlMockQueryExecer.EXPECT().ExecContext(
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),

--- a/pkg/experiment/storage/v2/experiment.go
+++ b/pkg/experiment/storage/v2/experiment.go
@@ -67,11 +67,11 @@ type ExperimentSummary struct {
 }
 
 type experimentStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewExperimentStorage(client mysql.Client) ExperimentStorage {
-	return &experimentStorage{client: client}
+func NewExperimentStorage(qe mysql.QueryExecer) ExperimentStorage {
+	return &experimentStorage{qe: qe}
 }
 
 func (s *experimentStorage) CreateExperiment(
@@ -79,7 +79,7 @@ func (s *experimentStorage) CreateExperiment(
 	e *domain.Experiment,
 	environmentId string,
 ) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertExperimentSQL,
 		e.Id,
@@ -117,7 +117,7 @@ func (s *experimentStorage) UpdateExperiment(
 	e *domain.Experiment,
 	environmentId string,
 ) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateExperimentSQL,
 		e.GoalId,
@@ -160,7 +160,7 @@ func (s *experimentStorage) GetExperiment(
 ) (*domain.Experiment, error) {
 	experiment := proto.Experiment{}
 	var status int32
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectExperimentSQL,
 		id,
@@ -207,7 +207,7 @@ func (s *experimentStorage) ListExperiments(
 	orderBySQL := mysql.ConstructOrderBySQLString(orders)
 	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
 	query := fmt.Sprintf(selectExperimentsSQL, whereSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, whereArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -250,7 +250,7 @@ func (s *experimentStorage) ListExperiments(
 	nextOffset := offset + len(experiments)
 	var totalCount int64
 	countQuery := fmt.Sprintf(countExperimentSQL, whereSQL)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, whereArgs...).Scan(
+	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(
 		&totalCount,
 	)
 	if err != nil {
@@ -265,7 +265,7 @@ func (s *experimentStorage) GetExperimentSummary(
 	environmentID string,
 ) (*ExperimentSummary, error) {
 	summary := &ExperimentSummary{}
-	err := s.client.Qe(ctx).QueryRowContext(ctx, summarizeExperimentSQL, environmentID).Scan(
+	err := s.qe.QueryRowContext(ctx, summarizeExperimentSQL, environmentID).Scan(
 		&summary.TotalWaitingCount,
 		&summary.TotalRunningCount,
 		&summary.TotalStoppedCount,

--- a/pkg/experiment/storage/v2/experiment_test.go
+++ b/pkg/experiment/storage/v2/experiment_test.go
@@ -50,11 +50,7 @@ func TestCreateExperiment(t *testing.T) {
 	}{
 		{
 			setup: func(s *experimentStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -66,11 +62,7 @@ func TestCreateExperiment(t *testing.T) {
 		},
 		{
 			setup: func(s *experimentStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -108,12 +100,7 @@ func TestUpdateExperiment(t *testing.T) {
 			setup: func(s *experimentStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -127,11 +114,7 @@ func TestUpdateExperiment(t *testing.T) {
 			setup: func(s *experimentStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -168,11 +151,7 @@ func TestGetExperiment(t *testing.T) {
 			setup: func(s *experimentStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -185,11 +164,7 @@ func TestGetExperiment(t *testing.T) {
 			setup: func(s *experimentStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -227,11 +202,7 @@ func TestListExperiments(t *testing.T) {
 	}{
 		{
 			setup: func(s *experimentStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe)
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -249,16 +220,12 @@ func TestListExperiments(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -308,11 +275,7 @@ func TestCountExperimentByStatus(t *testing.T) {
 			setup: func(s *experimentStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -324,11 +287,7 @@ func TestCountExperimentByStatus(t *testing.T) {
 			setup: func(s *experimentStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(
-					gomock.Any(),
-				).Return(qe).AnyTimes()
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -351,5 +310,5 @@ func TestCountExperimentByStatus(t *testing.T) {
 
 func newExperimentStorageWithMock(t *testing.T, mockController *gomock.Controller) *experimentStorage {
 	t.Helper()
-	return &experimentStorage{mock.NewMockClient(mockController)}
+	return &experimentStorage{mock.NewMockQueryExecer(mockController)}
 }

--- a/pkg/experiment/storage/v2/goal.go
+++ b/pkg/experiment/storage/v2/goal.go
@@ -69,15 +69,15 @@ type GoalStorage interface {
 }
 
 type goalStorage struct {
-	client mysql.Client
+	qe mysql.QueryExecer
 }
 
-func NewGoalStorage(client mysql.Client) GoalStorage {
-	return &goalStorage{client: client}
+func NewGoalStorage(qe mysql.QueryExecer) GoalStorage {
+	return &goalStorage{qe: qe}
 }
 
 func (s *goalStorage) CreateGoal(ctx context.Context, g *domain.Goal, environmentId string) error {
-	_, err := s.client.Qe(ctx).ExecContext(
+	_, err := s.qe.ExecContext(
 		ctx,
 		insertGoalSQL,
 		g.Id,
@@ -100,7 +100,7 @@ func (s *goalStorage) CreateGoal(ctx context.Context, g *domain.Goal, environmen
 }
 
 func (s *goalStorage) UpdateGoal(ctx context.Context, g *domain.Goal, environmentId string) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		updateGoalSQL,
 		g.Name,
@@ -129,7 +129,7 @@ func (s *goalStorage) GetGoal(ctx context.Context, id, environmentId string) (*d
 	goal := proto.Goal{}
 	var connectionType int32
 	var experiments []experimentRef
-	err := s.client.Qe(ctx).QueryRowContext(
+	err := s.qe.QueryRowContext(
 		ctx,
 		selectGoalSQL,
 		environmentId, // Case query
@@ -191,7 +191,7 @@ func (s *goalStorage) ListGoals(
 		}
 	}
 	query := fmt.Sprintf(selectGoalsSQL, whereSQL, isInUseStatusSQL, orderBySQL, limitOffsetSQL)
-	rows, err := s.client.Qe(ctx).QueryContext(ctx, query, prepareArgs...)
+	rows, err := s.qe.QueryContext(ctx, query, prepareArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -246,7 +246,7 @@ func (s *goalStorage) ListGoals(
 	prepareCountArgs = append(prepareCountArgs, environmentId)
 	prepareCountArgs = append(prepareCountArgs, whereArgs...)
 	countQuery := fmt.Sprintf(countGoalSQL, countConditionSQL, whereSQL)
-	err = s.client.Qe(ctx).QueryRowContext(ctx, countQuery, prepareCountArgs...).Scan(&totalCount)
+	err = s.qe.QueryRowContext(ctx, countQuery, prepareCountArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}
@@ -254,7 +254,7 @@ func (s *goalStorage) ListGoals(
 }
 
 func (s *goalStorage) DeleteGoal(ctx context.Context, id, environmentId string) error {
-	result, err := s.client.Qe(ctx).ExecContext(
+	result, err := s.qe.ExecContext(
 		ctx,
 		deleteGoalSQL,
 		id,

--- a/pkg/experiment/storage/v2/goal_test.go
+++ b/pkg/experiment/storage/v2/goal_test.go
@@ -50,9 +50,7 @@ func TestCreateGoal(t *testing.T) {
 	}{
 		{
 			setup: func(s *goalStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, mysql.ErrDuplicateEntry)
 			},
@@ -64,9 +62,7 @@ func TestCreateGoal(t *testing.T) {
 		},
 		{
 			setup: func(s *goalStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, nil)
 			},
@@ -104,9 +100,7 @@ func TestUpdateGoal(t *testing.T) {
 			setup: func(s *goalStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(0), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -120,9 +114,7 @@ func TestUpdateGoal(t *testing.T) {
 			setup: func(s *goalStorage) {
 				result := mock.NewMockResult(mockController)
 				result.EXPECT().RowsAffected().Return(int64(1), nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
-				qe.EXPECT().ExecContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(result, nil)
 			},
@@ -159,9 +151,7 @@ func TestGetGoal(t *testing.T) {
 			setup: func(s *goalStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -174,9 +164,7 @@ func TestGetGoal(t *testing.T) {
 			setup: func(s *goalStorage) {
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -216,9 +204,7 @@ func TestListGoals(t *testing.T) {
 	}{
 		{
 			setup: func(s *goalStorage) {
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
@@ -238,14 +224,12 @@ func TestListGoals(t *testing.T) {
 				rows.EXPECT().Close().Return(nil)
 				rows.EXPECT().Next().Return(false)
 				rows.EXPECT().Err().Return(nil)
-				qe := mock.NewMockQueryExecer(mockController)
-				s.client.(*mock.MockClient).EXPECT().Qe(gomock.Any()).Return(qe).AnyTimes()
-				qe.EXPECT().QueryContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 				row := mock.NewMockRow(mockController)
 				row.EXPECT().Scan(gomock.Any()).Return(nil)
-				qe.EXPECT().QueryRowContext(
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
@@ -286,5 +270,5 @@ func TestListGoals(t *testing.T) {
 
 func newGoalStorageWithMock(t *testing.T, mockController *gomock.Controller) *goalStorage {
 	t.Helper()
-	return &goalStorage{mock.NewMockClient(mockController)}
+	return &goalStorage{mock.NewMockQueryExecer(mockController)}
 }

--- a/pkg/storage/v2/mysql/client.go
+++ b/pkg/storage/v2/mysql/client.go
@@ -111,8 +111,6 @@ type Client interface {
 	// Transaction is passed because it is required for storage that does not support storage architecture refactoring,
 	// but we plan to remove it once the refactoring is complete.
 	RunInTransactionV2(ctx context.Context, f func(ctx context.Context, tx Transaction) error) error
-	// Deprecated
-	Qe(ctx context.Context) QueryExecer
 }
 
 type client struct {
@@ -245,13 +243,4 @@ func (c *client) RunInTransactionV2(
 		err = tx.Commit()
 	}
 	return err
-}
-
-// Deprecated
-func (c *client) Qe(ctx context.Context) QueryExecer {
-	tx, ok := ctx.Value(transactionKey).(Transaction)
-	if ok {
-		return tx
-	}
-	return c
 }

--- a/pkg/storage/v2/mysql/mock/client.go
+++ b/pkg/storage/v2/mysql/mock/client.go
@@ -277,20 +277,6 @@ func (mr *MockClientMockRecorder) ExecContext(ctx, query any, args ...any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecContext", reflect.TypeOf((*MockClient)(nil).ExecContext), varargs...)
 }
 
-// Qe mocks base method.
-func (m *MockClient) Qe(ctx context.Context) mysql.QueryExecer {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Qe", ctx)
-	ret0, _ := ret[0].(mysql.QueryExecer)
-	return ret0
-}
-
-// Qe indicates an expected call of Qe.
-func (mr *MockClientMockRecorder) Qe(ctx any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Qe", reflect.TypeOf((*MockClient)(nil).Qe), ctx)
-}
-
 // QueryContext mocks base method.
 func (m *MockClient) QueryContext(ctx context.Context, query string, args ...any) (mysql.Rows, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This pull request refactors the `experimentStorage` and `goalStorage` to use `mysql.QueryExecer` instead of `mysql.Client` and updates the corresponding tests to reflect this change. The main changes involve replacing `client` with `qe` in the storage structs and updating method calls accordingly.

This PR is a refactor to the deprecation of `Client.Qe()` in the PR below.
https://github.com/bucketeer-io/bucketeer/pull/1549
`Client.Qe()` is unnecessary so it has been removed.
