### PR TITLE
chore: replace deprecated ioutil

### DIFF
--- a/pkg/api/client/credentials.go
+++ b/pkg/api/client/credentials.go
@@ -16,7 +16,7 @@ package client
 
 import (
 	"context"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"google.golang.org/grpc/credentials"
@@ -27,7 +27,7 @@ type perRPCCredentials struct {
 }
 
 func NewPerRPCCredentials(apiKeyPath string) (credentials.PerRPCCredentials, error) {
-	data, err := ioutil.ReadFile(apiKeyPath)
+	data, err := os.ReadFile(apiKeyPath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -19,8 +19,8 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -1875,7 +1875,7 @@ func registerGoalEventWithEvaluations(
 }
 
 func sendHTTPTrack(t *testing.T, userID, goalID, tag string, value float64) {
-	data, err := ioutil.ReadFile(*apiKeyPath)
+	data, err := os.ReadFile(*apiKeyPath)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/util/rest.go
+++ b/test/e2e/util/rest.go
@@ -19,8 +19,8 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 
 	gwapi "github.com/bucketeer-io/bucketeer/pkg/api/api"
@@ -144,7 +144,7 @@ func RegisterEvents(t *testing.T, events []Event, gatewayAddr, apiKeyPath string
 }
 
 func SendHTTPRequest(t *testing.T, url string, body interface{}, apiKeyPath string) *successResponse {
-	data, err := ioutil.ReadFile(apiKeyPath)
+	data, err := os.ReadFile(apiKeyPath)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
`ioutil` pakcage is deprecated. 
We should use package io or package os instead.
https://pkg.go.dev/io/ioutil