### PR TITLE
fix: add validation for empty variation_id and set 'default'

### DIFF
--- a/pkg/api/api/grpc_validation.go
+++ b/pkg/api/api/grpc_validation.go
@@ -25,6 +25,7 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
+	"github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
 var (
@@ -189,7 +190,15 @@ func (v *eventEvaluationValidator) validate(ctx context.Context) (string, error)
 		)
 		return codeEmptyField, errEmptyFeatureID
 	}
-	if ev.VariationId == "" {
+	isErrorReason := ev.Reason != nil && (ev.Reason.Type == feature.Reason_ERROR_NO_EVALUATIONS ||
+		ev.Reason.Type == feature.Reason_ERROR_FLAG_NOT_FOUND ||
+		ev.Reason.Type == feature.Reason_ERROR_WRONG_TYPE ||
+		ev.Reason.Type == feature.Reason_ERROR_USER_ID_NOT_SPECIFIED ||
+		ev.Reason.Type == feature.Reason_ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED ||
+		ev.Reason.Type == feature.Reason_ERROR_EXCEPTION ||
+		ev.Reason.Type == feature.Reason_CLIENT)
+
+	if !isErrorReason && ev.VariationId == "" {
 		v.logger.Debug(
 			"Empty variation_id",
 			log.FieldsFromImcomingContext(ctx).AddFields(

--- a/pkg/api/api/grpc_validation_test.go
+++ b/pkg/api/api/grpc_validation_test.go
@@ -356,6 +356,202 @@ func TestGrpcValidateEvaluationEvent(t *testing.T) {
 			expectedErr: errEmptyVariationID,
 		},
 		{
+			desc: "empty variation_id with ERROR_NO_EVALUATIONS reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_ERROR_NO_EVALUATIONS,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "empty variation_id with ERROR_FLAG_NOT_FOUND reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_ERROR_FLAG_NOT_FOUND,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "empty variation_id with ERROR_WRONG_TYPE reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_ERROR_WRONG_TYPE,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "empty variation_id with ERROR_USER_ID_NOT_SPECIFIED reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_ERROR_USER_ID_NOT_SPECIFIED,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "empty variation_id with ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_ERROR_FEATURE_FLAG_ID_NOT_SPECIFIED,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "empty variation_id with ERROR_EXCEPTION reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_ERROR_EXCEPTION,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
+			desc: "empty variation_id with CLIENT reason",
+			inputFunc: func() *eventproto.Event {
+				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{
+					Timestamp:   time.Now().Unix(),
+					FeatureId:   "feature-id",
+					VariationId: "",
+					User: &user.User{
+						Id: "user-id",
+					},
+					Reason: &feature.Reason{
+						Type: feature.Reason_CLIENT,
+					},
+				})
+				if err != nil {
+					t.Fatal("could not serialize event")
+				}
+				return &eventproto.Event{
+					Id: "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+					Event: &any.Any{
+						TypeUrl: "github.com/bucketeer-io/bucketeer/proto/event/client/bucketeer.event.client.EvaluationEvent",
+						Value:   bEvaluationEvent,
+					},
+				}
+			},
+			expected:    "",
+			expectedErr: nil,
+		},
+		{
 			desc: "empty user_id",
 			inputFunc: func() *eventproto.Event {
 				bEvaluationEvent, err := proto.Marshal(&eventproto.EvaluationEvent{

--- a/pkg/subscriber/processor/evaluation_events_dwh.go
+++ b/pkg/subscriber/processor/evaluation_events_dwh.go
@@ -196,13 +196,20 @@ func (w *evalEvtWriter) convToEvaluationEvent(
 		// Tag is optional, so we insert none when is empty.
 		tag = "none"
 	}
+	variationID := e.VariationId
+	if variationID == "" {
+		// When the default value is returned to the app in the SDK,
+		// it creates a default evaluation event with an empty variation ID.
+		// Because we don't have the variation ID we insert "default" as the variation_id
+		variationID = "default"
+	}
 	return &epproto.EvaluationEvent{
 		Id:             id,
 		FeatureId:      e.FeatureId,
 		FeatureVersion: e.FeatureVersion,
 		UserData:       string(ud),
 		UserId:         userID,
-		VariationId:    e.VariationId,
+		VariationId:    variationID,
 		Reason:         e.Reason.Type.String(),
 		Tag:            tag,
 		SourceId:       e.SourceId.String(),


### PR DESCRIPTION
- Add validation for empty variation_id when the reason is about error.
- Set  variation_id 'default' when the reason is default, variation_id is empty in dwh subscriber. 
- Add tests.