### PR TITLE
fix: ambiguous column in get features

### DIFF
--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -135,7 +135,7 @@ func (s *FeatureService) GetFeatures(
 		ids = append(ids, id)
 	}
 	if len(ids) > 0 {
-		whereParts = append(whereParts, mysql.NewInFilter("id", ids))
+		whereParts = append(whereParts, mysql.NewInFilter("feature.id", ids))
 	}
 	featureStorage := v2fs.NewFeatureStorage(s.mysqlClient)
 	features, _, _, err := featureStorage.ListFeatures(


### PR DESCRIPTION
Fix ambiguous column in whereparts
```
"message":"Failed to get feature","serviceContext":{"service":"bucketeer-web.server","version":"-"}
"error":"Error 1052 (23000): Column 'id' in where clause is ambiguous"
```