### PR TITLE
feat: implement pubsub ordering key

### DIFF
--- a/pkg/api/api/api.go
+++ b/pkg/api/api/api.go
@@ -806,11 +806,11 @@ func (s *gatewayService) registerEvents(w http.ResponseWriter, req *http.Request
 		envAPIKey.Environment.OrganizationId, envAPIKey.ProjectId, envAPIKey.ProjectUrlCode,
 		envAPIKey.Environment.Id, envAPIKey.Environment.UrlCode, methodRegisterEvents, "").Inc()
 	errs := make(map[string]*registerEventsResponseError)
-	goalMessages := make([]publisher.Message, 0)
-	evaluationMessages := make([]publisher.Message, 0)
-	metricsMessages := make([]publisher.Message, 0)
-	publish := func(p publisher.Publisher, messages []publisher.Message, typ string) {
-		multiErrs := p.PublishMulti(req.Context(), messages)
+	goalMessages := make([]*publisher.OrderingMessage, 0)
+	evaluationMessages := make([]*publisher.OrderingMessage, 0)
+	metricsMessages := make([]*publisher.OrderingMessage, 0)
+	publish := func(p publisher.Publisher, messages []*publisher.OrderingMessage, typ string) {
+		multiErrs := p.PublishMultiWithOrdering(req.Context(), messages)
 		var repeatableErrors, nonRepeateableErrors float64
 		for id, err := range multiErrs {
 			retriable := err != publisher.ErrBadMessage
@@ -864,11 +864,12 @@ func (s *gatewayService) registerEvents(w http.ResponseWriter, req *http.Request
 				}
 				continue
 			}
-			goalMessages = append(goalMessages, &eventproto.Event{
+			eventMsg := &eventproto.Event{
 				Id:            event.ID,
 				Event:         goalAny,
 				EnvironmentId: event.EnvironmentId,
-			})
+			}
+			goalMessages = append(goalMessages, publisher.NewOrderingMessage(eventMsg, goal.UserId))
 		case EvaluationEventType:
 			eval, errCode, err := s.getEvaluationEvent(req.Context(), event)
 			if err != nil {
@@ -888,11 +889,12 @@ func (s *gatewayService) registerEvents(w http.ResponseWriter, req *http.Request
 				}
 				continue
 			}
-			evaluationMessages = append(evaluationMessages, &eventproto.Event{
+			eventMsg := &eventproto.Event{
 				Id:            event.ID,
 				Event:         evalAny,
 				EnvironmentId: event.EnvironmentId,
-			})
+			}
+			evaluationMessages = append(evaluationMessages, publisher.NewOrderingMessage(eventMsg, eval.UserId))
 		case MetricsEventType:
 			metrics, errCode, err := s.getMetricsEvent(req.Context(), event)
 			if err != nil {
@@ -912,11 +914,11 @@ func (s *gatewayService) registerEvents(w http.ResponseWriter, req *http.Request
 				}
 				continue
 			}
-			metricsMessages = append(metricsMessages, &eventproto.Event{
+			metricsMessages = append(metricsMessages, publisher.NewOrderingMessage(&eventproto.Event{
 				Id:            event.ID,
 				Event:         metricsAny,
 				EnvironmentId: event.EnvironmentId,
-			})
+			}, ""))
 		default:
 			errs[event.ID] = &registerEventsResponseError{
 				Retriable: false,

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -725,7 +725,7 @@ func TestGrpcTrack(t *testing.T) {
 							Disabled: false,
 						},
 					}, nil)
-				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.TrackRequest{
@@ -1846,7 +1846,7 @@ func TestGrpcGetEvaluationsValidation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input:       &gwproto.GetEvaluationsRequest{User: &userproto.User{Id: "id-0"}},
@@ -1886,7 +1886,7 @@ func TestGrpcGetEvaluationsValidation(t *testing.T) {
 					&featureproto.Features{
 						Features: []*featureproto.Feature{},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{Tag: "test", User: &userproto.User{Id: "id-0"}},
@@ -1940,7 +1940,7 @@ func TestGrpcGetEvaluationsZeroFeature(t *testing.T) {
 					&featureproto.Features{
 						Features: []*featureproto.Feature{},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{Tag: "test", User: &userproto.User{Id: "id-0"}},
@@ -2145,7 +2145,7 @@ func TestGrpcGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: multiFeatures,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
 				Tag: "android",
@@ -2177,7 +2177,7 @@ func TestGrpcGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: multiFeatures,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
 				Tag: "android",
@@ -2211,7 +2211,7 @@ func TestGrpcGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: multiFeatures,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
 				Tag: "android",
@@ -2244,7 +2244,7 @@ func TestGrpcGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: multiFeatures,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
 				Tag:               "android",
@@ -2275,7 +2275,7 @@ func TestGrpcGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: multiFeatures,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
 				Tag:               "android",
@@ -2427,7 +2427,7 @@ func TestGrpcGetEvaluationsNoSegmentList(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{Tag: "ios", User: &userproto.User{Id: "id-0"}},
 			expected: &gwproto.GetEvaluationsResponse{
@@ -2537,7 +2537,7 @@ func TestGrpcGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.segmentUsersCache.(*cachev3mock.MockSegmentUsersCache).EXPECT().Get(gomock.Any(), gomock.Any()).Return(
 					nil, errors.New("random error"))
@@ -2628,7 +2628,7 @@ func TestGrpcGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{Tag: "test", User: &userproto.User{Id: "user-id-1"}},
@@ -2722,7 +2722,7 @@ func TestGrpcGetEvaluationsEvaluateFeatures(t *testing.T) {
 					}, nil)
 				gs.segmentUsersCache.(*cachev3mock.MockSegmentUsersCache).EXPECT().Get(gomock.Any(), gomock.Any()).Return(
 					nil, errors.New("random error"))
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.featureClient.(*featureclientmock.MockClient).EXPECT().ListSegmentUsers(gomock.Any(), gomock.Any()).Return(
 					&featureproto.ListSegmentUsersResponse{}, nil)
@@ -2797,7 +2797,7 @@ func TestGrpcGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{Tag: "test", User: &userproto.User{Id: "user-id-1"}},
@@ -2892,7 +2892,7 @@ func TestGrpcGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{Tag: "test", User: &userproto.User{Id: "user-id-1"}},
@@ -3035,7 +3035,7 @@ func TestGrpcGetEvaluationsByEvaluatedAt(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
@@ -3142,7 +3142,7 @@ func TestGrpcGetEvaluationsByEvaluatedAt(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
@@ -3247,7 +3247,7 @@ func TestGrpcGetEvaluationsByEvaluatedAt(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
@@ -3352,7 +3352,7 @@ func TestGrpcGetEvaluationsByEvaluatedAt(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationsRequest{
@@ -3499,7 +3499,7 @@ func TestGrpcGetEvaluation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input:       &gwproto.GetEvaluationRequest{Tag: "test", User: &userproto.User{Id: "id-0"}, FeatureId: "feature-id-3"},
@@ -3587,7 +3587,7 @@ func TestGrpcGetEvaluation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.segmentUsersCache.(*cachev3mock.MockSegmentUsersCache).EXPECT().Get(gomock.Any(), gomock.Any()).Return(
 					nil, errors.New("random error"))
@@ -3660,7 +3660,7 @@ func TestGrpcGetEvaluation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.GetEvaluationRequest{Tag: "test", User: &userproto.User{Id: "user-id-2"}, FeatureId: "feature-id-2"},
@@ -3844,9 +3844,9 @@ func TestGrcpRegisterEvents(t *testing.T) {
 							Disabled: false,
 						},
 					}, nil)
-				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.RegisterEventsRequest{
@@ -3882,9 +3882,9 @@ func TestGrcpRegisterEvents(t *testing.T) {
 							Disabled: false,
 						},
 					}, nil)
-				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: &gwproto.RegisterEventsRequest{

--- a/pkg/api/api/api_test.go
+++ b/pkg/api/api/api_test.go
@@ -2232,7 +2232,7 @@ func TestRegisterEvents(t *testing.T) {
 					nil).MaxTimes(1)
 				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
+				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -2277,7 +2277,7 @@ func TestRegisterEvents(t *testing.T) {
 					nil).MaxTimes(1)
 				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
+				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(

--- a/pkg/api/api/api_test.go
+++ b/pkg/api/api/api_test.go
@@ -668,7 +668,7 @@ func TestGetEvaluationsValidation(t *testing.T) {
 					&featureproto.Features{
 						Features: []*featureproto.Feature{},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -736,7 +736,7 @@ func TestGetEvaluationsZeroFeature(t *testing.T) {
 					&featureproto.Features{
 						Features: []*featureproto.Feature{},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -943,7 +943,7 @@ func TestGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: features,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -981,7 +981,7 @@ func TestGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: multiFeatures,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -1021,7 +1021,7 @@ func TestGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: features,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -1060,7 +1060,7 @@ func TestGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: features,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -1098,7 +1098,7 @@ func TestGetEvaluationsUserEvaluationsID(t *testing.T) {
 					&featureproto.Features{
 						Features: features,
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -1253,7 +1253,7 @@ func testGetEvaluationsNoSegmentList(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -1375,7 +1375,7 @@ func TestGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.segmentUsersCache.(*cachev3mock.MockSegmentUsersCache).EXPECT().Get(gomock.Any(), gomock.Any()).Return(
 					nil, errors.New("random error"))
@@ -1472,7 +1472,7 @@ func TestGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -1559,7 +1559,7 @@ func TestGetEvaluationsEvaluateFeatures(t *testing.T) {
 					}, nil)
 				gs.segmentUsersCache.(*cachev3mock.MockSegmentUsersCache).EXPECT().Get(gomock.Any(), gomock.Any()).Return(
 					nil, errors.New("random error"))
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.featureClient.(*featureclientmock.MockClient).EXPECT().ListSegmentUsers(gomock.Any(), gomock.Any()).Return(
 					&featureproto.ListSegmentUsersResponse{}, nil)
@@ -1625,7 +1625,7 @@ func TestGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -1711,7 +1711,7 @@ func TestGetEvaluationsEvaluateFeatures(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -1834,7 +1834,7 @@ func TestGetEvaluation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -1930,7 +1930,7 @@ func TestGetEvaluation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 				gs.segmentUsersCache.(*cachev3mock.MockSegmentUsersCache).EXPECT().Get(gomock.Any(), gomock.Any()).Return(
 					nil, errors.New("random error"))
@@ -2009,7 +2009,7 @@ func TestGetEvaluation(t *testing.T) {
 							},
 						},
 					}, nil)
-				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
+				gs.userPublisher.(*publishermock.MockPublisher).EXPECT().PublishWithOrdering(gomock.Any(), gomock.Any()).Return(nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
 				"POST",
@@ -2228,11 +2228,11 @@ func TestRegisterEvents(t *testing.T) {
 							Disabled: false,
 						},
 					}, nil)
-				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(
@@ -2273,11 +2273,11 @@ func TestRegisterEvents(t *testing.T) {
 							Disabled: false,
 						},
 					}, nil)
-				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.goalPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.evaluationPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
-				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMulti(gomock.Any(), gomock.Any()).Return(
+				gs.metricsPublisher.(*publishermock.MockPublisher).EXPECT().PublishMultiWithOrdering(gomock.Any(), gomock.Any()).Return(
 					nil).MaxTimes(1)
 			},
 			input: httptest.NewRequest(

--- a/pkg/pubsub/publisher/metrics.go
+++ b/pkg/pubsub/publisher/metrics.go
@@ -24,8 +24,10 @@ import (
 )
 
 const (
-	methodPublish      = "Publish"
-	methodPublishMulti = "PublishMulti"
+	methodPublish                     = "Publish"
+	methodPublishMulti                = "PublishMulti"
+	methodPublishWithOrderingKey      = "PublishWithOrderingKey"
+	methodPublishMultiWithOrderingKey = "PublishMultiWithOrderingKey"
 
 	codeOK               = "OK"
 	codeBadMessage       = "BadMessage"

--- a/pkg/pubsub/publisher/mock/publisher.go
+++ b/pkg/pubsub/publisher/mock/publisher.go
@@ -144,6 +144,34 @@ func (mr *MockPublisherMockRecorder) PublishMulti(ctx, messages any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishMulti", reflect.TypeOf((*MockPublisher)(nil).PublishMulti), ctx, messages)
 }
 
+// PublishMultiWithOrdering mocks base method.
+func (m *MockPublisher) PublishMultiWithOrdering(ctx context.Context, messages []*publisher.OrderingMessage) map[string]error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishMultiWithOrdering", ctx, messages)
+	ret0, _ := ret[0].(map[string]error)
+	return ret0
+}
+
+// PublishMultiWithOrdering indicates an expected call of PublishMultiWithOrdering.
+func (mr *MockPublisherMockRecorder) PublishMultiWithOrdering(ctx, messages any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishMultiWithOrdering", reflect.TypeOf((*MockPublisher)(nil).PublishMultiWithOrdering), ctx, messages)
+}
+
+// PublishWithOrdering mocks base method.
+func (m *MockPublisher) PublishWithOrdering(ctx context.Context, msg *publisher.OrderingMessage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PublishWithOrdering", ctx, msg)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PublishWithOrdering indicates an expected call of PublishWithOrdering.
+func (mr *MockPublisherMockRecorder) PublishWithOrdering(ctx, msg any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishWithOrdering", reflect.TypeOf((*MockPublisher)(nil).PublishWithOrdering), ctx, msg)
+}
+
 // Stop mocks base method.
 func (m *MockPublisher) Stop() {
 	m.ctrl.T.Helper()

--- a/pkg/pubsub/publisher/publisher.go
+++ b/pkg/pubsub/publisher/publisher.go
@@ -44,6 +44,8 @@ type Message interface {
 type Publisher interface {
 	Publish(ctx context.Context, msg Message) error
 	PublishMulti(ctx context.Context, messages []Message) map[string]error
+	PublishWithOrdering(ctx context.Context, msg *OrderingMessage) error
+	PublishMultiWithOrdering(ctx context.Context, messages []*OrderingMessage) map[string]error
 	Stop()
 }
 
@@ -87,6 +89,60 @@ func NewPublisher(topic *pubsub.Topic, opts ...Option) Publisher {
 	}
 }
 
+func (p *publisher) publishMessage(ctx context.Context, msg Message, orderingKey string) (err error) {
+	data, err := proto.Marshal(msg)
+	if err != nil {
+		p.logger.Error("Failed to marshal message", zap.Error(err), zap.Any("message", msg))
+		return ErrBadMessage
+	}
+	p.topic.EnableMessageOrdering = orderingKey != ""
+	message := &pubsub.Message{
+		Data:       data,
+		Attributes: map[string]string{idAttribute: msg.GetId()},
+	}
+	if orderingKey != "" {
+		message.OrderingKey = orderingKey
+	}
+	res := p.topic.Publish(ctx, message)
+	_, err = res.Get(ctx)
+	return
+}
+
+func (p *publisher) publishMultiMessages(
+	ctx context.Context,
+	messages []Message,
+	orderingKeys map[string]string,
+) (errors map[string]error) {
+	errors = make(map[string]error)
+	results := make(map[string]*pubsub.PublishResult, len(messages))
+	p.topic.EnableMessageOrdering = len(orderingKeys) > 0
+
+	for _, msg := range messages {
+		id := msg.GetId()
+		data, err := proto.Marshal(msg)
+		if err != nil {
+			p.logger.Error("Failed to marshal message", zap.Error(err), zap.Any("message", msg))
+			errors[id] = ErrBadMessage
+			continue
+		}
+		message := &pubsub.Message{
+			Data:       data,
+			Attributes: map[string]string{idAttribute: id},
+		}
+		if orderingKey, ok := orderingKeys[id]; ok {
+			message.OrderingKey = orderingKey
+		}
+		results[id] = p.topic.Publish(ctx, message)
+	}
+
+	for id, result := range results {
+		if _, err := result.Get(ctx); err != nil {
+			errors[id] = err
+		}
+	}
+	return
+}
+
 func (p *publisher) Publish(ctx context.Context, msg Message) (err error) {
 	startTime := time.Now()
 	defer func() {
@@ -95,17 +151,7 @@ func (p *publisher) Publish(ctx context.Context, msg Message) (err error) {
 		handledCounter.WithLabelValues(topicID, methodPublish, code).Inc()
 		handledHistogram.WithLabelValues(topicID, methodPublish, code).Observe(time.Since(startTime).Seconds())
 	}()
-	data, err := proto.Marshal(msg)
-	if err != nil {
-		p.logger.Error("Failed to marshal message", zap.Error(err), zap.Any("message", msg))
-		return ErrBadMessage
-	}
-	res := p.topic.Publish(ctx, &pubsub.Message{
-		Data:       data,
-		Attributes: map[string]string{idAttribute: msg.GetId()},
-	})
-	_, err = res.Get(ctx)
-	return
+	return p.publishMessage(ctx, msg, "")
 }
 
 func (p *publisher) PublishMulti(ctx context.Context, messages []Message) (errors map[string]error) {
@@ -125,29 +171,67 @@ func (p *publisher) PublishMulti(ctx context.Context, messages []Message) (error
 		}
 		handledHistogram.WithLabelValues(topicID, methodPublishMulti, histogramCode).Observe(time.Since(startTime).Seconds())
 	}()
-	errors = make(map[string]error)
-	results := make(map[string]*pubsub.PublishResult, len(messages))
-	for _, msg := range messages {
-		id := msg.GetId()
-		data, err := proto.Marshal(msg)
-		if err != nil {
-			p.logger.Error("Failed to marshal message", zap.Error(err), zap.Any("message", msg))
-			errors[id] = ErrBadMessage
-			continue
+	return p.publishMultiMessages(ctx, messages, nil)
+}
+
+func (p *publisher) PublishWithOrdering(ctx context.Context, msg *OrderingMessage) (err error) {
+	startTime := time.Now()
+	defer func() {
+		topicID := p.topic.ID()
+		code := convertErrorToCode(err)
+		handledCounter.WithLabelValues(topicID, methodPublishWithOrderingKey, code).Inc()
+		handledHistogram.WithLabelValues(topicID, methodPublishWithOrderingKey, code).Observe(time.Since(startTime).Seconds())
+	}()
+	return p.publishMessage(ctx, msg.Message, msg.OrderingKey)
+}
+
+func (p *publisher) PublishMultiWithOrdering(
+	ctx context.Context,
+	messages []*OrderingMessage,
+) (errors map[string]error) {
+	startTime := time.Now()
+	defer func() {
+		topicID := p.topic.ID()
+		for _, err := range errors {
+			code := convertErrorToCode(err)
+			handledCounter.WithLabelValues(topicID, methodPublishMultiWithOrderingKey, code).Inc()
 		}
-		results[id] = p.topic.Publish(ctx, &pubsub.Message{
-			Data:       data,
-			Attributes: map[string]string{idAttribute: id},
-		})
-	}
-	for id, result := range results {
-		if _, err := result.Get(ctx); err != nil {
-			errors[id] = err
+		if successes := len(messages) - len(errors); successes > 0 {
+			handledCounter.WithLabelValues(topicID, methodPublishMultiWithOrderingKey, codeOK).Add(float64(successes))
 		}
+		histogramCode := codeOK
+		if len(errors) > 0 {
+			histogramCode = codeUnknown
+		}
+		handledHistogram.WithLabelValues(
+			topicID,
+			methodPublishMultiWithOrderingKey,
+			histogramCode,
+		).Observe(time.Since(startTime).Seconds())
+	}()
+
+	// Convert OrderingMessages to Messages and create ordering key map
+	msgs := make([]Message, len(messages))
+	orderingKeys := make(map[string]string, len(messages))
+	for i, msg := range messages {
+		msgs[i] = msg.Message
+		orderingKeys[msg.Message.GetId()] = msg.OrderingKey
 	}
-	return
+	return p.publishMultiMessages(ctx, msgs, orderingKeys)
 }
 
 func (p *publisher) Stop() {
 	p.topic.Stop()
+}
+
+type OrderingMessage struct {
+	Message     Message
+	OrderingKey string
+}
+
+func NewOrderingMessage(msg Message, orderingKey string) *OrderingMessage {
+	return &OrderingMessage{
+		Message:     msg,
+		OrderingKey: orderingKey,
+	}
 }

--- a/pkg/pubsub/puller/puller.go
+++ b/pkg/pubsub/puller/puller.go
@@ -23,9 +23,10 @@ import (
 )
 
 type Message struct {
-	ID         string
-	Data       []byte
-	Attributes map[string]string
+	ID          string
+	Data        []byte
+	Attributes  map[string]string
+	OrderingKey string // Optional, will be empty for unordered messages
 
 	Ack  func()
 	Nack func()
@@ -69,11 +70,13 @@ func NewPuller(sub *pubsub.Subscription, opts ...Option) Puller {
 func (p *puller) Pull(ctx context.Context, f func(context.Context, *Message)) error {
 	err := p.subscription.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		f(ctx, &Message{
-			ID:         msg.ID,
-			Data:       msg.Data,
-			Attributes: msg.Attributes,
-			Ack:        msg.Ack,
-			Nack:       msg.Nack})
+			ID:          msg.ID,
+			Data:        msg.Data,
+			Attributes:  msg.Attributes,
+			OrderingKey: msg.OrderingKey,
+			Ack:         msg.Ack,
+			Nack:        msg.Nack,
+		})
 	})
 	if err != nil {
 		p.logger.Error("Failed to receive message",


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/1719

Currently, because we evaluate the end user in real-time when linking the goal event to the experiment, we don't need to care about the events' ordering being pulled from GCP PubSub.

In the new architecture, we must ensure that the evaluation event will always be pulled before the goal event. Otherwise, when checking in BigQuery, if the evaluation event is not there, it wouldn't link the goal because we ignore goals that don't belong to any evaluation event.

I'm using the [PubSub Ordering](https://cloud.google.com/pubsub/docs/ordering) feature to achieve this.

