### PR TITLE
test: add unit tests to tag package

### DIFF
--- a/pkg/tag/api/api_test.go
+++ b/pkg/tag/api/api_test.go
@@ -153,6 +153,7 @@ func TestListTagsMySQL(t *testing.T) {
 		setup       func(*TagService)
 		req         *proto.ListTagsRequest
 		expectedErr error
+		expected    *proto.ListTagsResponse
 	}{
 		{
 			desc:        "errPermissionDenied",
@@ -160,6 +161,7 @@ func TestListTagsMySQL(t *testing.T) {
 			setup:       func(s *TagService) {},
 			req:         &proto.ListTagsRequest{EnvironmentId: "ns0", PageSize: 10, Cursor: "0"},
 			expectedErr: createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+			expected:    nil,
 		},
 		{
 			desc:    "success",
@@ -175,6 +177,11 @@ func TestListTagsMySQL(t *testing.T) {
 				Cursor:        "0",
 			},
 			expectedErr: nil,
+			expected: &proto.ListTagsResponse{
+				Tags:       []*proto.Tag{},
+				Cursor:     "0",
+				TotalCount: 0,
+			},
 		},
 	}
 	for _, p := range patterns {
@@ -183,8 +190,11 @@ func TestListTagsMySQL(t *testing.T) {
 			if p.setup != nil {
 				p.setup(service)
 			}
-			_, err := service.ListTags(ctx, p.req)
+			resp, err := service.ListTags(ctx, p.req)
 			assert.Equal(t, p.expectedErr, err)
+			if p.expectedErr == nil {
+				assert.Equal(t, p.expected, resp)
+			}
 		})
 	}
 }

