### PR TITLE
perf: add indexes to audit_log table for improved query performance

### DIFF
--- a/migration/mysql/20250411093510_update_audit_log_table.sql
+++ b/migration/mysql/20250411093510_update_audit_log_table.sql
@@ -1,0 +1,2 @@
+-- Modify "audit_log" table
+CREATE INDEX idx_environment_id_timestamp_desc ON audit_log (environment_id, timestamp DESC); 

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:UOOIztZELlX0M6BO/xwulnaBzJzjh9fvGrMN/AmtPlo=
+h1:Lk6rU2Ba4LW6nMYcq1wtJPchJcvVJMdvMQuRnsOzprc=
 20240626022133_initialization.sql h1:u9qmPkwWX7PN92qEcDDfR92lrMpwadQSMxUJgv6LjQ0=
 20240708065726_update_audit_log_table.sql h1:k7gK8Njv1yHMsYXAQtSgMaSbXy4lxyZ9MPzbJyMyyoM=
 20240815043128_update_auto_ops_rule_table.sql h1:6ib+XfS1uu9AUO3qESvkpUfOu3qUsLwHm9KHcrGEz0E=
@@ -29,3 +29,4 @@ h1:UOOIztZELlX0M6BO/xwulnaBzJzjh9fvGrMN/AmtPlo=
 20250131084331_sync_type_goal_table.sql h1:NP6KZXieFSlxUPtRywy2S59/WnKne6z1z8eG9e11WGI=
 20250226091538_create_scheduled_flag_update_table.sql h1:6T6fv8mwH/B5Cw/9++6k5N6kKIGakQM3nU3/omDthqs=
 20250331135358_update_feature_last_used_info_table.sql h1:VgFtTvuqWDu0OTFWFazMYtTdhOHOEF0rW5KDRUKK1IM=
+20250411093510_update_audit_log_table.sql h1:8gv6zi0RKueHpmpUgjnWpcmITaaGcE/CbNHDTub+7NA=


### PR DESCRIPTION
fix #1623

Currently, `ListAuditLogs` commonly filter by environment_id and sort by timestamp in descending order, which is not optimized by existing indexes. Adding this composite index will reduce query execution time and improve overall application response time.

