### PR TITLE
refactor: change the list retrieval API in the acount package to use ListOption

### DIFF
--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -1167,13 +1167,10 @@ func (s *AccountService) ListAccountsV2(
 	values := make([]interface{}, 1)
 	if req.EnvironmentId != nil && req.EnvironmentRole != nil {
 		values[0] = fmt.Sprintf("{\"environment_id\": \"%s\", \"role\": %d}", req.EnvironmentId.Value, req.EnvironmentRole.Value) // nolint:lll
-		//		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
 	} else if req.EnvironmentId != nil {
 		values[0] = fmt.Sprintf("{\"environment_id\": \"%s\"}", req.EnvironmentId.Value)
-		//		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
 	} else if req.EnvironmentRole != nil {
 		values[0] = fmt.Sprintf("{\"role\": %d}", req.EnvironmentRole.Value)
-		//		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
 	}
 	if values[0] != nil && values[0] != "" {
 		jsonFilters = append(
@@ -1186,7 +1183,6 @@ func (s *AccountService) ListAccountsV2(
 	}
 	var seachQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
-		//		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"email", "first_name", "last_name"}, req.SearchKeyword))
 		seachQuery = &mysql.SearchQuery{
 			Columns: []string{"email", "first_name", "last_name"},
 			Keyword: req.SearchKeyword,

--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -1129,40 +1129,68 @@ func (s *AccountService) ListAccountsV2(
 	if err != nil {
 		return nil, err
 	}
-	whereParts := []mysql.WherePart{
-		mysql.NewFilter("organization_id", "=", req.OrganizationId),
+	var filters = []*mysql.FilterV2{
+		{
+			Column:   "organization_id",
+			Operator: mysql.OperatorEqual,
+			Value:    req.OrganizationId,
+		},
 	}
 	if req.Disabled != nil {
-		whereParts = append(whereParts, mysql.NewFilter("disabled", "=", req.Disabled.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "disabled",
+			Operator: mysql.OperatorEqual,
+			Value:    req.Disabled.Value,
+		})
 	}
 	tagValues := make([]interface{}, 0, len(req.Tags))
 	for _, tag := range req.Tags {
 		tagValues = append(tagValues, tag)
 	}
+	var jsonFilters []*mysql.JSONFilter
 	if len(tagValues) > 0 {
-		whereParts = append(
-			whereParts,
-			mysql.NewJSONFilter("tags", mysql.JSONContainsString, tagValues),
-		)
+		jsonFilters = append(
+			jsonFilters,
+			&mysql.JSONFilter{
+				Column: "tags",
+				Func:   mysql.JSONContainsString,
+				Values: tagValues,
+			})
 	}
 	if req.OrganizationRole != nil {
-		whereParts = append(whereParts, mysql.NewFilter("organization_role", "=", req.OrganizationRole.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "organization_role",
+			Operator: mysql.OperatorEqual,
+			Value:    req.OrganizationRole.Value,
+		})
 	}
+	values := make([]interface{}, 1)
 	if req.EnvironmentId != nil && req.EnvironmentRole != nil {
-		values := make([]interface{}, 1)
 		values[0] = fmt.Sprintf("{\"environment_id\": \"%s\", \"role\": %d}", req.EnvironmentId.Value, req.EnvironmentRole.Value) // nolint:lll
-		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
+		//		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
 	} else if req.EnvironmentId != nil {
-		values := make([]interface{}, 1)
 		values[0] = fmt.Sprintf("{\"environment_id\": \"%s\"}", req.EnvironmentId.Value)
-		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
+		//		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
 	} else if req.EnvironmentRole != nil {
-		values := make([]interface{}, 1)
 		values[0] = fmt.Sprintf("{\"role\": %d}", req.EnvironmentRole.Value)
-		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
+		//		whereParts = append(whereParts, mysql.NewJSONFilter("environment_roles", mysql.JSONContainsJSON, values))
 	}
+	if values[0] != nil && values[0] != "" {
+		jsonFilters = append(
+			jsonFilters,
+			&mysql.JSONFilter{
+				Column: "environment_roles",
+				Func:   mysql.JSONContainsJSON,
+				Values: values,
+			})
+	}
+	var seachQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
-		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"email", "first_name", "last_name"}, req.SearchKeyword))
+		//		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"email", "first_name", "last_name"}, req.SearchKeyword))
+		seachQuery = &mysql.SearchQuery{
+			Columns: []string{"email", "first_name", "last_name"},
+			Keyword: req.SearchKeyword,
+		}
 	}
 	orders, err := s.newAccountV2ListOrders(req.OrderBy, req.OrderDirection, localizer)
 	if err != nil {
@@ -1188,13 +1216,17 @@ func (s *AccountService) ListAccountsV2(
 		}
 		return nil, dt.Err()
 	}
-	accounts, nextCursor, totalCount, err := s.accountStorage.ListAccountsV2(
-		ctx,
-		whereParts,
-		orders,
-		limit,
-		offset,
-	)
+	options := &mysql.ListOptions{
+		Limit:       limit,
+		Filters:     filters,
+		Offset:      offset,
+		JSONFilters: jsonFilters,
+		SearchQuery: seachQuery,
+		Orders:      orders,
+		NullFilters: nil,
+		InFilters:   nil,
+	}
+	accounts, nextCursor, totalCount, err := s.accountStorage.ListAccountsV2(ctx, options)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list accounts",

--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -1765,7 +1765,7 @@ func TestListAccountsV2MySQL(t *testing.T) {
 				}, nil)
 
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().ListAccountsV2(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("test"))
 			},
 			input:       &accountproto.ListAccountsV2Request{OrganizationId: "org0"},
