### PR TITLE
fix: add variationID parameter to newPFMergeKey

### DIFF
--- a/pkg/eventcounter/api/api_test.go
+++ b/pkg/eventcounter/api/api_test.go
@@ -1390,6 +1390,7 @@ func TestGetEvaluationTimeseriesCount(t *testing.T) {
 						UserCountPrefix,
 						fID,
 						environmentId,
+						vID,
 					)
 					for idx := range hourlyTimeStamps {
 						s.evaluationCountCacher.(*eccachemock.MockEventCounterCache).EXPECT().MergeMultiKeys(pfMergeKey, uc[idx], gomock.Any()).Return(nil)
@@ -1996,7 +1997,7 @@ func TestGetUserCounts(t *testing.T) {
 			if p.setup != nil {
 				p.setup(gs)
 			}
-			actual, _ := gs.getUserCounts(p.keys, featureID, environmentId, p.unit)
+			actual, _ := gs.getUserCounts(p.keys, featureID, environmentId, vID, p.unit)
 			assert.Len(t, actual, p.expectedLen)
 		})
 	}


### PR DESCRIPTION
### Issue

The user count of day unit causes the results to change each time on the evaluation console.

The `newPFMergeKey` function was generating cache keys based only on feature ID and environment ID, without including the variation ID. This caused all goroutines to operate on the same Redis keys, leading to race conditions where one goroutine would delete or modify keys that other goroutines were still using.

### Solution

We modified the `newPFMergeKey` function to include the variation ID in the generated keys:

```go
func newPFMergeKey(
  kind, featureID, environmentId string,
  variationID string, // Added variation ID parameter
) string {
  return cache.MakeKey(
    fmt.Sprintf("%s:%s", pfMergeKind, kind),
    fmt.Sprintf("%s:%s:%s", pfMergeKey, featureID, variationID), // Include variation ID in key
    environmentId,
  )
}
```

This change ensures that each goroutine operates on separate, unique keys in Redis based on the specific variation ID it's processing, eliminating race conditions and providing consistent results across multiple executions.
