### PR TITLE
refactor: change the list retrieval API in the flagTrigger package to use ListOption 

### DIFF
--- a/pkg/feature/api/flag_trigger_test.go
+++ b/pkg/feature/api/flag_trigger_test.go
@@ -1084,7 +1084,7 @@ func TestListFlagTriggers(t *testing.T) {
 			),
 			setup: func(s *FeatureService) {
 				s.flagTriggerStorage.(*mock.MockFlagTriggerStorage).EXPECT().ListFlagTriggers(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.FlagTrigger{}, 0, int64(0), nil)
 			},
 			input:    &proto.ListFlagTriggersRequest{FeatureId: "1", PageSize: 2, Cursor: ""},
@@ -1102,7 +1102,7 @@ func TestListFlagTriggers(t *testing.T) {
 			),
 			setup: func(s *FeatureService) {
 				s.flagTriggerStorage.(*mock.MockFlagTriggerStorage).EXPECT().ListFlagTriggers(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.FlagTrigger{}, 0, int64(0), nil)
 			},
 			input:    &proto.ListFlagTriggersRequest{FeatureId: "1", PageSize: 2, Cursor: "", EnvironmentId: "ns0"},

--- a/pkg/feature/storage/v2/flag_trigger_test.go
+++ b/pkg/feature/storage/v2/flag_trigger_test.go
@@ -282,10 +282,7 @@ func TestFlagTriggerStorageListFlagTriggers(t *testing.T) {
 	patterns := []struct {
 		desc           string
 		setup          func(storage *flagTriggerStorage)
-		whereParts     []mysql.WherePart
-		orders         []*mysql.Order
-		limit          int
-		offset         int
+		options        *mysql.ListOptions
 		expected       []*proto.FlagTrigger
 		expectedCursor int
 		expectedErr    error
@@ -297,10 +294,7 @@ func TestFlagTriggerStorageListFlagTriggers(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(nil, errors.New("error"))
 			},
-			whereParts:  []mysql.WherePart{},
-			orders:      []*mysql.Order{},
-			limit:       0,
-			offset:      0,
+			options:     nil,
 			expected:    nil,
 			expectedErr: errors.New("error"),
 		},
@@ -319,10 +313,15 @@ func TestFlagTriggerStorageListFlagTriggers(t *testing.T) {
 					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(row)
 			},
-			whereParts:     []mysql.WherePart{},
-			orders:         []*mysql.Order{},
-			limit:          0,
-			offset:         0,
+			options: &mysql.ListOptions{
+				Limit:       0,
+				Offset:      0,
+				Filters:     []*mysql.FilterV2{},
+				Orders:      []*mysql.Order{},
+				NullFilters: nil,
+				InFilters:   nil,
+				JSONFilters: nil,
+			},
 			expected:       []*proto.FlagTrigger{},
 			expectedCursor: 0,
 			expectedErr:    nil,
@@ -332,7 +331,7 @@ func TestFlagTriggerStorageListFlagTriggers(t *testing.T) {
 		t.Run(p.desc, func(t *testing.T) {
 			storage := &flagTriggerStorage{qe: mock.NewMockQueryExecer(mockController)}
 			p.setup(storage)
-			expected, nextOffset, _, err := storage.ListFlagTriggers(context.Background(), p.whereParts, p.orders, p.limit, p.offset)
+			expected, nextOffset, _, err := storage.ListFlagTriggers(context.Background(), p.options)
 			assert.Equal(t, p.expectedErr, err)
 			assert.Equal(t, p.expected, expected)
 			assert.Equal(t, p.expectedCursor, nextOffset)

--- a/pkg/feature/storage/v2/mock/flag_trigger.go
+++ b/pkg/feature/storage/v2/mock/flag_trigger.go
@@ -102,9 +102,9 @@ func (mr *MockFlagTriggerStorageMockRecorder) GetFlagTriggerByToken(ctx, token a
 }
 
 // ListFlagTriggers mocks base method.
-func (m *MockFlagTriggerStorage) ListFlagTriggers(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*feature.FlagTrigger, int, int64, error) {
+func (m *MockFlagTriggerStorage) ListFlagTriggers(ctx context.Context, options *mysql.ListOptions) ([]*feature.FlagTrigger, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListFlagTriggers", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListFlagTriggers", ctx, options)
 	ret0, _ := ret[0].([]*feature.FlagTrigger)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -113,9 +113,9 @@ func (m *MockFlagTriggerStorage) ListFlagTriggers(ctx context.Context, wherePart
 }
 
 // ListFlagTriggers indicates an expected call of ListFlagTriggers.
-func (mr *MockFlagTriggerStorageMockRecorder) ListFlagTriggers(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockFlagTriggerStorageMockRecorder) ListFlagTriggers(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFlagTriggers", reflect.TypeOf((*MockFlagTriggerStorage)(nil).ListFlagTriggers), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListFlagTriggers", reflect.TypeOf((*MockFlagTriggerStorage)(nil).ListFlagTriggers), ctx, options)
 }
 
 // UpdateFlagTrigger mocks base method.

--- a/pkg/feature/storage/v2/sql/flag_trigger/count_flag_trigger.sql
+++ b/pkg/feature/storage/v2/sql/flag_trigger/count_flag_trigger.sql
@@ -1,3 +1,2 @@
 SELECT COUNT(1)
 FROM flag_trigger
-%s

--- a/pkg/feature/storage/v2/sql/flag_trigger/list_flag_trigger.sql
+++ b/pkg/feature/storage/v2/sql/flag_trigger/list_flag_trigger.sql
@@ -9,4 +9,4 @@ SELECT id,
        disabled,
        created_at,
        updated_at
-FROM flag_trigger %s %s %s
+FROM flag_trigger


### PR DESCRIPTION
This pull request refactors the `ListFlagTriggers` functionality in the `FeatureService` and its associated storage layer to use a new `mysql.ListOptions` struct for query construction. This change simplifies and standardizes the query logic, improves maintainability, and updates corresponding tests and mock implementations.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475