### PR TITLE
refactor: change Segment related list retrieval APIs to use ListOption

### DIFF
--- a/pkg/feature/api/segment.go
+++ b/pkg/feature/api/segment.go
@@ -780,15 +780,31 @@ func (s *FeatureService) ListSegments(
 		)
 		return nil, err
 	}
-	whereParts := []mysql.WherePart{
-		mysql.NewFilter("seg.deleted", "=", false),
-		mysql.NewFilter("seg.environment_id", "=", req.EnvironmentId),
+	filters := []*mysql.FilterV2{
+		{
+			Column:   "seg.deleted",
+			Operator: mysql.OperatorEqual,
+			Value:    false,
+		},
+		{
+			Column:   "seg.environment_id",
+			Operator: mysql.OperatorEqual,
+			Value:    req.EnvironmentId,
+		},
 	}
 	if req.Status != nil {
-		whereParts = append(whereParts, mysql.NewFilter("seg.status", "=", req.Status.Value))
+		filters = append(filters, &mysql.FilterV2{
+			Column:   "seg.status",
+			Operator: mysql.OperatorEqual,
+			Value:    req.Status.Value,
+		})
 	}
+	var searchQuery *mysql.SearchQuery
 	if req.SearchKeyword != "" {
-		whereParts = append(whereParts, mysql.NewSearchQuery([]string{"seg.name", "seg.description"}, req.SearchKeyword))
+		searchQuery = &mysql.SearchQuery{
+			Columns: []string{"seg.name", "seg.description"},
+			Keyword: req.SearchKeyword,
+		}
 	}
 	orders, err := s.newSegmentListOrders(req.OrderBy, req.OrderDirection, localizer)
 	if err != nil {
@@ -818,14 +834,20 @@ func (s *FeatureService) ListSegments(
 	if req.IsInUseStatus != nil {
 		isInUseStatus = &req.IsInUseStatus.Value
 	}
+	options := &mysql.ListOptions{
+		Limit:       limit,
+		Offset:      offset,
+		Filters:     filters,
+		NullFilters: nil,
+		JSONFilters: nil,
+		InFilters:   nil,
+		SearchQuery: searchQuery,
+		Orders:      orders,
+	}
 	segments, nextCursor, totalCount, featureIDsMap, err := s.segmentStorage.ListSegments(
 		ctx,
-		whereParts,
-		orders,
-		limit,
-		offset,
+		options,
 		isInUseStatus,
-		req.EnvironmentId,
 	)
 	if err != nil {
 		s.logger.Error(

--- a/pkg/feature/api/segment_test.go
+++ b/pkg/feature/api/segment_test.go
@@ -750,7 +750,7 @@ func TestListSegmentsMySQL(t *testing.T) {
 			),
 			setup: func(s *FeatureService) {
 				s.segmentStorage.(*storagemock.MockSegmentStorage).EXPECT().ListSegments(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return([]*featureproto.Segment{
 					{
 						Id: "id",
@@ -781,7 +781,7 @@ func TestListSegmentsMySQL(t *testing.T) {
 			),
 			setup: func(s *FeatureService) {
 				s.segmentStorage.(*storagemock.MockSegmentStorage).EXPECT().ListSegments(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return([]*featureproto.Segment{
 					{
 						Id: "id",

--- a/pkg/feature/storage/v2/mock/segment.go
+++ b/pkg/feature/storage/v2/mock/segment.go
@@ -88,9 +88,9 @@ func (mr *MockSegmentStorageMockRecorder) GetSegment(ctx, id, environmentId any)
 }
 
 // ListSegments mocks base method.
-func (m *MockSegmentStorage) ListSegments(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int, isInUseStatus *bool, environmentId string) ([]*feature.Segment, int, int64, map[string][]string, error) {
+func (m *MockSegmentStorage) ListSegments(ctx context.Context, options *mysql.ListOptions, isInUseStatus *bool) ([]*feature.Segment, int, int64, map[string][]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSegments", ctx, whereParts, orders, limit, offset, isInUseStatus, environmentId)
+	ret := m.ctrl.Call(m, "ListSegments", ctx, options, isInUseStatus)
 	ret0, _ := ret[0].([]*feature.Segment)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -100,9 +100,9 @@ func (m *MockSegmentStorage) ListSegments(ctx context.Context, whereParts []mysq
 }
 
 // ListSegments indicates an expected call of ListSegments.
-func (mr *MockSegmentStorageMockRecorder) ListSegments(ctx, whereParts, orders, limit, offset, isInUseStatus, environmentId any) *gomock.Call {
+func (mr *MockSegmentStorageMockRecorder) ListSegments(ctx, options, isInUseStatus any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSegments", reflect.TypeOf((*MockSegmentStorage)(nil).ListSegments), ctx, whereParts, orders, limit, offset, isInUseStatus, environmentId)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSegments", reflect.TypeOf((*MockSegmentStorage)(nil).ListSegments), ctx, options, isInUseStatus)
 }
 
 // UpdateSegment mocks base method.

--- a/pkg/feature/storage/v2/segment_test.go
+++ b/pkg/feature/storage/v2/segment_test.go
@@ -15,12 +15,17 @@
 package v2
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 
+	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
+	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql/mock"
+	proto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
 func TestNewSegmentStorage(t *testing.T) {
@@ -29,4 +34,322 @@ func TestNewSegmentStorage(t *testing.T) {
 	defer mockController.Finish()
 	storage := NewSegmentStorage(mock.NewMockQueryExecer(mockController))
 	assert.IsType(t, &segmentStorage{}, storage)
+}
+
+func TestCreateSegment(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	tests := []struct {
+		desc        string
+		setup       func(*mock.MockQueryExecer)
+		segment     *domain.Segment
+		expectedErr error
+	}{
+		{
+			desc: "err: segment already exists",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				mockQueryExecer.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, mysql.ErrDuplicateEntry)
+			},
+			segment: &domain.Segment{
+				Segment: &proto.Segment{},
+			},
+			expectedErr: ErrSegmentAlreadyExists,
+		},
+		{
+			desc: "success",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				mockQueryExecer.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, nil)
+			},
+			segment: &domain.Segment{
+				Segment: &proto.Segment{},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockQueryExecer := mock.NewMockQueryExecer(mockController)
+			tt.setup(mockQueryExecer)
+			storage := NewSegmentStorage(mockQueryExecer)
+			err := storage.CreateSegment(context.Background(), tt.segment, "test-environment-id")
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestUpdateSegment(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	tests := []struct {
+		desc        string
+		setup       func(*mock.MockQueryExecer)
+		segment     *domain.Segment
+		expectedErr error
+	}{
+		{
+			desc: "error",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				mockQueryExecer.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, errors.New("test error"))
+			},
+			segment: &domain.Segment{
+				Segment: &proto.Segment{},
+			},
+			expectedErr: errors.New("test error"),
+		},
+		{
+			desc: "success",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				result := mock.NewMockResult(mockController)
+				mockQueryExecer.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(result, nil)
+				result.EXPECT().RowsAffected().Return(int64(1), nil)
+			},
+			segment: &domain.Segment{
+				Segment: &proto.Segment{},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockQueryExecer := mock.NewMockQueryExecer(mockController)
+			tt.setup(mockQueryExecer)
+			storage := NewSegmentStorage(mockQueryExecer)
+			err := storage.UpdateSegment(context.Background(), tt.segment, "test-environment-id")
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestGetSegment(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	tests := []struct {
+		desc        string
+		setup       func(*mock.MockQueryExecer)
+		expected    *domain.Segment
+		expectedErr error
+	}{
+		{
+			desc: "err: segment not found",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(mysql.ErrNoRows)
+				mockQueryExecer.EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(row)
+			},
+			expected:    nil,
+			expectedErr: ErrSegmentNotFound,
+		},
+		{
+			desc: "success",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				row := mock.NewMockRow(mockController)
+				mockQueryExecer.EXPECT().QueryRowContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(row)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+			},
+			expected: &domain.Segment{
+				Segment: &proto.Segment{},
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockQueryExecer := mock.NewMockQueryExecer(mockController)
+			tt.setup(mockQueryExecer)
+			storage := NewSegmentStorage(mockQueryExecer)
+			segment, _, err := storage.GetSegment(context.Background(), "test-segment-id", "test-environment-id")
+			assert.Equal(t, tt.expectedErr, err)
+			assert.Equal(t, tt.expected, segment)
+		})
+	}
+}
+
+func TestListSegments(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	tests := []struct {
+		desc        string
+		setup       func(*mock.MockQueryExecer)
+		options     *mysql.ListOptions
+		expectedErr error
+	}{
+		{
+			desc: "err: query error",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				mockQueryExecer.EXPECT().QueryContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, errors.New("test error"))
+			},
+			options: &mysql.ListOptions{
+				Limit:  10,
+				Offset: 0,
+			},
+			expectedErr: errors.New("test error"),
+		},
+		{
+			desc: "success",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				rows := mock.NewMockRows(mockController)
+				rows.EXPECT().Close().Return(nil)
+				rows.EXPECT().Next().Return(false)
+				rows.EXPECT().Err().Return(nil)
+				mockQueryExecer.EXPECT().QueryContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(rows, nil)
+				row := mock.NewMockRow(mockController)
+				row.EXPECT().Scan(gomock.Any()).Return(nil)
+				mockQueryExecer.EXPECT().QueryRowContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(row)
+			},
+			options: &mysql.ListOptions{
+				Limit:  10,
+				Offset: 0,
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockQueryExecer := mock.NewMockQueryExecer(mockController)
+			tt.setup(mockQueryExecer)
+			storage := NewSegmentStorage(mockQueryExecer)
+			isInUseStatus := false
+			_, _, _, _, err := storage.ListSegments(context.Background(), tt.options, &isInUseStatus)
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
+}
+
+func TestDeleteSegment(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	tests := []struct {
+		desc        string
+		setup       func(*mock.MockQueryExecer)
+		expectedErr error
+	}{
+		{
+			desc: "error",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				mockQueryExecer.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, errors.New("test error"))
+			},
+			expectedErr: errors.New("test error"),
+		},
+		{
+			desc: "success",
+			setup: func(mockQueryExecer *mock.MockQueryExecer) {
+				result := mock.NewMockResult(mockController)
+				mockQueryExecer.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(result, nil)
+				result.EXPECT().RowsAffected().Return(int64(1), nil)
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			mockQueryExecer := mock.NewMockQueryExecer(mockController)
+			tt.setup(mockQueryExecer)
+			storage := NewSegmentStorage(mockQueryExecer)
+			err := storage.DeleteSegment(context.Background(), "test-segment-id")
+			assert.Equal(t, tt.expectedErr, err)
+		})
+	}
 }

--- a/pkg/feature/storage/v2/sql/segment/delete_segment.sql
+++ b/pkg/feature/storage/v2/sql/segment/delete_segment.sql
@@ -1,0 +1,1 @@
+DELETE FROM segment WHERE id = ?

--- a/pkg/feature/storage/v2/sql/segment/get_segment.sql
+++ b/pkg/feature/storage/v2/sql/segment/get_segment.sql
@@ -1,0 +1,26 @@
+		SELECT
+			id,
+			name,
+			description,
+			rules,
+			created_at,
+			updated_at,
+			version,
+			deleted,
+			included_user_count,
+			excluded_user_count,
+			status,
+			(
+				SELECT 
+					GROUP_CONCAT(id)
+				FROM 
+					feature
+				WHERE
+					environment_id = ? AND
+					rules LIKE concat("%%", segment.id, "%%")
+			) AS feature_ids
+		FROM
+			segment
+		WHERE
+			id = ? AND
+			environment_id = ?

--- a/pkg/feature/storage/v2/sql/segment/insert_segment.sql
+++ b/pkg/feature/storage/v2/sql/segment/insert_segment.sql
@@ -1,0 +1,16 @@
+		INSERT INTO segment (
+			id,
+			name,
+			description,
+			rules,
+			created_at,
+			updated_at,
+			version,
+			deleted,
+			included_user_count,
+			excluded_user_count,
+			status,
+			environment_id
+		) VALUES (
+			?, ?, ?, ?, ?, ?, ?, ?, ?, ?,?, ?
+		)

--- a/pkg/feature/storage/v2/sql/segment/update_segment.sql
+++ b/pkg/feature/storage/v2/sql/segment/update_segment.sql
@@ -1,0 +1,16 @@
+		UPDATE 
+			segment
+		SET
+			name = ?,
+			description = ?,
+			rules = ?,
+			created_at = ?,
+			updated_at = ?,
+			version = ?,
+			deleted = ?,
+			included_user_count = ?,
+			excluded_user_count = ?,
+			status = ?
+		WHERE
+			id = ? AND
+			environment_id = ?


### PR DESCRIPTION
This pull request refactors the `ListSegments` functionality and improves the segment storage layer by introducing reusable SQL query files, updating the method signatures, and adding comprehensive unit tests. These changes enhance code maintainability, modularity, and test coverage.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475