### PR TITLE
refactor: change the list retrieval API in the opsevent package to use ListOption

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1527,12 +1527,12 @@ func (s *AutoOpsService) listAutoOpsRules(
 	for _, fID := range featureIds {
 		fIDs = append(fIDs, fID)
 	}
-	var infilter *mysql.InFilter
+	var inFilters []*mysql.InFilter
 	if len(fIDs) > 0 {
-		infilter = &mysql.InFilter{
+		inFilters = append(inFilters, &mysql.InFilter{
 			Column: "aor.feature_id",
 			Values: fIDs,
-		}
+		})
 	}
 	limit := int(pageSize)
 	if cursor == "" {
@@ -1554,7 +1554,7 @@ func (s *AutoOpsService) listAutoOpsRules(
 		Limit:       limit,
 		Offset:      offset,
 		Filters:     filters,
-		InFilter:    infilter,
+		InFilters:   inFilters,
 		NullFilters: nil,
 		JSONFilters: nil,
 		SearchQuery: nil,

--- a/pkg/autoops/api/api_test.go
+++ b/pkg/autoops/api/api_test.go
@@ -1539,7 +1539,7 @@ func TestListOpsCountsMySQL(t *testing.T) {
 			service: createAutoOpsService(mockController),
 			setup: func(s *AutoOpsService) {
 				s.opsCountStorage.(*mockOpsCountStorage.MockOpsCountStorage).EXPECT().ListOpsCounts(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*autoopsproto.OpsCount{}, 0, nil)
 			},
 			req:         &autoopsproto.ListOpsCountsRequest{EnvironmentId: "ns0", Cursor: ""},
@@ -1557,7 +1557,7 @@ func TestListOpsCountsMySQL(t *testing.T) {
 			service: createServiceWithGetAccountByEnvironmentMock(mockController, accountproto.AccountV2_Role_Organization_MEMBER, accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *AutoOpsService) {
 				s.opsCountStorage.(*mockOpsCountStorage.MockOpsCountStorage).EXPECT().ListOpsCounts(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*autoopsproto.OpsCount{}, 0, nil)
 			},
 			req:         &autoopsproto.ListOpsCountsRequest{EnvironmentId: "ns0", Cursor: ""},

--- a/pkg/autoops/api/progressive_rollout.go
+++ b/pkg/autoops/api/progressive_rollout.go
@@ -980,13 +980,13 @@ func (s *AutoOpsService) listProgressiveRollouts(
 		}
 		return nil, 0, 0, dt.Err()
 	}
-	var inFilter *mysql.InFilter = nil
+	var inFilters []*mysql.InFilter = nil
 	if len(req.FeatureIds) > 0 {
 		fIDs := s.convToInterfaceSlice(req.FeatureIds)
-		inFilter = &mysql.InFilter{
+		inFilters = append(inFilters, &mysql.InFilter{
 			Column: "feature_id",
 			Values: fIDs,
-		}
+		})
 	}
 	orders, err := s.newListProgressiveRolloutsOrdersMySQL(
 		req.OrderBy,
@@ -1012,7 +1012,7 @@ func (s *AutoOpsService) listProgressiveRollouts(
 	listOptions := &mysql.ListOptions{
 		Filters:     filters,
 		Orders:      orders,
-		InFilter:    inFilter,
+		InFilters:   inFilters,
 		NullFilters: nil,
 		JSONFilters: nil,
 		SearchQuery: nil,

--- a/pkg/autoops/api/stop_progressive_rollout_operation.go
+++ b/pkg/autoops/api/stop_progressive_rollout_operation.go
@@ -37,14 +37,16 @@ func executeStopProgressiveRolloutOperation(
 			Value:    environmentId,
 		},
 	}
-	inFilter := &mysql.InFilter{
-		Column: "feature_id",
-		Values: featureIDs,
+	inFilters := []*mysql.InFilter{
+		{
+			Column: "feature_id",
+			Values: featureIDs,
+		},
 	}
 	options := &mysql.ListOptions{
 		Filters:     filters,
 		Orders:      nil,
-		InFilter:    inFilter,
+		InFilters:   inFilters,
 		NullFilters: nil,
 		JSONFilters: nil,
 		SearchQuery: nil,

--- a/pkg/autoops/storage/v2/auto_ops_rule_test.go
+++ b/pkg/autoops/storage/v2/auto_ops_rule_test.go
@@ -226,7 +226,7 @@ func TestListAutoOpsRules(t *testing.T) {
 						Value:    5,
 					},
 				},
-				InFilter:    nil,
+				InFilters:   nil,
 				NullFilters: nil,
 				JSONFilters: nil,
 				SearchQuery: nil,

--- a/pkg/autoops/storage/v2/progressive_rollout_test.go
+++ b/pkg/autoops/storage/v2/progressive_rollout_test.go
@@ -135,7 +135,7 @@ func TestListProgressiveRollouts(t *testing.T) {
 						Value:    5,
 					},
 				},
-				InFilter:    nil,
+				InFilters:   nil,
 				NullFilters: nil,
 				JSONFilters: nil,
 				SearchQuery: nil,

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -2005,14 +2005,16 @@ func (s *FeatureService) stopProgressiveRollout(
 			Value:    EnvironmentId,
 		},
 	}
-	inFilter := &mysql.InFilter{
-		Column: "feature_id",
-		Values: ids,
+	inFilters := []*mysql.InFilter{
+		{
+			Column: "feature_id",
+			Values: ids,
+		},
 	}
 	listOptions := &mysql.ListOptions{
 		Filters:     filters,
 		Orders:      nil,
-		InFilter:    inFilter,
+		InFilters:   inFilters,
 		NullFilters: nil,
 		JSONFilters: nil,
 		SearchQuery: nil,

--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -776,7 +776,7 @@ func (s *NotificationService) listAdminSubscriptionsMySQL(
 		Limit:       limit,
 		Offset:      offset,
 		Filters:     filters,
-		InFilter:    nil,
+		InFilters:   nil,
 		NullFilters: nil,
 		JSONFilters: jsonFilters,
 		SearchQuery: seachQuery,

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -899,7 +899,7 @@ func (s *NotificationService) listSubscriptionsMySQL(
 		Limit:       limit,
 		Offset:      offset,
 		Filters:     filters,
-		InFilter:    nil,
+		InFilters:   nil,
 		NullFilters: nil,
 		JSONFilters: jsonFilters,
 		SearchQuery: seachQuery,

--- a/pkg/notification/storage/v2/admin_subscription_test.go
+++ b/pkg/notification/storage/v2/admin_subscription_test.go
@@ -381,7 +381,7 @@ func TestListAdminSubscriptions(t *testing.T) {
 						Direction: mysql.OrderDirectionDesc,
 					},
 				},
-				InFilter:    nil,
+				InFilters:   nil,
 				NullFilters: nil,
 				JSONFilters: nil,
 				SearchQuery: nil,

--- a/pkg/notification/storage/v2/subscription_test.go
+++ b/pkg/notification/storage/v2/subscription_test.go
@@ -410,7 +410,7 @@ func TestListSubscriptions(t *testing.T) {
 						Value:    disable,
 					},
 				},
-				InFilter:    nil,
+				InFilters:   nil,
 				NullFilters: nil,
 				JSONFilters: nil,
 				SearchQuery: nil,

--- a/pkg/opsevent/storage/v2/mock/ops_count.go
+++ b/pkg/opsevent/storage/v2/mock/ops_count.go
@@ -44,9 +44,9 @@ func (m *MockOpsCountStorage) EXPECT() *MockOpsCountStorageMockRecorder {
 }
 
 // ListOpsCounts mocks base method.
-func (m *MockOpsCountStorage) ListOpsCounts(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*autoops.OpsCount, int, error) {
+func (m *MockOpsCountStorage) ListOpsCounts(ctx context.Context, options *mysql.ListOptions) ([]*autoops.OpsCount, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpsCounts", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListOpsCounts", ctx, options)
 	ret0, _ := ret[0].([]*autoops.OpsCount)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -54,9 +54,9 @@ func (m *MockOpsCountStorage) ListOpsCounts(ctx context.Context, whereParts []my
 }
 
 // ListOpsCounts indicates an expected call of ListOpsCounts.
-func (mr *MockOpsCountStorageMockRecorder) ListOpsCounts(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockOpsCountStorageMockRecorder) ListOpsCounts(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpsCounts", reflect.TypeOf((*MockOpsCountStorage)(nil).ListOpsCounts), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpsCounts", reflect.TypeOf((*MockOpsCountStorage)(nil).ListOpsCounts), ctx, options)
 }
 
 // UpsertOpsCount mocks base method.

--- a/pkg/opsevent/storage/v2/ops_count_test.go
+++ b/pkg/opsevent/storage/v2/ops_count_test.go
@@ -74,10 +74,7 @@ func TestListOpsCounts(t *testing.T) {
 	defer mockController.Finish()
 	patterns := []struct {
 		setup          func(*opsCountStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
+		options        *mysql.ListOptions
 		expected       []*proto.OpsCount
 		expectedCursor int
 		expectedErr    error
@@ -88,10 +85,7 @@ func TestListOpsCounts(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
+			options:        nil,
 			expected:       nil,
 			expectedCursor: 0,
 			expectedErr:    errors.New("error"),
@@ -106,14 +100,23 @@ func TestListOpsCounts(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(rows, nil)
 			},
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("num", ">=", 5),
+			options: &mysql.ListOptions{
+				Limit:  10,
+				Offset: 5,
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "num",
+						Operator: mysql.OperatorGreaterThanOrEqual,
+						Value:    5,
+					},
+				},
+				Orders: []*mysql.Order{
+					{
+						Column:    "id",
+						Direction: mysql.OrderDirectionAsc,
+					},
+				},
 			},
-			orders: []*mysql.Order{
-				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-			},
-			limit:          10,
-			offset:         5,
 			expected:       []*proto.OpsCount{},
 			expectedCursor: 5,
 			expectedErr:    nil,
@@ -126,10 +129,7 @@ func TestListOpsCounts(t *testing.T) {
 		}
 		opsCounts, cursor, err := storage.ListOpsCounts(
 			context.Background(),
-			p.whereParts,
-			p.orders,
-			p.limit,
-			p.offset,
+			p.options,
 		)
 		assert.Equal(t, p.expected, opsCounts)
 		assert.Equal(t, p.expectedCursor, cursor)

--- a/pkg/opsevent/storage/v2/sql/ops_count/insert_ops_count.sql
+++ b/pkg/opsevent/storage/v2/sql/ops_count/insert_ops_count.sql
@@ -1,0 +1,18 @@
+INSERT INTO ops_count (
+	id,
+	auto_ops_rule_id,
+	clause_id,
+	updated_at,
+	ops_event_count,
+	evaluation_count,
+	feature_id,
+	environment_id
+) VALUES (
+	?, ?, ?, ?, ?, ?, ?, ?
+) ON DUPLICATE KEY UPDATE
+	auto_ops_rule_id = VALUES(auto_ops_rule_id),
+	clause_id = VALUES(clause_id),
+	updated_at = VALUES(updated_at),
+	ops_event_count = VALUES(ops_event_count),
+	evaluation_count = VALUES(evaluation_count),
+	feature_id = VALUES(feature_id)

--- a/pkg/opsevent/storage/v2/sql/ops_count/select_ops_counts.sql
+++ b/pkg/opsevent/storage/v2/sql/ops_count/select_ops_counts.sql
@@ -1,0 +1,10 @@
+SELECT
+	id,
+	auto_ops_rule_id,
+	clause_id,
+	updated_at,
+	ops_event_count,
+	evaluation_count,
+	feature_id
+FROM
+	ops_count

--- a/pkg/push/api/api.go
+++ b/pkg/push/api/api.go
@@ -1201,7 +1201,7 @@ func (s *PushService) listPushes(
 		Offset:      offset,
 		Filters:     filters,
 		SearchQuery: searchQuery,
-		InFilter:    nil,
+		InFilters:   nil,
 		Orders:      orders,
 		JSONFilters: nil,
 		NullFilters: nil,

--- a/pkg/push/storage/v2/push_test.go
+++ b/pkg/push/storage/v2/push_test.go
@@ -282,7 +282,7 @@ func TestListPushs(t *testing.T) {
 						Value:    5,
 					},
 				},
-				InFilter:    nil,
+				InFilters:   nil,
 				NullFilters: nil,
 				JSONFilters: nil,
 				SearchQuery: nil,

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -407,7 +407,7 @@ func ConstructLimitOffsetSQLString(limit, offset int) string {
 type ListOptions struct {
 	Limit       int
 	Filters     []*FilterV2
-	InFilter    *InFilter
+	InFilters   []*InFilter
 	NullFilters []*NullFilter
 	JSONFilters []*JSONFilter
 	SearchQuery *SearchQuery
@@ -422,8 +422,10 @@ func (lo *ListOptions) CreateWhereParts() []WherePart {
 			whereParts = append(whereParts, f)
 		}
 	}
-	if lo.InFilter != nil {
-		whereParts = append(whereParts, lo.InFilter)
+	if lo.InFilters != nil {
+		for _, f := range lo.InFilters {
+			whereParts = append(whereParts, f)
+		}
 	}
 	if lo.NullFilters != nil {
 		for _, f := range lo.NullFilters {

--- a/pkg/subscriber/processor/push_sender.go
+++ b/pkg/subscriber/processor/push_sender.go
@@ -292,8 +292,8 @@ func (p pushSender) listPushes(ctx context.Context, environmentId string) ([]*pu
 				Value:    environmentId,
 			},
 		},
-		InFilter: nil,
-		Orders:   nil,
+		InFilters: nil,
+		Orders:    nil,
 	}
 
 	storage := pushstorage.NewPushStorage(p.mysqlClient)


### PR DESCRIPTION
This pull request includes changes to the `opsevent` and related components to support multiple `InFilters` instead of a single `InFilter`. Additionally, it updates the corresponding tests and mock implementations to align with these changes.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475