### PR TITLE
fix(ui/dashboard): flag status showing incorrect

### DIFF
--- a/ui/dashboard/src/pages/feature-flags/collection-layout/elements/utils.ts
+++ b/ui/dashboard/src/pages/feature-flags/collection-layout/elements/utils.ts
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { isNumber } from 'lodash';
 import { Feature, FeatureVariationType } from '@types';
 import {
@@ -23,8 +24,9 @@ export function getFlagStatus(feature: Feature): FeatureActivityStatus {
 
   if (lastUsedAt && isNumber(+lastUsedAt)) {
     const _lastUsedAt = new Date(+lastUsedAt * 1000);
-    if (_lastUsedAt.getDate() - new Date().getDate() > -7)
-      return FeatureActivityStatus.ACTIVE;
+    const daysDifference = dayjs(_lastUsedAt).diff(dayjs(), 'day');
+
+    if (daysDifference > -7) return FeatureActivityStatus.ACTIVE;
   }
   return FeatureActivityStatus.INACTIVE;
 }


### PR DESCRIPTION
I checked the last used info object, and the timestamp is indeed older than 7 days, but on the list page, it shows active.

Fix #1746 