### PR TITLE
fix: admin audit logs not being acknowledged

### DIFF
--- a/pkg/subscriber/processor/auditlog_persister.go
+++ b/pkg/subscriber/processor/auditlog_persister.go
@@ -160,7 +160,7 @@ func (a auditLogPersister) createAuditLogsMySQL(
 ) {
 	for i, aud := range auditlogs {
 		if err := createFunc(ctx, aud); err != nil {
-			if errors.Is(err, v2als.ErrAuditLogAlreadyExists) {
+			if errors.Is(err, v2als.ErrAuditLogAlreadyExists) || errors.Is(err, v2als.ErrAdminAuditLogAlreadyExists) {
 				subscriberHandledCounter.WithLabelValues(subscriberAuditLog, codes.NonRepeatableError.String()).Inc()
 				messages[i].Ack()
 			} else {


### PR DESCRIPTION
The `createAuditLogsMySQL` func is also being used to create admin logs, and it was not acknowledging the audit logs messages correctly.