### PR TITLE
refactor: change the list retrieval API in the enviroment package to use ListOption

### DIFF
--- a/pkg/environment/api/environment_v2.go
+++ b/pkg/environment/api/environment_v2.go
@@ -101,28 +101,39 @@ func (s *EnvironmentService) ListEnvironmentsV2(
 	if err != nil {
 		return nil, err
 	}
-	var whereParts []mysql.WherePart
+	var filters []*mysql.FilterV2
 	if req.ProjectId != "" {
-		whereParts = append(whereParts, mysql.NewFilter("environment_v2.project_id", "=", req.ProjectId))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "environment_v2.project_id",
+			Operator: mysql.OperatorEqual,
+			Value:    req.ProjectId,
+		})
 	}
 	if req.OrganizationId != "" {
-		whereParts = append(whereParts, mysql.NewFilter("environment_v2.organization_id", "=", req.OrganizationId))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "environment_v2.organization_id",
+			Operator: mysql.OperatorEqual,
+			Value:    req.OrganizationId,
+		})
 	}
 	if req.Archived != nil {
-		whereParts = append(whereParts, mysql.NewFilter("environment_v2.archived", "=", req.Archived.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "environment_v2.archived",
+			Operator: mysql.OperatorEqual,
+			Value:    req.Archived.Value,
+		})
 	}
+	var searchQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
-		whereParts = append(
-			whereParts,
-			mysql.NewSearchQuery([]string{
+		searchQuery = &mysql.SearchQuery{
+			Columns: []string{
 				"environment_v2.id",
 				"environment_v2.name",
 				"environment_v2.url_code",
 				"environment_v2.description",
 			},
-				req.SearchKeyword,
-			),
-		)
+			Keyword: req.SearchKeyword,
+		}
 	}
 	orders, err := s.newEnvironmentV2ListOrders(req.OrderBy, req.OrderDirection, localizer)
 	if err != nil {
@@ -148,12 +159,18 @@ func (s *EnvironmentService) ListEnvironmentsV2(
 		}
 		return nil, dt.Err()
 	}
