### PR TITLE
fix(ui/dashboard): admin console always selects the first environment in the list

### DIFF
--- a/ui/dashboard/src/auth/auth-context.tsx
+++ b/ui/dashboard/src/auth/auth-context.tsx
@@ -13,7 +13,6 @@ import { PAGE_PATH_ROOT } from 'constants/routing';
 import { useToast } from 'hooks';
 import { Undefinable } from 'option-t/undefinable';
 import {
-  clearCurrentEnvIdStorage,
   getCurrentEnvIdStorage,
   setCurrentEnvIdStorage
 } from 'storage/environment';
@@ -120,7 +119,6 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
     setIsLogin(false);
     clearOrgIdStorage();
     clearTokenStorage();
-    clearCurrentEnvIdStorage();
     navigate(PAGE_PATH_ROOT);
   };
 

--- a/ui/dashboard/src/auth/utils.ts
+++ b/ui/dashboard/src/auth/utils.ts
@@ -11,11 +11,11 @@ export const currentEnvironmentRole = (
     ? currentEnvId
     : account.environmentRoles[0].environment.id;
 
-  let curEnvRole = account.environmentRoles.find(
-    environmentRole =>
-      environmentRole.environment.id === curEnvId ||
-      environmentRole.environment.urlCode === curEnvId
-  );
+  let curEnvRole = account.environmentRoles.find(environmentRole => {
+    const { environment } = environmentRole;
+    if (environment.id && curEnvId) return environment.id === curEnvId;
+    return environment.urlCode === curEnvId;
+  });
   if (!curEnvRole) {
     curEnvRole = account.environmentRoles[0];
   }
@@ -31,14 +31,21 @@ export const getCurrentEnvironment = (account: ConsoleAccount): Environment => {
 export const getCurrentProject = (
   roles: EnvironmentRole[],
   currentEnvId: string
-) =>
-  unwrapUndefinable(
-    roles.find(
-      role =>
-        role.environment.id == currentEnvId ||
-        role.environment.urlCode == currentEnvId
-    )
-  ).project;
+) => {
+  try {
+    return unwrapUndefinable(
+      roles.find(role => {
+        const { environment } = role;
+
+        if (!!environment.id && !!currentEnvId)
+          return environment.id == currentEnvId;
+        return role.environment.urlCode == currentEnvId;
+      })
+    )?.project;
+  } catch {
+    return null;
+  }
+};
 
 export const hasEditable = (account: ConsoleAccount): boolean => {
   if (account.isSystemAdmin) return true;

--- a/ui/dashboard/src/hooks/use-toast.tsx
+++ b/ui/dashboard/src/hooks/use-toast.tsx
@@ -37,10 +37,10 @@ export const useToast = () => {
       }
     );
 
-  const errorNotify = (error: unknown) =>
+  const errorNotify = (error?: unknown, message?: string) =>
     notify({
       messageType: 'error',
-      message: (error as Error)?.message || 'Something went wrong.'
+      message: message || (error as Error)?.message || 'Something went wrong.'
     });
 
   return {


### PR DESCRIPTION
When accessing the console after a while, it always selects the first environment from the list.
The local storage should have the last selected environment ID after the user logs in. If the selected environment ID is not present in the list, it should force the user to re-login.

Fix #1647 