### PR TITLE
refactor: change the list retrieval API in the auditlog package to use ListOption

### DIFF
--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -343,18 +343,34 @@ func (s *auditlogService) ListAdminAuditLogs(
 	if err != nil {
 		return nil, err
 	}
-	whereParts := []mysql.WherePart{}
+	filters := []*mysql.FilterV2{}
 	if req.From != 0 {
-		whereParts = append(whereParts, mysql.NewFilter("timestamp", ">=", req.From))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "timestamp",
+			Operator: mysql.OperatorGreaterThanOrEqual,
+			Value:    req.From,
+		})
 	}
 	if req.To != 0 {
-		whereParts = append(whereParts, mysql.NewFilter("timestamp", "<=", req.To))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "timestamp",
+			Operator: mysql.OperatorLessThanOrEqual,
+			Value:    req.To,
+		})
 	}
 	if req.EntityType != nil {
-		whereParts = append(whereParts, mysql.NewFilter("entity_type", "=", req.EntityType.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "entity_type",
+			Operator: mysql.OperatorEqual,
+			Value:    req.EntityType.Value,
+		})
 	}
+	var searchQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
-		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"editor"}, req.SearchKeyword))
+		searchQuery = &mysql.SearchQuery{
+			Columns: []string{"editor"},
+			Keyword: req.SearchKeyword,
+		}
 	}
 	orders, err := s.newAdminAuditLogListOrders(req.OrderBy, req.OrderDirection, localizer)
 	if err != nil {
@@ -380,13 +396,17 @@ func (s *auditlogService) ListAdminAuditLogs(
 		}
 		return nil, dt.Err()
 	}
-	auditlogs, nextCursor, totalCount, err := s.adminAuditLogStorage.ListAdminAuditLogs(
-		ctx,
-		whereParts,
-		orders,
-		limit,
-		offset,
-	)
+	options := &mysql.ListOptions{
+		Limit:       limit,
+		Offset:      offset,
+		SearchQuery: searchQuery,
+		Orders:      orders,
+		Filters:     filters,
+		NullFilters: nil,
+		InFilters:   nil,
+		JSONFilters: nil,
+	}
+	auditlogs, nextCursor, totalCount, err := s.adminAuditLogStorage.ListAdminAuditLogs(ctx, options)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list admin auditlogs",

