### PR TITLE
fix: cannot update flag when creating a new variation and set the same variation to a rule or off variation

### DIFF
--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -1161,6 +1161,9 @@ func (f *Feature) validateVariationChanges(variationChanges []*feature.Variation
 
 		switch change.ChangeType {
 		case feature.ChangeType_CREATE:
+			if err := uuid.ValidateUUID(change.Variation.Id); err != nil {
+				return err
+			}
 			if change.Variation.Name == "" {
 				return errVariationNameRequired
 			}


### PR DESCRIPTION
### Things done

- Refactored the code to apply variation changes as the first step when the action is CREATE or UPDATE
- Refactored the code to apply variation changes as the last step when the action is DELETE
- Changed to use the variation ID (UUID) from the admin console instead of generating on the backend and added a UUID validation

--- 

This pull request introduces a significant refactor to the `Feature` update process, focusing on improving the handling of variation changes. It also includes enhancements to test coverage and debugging outputs. The most notable changes involve splitting variation changes into separate steps for better data integrity, adding UUID validation, and improving test cases for variations.

### Refactoring and Validation Enhancements:
* Introduced a two-step approach to handling variation changes in the `Update` method: applying creations and updates first, followed by deletions, to ensure data integrity and prevent invalid intermediate states. (`pkg/feature/domain/feature_update.go`, [[1]](diffhunk://#diff-eaace16d324e7ffe31456f51b4787d6b7721929d9f946f474fe402ca97aee59fL48-R91) [[2]](diffhunk://#diff-eaace16d324e7ffe31456f51b4787d6b7721929d9f946f474fe402ca97aee59fL75-L90)
* Added a new `applyVariationChanges` method to handle variation changes separately from other granular updates. (`pkg/feature/domain/feature_update.go`, [pkg/feature/domain/feature_update.goL201-L206](diffhunk://#diff-eaace16d324e7ffe31456f51b4787d6b7721929d9f946f474fe402ca97aee59fL201-L206))
* Removed variation-specific logic from the `applyGranularChanges` method, simplifying its responsibilities. (`pkg/feature/domain/feature_update.go`, [pkg/feature/domain/feature_update.goL267-L298](diffhunk://#diff-eaace16d324e7ffe31456f51b4787d6b7721929d9f946f474fe402ca97aee59fL267-L298))
* Added UUID validation for variation IDs in the `validateVariationChanges` method to ensure proper formatting. (`pkg/feature/domain/feature.go`, [pkg/feature/domain/feature.goR1164-R1166](diffhunk://#diff-81df5bd949374ca9bfe9cf7a6cbe02269ccba87027f5be8db8c181128c1c4241R1164-R1166))

### Debugging and Logging Improvements:
* Added debug logging to `validateVariationChanges` to provide more context when variation index lookups fail. (`pkg/feature/domain/feature.go`, [pkg/feature/domain/feature.goR1193](diffhunk://#diff-81df5bd949374ca9bfe9cf7a6cbe02269ccba87027f5be8db8c181128c1c4241R1193))

### Test Coverage Enhancements:
* Enhanced test cases for `TestValidateVariationValue` and `TestUpdate` by including UUID generation and validating variations with multiple IDs. (`pkg/feature/domain/feature_test.go`, [[1]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451R1483-R1486) [[2]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451L1552-R1563) [[3]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451R1961) [[4]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451R2101)
* Refactored `TestUpdateVariationsGranular` to use helper methods for adding variations and validating changes, improving readability and maintainability. (`pkg/feature/domain/feature_test.go`, [[1]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451R2857) [[2]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451L2896-R2912) [[3]](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451L2915-R2921)
* Enabled parallel test execution in several test cases to improve test performance. (`pkg/feature/domain/feature_test.go`, [pkg/feature/domain/feature_test.goR3005](diffhunk://#diff-1647fa67378ceb415bf377a674f39ddf18d412fc9711b7b63029fca17d259451R3005))

### Miscellaneous:
* Removed an unused import for `uuid` in `feature_update.go`. (`pkg/feature/domain/feature_update.go`, [pkg/feature/domain/feature_update.goL23](diffhunk://#diff-eaace16d324e7ffe31456f51b4787d6b7721929d9f946f474fe402ca97aee59fL23))