### PR TITLE
chore: validate events from the sdk in api gateway

### DIFF
--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -3750,11 +3750,28 @@ func TestGrcpRegisterEvents(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{Timestamp: time.Now().Unix()})
+	bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+		Timestamp: time.Now().Unix(),
+		GoalId:    "goal-id-1",
+		UserId:    "user-id-1",
+		User: &userproto.User{
+			Id: "user-id-1",
+		},
+	})
 	if err != nil {
 		t.Fatal("could not serialize goal event")
 	}
-	bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{Timestamp: time.Now().Unix()})
+	bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+		Timestamp:   time.Now().Unix(),
+		FeatureId:   "feature-id-1",
+		VariationId: "variation-id-1",
+		User: &userproto.User{
+			Id: "user-id-1",
+		},
+		Reason: &featureproto.Reason{
+			Type: featureproto.Reason_DEFAULT,
+		},
+	})
 	if err != nil {
 		t.Fatal("could not serialize evaluation event")
 	}

--- a/pkg/api/api/grpc_validation.go
+++ b/pkg/api/api/grpc_validation.go
@@ -31,6 +31,12 @@ var (
 	errInvalidIDFormat  = errors.New("gateway: invalid event id format")
 	errInvalidTimestamp = errors.New("gateway: invalid event timestamp")
 	errUnmarshalFailed  = errors.New("gateway: failed to unmarshal event")
+	errEmptyFeatureID   = errors.New("gateway: feature_id is empty")
+	errEmptyUserID      = errors.New("gateway: user_id is empty")
+	errEmptyVariationID = errors.New("gateway: variation_id is empty")
+	errEmptyGoalID      = errors.New("gateway: goal_id is empty")
+	errNilUser          = errors.New("gateway: user is nil")
+	errNilReason        = errors.New("gateway: reason is nil")
 )
 
 type eventValidator interface {
@@ -105,6 +111,39 @@ func (v *eventGoalValidator) validate(ctx context.Context) (string, error) {
 	if err != nil {
 		return codeUnmarshalFailed, errUnmarshalFailed
 	}
+
+	// validate required fields
+	if ev.GoalId == "" {
+		v.logger.Debug(
+			"Empty goal_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("goal_id", ev.GoalId),
+			)...,
+		)
+		return codeEmptyField, errEmptyGoalID
+	}
+	if ev.User == nil {
+		v.logger.Debug(
+			"Nil user",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.Any("user", ev.User),
+			)...,
+		)
+		return codeEmptyField, errNilUser
+	}
+	if ev.User.Id == "" {
+		v.logger.Debug(
+			"Empty user_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("user_id", ev.User.Id),
+			)...,
+		)
+		return codeEmptyField, errEmptyUserID
+	}
+
 	if !validateTimestamp(ev.Timestamp, v.oldestTimestampDuration, v.furthestTimestampDuration) {
 		v.logger.Debug(
 			"Failed to validate goal event timestamp",
@@ -148,6 +187,58 @@ func (v *eventEvaluationValidator) validate(ctx context.Context) (string, error)
 	if err != nil {
 		return codeUnmarshalFailed, errUnmarshalFailed
 	}
+
+	// validate required fields
+	if ev.FeatureId == "" {
+		v.logger.Debug(
+			"Empty feature_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("feature_id", ev.FeatureId),
+			)...,
+		)
+		return codeEmptyField, errEmptyFeatureID
+	}
+	if ev.VariationId == "" {
+		v.logger.Debug(
+			"Empty variation_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("variation_id", ev.VariationId),
+			)...,
+		)
+		return codeEmptyField, errEmptyVariationID
+	}
+	if ev.User == nil {
+		v.logger.Debug(
+			"Nil user",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.Any("user", ev.User),
+			)...,
+		)
+		return codeEmptyField, errNilUser
+	}
+	if ev.User.Id == "" {
+		v.logger.Debug(
+			"Empty user_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+			)...,
+		)
+		return codeEmptyField, errEmptyUserID
+	}
+	if ev.Reason == nil {
+		v.logger.Debug(
+			"Nil reason",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.Any("reason", ev.Reason),
+			)...,
+		)
+		return codeEmptyField, errNilReason
+	}
+
 	if !validateTimestamp(ev.Timestamp, v.oldestTimestampDuration, v.furthestTimestampDuration) {
 		v.logger.Debug(
 			"Failed to validate evaluation event timestamp",

--- a/pkg/api/api/grpc_validation_test.go
+++ b/pkg/api/api/grpc_validation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	"github.com/bucketeer-io/bucketeer/proto/feature"
+	"github.com/bucketeer-io/bucketeer/proto/user"
 )
 
 const (
@@ -154,10 +155,84 @@ func TestGrpcValidateGoalEvent(t *testing.T) {
 			expectedErr: errUnmarshalFailed,
 		},
 		{
+			desc: "empty goal_id",
+			inputFunc: func() *eventproto.Event {
+				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+					Timestamp: time.Now().Unix(),
+					GoalId:    "",
+					User: &user.User{
+						Id: "user-id",
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
+						Value:   bGoalEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyGoalID,
+		},
+		{
+			desc: "nil user",
+			inputFunc: func() *eventproto.Event {
+				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+					Timestamp: time.Now().Unix(),
+					GoalId:    "goal-id",
+					User:      nil,
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
+						Value:   bGoalEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errNilUser,
+		},
+		{
+			desc: "empty user_id",
+			inputFunc: func() *eventproto.Event {
+				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+					Timestamp: time.Now().Unix(),
+					GoalId:    "goal-id",
+					User: &user.User{
+						Id: "",
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
+						Value:   bGoalEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyUserID,
+		},
+		{
 			desc: "invalid timestamp",
 			inputFunc: func() *eventproto.Event {
 				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
 					Timestamp: int64(999999999999999),
+					GoalId:    "goal-id",
+					User: &user.User{
+						Id: "user-id",
+					},
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")
@@ -178,6 +253,10 @@ func TestGrpcValidateGoalEvent(t *testing.T) {
 			inputFunc: func() *eventproto.Event {
 				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
 					Timestamp: time.Now().Unix(),
+					GoalId:    "goal-id",
+					User: &user.User{
+						Id: "user-id",
+					},
 					Evaluations: []*feature.Evaluation{
 						{
 							Id: "evaluation-id",
@@ -242,10 +321,154 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			expectedErr: errUnmarshalFailed,
 		},
 		{
+			desc: "empty feature_id",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyFeatureID,
+		},
+		{
+			desc: "empty variation_id",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyVariationID,
+		},
+		{
+			desc: "nil user",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User:        nil,
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errNilUser,
+		},
+		{
+			desc: "empty user_id",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyUserID,
+		},
+		{
+			desc: "nil reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: nil,
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errNilReason,
+		},
+		{
 			desc: "invalid timestamp",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
-					Timestamp: int64(999999999999999),
+					Timestamp:   int64(999999999999999),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")
@@ -265,7 +488,16 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			desc: "success",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
-					Timestamp: time.Now().Unix(),
+					Timestamp:      time.Now().Unix(),
+					FeatureId:      "feature-id",
+					FeatureVersion: 1,
+					VariationId:    "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")

--- a/pkg/api/api/metrics.go
+++ b/pkg/api/api/metrics.go
@@ -56,6 +56,7 @@ const (
 	codeNonRepeatableError      = "NonRepeatableError"
 	codeRepeatableError         = "RepeatableError"
 	codeInvalidURLParams        = "InvalidURLParams"
+	codeEmptyField              = "EmptyField"
 
 	codeAll           = "All"
 	codeDiff          = "Diff"


### PR DESCRIPTION
fix #1614 

- This PR adds validation for required fields in EvaluationEvent and GoalEvent to ensure all essential data is present before processing.

- When running experiments, evaluation and goal events are saved to BigQuery. Older SDK versions may send events with missing required fields, causing: #1614

