### PR TITLE
feat: support semver with v prefix when evaluate values

### DIFF
--- a/evaluation/go/clause_evaluator.go
+++ b/evaluation/go/clause_evaluator.go
@@ -276,12 +276,27 @@ func (c *clauseEvaluator) parseFloat(targetValue string, values []string) (float
 }
 
 func (c *clauseEvaluator) parseSemver(targetValue string, values []string) (semver.Version, []semver.Version, error) {
-	versionTarget, err := semver.Parse(targetValue)
+	targetValueWithoutV, targetHasV := strings.CutPrefix(targetValue, "v")
+	versionTarget, err := semver.Parse(targetValueWithoutV)
 	if err != nil {
 		return semver.Version{}, nil, err
 	}
 	versionValues := make([]semver.Version, 0, len(values))
+	if targetHasV {
+		for _, value := range values {
+			// if target value has v prefix, compare only values with v prefix
+			valueWithoutV, valueHasV := strings.CutPrefix(value, "v")
+			if valueHasV {
+				v, err := semver.Parse(valueWithoutV)
+				if err == nil {
+					versionValues = append(versionValues, v)
+				}
+			}
+		}
+		return versionTarget, versionValues, nil
+	}
 	for _, value := range values {
+		// if target value has no v prefix, compare only values without v prefix
 		v, err := semver.Parse(value)
 		if err == nil {
 			versionValues = append(versionValues, v)

--- a/evaluation/go/clause_evaluator_test.go
+++ b/evaluation/go/clause_evaluator_test.go
@@ -187,6 +187,47 @@ func TestGreaterSemver(t *testing.T) {
 			values:      []string{"2.1.1", "v2.0.9", "2.1.0"},
 			expected:    true,
 		},
+		// with 'v' prefix
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.0", "v0.0", "v1.0.1"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.0", "v1.0.1", "0.0.7"},
+			expected:    false,
+		},
+		{
+			targetValue: "v0.0.8",
+			values:      []string{"v1.0.0", "v0.0.9", "v1.0.1"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.1.0",
+			values:      []string{"v1.1.0", "1.0.9", "v1.1.1"},
+			expected:    false,
+		},
+		{
+			targetValue: "v2.1.0",
+			values:      []string{"v2.1.0", "2.0.9", "v2.1.1"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.1", "v1.0.0", "0.0.7"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.1", "1.0.9", "v1.1.0"},
+			expected:    true,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.1", "2.0.9", "v2.1.0"},
+			expected:    true,
+		},
 	}
 	clauseEvaluator := &clauseEvaluator{}
 	for i, tc := range testcases {
@@ -454,6 +495,61 @@ func TestGreaterOrEqualSemver(t *testing.T) {
 			values:      []string{"2.1.2", "v2.0.9", "2.1.0"},
 			expected:    true,
 		},
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.1", "v0.0", "v1.0.2"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.1", "v1.0.2", "0.0.7"},
+			expected:    false,
+		},
+		{
+			targetValue: "v0.0.8",
+			values:      []string{"v1.0.0", "v0.0.9", "v1.0.1"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.1.0",
+			values:      []string{"v1.1.1", "1.0.9", "v1.1.2"},
+			expected:    false,
+		},
+		{
+			targetValue: "v2.1.0",
+			values:      []string{"v2.1.1", "2.0.9", "v2.1.2"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.1", "v1.0.0", "0.0.7"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.2", "1.0.9", "v1.1.1"},
+			expected:    true,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.2", "2.0.9", "v2.1.1"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.2", "v1.0.1", "0.0.7"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.2", "1.0.9", "v1.1.0"},
+			expected:    true,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.2", "2.0.9", "v2.1.0"},
+			expected:    true,
+		},
 	}
 	clauseEvaluator := &clauseEvaluator{}
 	for i, tc := range testcases {
@@ -572,6 +668,46 @@ func TestLessThanSemver(t *testing.T) {
 		{
 			targetValue: "2.1.1",
 			values:      []string{"2.1.1", "v2.0.9", "2.1.2"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.0", "v0.0", "v0.0.9"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.0",
+			values:      []string{"v1.0.0", "0.0.8", "v0.0.7"},
+			expected:    false,
+		},
+		{
+			targetValue: "v0.0.8",
+			values:      []string{"v0.0.8", "v0.0.7", "0.0.9"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.1.0",
+			values:      []string{"v1.1.0", "1.0.9", "v1.0.8"},
+			expected:    false,
+		},
+		{
+			targetValue: "v2.1.0",
+			values:      []string{"v2.1.0", "2.0.9", "v2.0.9"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.1", "0.0.7", "v1.0.2"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.1", "1.0.9", "v1.1.2"},
+			expected:    true,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.1", "2.0.9", "v2.1.2"},
 			expected:    true,
 		},
 	}
@@ -956,6 +1092,61 @@ func TestLessThanOrEqualSemver(t *testing.T) {
 		{
 			targetValue: "2.1.1",
 			values:      []string{"2.1.0", "v2.0.9", "2.1.2"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.0", "v0.0", "v0.0.9"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.0", "0.0.8", "v0.0.7"},
+			expected:    false,
+		},
+		{
+			targetValue: "v0.0.9",
+			values:      []string{"v0.0.8", "v0.0.7", "0.0.9"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.0", "1.0.9", "v1.0.8"},
+			expected:    false,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.0", "2.0.9", "v2.0.9"},
+			expected:    false,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.1", "0.0.7", "v1.0.0"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.1", "1.0.9", "v1.1.0"},
+			expected:    true,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.1", "2.0.9", "v2.1.0"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.0.1",
+			values:      []string{"v1.0.0", "0.0.7", "v1.0.2"},
+			expected:    true,
+		},
+		{
+			targetValue: "v1.1.1",
+			values:      []string{"v1.1.0", "1.0.9", "v1.1.2"},
+			expected:    true,
+		},
+		{
+			targetValue: "v2.1.1",
+			values:      []string{"v2.1.0", "2.0.9", "v2.1.2"},
 			expected:    true,
 		},
 	}


### PR DESCRIPTION
fix #1248 

Updated the `parseSemver` function to maintain consistency when comparing semantic versions by:

1. Detecting if the target value has a 'v' prefix
2. When the target has a 'v' prefix, only comparing it with values that also have a 'v' prefix
3. When the target doesn't have a 'v' prefix, only comparing it with values without a 'v' prefix

This approach ensures that version comparisons are done consistently within the same format, aligning with the broader Go ecosystem's practice of supporting the 'v' prefix in semantic versioning (as noted in golang.org/x/mod/semver).