@@ -1787,7 +1787,7 @@ func TestListAccountsV2MySQL(t *testing.T) {
 				}, nil)
 
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().ListAccountsV2(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*accountproto.AccountV2{}, 0, int64(0), nil)
 			},
 			input:       &accountproto.ListAccountsV2Request{PageSize: 2, Cursor: "", OrganizationId: "org0"},

--- a/pkg/account/storage/v2/account_test.go
+++ b/pkg/account/storage/v2/account_test.go
@@ -291,7 +291,7 @@ func TestGetAccountsV2ByEnvironmentID(t *testing.T) {
 		desc        string
 		setup       func(*accountStorage)
 		expectedErr error
-		whereParts  []mysql.WherePart
+		options     *mysql.ListOptions
 	}{
 		{
 			desc: "Error",
@@ -301,8 +301,21 @@ func TestGetAccountsV2ByEnvironmentID(t *testing.T) {
 				).Return(nil, errors.New("error"))
 			},
 			expectedErr: errors.New("error"),
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("num", ">=", 5),
+			options: &mysql.ListOptions{
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "num",
+						Operator: mysql.OperatorEqual,
+						Value:    5,
+					},
+				},
+				InFilters:   nil,
+				NullFilters: nil,
+				JSONFilters: nil,
+				SearchQuery: nil,
+				Orders:      nil,
+				Limit:       10,
+				Offset:      0,
 			},
 		},
 		{
@@ -317,8 +330,21 @@ func TestGetAccountsV2ByEnvironmentID(t *testing.T) {
 				).Return(rows, nil)
 			},
 			expectedErr: nil,
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("num", ">=", 5),
+			options: &mysql.ListOptions{
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "num",
+						Operator: mysql.OperatorEqual,
+						Value:    5,
+					},
+				},
+				InFilters:   nil,
+				NullFilters: nil,
+				JSONFilters: nil,
+				SearchQuery: nil,
+				Orders:      nil,
+				Limit:       10,
+				Offset:      0,
 			},
 		},
 	}
@@ -331,7 +357,7 @@ func TestGetAccountsV2ByEnvironmentID(t *testing.T) {
 			}
 			_, err := storage.GetAvatarAccountsV2(
 				context.Background(),
-				p.whereParts,
+				p.options,
 			)
 			assert.Equal(t, p.expectedErr, err)
 		})
