### PR TITLE
refactor: change the list retrieval API in the experiment package to use ListOption

### DIFF
--- a/pkg/experiment/api/experiment.go
+++ b/pkg/experiment/api/experiment.go
@@ -179,16 +179,16 @@ func (s *experimentService) ListExperiments(
 			Value:    req.Maintainer,
 		})
 	}
-	var inFilter *mysql.InFilter
+	var inFilters []*mysql.InFilter
 	if len(req.Statuses) > 0 {
 		statuses := make([]interface{}, 0, len(req.Statuses))
 		for _, sts := range req.Statuses {
 			statuses = append(statuses, sts)
 		}
-		inFilter = &mysql.InFilter{
+		inFilters = append(inFilters, &mysql.InFilter{
 			Column: "status",
 			Values: statuses,
-		}
+		})
 	}
 	var searchQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
@@ -226,7 +226,7 @@ func (s *experimentService) ListExperiments(
 		Offset:      offset,
 		Filters:     filters,
 		Orders:      orders,
-		InFilter:    inFilter,
+		InFilters:   inFilters,
 		SearchQuery: searchQuery,
 		NullFilters: nil,
 		JSONFilters: nil,

--- a/pkg/experiment/api/experiment_test.go
+++ b/pkg/experiment/api/experiment_test.go
@@ -137,7 +137,7 @@ func TestListExperimentsMySQL(t *testing.T) {
 			envRole: toPtr(accountproto.AccountV2_Role_Environment_VIEWER),
 			setup: func(s *experimentService) {
 				s.experimentStorage.(*storagemock.MockExperimentStorage).EXPECT().ListExperiments(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*experimentproto.Experiment{
 					{Id: "id-1"},
 				}, 0, int64(0), nil)

--- a/pkg/experiment/storage/v2/experiment.go
+++ b/pkg/experiment/storage/v2/experiment.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/experiment/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -52,9 +51,7 @@ type ExperimentStorage interface {
 	GetExperiment(ctx context.Context, id, environmentId string) (*domain.Experiment, error)
 	ListExperiments(
 		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
+		options *mysql.ListOptions,
 	) ([]*proto.Experiment, int, int64, error)
 	// GetExperimentSummary returns the total count of experiments by status.
 	GetExperimentSummary(ctx context.Context, environmentID string) (*ExperimentSummary, error)
@@ -199,19 +196,19 @@ func (s *experimentStorage) GetExperiment(
 
 func (s *experimentStorage) ListExperiments(
 	ctx context.Context,
-	whereParts []mysql.WherePart,
-	orders []*mysql.Order,
-	limit, offset int,
+	options *mysql.ListOptions,
 ) ([]*proto.Experiment, int, int64, error) {
-	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
-	orderBySQL := mysql.ConstructOrderBySQLString(orders)
-	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	query := fmt.Sprintf(selectExperimentsSQL, whereSQL, orderBySQL, limitOffsetSQL)
+	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectExperimentsSQL, options)
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
+	var limit, offset int
+	if options != nil {
+		limit = options.Limit
+		offset = options.Offset
+	}
 	experiments := make([]*proto.Experiment, 0, limit)
 	for rows.Next() {
 		experiment := proto.Experiment{}
@@ -249,8 +246,9 @@ func (s *experimentStorage) ListExperiments(
 	}
 	nextOffset := offset + len(experiments)
 	var totalCount int64
-	countQuery := fmt.Sprintf(countExperimentSQL, whereSQL)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countExperimentSQL, options)
+	// countQuery := fmt.Sprintf(countExperimentSQL, whereSQL)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(
 		&totalCount,
 	)
 	if err != nil {

--- a/pkg/experiment/storage/v2/experiment.go
+++ b/pkg/experiment/storage/v2/experiment.go
@@ -247,7 +247,6 @@ func (s *experimentStorage) ListExperiments(
 	nextOffset := offset + len(experiments)
 	var totalCount int64
 	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countExperimentSQL, options)
-	// countQuery := fmt.Sprintf(countExperimentSQL, whereSQL)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(
 		&totalCount,
 	)

--- a/pkg/experiment/storage/v2/mock/experiment.go
+++ b/pkg/experiment/storage/v2/mock/experiment.go
@@ -89,9 +89,9 @@ func (mr *MockExperimentStorageMockRecorder) GetExperimentSummary(ctx, environme
 }
 
 // ListExperiments mocks base method.
-func (m *MockExperimentStorage) ListExperiments(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*experiment.Experiment, int, int64, error) {
+func (m *MockExperimentStorage) ListExperiments(ctx context.Context, options *mysql.ListOptions) ([]*experiment.Experiment, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListExperiments", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListExperiments", ctx, options)
 	ret0, _ := ret[0].([]*experiment.Experiment)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -100,9 +100,9 @@ func (m *MockExperimentStorage) ListExperiments(ctx context.Context, whereParts 
 }
 
 // ListExperiments indicates an expected call of ListExperiments.
-func (mr *MockExperimentStorageMockRecorder) ListExperiments(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockExperimentStorageMockRecorder) ListExperiments(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExperiments", reflect.TypeOf((*MockExperimentStorage)(nil).ListExperiments), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListExperiments", reflect.TypeOf((*MockExperimentStorage)(nil).ListExperiments), ctx, options)
 }
 
 // UpdateExperiment mocks base method.

--- a/pkg/experiment/storage/v2/sql/experiment/count_experiment.sql
+++ b/pkg/experiment/storage/v2/sql/experiment/count_experiment.sql
@@ -1,5 +1,4 @@
 SELECT
     COUNT(1) AS total
 FROM
-    experiment
-%s
+    experiment ex

--- a/pkg/experiment/storage/v2/sql/experiment/select_experiments.sql
+++ b/pkg/experiment/storage/v2/sql/experiment/select_experiments.sql
@@ -27,4 +27,3 @@ SELECT
     ) as goals
 FROM
     experiment ex
-%s %s %s


### PR DESCRIPTION
This pull request includes significant refactoring of the `ListExperiments` method in the `experimentService` and related files to improve the handling of query filters and options. The changes primarily involve replacing the old `WherePart` and other individual filter constructs with a new `ListOptions` structure that consolidates all query parameters.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475