### PR TITLE
fix: add localized message to ListAuditLogs

### DIFF
--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -214,6 +214,7 @@ func (s *auditlogService) ListAuditLogs(
 				auditlogs[i].Editor.PublicApiEditor.AvatarFileType = account.AvatarFileType
 			}
 		}
+		auditlogs[i].LocalizedMessage = domainevent.LocalizedMessage(auditlogs[i].Type, localizer)
 	}
 
 	return &proto.ListAuditLogsResponse{


### PR DESCRIPTION
Fix this error in audit log page,
`TypeError: Cannot read properties of undefined (reading 'message')`

In this pr (https://github.com/bucketeer-io/bucketeer/pull/1684),
removing setting of `auditlog.LocalizedMessage` could cause this error.
   