### PR TITLE
refactor: change the list retrieval API in the notification package to use ListOption

### DIFF
--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -629,13 +629,20 @@ func (s *NotificationService) ListAdminSubscriptions(
 	if req.Disabled != nil {
 		disabled = &req.Disabled.Value
 	}
+	orders, err := s.newAdminSubscriptionListOrders(req.OrderBy, req.OrderDirection, localizer)
+	if err != nil {
+		s.logger.Error(
+			"Invalid argument",
+			log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
+		)
+		return nil, err
 
 	subscriptions, cursor, totalCount, err := s.listAdminSubscriptionsMySQL(
 		ctx,
 		req.SourceTypes,
 		disabled,
 		req.SearchKeyword,
-		nil,
+		orders,
 		req.PageSize,
 		req.Cursor,
 		localizer,

--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -625,39 +625,22 @@ func (s *NotificationService) ListAdminSubscriptions(
 	if err != nil {
 		return nil, err
 	}
-	var whereParts []mysql.WherePart
-	sourceTypesValues := make([]interface{}, len(req.SourceTypes))
-	for i, st := range req.SourceTypes {
-		sourceTypesValues[i] = int32(st)
-	}
-	if len(sourceTypesValues) > 0 {
-		whereParts = append(
-			whereParts,
-			mysql.NewJSONFilter("source_types", mysql.JSONContainsNumber, sourceTypesValues),
-		)
-	}
+	var disabled *bool
 	if req.Disabled != nil {
-		whereParts = append(whereParts, mysql.NewFilter("disabled", "=", req.Disabled.Value))
+		disabled = &req.Disabled.Value
 	}
-	if req.SearchKeyword != "" {
-		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"name"}, req.SearchKeyword))
-	}
-	orders, err := s.newAdminSubscriptionListOrders(req.OrderBy, req.OrderDirection, localizer)
-	if err != nil {
-		s.logger.Error(
-			"Invalid argument",
-			log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
-		)
-		return nil, err
-	}
+
 	subscriptions, cursor, totalCount, err := s.listAdminSubscriptionsMySQL(
 		ctx,
-		whereParts,
-		orders,
+		req.SourceTypes,
+		disabled,
+		req.SearchKeyword,
+		nil,
 		req.PageSize,
 		req.Cursor,
 		localizer,
 	)
+
 	if err != nil {
 		return nil, err
 	}
@@ -708,26 +691,18 @@ func (s *NotificationService) ListEnabledAdminSubscriptions(
 	if err != nil {
 		return nil, err
 	}
-	var whereParts []mysql.WherePart
-	whereParts = append(whereParts, mysql.NewFilter("disabled", "=", false))
-	sourceTypesValues := make([]interface{}, len(req.SourceTypes))
-	for i, st := range req.SourceTypes {
-		sourceTypesValues[i] = int32(st)
-	}
-	if len(sourceTypesValues) > 0 {
-		whereParts = append(
-			whereParts,
-			mysql.NewJSONFilter("source_types", mysql.JSONContainsNumber, sourceTypesValues),
-		)
-	}
+	var disabled = false
 	subscriptions, cursor, _, err := s.listAdminSubscriptionsMySQL(
 		ctx,
-		whereParts,
+		req.SourceTypes,
+		&disabled,
+		"",
 		nil,
 		req.PageSize,
 		req.Cursor,
 		localizer,
 	)
+
 	if err != nil {
 		return nil, err
 	}
@@ -739,12 +714,41 @@ func (s *NotificationService) ListEnabledAdminSubscriptions(
 
 func (s *NotificationService) listAdminSubscriptionsMySQL(
 	ctx context.Context,
-	whereParts []mysql.WherePart,
+	sourceTypes []notificationproto.Subscription_SourceType,
+	disabled *bool,
+	searchKeyword string,
 	orders []*mysql.Order,
 	pageSize int64,
 	cursor string,
 	localizer locale.Localizer,
 ) ([]*notificationproto.Subscription, string, int64, error) {
+	var filters []*mysql.FilterV2
+	if disabled != nil {
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "disabled",
+			Operator: mysql.OperatorEqual,
+			Value:    disabled,
+		})
+	}
+	sourceTypesValues := make([]interface{}, len(sourceTypes))
+	for i, st := range sourceTypes {
+		sourceTypesValues[i] = int32(st)
+	}
+	var jsonFilters []*mysql.JSONFilter
+	if len(sourceTypesValues) > 0 {
+		jsonFilters = append(jsonFilters, &mysql.JSONFilter{
+			Column: "source_types",
+			Func:   mysql.JSONContainsNumber,
+			Values: sourceTypesValues,
+		})
+	}
+	var seachQuery *mysql.SearchQuery
+	if searchKeyword != "" {
+		seachQuery = &mysql.SearchQuery{
+			Columns: []string{"name"},
+			Keyword: searchKeyword,
+		}
+	}
 	limit := int(pageSize)
 	if cursor == "" {
 		cursor = "0"
@@ -760,12 +764,20 @@ func (s *NotificationService) listAdminSubscriptionsMySQL(
 		}
 		return nil, "", 0, dt.Err()
 	}
+	options := &mysql.ListOptions{
+		Limit:       limit,
+		Offset:      offset,
+		Filters:     filters,
+		InFilter:    nil,
+		NullFilters: nil,
+		JSONFilters: jsonFilters,
+		SearchQuery: seachQuery,
+		Orders:      orders,
+	}
+
 	subscriptions, nextCursor, totalCount, err := s.adminSubscriptionStorage.ListAdminSubscriptions(
 		ctx,
-		whereParts,
-		orders,
-		limit,
-		offset,
+		options,
 	)
 	if err != nil {
 		s.logger.Error(

--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -636,6 +636,7 @@ func (s *NotificationService) ListAdminSubscriptions(
 			log.FieldsFromImcomingContext(ctx).AddFields(zap.Error(err))...,
 		)
 		return nil, err
+	}
 
 	subscriptions, cursor, totalCount, err := s.listAdminSubscriptionsMySQL(
 		ctx,

--- a/pkg/notification/api/admin_subscription_test.go
+++ b/pkg/notification/api/admin_subscription_test.go
@@ -796,7 +796,7 @@ func TestListAdminSubscriptionsMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *NotificationService) {
 				s.adminSubscriptionStorage.(*staragemock.MockAdminSubscriptionStorage).EXPECT().ListAdminSubscriptions(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Subscription{}, 0, int64(0), nil)
 
 			},
@@ -866,7 +866,7 @@ func TestListEnabledAdminSubscriptionsMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *NotificationService) {
 				s.adminSubscriptionStorage.(*staragemock.MockAdminSubscriptionStorage).EXPECT().ListAdminSubscriptions(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Subscription{}, 1, int64(1), nil)
 			},
 			isSystemAdmin: true,

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -903,7 +903,7 @@ func (s *NotificationService) listSubscriptionsMySQL(
 		NullFilters: nil,
 		JSONFilters: jsonFilters,
 		SearchQuery: seachQuery,
-		Orders:      nil,
+		Orders:      orders,
 	}
 
 	subscriptions, nextCursor, totalCount, err := s.subscriptionStorage.ListSubscriptions(

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -840,7 +840,7 @@ func (s *NotificationService) listSubscriptionsMySQL(
 ) ([]*notificationproto.Subscription, string, int64, error) {
 	var filters []*mysql.FilterV2
 	if organizationId != "" {
-		// New console
+		// console v3
 		filters = append(filters, &mysql.FilterV2{
 			Column:   "env.organization_id",
 			Operator: mysql.OperatorEqual,

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -847,7 +847,7 @@ func (s *NotificationService) listSubscriptionsMySQL(
 			Value:    organizationId,
 		})
 	} else {
-		// Current console
+		// console v2
 		filters = append(filters, &mysql.FilterV2{
 			Column:   "sub.environment_id",
 			Operator: mysql.OperatorEqual,

--- a/pkg/notification/api/subscription_test.go
+++ b/pkg/notification/api/subscription_test.go
@@ -1046,7 +1046,7 @@ func TestListSubscriptionsMySQL(t *testing.T) {
 			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
 				s.subscriptionStorage.(*storagemock.MockSubscriptionStorage).EXPECT().ListSubscriptions(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Subscription{}, 0, int64(0), nil)
 			},
 			input: &proto.ListSubscriptionsRequest{
@@ -1131,7 +1131,7 @@ func TestListEnabledSubscriptionsMySQL(t *testing.T) {
 			envRole:       toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *NotificationService) {
 				s.subscriptionStorage.(*storagemock.MockSubscriptionStorage).EXPECT().ListSubscriptions(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Subscription{}, 1, int64(1), nil)
 			},
 			input: &proto.ListEnabledSubscriptionsRequest{

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -188,7 +188,7 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countQueryWhereArgs := mysql.ConstructQueryAndWhereArgs(selectSubscriptionV2CountSQLQuery, options)
+	countQuery, countQueryWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAdminSubscriptionV2CountSQLQuery, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countQueryWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -52,9 +51,7 @@ type AdminSubscriptionStorage interface {
 	GetAdminSubscription(ctx context.Context, id string) (*domain.Subscription, error)
 	ListAdminSubscriptions(
 		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
+		options *mysql.ListOptions,
 	) ([]*proto.Subscription, int, int64, error)
 }
 
@@ -156,21 +153,20 @@ func (s *adminSubscriptionStorage) GetAdminSubscription(ctx context.Context, id 
 
 func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	ctx context.Context,
-	whereParts []mysql.WherePart,
-	orders []*mysql.Order,
-	limit, offset int,
+	options *mysql.ListOptions,
 ) ([]*proto.Subscription, int, int64, error) {
-	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
-	orderBySQL := mysql.ConstructOrderBySQLString(orders)
-	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	query := fmt.Sprintf(selectAdminSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
+	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectAdminSubscriptionV2AnySQLQuery, options)
+	// whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
+	// orderBySQL := mysql.ConstructOrderBySQLString(orders)
+	// limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
+	// query := fmt.Sprintf(selectAdminSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
-	subscriptions := make([]*proto.Subscription, 0, limit)
+	subscriptions := make([]*proto.Subscription, 0)
 	for rows.Next() {
 		subscription := proto.Subscription{}
 		err := rows.Scan(
@@ -190,11 +186,14 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	if rows.Err() != nil {
 		return nil, 0, 0, err
 	}
+	var offset int
+	if options != nil {
+		offset = options.Offset
+	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery := fmt.Sprintf(selectAdminSubscriptionV2CountSQLQuery, whereSQL)
-
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	countQuery, countQueryWhereArgs := mysql.ConstructQueryAndWhereArgs(selectSubscriptionV2CountSQLQuery, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countQueryWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -156,10 +156,6 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	options *mysql.ListOptions,
 ) ([]*proto.Subscription, int, int64, error) {
 	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectAdminSubscriptionV2AnySQLQuery, options)
-	// whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
-	// orderBySQL := mysql.ConstructOrderBySQLString(orders)
-	// limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	// query := fmt.Sprintf(selectAdminSubscriptionV2AnySQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 
 	if err != nil {

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -162,7 +162,13 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
-	subscriptions := make([]*proto.Subscription, 0)
+	var offset int
+	var limit int
+	if options != nil {
+		offset = options.Offset
+		limit = options.Limit
+	}
+	subscriptions := make([]*proto.Subscription, 0, limit)
 	for rows.Next() {
 		subscription := proto.Subscription{}
 		err := rows.Scan(
@@ -181,10 +187,6 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	}
 	if rows.Err() != nil {
 		return nil, 0, 0, err
-	}
-	var offset int
-	if options != nil {
-		offset = options.Offset
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64

--- a/pkg/notification/storage/v2/admin_subscription_test.go
+++ b/pkg/notification/storage/v2/admin_subscription_test.go
@@ -314,10 +314,7 @@ func TestListAdminSubscriptions(t *testing.T) {
 	patterns := []struct {
 		desc           string
 		setup          func(*adminSubscriptionStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
+		listOpts       *mysql.ListOptions
 		expectedCount  int
 		expectedCursor int
 		expectedErr    error
@@ -329,10 +326,7 @@ func TestListAdminSubscriptions(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
+			listOpts:       nil,
 			expectedCount:  0,
 			expectedCursor: 0,
 			expectedErr:    errors.New("error"),
@@ -362,16 +356,36 @@ func TestListAdminSubscriptions(t *testing.T) {
 					updatedAt, disable,
 				).Return(row)
 			},
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("updated_at", ">=", updatedAt),
-				mysql.NewFilter("disabled", "=", disable),
+			listOpts: &mysql.ListOptions{
+				Limit:  limit,
+				Offset: offset,
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "updated_at",
+						Operator: mysql.OperatorGreaterThanOrEqual,
+						Value:    updatedAt,
+					},
+					{
+						Column:   "disabled",
+						Operator: mysql.OperatorEqual,
+						Value:    disable,
+					},
+				},
+				Orders: []*mysql.Order{
+					{
+						Column:    "id",
+						Direction: mysql.OrderDirectionAsc,
+					},
+					{
+						Column:    "create_at",
+						Direction: mysql.OrderDirectionDesc,
+					},
+				},
+				InFilter:    nil,
+				NullFilters: nil,
+				JSONFilters: nil,
+				SearchQuery: nil,
 			},
-			orders: []*mysql.Order{
-				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-				mysql.NewOrder("create_at", mysql.OrderDirectionDesc),
-			},
-			limit:          limit,
-			offset:         offset,
 			expectedCount:  getSize,
 			expectedCursor: offset + getSize,
 			expectedErr:    nil,
@@ -397,10 +411,7 @@ func TestListAdminSubscriptions(t *testing.T) {
 					[]interface{}{},
 				).Return(row)
 			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
+			listOpts:       nil,
 			expectedCount:  0,
 			expectedCursor: 0,
 			expectedErr:    nil,
@@ -414,10 +425,7 @@ func TestListAdminSubscriptions(t *testing.T) {
 			}
 			subscriptions, cursor, _, err := storage.ListAdminSubscriptions(
 				context.Background(),
-				p.whereParts,
-				p.orders,
-				p.limit,
-				p.offset,
+				p.listOpts,
 			)
 			assert.Equal(t, p.expectedCount, len(subscriptions))
 			if len(subscriptions) > 0 {

--- a/pkg/notification/storage/v2/mock/admin_subscription.go
+++ b/pkg/notification/storage/v2/mock/admin_subscription.go
@@ -87,9 +87,9 @@ func (mr *MockAdminSubscriptionStorageMockRecorder) GetAdminSubscription(ctx, id
 }
 
 // ListAdminSubscriptions mocks base method.
-func (m *MockAdminSubscriptionStorage) ListAdminSubscriptions(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*notification.Subscription, int, int64, error) {
+func (m *MockAdminSubscriptionStorage) ListAdminSubscriptions(ctx context.Context, options *mysql.ListOptions) ([]*notification.Subscription, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAdminSubscriptions", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAdminSubscriptions", ctx, options)
 	ret0, _ := ret[0].([]*notification.Subscription)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -98,9 +98,9 @@ func (m *MockAdminSubscriptionStorage) ListAdminSubscriptions(ctx context.Contex
 }
 
 // ListAdminSubscriptions indicates an expected call of ListAdminSubscriptions.
-func (mr *MockAdminSubscriptionStorageMockRecorder) ListAdminSubscriptions(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAdminSubscriptionStorageMockRecorder) ListAdminSubscriptions(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAdminSubscriptions", reflect.TypeOf((*MockAdminSubscriptionStorage)(nil).ListAdminSubscriptions), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAdminSubscriptions", reflect.TypeOf((*MockAdminSubscriptionStorage)(nil).ListAdminSubscriptions), ctx, options)
 }
 
 // UpdateAdminSubscription mocks base method.

--- a/pkg/notification/storage/v2/mock/subscription.go
+++ b/pkg/notification/storage/v2/mock/subscription.go
@@ -87,9 +87,9 @@ func (mr *MockSubscriptionStorageMockRecorder) GetSubscription(ctx, id, environm
 }
 
 // ListSubscriptions mocks base method.
-func (m *MockSubscriptionStorage) ListSubscriptions(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*notification.Subscription, int, int64, error) {
+func (m *MockSubscriptionStorage) ListSubscriptions(ctx context.Context, options *mysql.ListOptions) ([]*notification.Subscription, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSubscriptions", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListSubscriptions", ctx, options)
 	ret0, _ := ret[0].([]*notification.Subscription)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -98,9 +98,9 @@ func (m *MockSubscriptionStorage) ListSubscriptions(ctx context.Context, wherePa
 }
 
 // ListSubscriptions indicates an expected call of ListSubscriptions.
-func (mr *MockSubscriptionStorageMockRecorder) ListSubscriptions(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockSubscriptionStorageMockRecorder) ListSubscriptions(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockSubscriptionStorage)(nil).ListSubscriptions), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSubscriptions", reflect.TypeOf((*MockSubscriptionStorage)(nil).ListSubscriptions), ctx, options)
 }
 
 // UpdateSubscription mocks base method.

--- a/pkg/notification/storage/v2/sql/admin_subscription/select_admin_subscription_v2_any.sql
+++ b/pkg/notification/storage/v2/sql/admin_subscription/select_admin_subscription_v2_any.sql
@@ -8,4 +8,3 @@ SELECT
     name
 FROM
     admin_subscription
-    %s %s %s

--- a/pkg/notification/storage/v2/sql/admin_subscription/select_admin_subscription_v2_count.sql
+++ b/pkg/notification/storage/v2/sql/admin_subscription/select_admin_subscription_v2_count.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     admin_subscription
-%s

--- a/pkg/notification/storage/v2/sql/subscription/select_subscription_v2_any.sql
+++ b/pkg/notification/storage/v2/sql/subscription/select_subscription_v2_any.sql
@@ -13,4 +13,3 @@ FROM
     subscription sub
 JOIN
     environment_v2 env ON sub.environment_id = env.id
-    %s %s %s

--- a/pkg/notification/storage/v2/sql/subscription/select_subscription_v2_count.sql
+++ b/pkg/notification/storage/v2/sql/subscription/select_subscription_v2_count.sql
@@ -4,4 +4,3 @@ FROM
     subscription sub
 JOIN
     environment_v2 env ON sub.environment_id = env.id
-%s

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -184,7 +184,14 @@ func (s *subscriptionStorage) ListSubscriptions(
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
-	subscriptions := make([]*proto.Subscription, 0)
+	var offset int
+	var limit int
+	if options != nil {
+		offset = options.Offset
+		limit = options.Limit
+	}
+
+	subscriptions := make([]*proto.Subscription, 0, limit)
 	for rows.Next() {
 		subscription := proto.Subscription{}
 		err := rows.Scan(
@@ -206,10 +213,6 @@ func (s *subscriptionStorage) ListSubscriptions(
 	}
 	if rows.Err() != nil {
 		return nil, 0, 0, err
-	}
-	var offset int
-	if options != nil {
-		offset = options.Offset
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64


### PR DESCRIPTION
This pull request focuses on refactoring the subscription listing methods in the `NotificationService` to simplify the code and enhance maintainability. The changes include replacing the use of `whereParts` and other individual parameters with a unified `ListOptions` struct, which consolidates filters, orders, and other query options.

relate of #1475