### PR TITLE
refactor: change the list retrieval API in the push package to use ListOption

### DIFF
--- a/pkg/push/api/api_test.go
+++ b/pkg/push/api/api_test.go
@@ -153,7 +153,7 @@ func TestCreatePushMySQL(t *testing.T) {
 			desc: "err: ErrAlreadyExists",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
@@ -178,7 +178,7 @@ func TestCreatePushMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
@@ -267,7 +267,7 @@ func TestCreatePushNoCommandMySQL(t *testing.T) {
 			desc: "err: ErrAlreadyExists",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
@@ -290,7 +290,7 @@ func TestCreatePushNoCommandMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
@@ -392,7 +392,7 @@ func TestUpdatePushMySQL(t *testing.T) {
 			desc: "err: ErrNotFound",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().GetPush(
 					gomock.Any(), gomock.Any(), gomock.Any(),
@@ -468,7 +468,7 @@ func TestUpdatePushMySQL(t *testing.T) {
 			desc: "success: addPushTags",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().GetPush(
 					gomock.Any(), gomock.Any(), gomock.Any(),
@@ -499,7 +499,7 @@ func TestUpdatePushMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
@@ -912,7 +912,7 @@ func TestListPushesMySQL(t *testing.T) {
 			desc: "err: ErrInternal",
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("error"))
 			},
 			input:       &pushproto.ListPushesRequest{EnvironmentId: "ns0"},
@@ -933,7 +933,7 @@ func TestListPushesMySQL(t *testing.T) {
 			envRole: toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *PushService) {
 				s.pushStorage.(*storagemock.MockPushStorage).EXPECT().ListPushes(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Push{}, 0, int64(0), nil)
 			},
 			input:       &pushproto.ListPushesRequest{PageSize: 2, Cursor: "", EnvironmentId: "ns0"},

--- a/pkg/push/storage/v2/mock/push.go
+++ b/pkg/push/storage/v2/mock/push.go
@@ -73,9 +73,9 @@ func (mr *MockPushStorageMockRecorder) GetPush(ctx, id, environmentId any) *gomo
 }
 
 // ListPushes mocks base method.
-func (m *MockPushStorage) ListPushes(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*push.Push, int, int64, error) {
+func (m *MockPushStorage) ListPushes(ctx context.Context, option *mysql.ListOptions) ([]*push.Push, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPushes", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListPushes", ctx, option)
 	ret0, _ := ret[0].([]*push.Push)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -84,9 +84,9 @@ func (m *MockPushStorage) ListPushes(ctx context.Context, whereParts []mysql.Whe
 }
 
 // ListPushes indicates an expected call of ListPushes.
-func (mr *MockPushStorageMockRecorder) ListPushes(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockPushStorageMockRecorder) ListPushes(ctx, option any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPushes", reflect.TypeOf((*MockPushStorage)(nil).ListPushes), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPushes", reflect.TypeOf((*MockPushStorage)(nil).ListPushes), ctx, option)
 }
 
 // UpdatePush mocks base method.

--- a/pkg/push/storage/v2/push.go
+++ b/pkg/push/storage/v2/push.go
@@ -147,8 +147,15 @@ func (s *pushStorage) ListPushes(
 	if err != nil {
 		return nil, 0, 0, err
 	}
+	var offset int
+	var limit int
+	if options != nil {
+		offset = options.Offset
+		limit = options.Limit
+	}
+
 	defer rows.Close()
-	pushes := make([]*proto.Push, 0)
+	pushes := make([]*proto.Push, 0, limit)
 	for rows.Next() {
 		push := proto.Push{}
 		err := rows.Scan(
@@ -170,10 +177,6 @@ func (s *pushStorage) ListPushes(
 	}
 	if rows.Err() != nil {
 		return nil, 0, 0, err
-	}
-	var offset int
-	if options != nil {
-		offset = options.Offset
 	}
 	nextOffset := offset + len(pushes)
 	var totalCount int64

--- a/pkg/push/storage/v2/sql/push/count_pushes.sql
+++ b/pkg/push/storage/v2/sql/push/count_pushes.sql
@@ -4,4 +4,3 @@ FROM
     push
 JOIN
     environment_v2 env ON push.environment_id = env.id
-%s 

--- a/pkg/push/storage/v2/sql/push/list_pushes.sql
+++ b/pkg/push/storage/v2/sql/push/list_pushes.sql
@@ -13,4 +13,3 @@ FROM
     push
 JOIN
     environment_v2 env ON push.environment_id = env.id
-%s %s %s 

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -113,11 +113,12 @@ func NewInFilter(column string, values []interface{}) WherePart {
 }
 
 func (f *InFilter) SQLString() (sql string, args []interface{}) {
+	var sb strings.Builder
 	if f.Column == "" || len(f.Values) == 0 {
 		return "", nil
+	} else {
+		sb.WriteString(fmt.Sprintf(" %s IN (", f.Column))
 	}
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%s IN (", f.Column))
 	for i := range f.Values {
 		if i != 0 {
 			sb.WriteString(", ")
@@ -143,10 +144,12 @@ func NewNullFilter(column string, isNull bool) WherePart {
 }
 
 func (f *NullFilter) SQLString() (sql string, args []interface{}) {
+	var sb strings.Builder
 	if f.Column == "" {
 		return "", nil
+	} else {
+		sb.WriteString(" ")
 	}
-	var sb strings.Builder
 	if f.IsNull {
 		sb.WriteString(fmt.Sprintf("%s IS NULL", f.Column))
 	} else {
@@ -255,11 +258,12 @@ func NewSearchQuery(columns []string, keyword string) WherePart {
 }
 
 func (q *SearchQuery) SQLString() (sql string, args []interface{}) {
+	var sb strings.Builder
 	if len(q.Columns) == 0 {
 		return "", nil
+	} else {
+		sb.WriteString(" (")
 	}
-	var sb strings.Builder
-	sb.WriteString("(")
 	for i, col := range q.Columns {
 		if i != 0 {
 			sb.WriteString(" OR ")
@@ -273,11 +277,12 @@ func (q *SearchQuery) SQLString() (sql string, args []interface{}) {
 }
 
 func ConstructWhereSQLString(wps []WherePart) (sql string, args []interface{}) {
+	var sb strings.Builder
 	if len(wps) == 0 {
 		return "", nil
+	} else {
+		sb.WriteString(" WHERE ")
 	}
-	var sb strings.Builder
-	sb.WriteString("WHERE ")
 	for i, wp := range wps {
 		if i != 0 {
 			sb.WriteString(" AND ")
@@ -322,11 +327,12 @@ func NewOrder(column string, direction OrderDirection) *Order {
 }
 
 func ConstructOrderBySQLString(orders []*Order) string {
+	var sb strings.Builder
 	if len(orders) == 0 {
 		return ""
+	} else {
+		sb.WriteString(" ORDER BY ")
 	}
-	var sb strings.Builder
-	sb.WriteString("ORDER BY ")
 	for i, o := range orders {
 		if i != 0 {
 			sb.WriteString(", ")
@@ -359,11 +365,12 @@ type Orders struct {
 }
 
 func (o *Orders) SQLString() (sql string, args []interface{}) {
+	var sb strings.Builder
 	if len(o.Orders) == 0 {
 		return "", nil
+	} else {
+		sb.WriteString("ORDER BY ")
 	}
-	var sb strings.Builder
-	sb.WriteString("ORDER BY ")
 	for i, o := range o.Orders {
 		if i != 0 {
 			sb.WriteString(", ")
@@ -389,12 +396,12 @@ func ConstructLimitOffsetSQLString(limit, offset int) string {
 		return ""
 	}
 	if limit == QueryNoLimit && offset != QueryNoOffset {
-		return fmt.Sprintf("LIMIT %d OFFSET %d", queryLimitAllRows, offset)
+		return fmt.Sprintf(" LIMIT %d OFFSET %d", queryLimitAllRows, offset)
 	}
 	if limit != QueryNoLimit && offset == QueryNoOffset {
-		return fmt.Sprintf("LIMIT %d", limit)
+		return fmt.Sprintf(" LIMIT %d", limit)
 	}
-	return fmt.Sprintf("LIMIT %d OFFSET %d", limit, offset)
+	return fmt.Sprintf(" LIMIT %d OFFSET %d", limit, offset)
 }
 
 type ListOptions struct {

--- a/pkg/storage/v2/mysql/query_test.go
+++ b/pkg/storage/v2/mysql/query_test.go
@@ -71,7 +71,7 @@ func TestInFilterSQLString(t *testing.T) {
 		{
 			desc: "Success",
 			input: &InFilter{
-				Column: " name",
+				Column: "name",
 				Values: []interface{}{"v1", "v2"},
 			},
 			expectedSQL:  " name IN (?, ?)",

--- a/pkg/storage/v2/mysql/query_test.go
+++ b/pkg/storage/v2/mysql/query_test.go
@@ -71,10 +71,10 @@ func TestInFilterSQLString(t *testing.T) {
 		{
 			desc: "Success",
 			input: &InFilter{
-				Column: "name",
+				Column: " name",
 				Values: []interface{}{"v1", "v2"},
 			},
-			expectedSQL:  "name IN (?, ?)",
+			expectedSQL:  " name IN (?, ?)",
 			expectedArgs: []interface{}{"v1", "v2"},
 		},
 	}
@@ -107,7 +107,7 @@ func TestNullFilterSQLString(t *testing.T) {
 				Column: "name",
 				IsNull: true,
 			},
-			expectedSQL:  "name IS NULL",
+			expectedSQL:  " name IS NULL",
 			expectedArgs: nil,
 		},
 		{
@@ -116,7 +116,7 @@ func TestNullFilterSQLString(t *testing.T) {
 				Column: "name",
 				IsNull: false,
 			},
-			expectedSQL:  "name IS NOT NULL",
+			expectedSQL:  " name IS NOT NULL",
 			expectedArgs: nil,
 		},
 	}
@@ -243,7 +243,7 @@ func TestSearchQuerySQLString(t *testing.T) {
 				Columns: []string{"id", "name"},
 				Keyword: "test",
 			},
-			expectedSQL:  "(id LIKE ? OR name LIKE ?)",
+			expectedSQL:  " (id LIKE ? OR name LIKE ?)",
 			expectedArgs: []interface{}{"%test%", "%test%"},
 		},
 	}
@@ -276,7 +276,7 @@ func TestConstructWhereSQLString(t *testing.T) {
 				NewFilter("name", "=", "feature"),
 				NewJSONFilter("enums", JSONContainsNumber, []interface{}{1, 3}),
 			},
-			expectedSQL:  "WHERE name = ? AND JSON_CONTAINS(enums, ?) ",
+			expectedSQL:  " WHERE name = ? AND JSON_CONTAINS(enums, ?) ",
 			expectedArgs: []interface{}{"feature", "[1, 3]"},
 		},
 	}
@@ -307,7 +307,7 @@ func TestConstructOrderBySQLString(t *testing.T) {
 				NewOrder("created_at", OrderDirectionDesc),
 				NewOrder("id", OrderDirectionAsc),
 			},
-			expectedSQL: "ORDER BY created_at DESC, id ASC ",
+			expectedSQL: " ORDER BY created_at DESC, id ASC ",
 		},
 	}
 	for _, p := range patterns {
@@ -336,19 +336,19 @@ func TestConstructLimitOffsetSQLString(t *testing.T) {
 			desc:        "no limit & offset",
 			limit:       0,
 			offset:      5,
-			expectedSQL: "LIMIT 9223372036854775807 OFFSET 5",
+			expectedSQL: " LIMIT 9223372036854775807 OFFSET 5",
 		},
 		{
 			desc:        "limit & no offset",
 			limit:       10,
 			offset:      0,
-			expectedSQL: "LIMIT 10",
+			expectedSQL: " LIMIT 10",
 		},
 		{
 			desc:        "limit & offset",
 			limit:       10,
 			offset:      5,
-			expectedSQL: "LIMIT 10 OFFSET 5",
+			expectedSQL: " LIMIT 10 OFFSET 5",
 		},
 	}
 	for _, p := range patterns {

--- a/pkg/subscriber/processor/push_sender.go
+++ b/pkg/subscriber/processor/push_sender.go
@@ -281,12 +281,12 @@ func (p pushSender) listPushes(ctx context.Context, environmentId string) ([]*pu
 		Limit:  mysql.QueryNoLimit,
 		Offset: 0,
 		Filters: []*mysql.FilterV2{
-			&mysql.FilterV2{
+			{
 				Column:   "deleted",
 				Operator: mysql.OperatorEqual,
 				Value:    false,
 			},
-			&mysql.FilterV2{
+			{
 				Column:   "environment_id",
 				Operator: mysql.OperatorEqual,
 				Value:    environmentId,

--- a/pkg/subscriber/processor/push_sender.go
+++ b/pkg/subscriber/processor/push_sender.go
@@ -277,17 +277,29 @@ func (p pushSender) getFCMCredentials(ctx context.Context, fcmServiceAccount str
 // Because the `ListPushes` API removes the FCM service account from the response
 // due to security reasons, we list the pushes directly from the storage interface
 func (p pushSender) listPushes(ctx context.Context, environmentId string) ([]*pushproto.Push, error) {
-	whereParts := []mysql.WherePart{
-		mysql.NewFilter("deleted", "=", false),
-		mysql.NewFilter("environment_id", "=", environmentId),
+	options := &mysql.ListOptions{
+		Limit:  mysql.QueryNoLimit,
+		Offset: 0,
+		Filters: []*mysql.FilterV2{
+			&mysql.FilterV2{
+				Column:   "deleted",
+				Operator: mysql.OperatorEqual,
+				Value:    false,
+			},
+			&mysql.FilterV2{
+				Column:   "environment_id",
+				Operator: mysql.OperatorEqual,
+				Value:    environmentId,
+			},
+		},
+		InFilter: nil,
+		Orders:   nil,
 	}
+
 	storage := pushstorage.NewPushStorage(p.mysqlClient)
 	pushes, _, _, err := storage.ListPushes(
 		ctx,
-		whereParts,
-		nil, // order by
-		mysql.QueryNoLimit,
-		0, // offset
+		options,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This pull request includes significant changes to the `PushService` and its related components to improve the handling of push listing and filtering. The changes involve the refactoring of methods to use a new `mysql.ListOptions` structure instead of the previous `mysql.WherePart` filters, and the update of test cases accordingly.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475