--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -211,7 +211,7 @@ func (s *auditlogService) ListAuditLogs(
 		return nil, dt.Err()
 	}
 	var filters = []*mysql.FilterV2{
-		&mysql.FilterV2{
+		{
 			Column:   "environment_id",
 			Operator: mysql.OperatorEqual,
 			Value:    req.EnvironmentId,

--- a/pkg/auditlog/api/api_test.go
+++ b/pkg/auditlog/api/api_test.go
@@ -223,7 +223,7 @@ func TestListAuditLogsMySQL(t *testing.T) {
 			context: createContextWithToken(t, true),
 			setup: func(s *auditlogService) {
 				s.auditLogStorage.(*v2alsmock.MockAuditLogStorage).EXPECT().ListAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("test"))
 			},
 			input:    &proto.ListAuditLogsRequest{EnvironmentId: "ns0"},
@@ -249,7 +249,7 @@ func TestListAuditLogsMySQL(t *testing.T) {
 			context: createContextWithToken(t, true),
 			setup: func(s *auditlogService) {
 				s.auditLogStorage.(*v2alsmock.MockAuditLogStorage).EXPECT().ListAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(createAuditLogs(t), 2, int64(10), nil)
 				s.accountStorage.(*v2asmock.MockAccountStorage).EXPECT().GetAvatarAccountsV2(
 					gomock.Any(), gomock.Any(),
@@ -267,7 +267,7 @@ func TestListAuditLogsMySQL(t *testing.T) {
 			context: createContextWithToken(t, false),
 			setup: func(s *auditlogService) {
 				s.auditLogStorage.(*v2alsmock.MockAuditLogStorage).EXPECT().ListAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(createAuditLogs(t), 2, int64(10), nil)
 				s.accountStorage.(*v2asmock.MockAccountStorage).EXPECT().GetAvatarAccountsV2(
 					gomock.Any(), gomock.Any(),
@@ -409,7 +409,7 @@ func TestListFeatureHistoryMySQL(t *testing.T) {
 			context: createContextWithToken(t, false),
 			setup: func(s *auditlogService) {
 				s.auditLogStorage.(*v2alsmock.MockAuditLogStorage).EXPECT().ListAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("test"))
 			},
 			input:    &proto.ListFeatureHistoryRequest{EnvironmentId: "ns0"},
@@ -437,7 +437,7 @@ func TestListFeatureHistoryMySQL(t *testing.T) {
 			context: createContextWithToken(t, false),
 			setup: func(s *auditlogService) {
 				s.auditLogStorage.(*v2alsmock.MockAuditLogStorage).EXPECT().ListAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(createAuditLogs(t), 2, int64(10), nil)
 			},
 			input: &proto.ListFeatureHistoryRequest{
@@ -454,7 +454,7 @@ func TestListFeatureHistoryMySQL(t *testing.T) {
 			context: createContextWithTokenRoleUnassigned(t),
 			setup: func(s *auditlogService) {
 				s.auditLogStorage.(*v2alsmock.MockAuditLogStorage).EXPECT().ListAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(createAuditLogs(t), 2, int64(10), nil)
 			},
 			input: &proto.ListFeatureHistoryRequest{

--- a/pkg/auditlog/api/api_test.go
+++ b/pkg/auditlog/api/api_test.go
@@ -337,7 +337,7 @@ func TestListAdminAuditLogsMySQL(t *testing.T) {
 			desc: "err: ErrInternal",
 			setup: func(s *auditlogService) {
 				s.adminAuditLogStorage.(*v2alsmock.MockAdminAuditLogStorage).EXPECT().ListAdminAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("test"))
 			},
 			input:       &proto.ListAdminAuditLogsRequest{},
@@ -348,7 +348,7 @@ func TestListAdminAuditLogsMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(s *auditlogService) {
 				s.adminAuditLogStorage.(*v2alsmock.MockAdminAuditLogStorage).EXPECT().ListAdminAuditLogs(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(createAuditLogs(t), 2, int64(10), nil)
 			},
 			input:       &proto.ListAdminAuditLogsRequest{PageSize: 2, Cursor: ""},

--- a/pkg/auditlog/storage/v2/admin_audit_log_test.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log_test.go
@@ -195,10 +195,7 @@ func TestListAdminAuditLogs(t *testing.T) {
 	patterns := []struct {
 		desc                string
 		setup               func(*adminAuditLogStorage)
-		whereParts          []mysql.WherePart
-		orders              []*mysql.Order
-		limit               int
-		offset              int
+		options             *mysql.ListOptions
 		expectedResultCount int
 		expectedCursor      int
 		expectedErr         error
@@ -210,10 +207,7 @@ func TestListAdminAuditLogs(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:          nil,
-			orders:              nil,
-			limit:               0,
-			offset:              0,
+			options:             nil,
 			expectedResultCount: 0,
 			expectedCursor:      0,
 			expectedErr:         errors.New("error"),
@@ -238,10 +232,16 @@ func TestListAdminAuditLogs(t *testing.T) {
 					[]interface{}{},
 				).Return(row)
 			},
-			whereParts:          nil,
-			orders:              nil,
-			limit:               0,
-			offset:              0,
+			options: &mysql.ListOptions{
+				Limit:       0,
+				Filters:     nil,
+				InFilters:   nil,
+				Offset:      0,
+				Orders:      nil,
+				NullFilters: nil,
+				JSONFilters: nil,
+				SearchQuery: nil,
+			},
 			expectedResultCount: 0,
 			expectedCursor:      0,
 		},
@@ -270,16 +270,32 @@ func TestListAdminAuditLogs(t *testing.T) {
 					timestamp, entityType,
 				).Return(row)
 			},
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("timestamp", ">=", timestamp),
-				mysql.NewFilter("entity_type", "=", entityType),
+			options: &mysql.ListOptions{
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "timestamp",
+						Operator: mysql.OperatorGreaterThanOrEqual,
+						Value:    timestamp,
+					},
+					{
+						Column:   "entity_type",
+						Operator: mysql.OperatorEqual,
+						Value:    entityType,
+					},
+				},
+				Orders: []*mysql.Order{
+					{
+						Column:    "id",
+						Direction: mysql.OrderDirectionAsc,
+					},
+					{
+						Column:    "timestamp",
+						Direction: mysql.OrderDirectionDesc,
+					},
+				},
+				Limit:  limit,
+				Offset: offset,
 			},
-			orders: []*mysql.Order{
-				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-				mysql.NewOrder("timestamp", mysql.OrderDirectionDesc),
-			},
-			limit:               limit,
-			offset:              offset,
 			expectedResultCount: getSize,
 			expectedCursor:      offset + getSize,
 			expectedErr:         nil,
@@ -293,10 +309,7 @@ func TestListAdminAuditLogs(t *testing.T) {
 			}
 			auditLogs, cursor, _, err := storage.ListAdminAuditLogs(
 				context.Background(),
-				p.whereParts,
-				p.orders,
-				p.limit,
-				p.offset,
+				p.options,
 			)
 			assert.Equal(t, p.expectedResultCount, len(auditLogs))
 			if auditLogs != nil {

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/bucketeer-io/bucketeer/pkg/auditlog/domain"
@@ -49,9 +48,7 @@ type AuditLogStorage interface {
 	CreateAuditLog(ctx context.Context, auditLog *domain.AuditLog) error
 	ListAuditLogs(
 		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
+		options *mysql.ListOptions,
 	) ([]*proto.AuditLog, int, int64, error)
 }
 
@@ -156,19 +153,19 @@ func (s *auditLogStorage) CreateAuditLog(ctx context.Context, auditLog *domain.A
 
 func (s *auditLogStorage) ListAuditLogs(
 	ctx context.Context,
-	whereParts []mysql.WherePart,
-	orders []*mysql.Order,
-	limit, offset int,
+	options *mysql.ListOptions,
 ) ([]*proto.AuditLog, int, int64, error) {
-	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
-	orderBySQL := mysql.ConstructOrderBySQLString(orders)
-	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	query := fmt.Sprintf(selectAuditLogsV2SQL, whereSQL, orderBySQL, limitOffsetSQL)
+	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectAuditLogsV2SQL, options)
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
+	var limit, offset int
+	if options != nil {
+		limit = options.Limit
+		offset = options.Offset
+	}
 	auditLogs := make([]*proto.AuditLog, 0, limit)
 	for rows.Next() {
 		auditLog := proto.AuditLog{}
@@ -198,8 +195,8 @@ func (s *auditLogStorage) ListAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	countQuery := fmt.Sprintf(selectAuditLogV2CountSQL, whereSQL)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAuditLogV2CountSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/mock/admin_audit_log.go
+++ b/pkg/auditlog/storage/v2/mock/admin_audit_log.go
@@ -72,9 +72,9 @@ func (mr *MockAdminAuditLogStorageMockRecorder) CreateAdminAuditLogs(ctx, auditL
 }
 
 // ListAdminAuditLogs mocks base method.
-func (m *MockAdminAuditLogStorage) ListAdminAuditLogs(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*auditlog.AuditLog, int, int64, error) {
+func (m *MockAdminAuditLogStorage) ListAdminAuditLogs(ctx context.Context, options *mysql.ListOptions) ([]*auditlog.AuditLog, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAdminAuditLogs", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAdminAuditLogs", ctx, options)
 	ret0, _ := ret[0].([]*auditlog.AuditLog)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -83,7 +83,7 @@ func (m *MockAdminAuditLogStorage) ListAdminAuditLogs(ctx context.Context, where
 }
 
 // ListAdminAuditLogs indicates an expected call of ListAdminAuditLogs.
-func (mr *MockAdminAuditLogStorageMockRecorder) ListAdminAuditLogs(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAdminAuditLogStorageMockRecorder) ListAdminAuditLogs(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAdminAuditLogs", reflect.TypeOf((*MockAdminAuditLogStorage)(nil).ListAdminAuditLogs), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAdminAuditLogs", reflect.TypeOf((*MockAdminAuditLogStorage)(nil).ListAdminAuditLogs), ctx, options)
 }

--- a/pkg/auditlog/storage/v2/mock/audit_log.go
+++ b/pkg/auditlog/storage/v2/mock/audit_log.go
@@ -87,9 +87,9 @@ func (mr *MockAuditLogStorageMockRecorder) GetAuditLog(ctx, id, environmentID an
 }
 
 // ListAuditLogs mocks base method.
-func (m *MockAuditLogStorage) ListAuditLogs(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*auditlog.AuditLog, int, int64, error) {
+func (m *MockAuditLogStorage) ListAuditLogs(ctx context.Context, options *mysql.ListOptions) ([]*auditlog.AuditLog, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditLogs", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAuditLogs", ctx, options)
 	ret0, _ := ret[0].([]*auditlog.AuditLog)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -98,7 +98,7 @@ func (m *MockAuditLogStorage) ListAuditLogs(ctx context.Context, whereParts []my
 }
 
 // ListAuditLogs indicates an expected call of ListAuditLogs.
-func (mr *MockAuditLogStorageMockRecorder) ListAuditLogs(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAuditLogStorageMockRecorder) ListAuditLogs(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditLogs", reflect.TypeOf((*MockAuditLogStorage)(nil).ListAuditLogs), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditLogs", reflect.TypeOf((*MockAuditLogStorage)(nil).ListAuditLogs), ctx, options)
 }

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2.sql
@@ -11,4 +11,3 @@ SELECT
     previous_entity_data
 FROM
     admin_audit_log
-    %s %s %s

--- a/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2_count.sql
+++ b/pkg/auditlog/storage/v2/sql/adminauditlog/select_admin_audit_log_v2_count.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     admin_audit_log
-%s

--- a/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2_count.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/select_audit_log_v2_count.sql
@@ -2,4 +2,3 @@ SELECT
     COUNT(1)
 FROM
     audit_log
-%s

--- a/pkg/auditlog/storage/v2/sql/auditlog/select_audit_logs_v2.sql
+++ b/pkg/auditlog/storage/v2/sql/auditlog/select_audit_logs_v2.sql
@@ -11,4 +11,3 @@ SELECT
     previous_entity_data
 FROM
     audit_log
-    %s %s %s


### PR DESCRIPTION
This pull request refactors the audit log services and storage layers to use a new `mysql.ListOptions` struct for query filtering, ordering, and pagination. It replaces the older `mysql.WherePart` and individual parameters with a more flexible and centralized approach. Additionally, corresponding test cases and imports have been updated to align with these changes.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475