### PR TITLE
fix: duplicate features returned in the list api

### DIFF
--- a/pkg/feature/storage/v2/sql/feature/count_features.sql
+++ b/pkg/feature/storage/v2/sql/feature/count_features.sql
@@ -4,5 +4,6 @@ FROM
     feature
 LEFT OUTER JOIN feature_last_used_info ON
     feature.id = feature_last_used_info.feature_id AND
-    feature.environment_id = feature_last_used_info.environment_id
+    feature.environment_id = feature_last_used_info.environment_id AND
+    feature.version = feature_last_used_info.version
 %s

--- a/pkg/feature/storage/v2/sql/feature/count_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/sql/feature/count_features_by_experiment.sql
@@ -6,7 +6,8 @@ LEFT OUTER JOIN
     feature_last_used_info
 ON
     feature.id = feature_last_used_info.feature_id AND
-    feature.environment_id = feature_last_used_info.environment_id
+    feature.environment_id = feature_last_used_info.environment_id AND
+    feature.version = feature_last_used_info.version
 LEFT OUTER JOIN
     experiment
 ON

--- a/pkg/feature/storage/v2/sql/feature/count_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/sql/feature/count_features_by_experiment.sql
@@ -12,5 +12,6 @@ LEFT OUTER JOIN
     experiment
 ON
     feature.id = experiment.feature_id AND
-    feature.environment_id = experiment.environment_id
+    feature.environment_id = experiment.environment_id AND
+    feature.version = experiment.feature_version
 %s

--- a/pkg/feature/storage/v2/sql/feature/select_feature_count_by_status.sql
+++ b/pkg/feature/storage/v2/sql/feature/select_feature_count_by_status.sql
@@ -6,7 +6,8 @@ FROM
     feature
 LEFT JOIN feature_last_used_info ON
     feature.id = feature_last_used_info.feature_id AND
-    feature.environment_id = feature_last_used_info.environment_id
+    feature.environment_id = feature_last_used_info.environment_id AND
+    feature.version = feature_last_used_info.version
 WHERE
     feature.archived = 0 AND
     feature.deleted = 0 AND

--- a/pkg/feature/storage/v2/sql/feature/select_features.sql
+++ b/pkg/feature/storage/v2/sql/feature/select_features.sql
@@ -54,5 +54,6 @@ FROM
     feature
 LEFT OUTER JOIN feature_last_used_info ON
     feature.id = feature_last_used_info.feature_id AND
-    feature.environment_id = feature_last_used_info.environment_id
+    feature.environment_id = feature_last_used_info.environment_id AND
+    feature.version = feature_last_used_info.version
     %s %s %s

--- a/pkg/feature/storage/v2/sql/feature/select_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/sql/feature/select_features_by_experiment.sql
@@ -58,5 +58,6 @@ LEFT OUTER JOIN feature_last_used_info ON
     feature.version = feature_last_used_info.version
 LEFT OUTER JOIN experiment ON
     feature.id = experiment.feature_id AND
-    feature.environment_id = experiment.environment_id
+    feature.environment_id = experiment.environment_id AND
+    feature.version = experiment.feature_version
 %s %s %s

--- a/pkg/feature/storage/v2/sql/feature/select_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/sql/feature/select_features_by_experiment.sql
@@ -54,7 +54,8 @@ FROM
     feature
 LEFT OUTER JOIN feature_last_used_info ON
     feature.id = feature_last_used_info.feature_id AND
-    feature.environment_id = feature_last_used_info.environment_id
+    feature.environment_id = feature_last_used_info.environment_id AND
+    feature.version = feature_last_used_info.version
 LEFT OUTER JOIN experiment ON
     feature.id = experiment.feature_id AND
     feature.environment_id = experiment.environment_id


### PR DESCRIPTION
List features return duplicated data because pair of feature id and environment can exist in different version in feature_last_used_info table