### PR TITLE
chore: validate events from the sdk in api gateway

### DIFF
--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -3750,11 +3750,28 @@ func TestGrcpRegisterEvents(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{Timestamp: time.Now().Unix()})
+	bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+		Timestamp: time.Now().Unix(),
+		GoalId:    "goal-id-1",
+		UserId:    "user-id-1",
+		User: &userproto.User{
+			Id: "user-id-1",
+		},
+	})
 	if err != nil {
 		t.Fatal("could not serialize goal event")
 	}
-	bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{Timestamp: time.Now().Unix()})
+	bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+		Timestamp:   time.Now().Unix(),
+		FeatureId:   "feature-id-1",
+		VariationId: "variation-id-1",
+		User: &userproto.User{
+			Id: "user-id-1",
+		},
+		Reason: &featureproto.Reason{
+			Type: featureproto.Reason_DEFAULT,
+		},
+	})
 	if err != nil {
 		t.Fatal("could not serialize evaluation event")
 	}

--- a/pkg/api/api/grpc_validation.go
+++ b/pkg/api/api/grpc_validation.go
@@ -122,7 +122,7 @@ func (v *eventGoalValidator) validate(ctx context.Context) (string, error) {
 		)
 		return codeEmptyField, errEmptyGoalID
 	}
-	if ev.User.Id == "" && ev.UserId == "" {
+	if (ev.User == nil || (ev.User != nil && ev.User.Id == "")) && ev.UserId == "" {
 		v.logger.Debug(
 			"Empty user_id",
 			log.FieldsFromImcomingContext(ctx).AddFields(
@@ -199,7 +199,7 @@ func (v *eventEvaluationValidator) validate(ctx context.Context) (string, error)
 		)
 		return codeEmptyField, errEmptyVariationID
 	}
-	if ev.User.Id == "" && ev.UserId == "" {
+	if (ev.User == nil || (ev.User != nil && ev.User.Id == "")) && ev.UserId == "" {
 		v.logger.Debug(
 			"Empty user_id",
 			log.FieldsFromImcomingContext(ctx).AddFields(

--- a/pkg/api/api/grpc_validation.go
+++ b/pkg/api/api/grpc_validation.go
@@ -35,7 +35,6 @@ var (
 	errEmptyUserID      = errors.New("gateway: user_id is empty")
 	errEmptyVariationID = errors.New("gateway: variation_id is empty")
 	errEmptyGoalID      = errors.New("gateway: goal_id is empty")
-	errNilUser          = errors.New("gateway: user is nil")
 	errNilReason        = errors.New("gateway: reason is nil")
 )
 
@@ -123,22 +122,13 @@ func (v *eventGoalValidator) validate(ctx context.Context) (string, error) {
 		)
 		return codeEmptyField, errEmptyGoalID
 	}
-	if ev.User == nil {
-		v.logger.Debug(
-			"Nil user",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.String("id", v.event.Id),
-				zap.Any("user", ev.User),
-			)...,
-		)
-		return codeEmptyField, errNilUser
-	}
-	if ev.User.Id == "" {
+	if ev.User.Id == "" && ev.UserId == "" {
 		v.logger.Debug(
 			"Empty user_id",
 			log.FieldsFromImcomingContext(ctx).AddFields(
 				zap.String("id", v.event.Id),
-				zap.String("user_id", ev.User.Id),
+				zap.Any("user", ev.User),
+				zap.String("user_id", ev.UserId),
 			)...,
 		)
 		return codeEmptyField, errEmptyUserID
@@ -209,21 +199,13 @@ func (v *eventEvaluationValidator) validate(ctx context.Context) (string, error)
 		)
 		return codeEmptyField, errEmptyVariationID
 	}
-	if ev.User == nil {
-		v.logger.Debug(
-			"Nil user",
-			log.FieldsFromImcomingContext(ctx).AddFields(
-				zap.String("id", v.event.Id),
-				zap.Any("user", ev.User),
-			)...,
-		)
-		return codeEmptyField, errNilUser
-	}
-	if ev.User.Id == "" {
+	if ev.User.Id == "" && ev.UserId == "" {
 		v.logger.Debug(
 			"Empty user_id",
 			log.FieldsFromImcomingContext(ctx).AddFields(
 				zap.String("id", v.event.Id),
+				zap.Any("user", ev.User),
+				zap.String("user_id", ev.UserId),
 			)...,
 		)
 		return codeEmptyField, errEmptyUserID

--- a/pkg/api/api/grpc_validation.go
+++ b/pkg/api/api/grpc_validation.go
@@ -31,6 +31,12 @@ var (
 	errInvalidIDFormat  = errors.New("gateway: invalid event id format")
 	errInvalidTimestamp = errors.New("gateway: invalid event timestamp")
 	errUnmarshalFailed  = errors.New("gateway: failed to unmarshal event")
+	errEmptyFeatureID   = errors.New("gateway: feature_id is empty")
+	errEmptyUserID      = errors.New("gateway: user_id is empty")
+	errEmptyVariationID = errors.New("gateway: variation_id is empty")
+	errEmptyGoalID      = errors.New("gateway: goal_id is empty")
+	errNilUser          = errors.New("gateway: user is nil")
+	errNilReason        = errors.New("gateway: reason is nil")
 )
 
 type eventValidator interface {
@@ -105,6 +111,39 @@ func (v *eventGoalValidator) validate(ctx context.Context) (string, error) {
 	if err != nil {
 		return codeUnmarshalFailed, errUnmarshalFailed
 	}
+
+	// validate required fields
+	if ev.GoalId == "" {
+		v.logger.Debug(
+			"Empty goal_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("goal_id", ev.GoalId),
+			)...,
+		)
+		return codeEmptyField, errEmptyGoalID
+	}
+	if ev.User == nil {
+		v.logger.Debug(
+			"Nil user",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.Any("user", ev.User),
+			)...,
+		)
+		return codeEmptyField, errNilUser
+	}
+	if ev.User.Id == "" {
+		v.logger.Debug(
+			"Empty user_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("user_id", ev.User.Id),
+			)...,
+		)
+		return codeEmptyField, errEmptyUserID
+	}
+
 	if !validateTimestamp(ev.Timestamp, v.oldestTimestampDuration, v.furthestTimestampDuration) {
 		v.logger.Debug(
 			"Failed to validate goal event timestamp",
@@ -148,6 +187,58 @@ func (v *eventEvaluationValidator) validate(ctx context.Context) (string, error)
 	if err != nil {
 		return codeUnmarshalFailed, errUnmarshalFailed
 	}
+
+	// validate required fields
+	if ev.FeatureId == "" {
+		v.logger.Debug(
+			"Empty feature_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("feature_id", ev.FeatureId),
+			)...,
+		)
+		return codeEmptyField, errEmptyFeatureID
+	}
+	if ev.VariationId == "" {
+		v.logger.Debug(
+			"Empty variation_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.String("variation_id", ev.VariationId),
+			)...,
+		)
+		return codeEmptyField, errEmptyVariationID
+	}
+	if ev.User == nil {
+		v.logger.Debug(
+			"Nil user",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.Any("user", ev.User),
+			)...,
+		)
+		return codeEmptyField, errNilUser
+	}
+	if ev.User.Id == "" {
+		v.logger.Debug(
+			"Empty user_id",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+			)...,
+		)
+		return codeEmptyField, errEmptyUserID
+	}
+	if ev.Reason == nil {
+		v.logger.Debug(
+			"Nil reason",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("id", v.event.Id),
+				zap.Any("reason", ev.Reason),
+			)...,
+		)
+		return codeEmptyField, errNilReason
+	}
+
 	if !validateTimestamp(ev.Timestamp, v.oldestTimestampDuration, v.furthestTimestampDuration) {
 		v.logger.Debug(
 			"Failed to validate evaluation event timestamp",

--- a/pkg/api/api/grpc_validation_test.go
+++ b/pkg/api/api/grpc_validation_test.go
@@ -385,6 +385,32 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			expectedErr: errEmptyUserID,
 		},
 		{
+			desc: "nil user",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User:        nil,
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyUserID,
+		},
+		{
 			desc: "nil reason",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{

--- a/pkg/api/api/grpc_validation_test.go
+++ b/pkg/api/api/grpc_validation_test.go
@@ -179,28 +179,6 @@ func TestGrpcValidateGoalEvent(t *testing.T) {
 			expectedErr: errEmptyGoalID,
 		},
 		{
-			desc: "nil user",
-			inputFunc: func() *eventproto.Event {
-				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
-					Timestamp: time.Now().Unix(),
-					GoalId:    "goal-id",
-					User:      nil,
-				})
-				if err != nil {
-					t.Fatal("could not serialize event")
-				}
-				return &eventproto.Event{
-					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
-					Event: &any.Any{
-						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
-						Value:   bGoalEvent,
-					},
-				}
-			},
-			expected:    codeEmptyField,
-			expectedErr: errNilUser,
-		},
-		{
 			desc: "empty user_id",
 			inputFunc: func() *eventproto.Event {
 				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
@@ -209,6 +187,7 @@ func TestGrpcValidateGoalEvent(t *testing.T) {
 					User: &user.User{
 						Id: "",
 					},
+					UserId: "",
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")
@@ -377,32 +356,6 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			expectedErr: errEmptyVariationID,
 		},
 		{
-			desc: "nil user",
-			inputFunc: func() *eventproto.Event {
-				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
-					Timestamp:   time.Now().Unix(),
-					FeatureId:   "feature-id",
-					VariationId: "variation-id",
-					User:        nil,
-					Reason: &feature.Reason{
-						Type: feature.Reason_DEFAULT,
-					},
-				})
-				if err != nil {
-					t.Fatal("could not serialize event")
-				}
-				return &eventproto.Event{
-					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
-					Event: &any.Any{
-						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
-						Value:   bEvaluationEvent,
-					},
-				}
-			},
-			expected:    codeEmptyField,
-			expectedErr: errNilUser,
-		},
-		{
 			desc: "empty user_id",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
@@ -412,6 +365,7 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 					User: &user.User{
 						Id: "",
 					},
+					UserId: "",
 					Reason: &feature.Reason{
 						Type: feature.Reason_DEFAULT,
 					},

--- a/pkg/api/api/grpc_validation_test.go
+++ b/pkg/api/api/grpc_validation_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	"github.com/bucketeer-io/bucketeer/proto/feature"
+	"github.com/bucketeer-io/bucketeer/proto/user"
 )
 
 const (
@@ -154,10 +155,84 @@ func TestGrpcValidateGoalEvent(t *testing.T) {
 			expectedErr: errUnmarshalFailed,
 		},
 		{
+			desc: "empty goal_id",
+			inputFunc: func() *eventproto.Event {
+				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+					Timestamp: time.Now().Unix(),
+					GoalId:    "",
+					User: &user.User{
+						Id: "user-id",
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
+						Value:   bGoalEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyGoalID,
+		},
+		{
+			desc: "nil user",
+			inputFunc: func() *eventproto.Event {
+				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+					Timestamp: time.Now().Unix(),
+					GoalId:    "goal-id",
+					User:      nil,
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
+						Value:   bGoalEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errNilUser,
+		},
+		{
+			desc: "empty user_id",
+			inputFunc: func() *eventproto.Event {
+				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
+					Timestamp: time.Now().Unix(),
+					GoalId:    "goal-id",
+					User: &user.User{
+						Id: "",
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.GoalEvent",
+						Value:   bGoalEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyUserID,
+		},
+		{
 			desc: "invalid timestamp",
 			inputFunc: func() *eventproto.Event {
 				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
 					Timestamp: int64(999999999999999),
+					GoalId:    "goal-id",
+					User: &user.User{
+						Id: "user-id",
+					},
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")
@@ -178,6 +253,10 @@ func TestGrpcValidateGoalEvent(t *testing.T) {
 			inputFunc: func() *eventproto.Event {
 				bGoalEvent, err := proto.Marshal(&eventproto.GoalEvent{
 					Timestamp: time.Now().Unix(),
+					GoalId:    "goal-id",
+					User: &user.User{
+						Id: "user-id",
+					},
 					Evaluations: []*feature.Evaluation{
 						{
 							Id: "evaluation-id",
@@ -242,10 +321,154 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			expectedErr: errUnmarshalFailed,
 		},
 		{
+			desc: "empty feature_id",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyFeatureID,
+		},
+		{
+			desc: "empty variation_id",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyVariationID,
+		},
+		{
+			desc: "nil user",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User:        nil,
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errNilUser,
+		},
+		{
+			desc: "empty user_id",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errEmptyUserID,
+		},
+		{
+			desc: "nil reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: nil,
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    codeEmptyField,
+			expectedErr: errNilReason,
+		},
+		{
 			desc: "invalid timestamp",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
-					Timestamp: int64(999999999999999),
+					Timestamp:   int64(999999999999999),
+					FeatureId:   "feature-id",
+					VariationId: "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")
@@ -265,7 +488,16 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			desc: "success",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
-					Timestamp: time.Now().Unix(),
+					Timestamp:      time.Now().Unix(),
+					FeatureId:      "feature-id",
+					FeatureVersion: 1,
+					VariationId:    "variation-id",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_DEFAULT,
+					},
 				})
 				if err != nil {
 					t.Fatal("could not serialize event")

--- a/pkg/api/api/metrics.go
+++ b/pkg/api/api/metrics.go
@@ -56,6 +56,7 @@ const (
 	codeNonRepeatableError      = "NonRepeatableError"
 	codeRepeatableError         = "RepeatableError"
 	codeInvalidURLParams        = "InvalidURLParams"
+	codeEmptyField              = "EmptyField"
 
 	codeAll           = "All"
 	codeDiff          = "Diff"

--- a/pkg/subscriber/processor/evaluation_events_dwh.go
+++ b/pkg/subscriber/processor/evaluation_events_dwh.go
@@ -190,6 +190,7 @@ func (w *evalEvtWriter) convToEvaluationEvent(
 			return nil, false, err
 		}
 	}
+	userID := getUserID(e.UserId, e.User)
 	tag := e.Tag
 	if tag == "" {
 		// Tag is optional, so we insert none when is empty.
@@ -200,7 +201,7 @@ func (w *evalEvtWriter) convToEvaluationEvent(
 		FeatureId:      e.FeatureId,
 		FeatureVersion: e.FeatureVersion,
 		UserData:       string(ud),
-		UserId:         e.UserId,
+		UserId:         userID,
 		VariationId:    e.VariationId,
 		Reason:         e.Reason.Type.String(),
 		Tag:            tag,

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -35,7 +35,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/subscriber"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
-	uproto "github.com/bucketeer-io/bucketeer/proto/user"
 )
 
 const (
@@ -228,16 +227,6 @@ func getVariationID(reason *featureproto.Reason, vID string) (string, error) {
 		return defaultVariationID, nil
 	}
 	return vID, nil
-}
-
-// Because the `userId` field in the EvaluationEvent proto message is already in the `User` field,
-// we should remove it to avoid sending the same value twice.
-// To keep compatibility, we must check both fields until all the SDKs are updated
-func getUserID(userID string, user *uproto.User) string {
-	if userID == "" {
-		return user.Id
-	}
-	return userID
 }
 
 func (p *evaluationCountEventPersister) incrementEvaluationCount(

--- a/pkg/subscriber/processor/evaluation_events_ops.go
+++ b/pkg/subscriber/processor/evaluation_events_ops.go
@@ -134,6 +134,7 @@ func (u *evalEvtUpdater) updateUserCount(
 		}
 		linkedOpsRules[rule.Id] = clauseIDs
 	}
+	userID := getUserID(event.UserId, event.User)
 	// Update the user count per rule
 	for ruleID, clauseIDs := range linkedOpsRules {
 		err := u.updateUserCountPerClause(
@@ -141,7 +142,7 @@ func (u *evalEvtUpdater) updateUserCount(
 			event.FeatureId,
 			event.FeatureVersion,
 			event.VariationId,
-			event.UserId,
+			userID,
 			ruleID,
 			clauseIDs,
 		)

--- a/pkg/subscriber/processor/event.go
+++ b/pkg/subscriber/processor/event.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"github.com/golang/protobuf/proto"
+
+	uproto "github.com/bucketeer-io/bucketeer/proto/user"
 )
 
 type eventDWHMap map[string]proto.Message
@@ -32,4 +34,14 @@ type Writer interface {
 
 type Updater interface {
 	UpdateUserCounts(ctx context.Context, events environmentEventOPSMap) map[string]bool
+}
+
+// Because the `userId` field in the EvaluationEvent proto message is already in the `User` field,
+// we should remove it to avoid sending the same value twice.
+// To keep compatibility, we must check both fields until all the SDKs are updated
+func getUserID(userID string, user *uproto.User) string {
+	if userID == "" {
+		return user.Id
+	}
+	return userID
 }

--- a/pkg/subscriber/processor/goal_events_dwh.go
+++ b/pkg/subscriber/processor/goal_events_dwh.go
@@ -204,6 +204,7 @@ func (w *goalEvtWriter) convToGoalEvent(
 			return nil, false, err
 		}
 	}
+	userID := getUserID(e.UserId, e.User)
 	if tag == "" {
 		// Tag is optional, so we insert none when is empty.
 		tag = "none"
@@ -213,7 +214,7 @@ func (w *goalEvtWriter) convToGoalEvent(
 		GoalId:         e.GoalId,
 		Value:          float32(e.Value),
 		UserData:       string(ud),
-		UserId:         e.UserId,
+		UserId:         userID,
 		Tag:            tag,
 		SourceId:       e.SourceId.String(),
 		EnvironmentId:  environmentId,

--- a/pkg/subscriber/processor/goal_events_ops.go
+++ b/pkg/subscriber/processor/goal_events_ops.go
@@ -154,6 +154,7 @@ func (u *evalGoalUpdater) updateUserCount(
 		subscriberHandledCounter.WithLabelValues(subscriberGoalEventOPS, codeGetFeaturesReturnedEmpty).Inc()
 		return true, ErrFeatureEmptyList
 	}
+	userID := getUserID(event.UserId, event.User)
 	for _, r := range linkedRules {
 		// Get the latest feature version
 		fVersion, err := u.getFeatureVersion(r.featureID, resp.Features)
@@ -172,7 +173,7 @@ func (u *evalGoalUpdater) updateUserCount(
 			environmentId,
 			r.featureID,
 			fVersion,
-			event.UserId,
+			userID,
 			r,
 		)
 		if err != nil {


### PR DESCRIPTION
- Reverts bucketeer-io/bucketeer#1637
- Validate if userID is empty or userID in User Object is empty.(We want to use User Object, but userID is still used in old sdk)
- Unify userID retrieval in subscriver because some processers use userID not in User Object.