### PR TITLE
chore(ui/dashboard): change tags place holder on the member page

### DIFF
--- a/ui/dashboard/public/locales/en/form.json
+++ b/ui/dashboard/public/locales/en/form.json
@@ -151,5 +151,6 @@
   "origin-env": "Origin Environment",
   "destination-env": "Destination Environment",
   "comment-for-update": "Comment for update",
-  "placeholder-comment": "Enter comment"
+  "placeholder-comment": "Enter comment",
+  "placeholder-member-tags": "Tags can be used to group members as teams"
 }

--- a/ui/dashboard/public/locales/ja/form.json
+++ b/ui/dashboard/public/locales/ja/form.json
@@ -151,5 +151,6 @@
   "origin-env": "Origin Environment",
   "destination-env": "Destination Environment",
   "comment-for-update": "Comment for update",
-  "placeholder-comment": "Enter comment"
+  "placeholder-comment": "Enter comment",
+  "placeholder-member-tags": "Tags can be used to group members as teams"
 }

--- a/ui/dashboard/src/pages/members/member-modal/add-member-modal/index.tsx
+++ b/ui/dashboard/src/pages/members/member-modal/add-member-modal/index.tsx
@@ -253,7 +253,7 @@ const AddMemberModal = ({ isOpen, onClose }: AddMemberModalProps) => {
                     <CreatableSelect
                       disabled={isLoadingTags}
                       loading={isLoadingTags}
-                      placeholder={t(`form:placeholder-tags`)}
+                      placeholder={t(`form:placeholder-member-tags`)}
                       options={tagOptions?.map(tag => ({
                         label: tag.name,
                         value: tag.id

--- a/ui/dashboard/src/pages/members/member-modal/edit-member-modal/index.tsx
+++ b/ui/dashboard/src/pages/members/member-modal/edit-member-modal/index.tsx
@@ -297,7 +297,7 @@ const EditMemberModal = ({ isOpen, onClose, member }: EditMemberModalProps) => {
                     {t('tags')}
                     <Tooltip
                       align="start"
-                      alignOffset={-130}
+                      alignOffset={-30}
                       trigger={
                         <div className="flex-center absolute top-0 -right-6">
                           <Icon icon={IconInfo} size={'sm'} color="gray-600" />
@@ -312,7 +312,7 @@ const EditMemberModal = ({ isOpen, onClose, member }: EditMemberModalProps) => {
                       defaultValues={defaultTagsValue}
                       disabled={isLoadingTags}
                       loading={isLoadingTags}
-                      placeholder={t(`form:placeholder-tags`)}
+                      placeholder={t(`form:placeholder-member-tags`)}
                       options={tagOptions?.map(tag => ({
                         label: tag.name,
                         value: tag.id


### PR DESCRIPTION
Change it from "Select tags" to "Tags can be used to group members as teams".

Fix #1630 