@@ -392,10 +418,7 @@ func TestListAccountsV2(t *testing.T) {
 	patterns := []struct {
 		desc           string
 		setup          func(*accountStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
+		options        *mysql.ListOptions
 		expected       []*proto.AccountV2
 		expectedCursor int
 		expectedErr    error
@@ -407,10 +430,7 @@ func TestListAccountsV2(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:     nil,
-			orders:         nil,
-			limit:          0,
-			offset:         0,
+			options:        nil,
 			expected:       nil,
 			expectedCursor: 0,
 			expectedErr:    errors.New("error"),
@@ -431,14 +451,27 @@ func TestListAccountsV2(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
-			whereParts: []mysql.WherePart{
-				mysql.NewFilter("num", ">=", 5),
+			options: &mysql.ListOptions{
+				Filters: []*mysql.FilterV2{
+					{
+						Column:   "num",
+						Operator: mysql.OperatorEqual,
+						Value:    5,
+					},
+				},
+				InFilters:   nil,
+				NullFilters: nil,
+				JSONFilters: nil,
+				SearchQuery: nil,
+				Orders: []*mysql.Order{
+					{
+						Column:    "id",
+						Direction: mysql.OrderDirectionAsc,
+					},
+				},
+				Limit:  10,
+				Offset: 5,
 			},
-			orders: []*mysql.Order{
-				mysql.NewOrder("id", mysql.OrderDirectionAsc),
-			},
-			limit:          10,
-			offset:         5,
 			expected:       []*proto.AccountV2{},
 			expectedCursor: 5,
 			expectedErr:    nil,
@@ -452,10 +485,7 @@ func TestListAccountsV2(t *testing.T) {
 			}
 			accounts, cursor, _, err := storage.ListAccountsV2(
 				context.Background(),
-				p.whereParts,
-				p.orders,
-				p.limit,
-				p.offset,
+				p.options,
 			)
 			assert.Equal(t, p.expected, accounts)
 			assert.Equal(t, p.expectedCursor, cursor)

--- a/pkg/account/storage/v2/mock/storage.go
+++ b/pkg/account/storage/v2/mock/storage.go
@@ -161,18 +161,18 @@ func (mr *MockAccountStorageMockRecorder) GetAccountsWithOrganization(ctx, email
 }
 
 // GetAvatarAccountsV2 mocks base method.
-func (m *MockAccountStorage) GetAvatarAccountsV2(ctx context.Context, whereParts []mysql.WherePart) ([]*account.AccountV2, error) {
+func (m *MockAccountStorage) GetAvatarAccountsV2(ctx context.Context, options *mysql.ListOptions) ([]*account.AccountV2, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAvatarAccountsV2", ctx, whereParts)
+	ret := m.ctrl.Call(m, "GetAvatarAccountsV2", ctx, options)
 	ret0, _ := ret[0].([]*account.AccountV2)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAvatarAccountsV2 indicates an expected call of GetAvatarAccountsV2.
-func (mr *MockAccountStorageMockRecorder) GetAvatarAccountsV2(ctx, whereParts any) *gomock.Call {
+func (mr *MockAccountStorageMockRecorder) GetAvatarAccountsV2(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvatarAccountsV2", reflect.TypeOf((*MockAccountStorage)(nil).GetAvatarAccountsV2), ctx, whereParts)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAvatarAccountsV2", reflect.TypeOf((*MockAccountStorage)(nil).GetAvatarAccountsV2), ctx, options)
 }
 
 // GetEnvironmentAPIKey mocks base method.
@@ -223,9 +223,9 @@ func (mr *MockAccountStorageMockRecorder) ListAPIKeys(ctx, whereParts, orders, l
 }
 
 // ListAccountsV2 mocks base method.
-func (m *MockAccountStorage) ListAccountsV2(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*account.AccountV2, int, int64, error) {
+func (m *MockAccountStorage) ListAccountsV2(ctx context.Context, options *mysql.ListOptions) ([]*account.AccountV2, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAccountsV2", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAccountsV2", ctx, options)
 	ret0, _ := ret[0].([]*account.AccountV2)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -234,9 +234,9 @@ func (m *MockAccountStorage) ListAccountsV2(ctx context.Context, whereParts []my
 }
 
 // ListAccountsV2 indicates an expected call of ListAccountsV2.
-func (mr *MockAccountStorageMockRecorder) ListAccountsV2(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAccountStorageMockRecorder) ListAccountsV2(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountsV2", reflect.TypeOf((*MockAccountStorage)(nil).ListAccountsV2), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccountsV2", reflect.TypeOf((*MockAccountStorage)(nil).ListAccountsV2), ctx, options)
 }
 
 // ListAllEnvironmentAPIKeys mocks base method.

--- a/pkg/account/storage/v2/sql/account_v2/count_accounts_v2.sql
+++ b/pkg/account/storage/v2/sql/account_v2/count_accounts_v2.sql
@@ -1,4 +1,3 @@
 SELECT
     COUNT(1)
 FROM account_v2
-%s

--- a/pkg/account/storage/v2/sql/account_v2/select_accounts_v2.sql
+++ b/pkg/account/storage/v2/sql/account_v2/select_accounts_v2.sql
@@ -18,6 +18,3 @@ SELECT
     search_filters,
     JSON_LENGTH(environment_roles) as environment_count
 FROM account_v2
-%s  
-%s  
-%s  

--- a/pkg/account/storage/v2/sql/account_v2/select_avatar_accounts_v2.sql
+++ b/pkg/account/storage/v2/sql/account_v2/select_avatar_accounts_v2.sql
@@ -5,4 +5,3 @@ SELECT
 FROM account_v2 AS a
 INNER JOIN environment_v2 AS e
 ON a.organization_id = e.organization_id
-%s

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -29,13 +29,11 @@ type AccountStorage interface {
 	DeleteAccountV2(ctx context.Context, a *domain.AccountV2) error
 	GetAccountV2(ctx context.Context, email, organizationID string) (*domain.AccountV2, error)
 	GetAccountV2ByEnvironmentID(ctx context.Context, email, environmentID string) (*domain.AccountV2, error)
-	GetAvatarAccountsV2(ctx context.Context, whereParts []mysql.WherePart) ([]*proto.AccountV2, error)
+	GetAvatarAccountsV2(ctx context.Context, options *mysql.ListOptions) ([]*proto.AccountV2, error)
 	GetAccountsWithOrganization(ctx context.Context, email string) ([]*domain.AccountWithOrganization, error)
 	ListAccountsV2(
 		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
+		options *mysql.ListOptions,
 	) ([]*proto.AccountV2, int, int64, error)
 	GetSystemAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error)
 	CreateAPIKey(ctx context.Context, k *domain.APIKey, environmentID string) error

--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -513,14 +513,25 @@ func (s *auditlogService) getAccountMapByEmails(
 	for i, email := range emails {
 		emailsArg[i] = email
 	}
-	whereParts := []mysql.WherePart{
-		mysql.NewInFilter("a.email", emailsArg),
-		mysql.NewFilter("e.id", "=", environmentID),
+	options := &mysql.ListOptions{
+		Limit:  1000,
+		Offset: 0,
+		Orders: nil,
+		InFilters: []*mysql.InFilter{
+			&mysql.InFilter{
+				Column: "a.email",
+				Values: emailsArg,
+			},
+		},
+		Filters: []*mysql.FilterV2{
+			&mysql.FilterV2{
+				Column:   "e.id",
+				Operator: mysql.OperatorEqual,
+				Value:    environmentID,
+			},
+		},
 	}
-	accounts, err := s.accountStorage.GetAvatarAccountsV2(
-		ctx,
-		whereParts,
-	)
+	accounts, err := s.accountStorage.GetAvatarAccountsV2(ctx, options)
 	if err != nil {
 		s.logger.Error(
 			"Failed to list feature history",

--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -514,7 +514,7 @@ func (s *auditlogService) getAccountMapByEmails(
 		emailsArg[i] = email
 	}
 	options := &mysql.ListOptions{
-		Limit:  1000,
+		Limit:  0,
 		Offset: 0,
 		Orders: nil,
 		InFilters: []*mysql.InFilter{


### PR DESCRIPTION
This pull request refactors the account listing and retrieval logic to use a unified `ListOptions` structure for query parameters, improving maintainability and flexibility. The changes affect the `ListAccountsV2` and `GetAvatarAccountsV2` methods, related tests, and SQL query construction.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475