+	options := &mysql.ListOptions{
+		Limit:       limit,
+		Offset:      offset,
+		Filters:     filters,
+		Orders:      orders,
+		SearchQuery: searchQuery,
+		NullFilters: nil,
+		JSONFilters: nil,
+	}
 	environments, nextCursor, totalCount, err := s.environmentStorage.ListEnvironmentsV2(
 		ctx,
-		whereParts,
-		orders,
-		limit,
-		offset,
+		options,
 	)
 	if err != nil {
 		s.logger.Error(

--- a/pkg/environment/api/environment_v2.go
+++ b/pkg/environment/api/environment_v2.go
@@ -165,6 +165,7 @@ func (s *EnvironmentService) ListEnvironmentsV2(
 		Filters:     filters,
 		Orders:      orders,
 		SearchQuery: searchQuery,
+		InFilters:   nil,
 		NullFilters: nil,
 		JSONFilters: nil,
 	}

--- a/pkg/environment/api/environment_v2_test.go
+++ b/pkg/environment/api/environment_v2_test.go
@@ -150,7 +150,7 @@ func TestListEnvironmentsV2(t *testing.T) {
 			desc: "err: ErrInternal",
 			setup: func(s *EnvironmentService) {
 				s.environmentStorage.(*storagemock.MockEnvironmentStorage).EXPECT().ListEnvironmentsV2(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("error"))
 			},
 			input:       &proto.ListEnvironmentsV2Request{},
@@ -161,7 +161,7 @@ func TestListEnvironmentsV2(t *testing.T) {
 			desc: "success",
 			setup: func(s *EnvironmentService) {
 				s.environmentStorage.(*storagemock.MockEnvironmentStorage).EXPECT().ListEnvironmentsV2(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.EnvironmentV2{}, 0, int64(0), nil)
 			},
 			input:       &proto.ListEnvironmentsV2Request{PageSize: 2, Cursor: ""},

--- a/pkg/environment/api/organization.go
+++ b/pkg/environment/api/organization.go
@@ -125,21 +125,27 @@ func (s *EnvironmentService) ListOrganizations(
 	if err != nil {
 		return nil, err
 	}
-	whereParts := []mysql.WherePart{}
+	var filters []*mysql.FilterV2
 	if req.Disabled != nil {
-		whereParts = append(whereParts, mysql.NewFilter("organization.disabled", "=", req.Disabled.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "organization.disabled",
+			Operator: mysql.OperatorEqual,
+			Value:    req.Disabled.Value,
+		})
 	}
 	if req.Archived != nil {
-		whereParts = append(whereParts, mysql.NewFilter("organization.archived", "=", req.Archived.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "organization.archived",
+			Operator: mysql.OperatorEqual,
+			Value:    req.Archived.Value,
+		})
 	}
+	var searchQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
-		whereParts = append(
-			whereParts,
-			mysql.NewSearchQuery(
-				[]string{"organization.id", "organization.name", "organization.url_code"},
-				req.SearchKeyword,
-			),
-		)
+		searchQuery = &mysql.SearchQuery{
+			Columns: []string{"organization.id", "organization.name", "organization.url_code"},
+			Keyword: req.SearchKeyword,
+		}
 	}
 	orders, err := s.newOrganizationListOrders(req.OrderBy, req.OrderDirection, localizer)
 	if err != nil {
@@ -167,7 +173,17 @@ func (s *EnvironmentService) ListOrganizations(
 		}
 		return nil, dt.Err()
 	}
-	organizations, nextCursor, totalCount, err := s.orgStorage.ListOrganizations(ctx, whereParts, orders, limit, offset)
+	options := &mysql.ListOptions{
+		Limit:       limit,
+		Offset:      offset,
+		Filters:     filters,
+		InFilter:    nil,
+		NullFilters: nil,
+		JSONFilters: nil,
+		SearchQuery: searchQuery,
+		Orders:      orders,
+	}
+	organizations, nextCursor, totalCount, err := s.orgStorage.ListOrganizations(ctx, options)
 	if err != nil {
 		s.logger.Error(
 			"failed to list organizations",

--- a/pkg/environment/api/organization.go
+++ b/pkg/environment/api/organization.go
@@ -177,7 +177,7 @@ func (s *EnvironmentService) ListOrganizations(
 		Limit:       limit,
 		Offset:      offset,
 		Filters:     filters,
-		InFilter:    nil,
+		InFilters:   nil,
 		NullFilters: nil,
 		JSONFilters: nil,
 		SearchQuery: searchQuery,

--- a/pkg/environment/api/organization_test.go
+++ b/pkg/environment/api/organization_test.go
@@ -142,7 +142,7 @@ func TestListOrganizationsMySQL(t *testing.T) {
 			desc: "err: ErrInternal",
 			setup: func(s *EnvironmentService) {
 				s.orgStorage.(*storagemock.MockOrganizationStorage).EXPECT().ListOrganizations(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("error"))
 			},
 			input:       &proto.ListOrganizationsRequest{},
@@ -153,7 +153,7 @@ func TestListOrganizationsMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *EnvironmentService) {
 				s.orgStorage.(*storagemock.MockOrganizationStorage).EXPECT().ListOrganizations(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Organization{}, 0, int64(0), nil)
 			},
 			input:       &proto.ListOrganizationsRequest{PageSize: 2, Cursor: ""},

--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -1273,6 +1273,7 @@ func (s *EnvironmentService) ListProjectsV2(
 		Offset:      offset,
 		SearchQuery: searchQuery,
 		Filters:     filters,
+		InFilters:   nil,
 		NullFilters: nil,
 		JSONFilters: nil,
 		Orders:      orders,

--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -126,13 +126,13 @@ func (s *EnvironmentService) ListProjects(
 	if err != nil {
 		return nil, err
 	}
-	var infilter *mysql.InFilter
+	var infilters []*mysql.InFilter
 	if len(req.OrganizationIds) > 0 {
 		oIDs := convToInterfaceSlice(req.OrganizationIds)
-		infilter = &mysql.InFilter{
+		infilters = append(infilters, &mysql.InFilter{
 			Column: "project.organization_id",
 			Values: oIDs,
-		}
+		})
 	}
 	var filters []*mysql.FilterV2
 	if req.Disabled != nil {
@@ -177,7 +177,7 @@ func (s *EnvironmentService) ListProjects(
 		Limit:       limit,
 		Offset:      offset,
 		Filters:     filters,
-		InFilter:    infilter,
+		InFilters:   infilters,
 		Orders:      orders,
 		SearchQuery: searchQuery,
 		JSONFilters: nil,

--- a/pkg/environment/api/project_test.go
+++ b/pkg/environment/api/project_test.go
@@ -158,7 +158,7 @@ func TestListProjectsMySQL(t *testing.T) {
 			desc: "err: ErrInternal",
 			setup: func(s *EnvironmentService) {
 				s.projectStorage.(*storagemock.MockProjectStorage).EXPECT().ListProjects(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("error"))
 			},
 			input:       &proto.ListProjectsRequest{},
@@ -169,7 +169,7 @@ func TestListProjectsMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *EnvironmentService) {
 				s.projectStorage.(*storagemock.MockProjectStorage).EXPECT().ListProjects(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Project{}, 0, int64(0), nil)
 			},
 			input:       &proto.ListProjectsRequest{PageSize: 2, Cursor: "", OrganizationIds: []string{"org-1", "org-2"}},
@@ -1459,7 +1459,7 @@ func TestListProjectsV2(t *testing.T) {
 					},
 				}, nil)
 				s.projectStorage.(*storagemock.MockProjectStorage).EXPECT().ListProjects(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*environmentproto.Project{{}}, 1, int64(1), nil)
 			},
 			input: &environmentproto.ListProjectsV2Request{
@@ -1526,7 +1526,7 @@ func TestListProjectsV2(t *testing.T) {
 					},
 				}, nil)
 				s.projectStorage.(*storagemock.MockProjectStorage).EXPECT().ListProjects(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("internal error"))
 			},
 			input: &environmentproto.ListProjectsV2Request{

--- a/pkg/environment/storage/v2/environment.go
+++ b/pkg/environment/storage/v2/environment.go
@@ -151,9 +151,9 @@ func (s *environmentStorage) ListEnvironmentsV2(
 		whereSQL, whereArgs = mysql.ConstructWhereSQLString(whereParts)
 		orderBySQL := mysql.ConstructOrderBySQLString(options.Orders)
 		limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(options.Limit, options.Offset)
-		query = fmt.Sprintf(selectOrganizationsSQL, whereSQL, orderBySQL, limitOffsetSQL)
+		query = fmt.Sprintf(selectEnvironmentsSQL, whereSQL, orderBySQL, limitOffsetSQL)
 	} else {
-		query = selectOrganizationsSQL
+		query = selectEnvironmentsSQL
 		whereArgs = []interface{}{}
 	}
 

--- a/pkg/environment/storage/v2/mock/environment.go
+++ b/pkg/environment/storage/v2/mock/environment.go
@@ -73,9 +73,9 @@ func (mr *MockEnvironmentStorageMockRecorder) GetEnvironmentV2(ctx, id any) *gom
 }
 
 // ListEnvironmentsV2 mocks base method.
-func (m *MockEnvironmentStorage) ListEnvironmentsV2(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*environment.EnvironmentV2, int, int64, error) {
+func (m *MockEnvironmentStorage) ListEnvironmentsV2(ctx context.Context, options *mysql.ListOptions) ([]*environment.EnvironmentV2, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListEnvironmentsV2", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListEnvironmentsV2", ctx, options)
 	ret0, _ := ret[0].([]*environment.EnvironmentV2)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -84,9 +84,9 @@ func (m *MockEnvironmentStorage) ListEnvironmentsV2(ctx context.Context, wherePa
 }
 
 // ListEnvironmentsV2 indicates an expected call of ListEnvironmentsV2.
-func (mr *MockEnvironmentStorageMockRecorder) ListEnvironmentsV2(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockEnvironmentStorageMockRecorder) ListEnvironmentsV2(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsV2", reflect.TypeOf((*MockEnvironmentStorage)(nil).ListEnvironmentsV2), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListEnvironmentsV2", reflect.TypeOf((*MockEnvironmentStorage)(nil).ListEnvironmentsV2), ctx, options)
 }
 
 // UpdateEnvironmentV2 mocks base method.

--- a/pkg/environment/storage/v2/mock/organization.go
+++ b/pkg/environment/storage/v2/mock/organization.go
@@ -88,9 +88,9 @@ func (mr *MockOrganizationStorageMockRecorder) GetSystemAdminOrganization(ctx an
 }
 
 // ListOrganizations mocks base method.
-func (m *MockOrganizationStorage) ListOrganizations(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*environment.Organization, int, int64, error) {
+func (m *MockOrganizationStorage) ListOrganizations(ctx context.Context, options *mysql.ListOptions) ([]*environment.Organization, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOrganizations", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListOrganizations", ctx, options)
 	ret0, _ := ret[0].([]*environment.Organization)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -99,9 +99,9 @@ func (m *MockOrganizationStorage) ListOrganizations(ctx context.Context, wherePa
 }
 
 // ListOrganizations indicates an expected call of ListOrganizations.
-func (mr *MockOrganizationStorageMockRecorder) ListOrganizations(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockOrganizationStorageMockRecorder) ListOrganizations(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizations", reflect.TypeOf((*MockOrganizationStorage)(nil).ListOrganizations), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOrganizations", reflect.TypeOf((*MockOrganizationStorage)(nil).ListOrganizations), ctx, options)
 }
 
 // UpdateOrganization mocks base method.

--- a/pkg/environment/storage/v2/mock/project.go
+++ b/pkg/environment/storage/v2/mock/project.go
@@ -88,9 +88,9 @@ func (mr *MockProjectStorageMockRecorder) GetTrialProjectByEmail(ctx, email, dis
 }
 
 // ListProjects mocks base method.
-func (m *MockProjectStorage) ListProjects(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*environment.Project, int, int64, error) {
+func (m *MockProjectStorage) ListProjects(ctx context.Context, options *mysql.ListOptions) ([]*environment.Project, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListProjects", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListProjects", ctx, options)
 	ret0, _ := ret[0].([]*environment.Project)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -99,9 +99,9 @@ func (m *MockProjectStorage) ListProjects(ctx context.Context, whereParts []mysq
 }
 
 // ListProjects indicates an expected call of ListProjects.
-func (mr *MockProjectStorageMockRecorder) ListProjects(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockProjectStorageMockRecorder) ListProjects(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProjects", reflect.TypeOf((*MockProjectStorage)(nil).ListProjects), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListProjects", reflect.TypeOf((*MockProjectStorage)(nil).ListProjects), ctx, options)
 }
 
 // UpdateProject mocks base method.

--- a/pkg/environment/storage/v2/organization.go
+++ b/pkg/environment/storage/v2/organization.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -176,7 +177,22 @@ func (s *organizationStorage) ListOrganizations(
 	ctx context.Context,
 	options *mysql.ListOptions,
 ) ([]*proto.Organization, int, int64, error) {
-	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectOrganizationsSQL, options)
+	// Because select_organizations.sql defines the variable strings in a complex constructed way,
+	//  we do not use ConstructQueryAndWhereArgs() here.
+	var query string
+	var whereArgs []any
+	if options != nil {
+		var whereSQL string
+		whereParts := options.CreateWhereParts()
+		whereSQL, whereArgs = mysql.ConstructWhereSQLString(whereParts)
+		orderBySQL := mysql.ConstructOrderBySQLString(options.Orders)
+		limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(options.Limit, options.Offset)
+		query = fmt.Sprintf(selectOrganizationsSQL, whereSQL, orderBySQL, limitOffsetSQL)
+	} else {
+		query = selectOrganizationsSQL
+		whereArgs = []interface{}{}
+	}
+	// Construct the SQL query
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/environment/storage/v2/project_test.go
+++ b/pkg/environment/storage/v2/project_test.go
@@ -357,10 +357,6 @@ func TestListProjects(t *testing.T) {
 			accounts, cursor, _, err := storage.ListProjects(
 				context.Background(),
 				p.options,
-				// p.whereParts,
-				// p.orders,
-				// p.limit,
-				// p.offset,
 			)
 			assert.Equal(t, p.expected, accounts)
 			assert.Equal(t, p.expectedCursor, cursor)

--- a/pkg/environment/storage/v2/sql/environment/count_environments.sql
+++ b/pkg/environment/storage/v2/sql/environment/count_environments.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     environment_v2
-%s

--- a/pkg/environment/storage/v2/sql/environment/select_environments.sql
+++ b/pkg/environment/storage/v2/sql/environment/select_environments.sql
@@ -8,4 +8,3 @@ FROM
 %s
 GROUP BY
     environment_v2.id
-%s %s

--- a/pkg/environment/storage/v2/sql/environment/select_environments.sql
+++ b/pkg/environment/storage/v2/sql/environment/select_environments.sql
@@ -8,3 +8,4 @@ FROM
 %s
 GROUP BY
     environment_v2.id
+%s %s

--- a/pkg/environment/storage/v2/sql/organization/count_organizations.sql
+++ b/pkg/environment/storage/v2/sql/organization/count_organizations.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     organization
-%s

--- a/pkg/environment/storage/v2/sql/project/count_projects.sql
+++ b/pkg/environment/storage/v2/sql/project/count_projects.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     project
-%s


### PR DESCRIPTION
This pull request refactors the query-building logic for listing environments, organizations, and projects in the `EnvironmentService` by introducing a unified `mysql.ListOptions` structure. This change simplifies the codebase, improves maintainability, and enhances test coverage. 

relate of https://github.com/bucketeer-io/bucketeer/issues/1475