--- a/pkg/tag/api/api_test.go
+++ b/pkg/tag/api/api_test.go
@@ -1,0 +1,365 @@
+// Copyright 2025 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/metadata"
+	gstatus "google.golang.org/grpc/status"
+
+	accountclientmock "github.com/bucketeer-io/bucketeer/pkg/account/client/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/locale"
+	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/rpc"
+	mysqlmock "github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/tag/domain"
+	tagstoragemock "github.com/bucketeer-io/bucketeer/pkg/tag/storage/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/token"
+	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
+	proto "github.com/bucketeer-io/bucketeer/proto/tag"
+)
+
+func TestNewTagService(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+	mysqlClientMock := mysqlmock.NewMockClient(mockController)
+	accountClientMock := accountclientmock.NewMockClient(mockController)
+	p := publishermock.NewMockPublisher(mockController)
+	logger := zap.NewNop()
+	s := NewTagService(
+		mysqlClientMock,
+		accountClientMock,
+		p,
+		WithLogger(logger),
+	)
+	assert.IsType(t, &TagService{}, s)
+}
+
+func TestCreateTagMySQL(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithTokenRoleOwner(t)
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(*TagService)
+		req         *proto.CreateTagRequest
+		expectedErr error
+	}{
+		{
+			desc: "err: ErrNameRequired",
+			req: &proto.CreateTagRequest{
+				EnvironmentId: "ns0",
+				EntityType:    proto.Tag_FEATURE_FLAG,
+			},
+			expectedErr: createError(statusNameRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "name")),
+		},
+		{
+			desc: "err: ErrEntityTypeRequired",
+			req: &proto.CreateTagRequest{
+				EnvironmentId: "ns0",
+				Name:          "test-tag",
+			},
+			expectedErr: createError(statusEntityTypeRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "entity_type")),
+		},
+		{
+			desc: "success",
+			setup: func(s *TagService) {
+				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().UpsertTag(
+					gomock.Any(), gomock.Any(),
+				).Return(nil)
+				s.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
+					gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			req: &proto.CreateTagRequest{
+				EnvironmentId: "ns0",
+				Name:          "test-tag",
+				EntityType:    proto.Tag_FEATURE_FLAG,
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createTagService(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			_, err := s.CreateTag(ctx, p.req)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func TestListTagsMySQL(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithTokenRoleUnassigned(t)
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		service     *TagService
+		setup       func(*TagService)
+		req         *proto.ListTagsRequest
+		expectedErr error
+	}{
+		{
+			desc:        "errPermissionDenied",
+			service:     createServiceWithGetAccountByEnvironmentMock(mockController, accountproto.AccountV2_Role_Organization_UNASSIGNED, accountproto.AccountV2_Role_Environment_UNASSIGNED),
+			setup:       func(s *TagService) {},
+			req:         &proto.ListTagsRequest{EnvironmentId: "ns0", PageSize: 10, Cursor: "0"},
+			expectedErr: createError(statusPermissionDenied, localizer.MustLocalize(locale.PermissionDenied)),
+		},
+		{
+			desc:    "success",
+			service: createTagService(mockController),
+			setup: func(s *TagService) {
+				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().ListTags(
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return([]*proto.Tag{}, 0, int64(0), nil)
+			},
+			req: &proto.ListTagsRequest{
+				EnvironmentId: "ns0",
+				PageSize:      10,
+				Cursor:        "0",
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			service := p.service
+			if p.setup != nil {
+				p.setup(service)
+			}
+			_, err := service.ListTags(ctx, p.req)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func TestDeleteTagMySQL(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := createContextWithTokenRoleOwner(t)
+	ctx = metadata.NewIncomingContext(ctx, metadata.MD{
+		"accept-language": []string{"ja"},
+	})
+	localizer := locale.NewLocalizer(ctx)
+	createError := func(status *gstatus.Status, msg string) error {
+		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+			Locale:  localizer.GetLocale(),
+			Message: msg,
+		})
+		require.NoError(t, err)
+		return st.Err()
+	}
+
+	patterns := []struct {
+		desc        string
+		setup       func(*TagService)
+		req         *proto.DeleteTagRequest
+		expectedErr error
+	}{
+		{
+			desc: "err: ErrIDRequired",
+			req: &proto.DeleteTagRequest{
+				EnvironmentId: "ns0",
+			},
+			expectedErr: createError(statusNameRequired, localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id")),
+		},
+		{
+			desc: "err: GetTag",
+			setup: func(s *TagService) {
+				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().GetTag(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			req: &proto.DeleteTagRequest{
+				Id:            "tag-0",
+				EnvironmentId: "ns0",
+			},
+			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+		},
+		{
+			desc: "success",
+			setup: func(s *TagService) {
+				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().GetTag(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(&domain.Tag{
+					Tag: &proto.Tag{
+						Id:            "tag-0",
+						Name:          "test-tag",
+						EnvironmentId: "ns0",
+						EntityType:    proto.Tag_FEATURE_FLAG,
+					},
+				}, nil)
+				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().DeleteTag(
+					gomock.Any(), gomock.Any(),
+				).Return(nil)
+				s.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
+					gomock.Any(), gomock.Any(),
+				).Return(nil)
+			},
+			req: &proto.DeleteTagRequest{
+				Id:            "tag-0",
+				EnvironmentId: "ns0",
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createTagService(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			_, err := s.DeleteTag(ctx, p.req)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func createTagService(c *gomock.Controller) *TagService {
+	mysqlClientMock := mysqlmock.NewMockClient(c)
+	accountClientMock := accountclientmock.NewMockClient(c)
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: "ns0",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+				{
+					EnvironmentId: "",
+					Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+				},
+			},
+		},
+	}
+	accountClientMock.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	p := publishermock.NewMockPublisher(c)
+	logger := zap.NewNop()
+	return &TagService{
+		mysqlClient:   mysqlClientMock,
+		tagStorage:    tagstoragemock.NewMockTagStorage(c),
+		accountClient: accountClientMock,
+		publisher:     p,
+		opts: &options{
+			logger: zap.NewNop(),
+		},
+		logger: logger,
+	}
+}
+
+func createServiceWithGetAccountByEnvironmentMock(c *gomock.Controller, ro accountproto.AccountV2_Role_Organization, re accountproto.AccountV2_Role_Environment) *TagService {
+	mysqlClientMock := mysqlmock.NewMockClient(c)
+	accountClientMock := accountclientmock.NewMockClient(c)
+	ar := &accountproto.GetAccountV2ByEnvironmentIDResponse{
+		Account: &accountproto.AccountV2{
+			Email:            "email",
+			OrganizationRole: ro,
+			EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+				{
+					EnvironmentId: "ns0",
+					Role:          re,
+				},
+			},
+		},
+	}
+	accountClientMock.EXPECT().GetAccountV2ByEnvironmentID(gomock.Any(), gomock.Any()).Return(ar, nil).AnyTimes()
+	p := publishermock.NewMockPublisher(c)
+	logger := zap.NewNop()
+	return &TagService{
+		mysqlClient:   mysqlClientMock,
+		tagStorage:    tagstoragemock.NewMockTagStorage(c),
+		accountClient: accountClientMock,
+		publisher:     p,
+		opts: &options{
+			logger: zap.NewNop(),
+		},
+		logger: logger,
+	}
+}
+
+func createContextWithTokenRoleUnassigned(t *testing.T) context.Context {
+	t.Helper()
+	token := &token.AccessToken{
+		Issuer:   "issuer",
+		Audience: "audience",
+		Expiry:   time.Now().AddDate(100, 0, 0),
+		IssuedAt: time.Now(),
+		Email:    "email",
+	}
+	ctx := context.TODO()
+	return context.WithValue(ctx, rpc.Key, token)
+}
+
+func createContextWithTokenRoleOwner(t *testing.T) context.Context {
+	t.Helper()
+	token := &token.AccessToken{
+		Issuer:        "issuer",
+		Audience:      "audience",
+		Expiry:        time.Now().AddDate(100, 0, 0),
+		IssuedAt:      time.Now(),
+		Email:         "email",
+		IsSystemAdmin: true,
+	}
+	ctx := context.TODO()
+	return context.WithValue(ctx, rpc.Key, token)
+}

--- a/pkg/tag/api/api_test.go
+++ b/pkg/tag/api/api_test.go
@@ -169,7 +169,14 @@ func TestListTagsMySQL(t *testing.T) {
 			setup: func(s *TagService) {
 				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().ListTags(
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return([]*proto.Tag{}, 0, int64(0), nil)
+				).Return([]*proto.Tag{
+					{
+						Id:            "tag-0",
+						Name:          "test-tag",
+						EnvironmentId: "ns0",
+						EntityType:    proto.Tag_FEATURE_FLAG,
+					},
+				}, 0, int64(0), nil)
 			},
 			req: &proto.ListTagsRequest{
 				EnvironmentId: "ns0",
@@ -178,7 +185,14 @@ func TestListTagsMySQL(t *testing.T) {
 			},
 			expectedErr: nil,
 			expected: &proto.ListTagsResponse{
-				Tags:       []*proto.Tag{},
+				Tags: []*proto.Tag{
+					{
+						Id:            "tag-0",
+						Name:          "test-tag",
+						EnvironmentId: "ns0",
+						EntityType:    proto.Tag_FEATURE_FLAG,
+					},
+				},
 				Cursor:     "0",
 				TotalCount: 0,
 			},

--- a/pkg/tag/storage/tag_test.go
+++ b/pkg/tag/storage/tag_test.go
@@ -15,12 +15,17 @@
 package storage
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/tag/domain"
+	proto "github.com/bucketeer-io/bucketeer/proto/tag"
 )
 
 func TestNewTagStorage(t *testing.T) {
@@ -29,4 +34,400 @@ func TestNewTagStorage(t *testing.T) {
 	defer mockController.Finish()
 	storage := NewTagStorage(mock.NewMockQueryExecer(mockController))
 	assert.IsType(t, &tagStorage{}, storage)
+}
+
+func TestUpsertTag(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc        string
+		setup       func(*tagStorage)
+		input       *domain.Tag
+		expectedErr error
+	}{
+		{
+			desc: "ErrTagAlreadyExists",
+			setup: func(s *tagStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, mysql.ErrDuplicateEntry)
+			},
+			input: &domain.Tag{
+				Tag: &proto.Tag{Id: "tag-id-0"},
+			},
+			expectedErr: mysql.ErrDuplicateEntry,
+		},
+		{
+			desc: "Error",
+			setup: func(s *tagStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			input: &domain.Tag{
+				Tag: &proto.Tag{Id: "tag-id-0"},
+			},
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *tagStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					insertTagSQL,
+					"tag-id-0",
+					gomock.Any(),
+					int64(1),
+					int64(2),
+					int32(proto.Tag_FEATURE_FLAG),
+					"env-0",
+				).Return(nil, nil)
+			},
+			input: &domain.Tag{
+				Tag: &proto.Tag{
+					Id:            "tag-id-0",
+					Name:          "test-tag",
+					CreatedAt:     1,
+					UpdatedAt:     2,
+					EntityType:    proto.Tag_FEATURE_FLAG,
+					EnvironmentId: "env-0",
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newTagStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.UpsertTag(context.Background(), p.input)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func TestGetTag(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc          string
+		setup         func(*tagStorage)
+		id            string
+		environmentId string
+		expectedTag   *domain.Tag
+		expectedErr   error
+	}{
+		{
+			desc: "ErrTagNotFound",
+			setup: func(s *tagStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			id:            "tag-id-0",
+			environmentId: "env-0",
+			expectedTag:   nil,
+			expectedErr:   ErrTagNotFound,
+		},
+		{
+			desc: "Error",
+			setup: func(s *tagStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(errors.New("error"))
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			id:            "tag-id-0",
+			environmentId: "env-0",
+			expectedTag:   nil,
+			expectedErr:   errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *tagStorage) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(
+					gomock.Any(), // id
+					gomock.Any(), // name
+					gomock.Any(), // created_at
+					gomock.Any(), // updated_at
+					gomock.Any(), // entity_type
+					gomock.Any(), // environment_id
+					gomock.Any(), // environment_name
+				).Do(func(args ...interface{}) {
+					// スキャン先のポインタに値を設定
+					*args[0].(*string) = "tag-id-0"
+					*args[1].(*string) = "test-tag"
+					*args[2].(*int64) = int64(1)
+					*args[3].(*int64) = int64(2)
+					*args[4].(*int32) = int32(proto.Tag_FEATURE_FLAG)
+					*args[5].(*string) = "env-0"
+					*args[6].(*string) = "test-env"
+				}).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					selectTagSQL,
+					"tag-id-0",
+					"env-0",
+				).Return(row)
+			},
+			id:            "tag-id-0",
+			environmentId: "env-0",
+			expectedTag: &domain.Tag{
+				Tag: &proto.Tag{
+					Id:              "tag-id-0",
+					Name:            "test-tag",
+					CreatedAt:       1,
+					UpdatedAt:       2,
+					EntityType:      proto.Tag_FEATURE_FLAG,
+					EnvironmentId:   "env-0",
+					EnvironmentName: "test-env",
+				},
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newTagStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			tag, err := storage.GetTag(context.Background(), p.id, p.environmentId)
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.Equal(t, p.expectedTag, tag)
+			}
+		})
+	}
+}
+
+func TestListTags(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc           string
+		setup          func(*tagStorage)
+		whereParts     []mysql.WherePart
+		orders         []*mysql.Order
+		limit          int
+		offset         int
+		expectedCount  int
+		expectedCursor int
+		expectedErr    error
+	}{
+		{
+			desc: "Error",
+			setup: func(s *tagStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			whereParts:     nil,
+			orders:         nil,
+			limit:          10,
+			offset:         0,
+			expectedCount:  0,
+			expectedCursor: 0,
+			expectedErr:    errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *tagStorage) {
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().Return(false)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(row)
+			},
+			whereParts: []mysql.WherePart{
+				mysql.NewFilter("tag.environment_id", "=", "env-0"),
+			},
+			orders: []*mysql.Order{
+				mysql.NewOrder("tag.name", mysql.OrderDirectionAsc),
+			},
+			limit:          10,
+			offset:         0,
+			expectedCount:  0,
+			expectedCursor: 0,
+			expectedErr:    nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newTagStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			tags, cursor, _, err := storage.ListTags(
+				context.Background(),
+				p.whereParts,
+				p.orders,
+				p.limit,
+				p.offset,
+			)
+			assert.Equal(t, p.expectedCount, len(tags))
+			if tags != nil {
+				assert.IsType(t, []*proto.Tag{}, tags)
+			}
+			assert.Equal(t, p.expectedCursor, cursor)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func TestListAllEnvironmentTags(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc        string
+		setup       func(*tagStorage)
+		expectedErr error
+	}{
+		{
+			desc: "Error",
+			setup: func(s *tagStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "Success:Empty",
+			setup: func(s *tagStorage) {
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().Return(false)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					selectAllEnvironmentTagsSQL,
+				).Return(rows, nil)
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "Success:WithData",
+			setup: func(s *tagStorage) {
+				var nextCallCount = 0
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().DoAndReturn(func() bool {
+					nextCallCount++
+					return nextCallCount <= 2
+				}).Times(3)
+				rows.EXPECT().Scan(gomock.Any()).Return(nil).Times(2)
+				rows.EXPECT().Err().Return(nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().QueryContext(
+					gomock.Any(),
+					selectAllEnvironmentTagsSQL,
+				).Return(rows, nil)
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newTagStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			envTags, err := storage.ListAllEnvironmentTags(context.Background())
+			assert.Equal(t, p.expectedErr, err)
+			if err == nil {
+				assert.NotNil(t, envTags)
+				assert.IsType(t, []*proto.EnvironmentTag{}, envTags)
+			}
+		})
+	}
+}
+
+func TestDeleteTag(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc        string
+		setup       func(*tagStorage)
+		id          string
+		expectedErr error
+	}{
+		{
+			desc: "ErrTagUnexpectedAffectedRows",
+			setup: func(s *tagStorage) {
+				result := mock.NewMockResult(mockController)
+				result.EXPECT().RowsAffected().Return(int64(0), nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(result, nil)
+			},
+			id:          "tag-id-0",
+			expectedErr: ErrTagUnexpectedAffectedRows,
+		},
+		{
+			desc: "Error",
+			setup: func(s *tagStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			id:          "tag-id-0",
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *tagStorage) {
+				result := mock.NewMockResult(mockController)
+				result.EXPECT().RowsAffected().Return(int64(1), nil)
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					deleteTagSQL,
+					"tag-id-0",
+				).Return(result, nil)
+			},
+			id:          "tag-id-0",
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := newTagStorageWithMock(t, mockController)
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.DeleteTag(context.Background(), p.id)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}
+
+func newTagStorageWithMock(t *testing.T, mockController *gomock.Controller) *tagStorage {
+	t.Helper()
+	return &tagStorage{mock.NewMockQueryExecer(mockController)}
 }

--- a/pkg/tag/storage/tag_test.go
+++ b/pkg/tag/storage/tag_test.go
@@ -226,6 +226,7 @@ func TestListTags(t *testing.T) {
 		expectedCount  int
 		expectedCursor int
 		expectedErr    error
+		expectedTags   []*proto.Tag
 	}{
 		{
 			desc: "Error",
@@ -241,6 +242,7 @@ func TestListTags(t *testing.T) {
 			expectedCount:  0,
 			expectedCursor: 0,
 			expectedErr:    errors.New("error"),
+			expectedTags:   nil,
 		},
 		{
 			desc: "Success",
@@ -273,6 +275,7 @@ func TestListTags(t *testing.T) {
 			expectedCount:  0,
 			expectedCursor: 0,
 			expectedErr:    nil,
+			expectedTags:   []*proto.Tag{},
 		},
 	}
 	for _, p := range patterns {
@@ -291,6 +294,7 @@ func TestListTags(t *testing.T) {
 			assert.Equal(t, p.expectedCount, len(tags))
 			if tags != nil {
 				assert.IsType(t, []*proto.Tag{}, tags)
+				assert.Equal(t, p.expectedTags, tags)
 			}
 			assert.Equal(t, p.expectedCursor, cursor)
 			assert.Equal(t, p.expectedErr, err)


### PR DESCRIPTION
This pull request refactors the `TagService` to use a `tagStorage` instance instead of creating a new `TagStorage` object in each method. Additionally, it introduces comprehensive unit tests for the `TagService` to improve test coverage and reliability.