### PR TITLE
chore: improve docker build when using dev container on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,8 @@ LOCAL_IMPORT_PATH := github.com/bucketeer-io/bucketeer
 # go applications
 GO_APP_DIRS := $(wildcard cmd/*)
 GO_APP_BUILD_TARGETS := $(addprefix build-,$(notdir $(GO_APP_DIRS)))
-
-ifndef GOOS
-	GOOS := $(shell go env GOOS)
-endif
-
-ifndef GOARCH
-	GOARCH := $(shell go env GOARCH)
-endif
+GOOS ?= linux
+GOARCH ?= amd64
 
 LDFLAGS_PACKAGE := github.com/bucketeer-io/bucketeer/pkg/ldflags
 LDFLAGS_VERSION := $(LDFLAGS_PACKAGE).Version
@@ -384,10 +378,10 @@ build-docker-images:
 	for APP in `ls bin`; do \
 		./tools/build/show-dockerfile.sh bin $$APP > Dockerfile-app-$$APP; \
 		IMAGE=`./tools/build/show-image-name.sh $$APP`; \
-		docker build -f Dockerfile-app-$$APP -t ghcr.io/bucketeer-io/bucketeer-$$IMAGE:${TAG} .; \
+		docker build --platform linux/x86_64 -f Dockerfile-app-$$APP -t ghcr.io/bucketeer-io/bucketeer-$$IMAGE:${TAG} .; \
 		rm Dockerfile-app-$$APP; \
 	done
-	docker build migration/ -t ghcr.io/bucketeer-io/bucketeer-migration:${TAG}
+	docker build --platform linux/x86_64 migration/ -t ghcr.io/bucketeer-io/bucketeer-migration:${TAG}
 
 # copy go application docker image to minikube
 # please keep the same TAG env as used in build-docker-images, eg: TAG=test make minikube-load-images


### PR DESCRIPTION
To develop on macOS, it's better to pass the platform flag and fix the platform env for Go.