### PR TITLE
fix: docker build fails when using apple cpu architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,14 @@ LOCAL_IMPORT_PATH := github.com/bucketeer-io/bucketeer
 # go applications
 GO_APP_DIRS := $(wildcard cmd/*)
 GO_APP_BUILD_TARGETS := $(addprefix build-,$(notdir $(GO_APP_DIRS)))
-GOOS ?= linux
-GOARCH ?= amd64
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+ifeq ($(GOARCH), arm64)
+	PLATFORM = linux/arm64
+else
+	PLATFORM = linux/x86_64
+endif
 
 LDFLAGS_PACKAGE := github.com/bucketeer-io/bucketeer/pkg/ldflags
 LDFLAGS_VERSION := $(LDFLAGS_PACKAGE).Version
@@ -378,10 +384,10 @@ build-docker-images:
 	for APP in `ls bin`; do \
 		./tools/build/show-dockerfile.sh bin $$APP > Dockerfile-app-$$APP; \
 		IMAGE=`./tools/build/show-image-name.sh $$APP`; \
-		docker build --platform linux/x86_64 -f Dockerfile-app-$$APP -t ghcr.io/bucketeer-io/bucketeer-$$IMAGE:${TAG} .; \
+		docker build --platform $(PLATFORM) -f Dockerfile-app-$$APP -t ghcr.io/bucketeer-io/bucketeer-$$IMAGE:${TAG} .; \
 		rm Dockerfile-app-$$APP; \
 	done
-	docker build --platform linux/x86_64 migration/ -t ghcr.io/bucketeer-io/bucketeer-migration:${TAG}
+	docker build --platform $(PLATFORM) migration/ -t ghcr.io/bucketeer-io/bucketeer-migration:${TAG}
 
 # copy go application docker image to minikube
 # please keep the same TAG env as used in build-docker-images, eg: TAG=test make minikube-load-images


### PR DESCRIPTION
Due to the changes made in this [PR](https://github.com/bucketeer-io/bucketeer/pull/1680), the docker build fails on the `aarch64` Mac.