### PR TITLE
refactor: change apikey related list retrieval APIs to use ListOption

### DIFF
--- a/pkg/account/api/api_key_test.go
+++ b/pkg/account/api/api_key_test.go
@@ -728,7 +728,7 @@ func TestListAPIKeysMySQL(t *testing.T) {
 			context: createContextWithDefaultToken(t, true),
 			setup: func(s *AccountService) {
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().ListAPIKeys(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("error"))
 			},
 			input: &accountproto.ListAPIKeysRequest{
@@ -773,7 +773,7 @@ func TestListAPIKeysMySQL(t *testing.T) {
 			context: createContextWithDefaultToken(t, true),
 			setup: func(s *AccountService) {
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().ListAPIKeys(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*accountproto.APIKey{}, 0, int64(0), nil)
 			},
 			input: &accountproto.ListAPIKeysRequest{
@@ -805,7 +805,7 @@ func TestListAPIKeysMySQL(t *testing.T) {
 					},
 				}, nil).AnyTimes()
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().ListAPIKeys(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*accountproto.APIKey{}, 0, int64(0), nil)
 			},
 			input: &accountproto.ListAPIKeysRequest{

--- a/pkg/account/storage/v2/api_key.go
+++ b/pkg/account/storage/v2/api_key.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/account/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -275,19 +274,19 @@ func (s *accountStorage) GetEnvironmentAPIKey(
 
 func (s *accountStorage) ListAPIKeys(
 	ctx context.Context,
-	whereParts []mysql.WherePart,
-	orders []*mysql.Order,
-	limit, offset int,
+	options *mysql.ListOptions,
 ) ([]*proto.APIKey, int, int64, error) {
-	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
-	orderBySQL := mysql.ConstructOrderBySQLString(orders)
-	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	query := fmt.Sprintf(selectAPIKeyV2SQLQuery, whereSQL, orderBySQL, limitOffsetSQL)
+	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectAPIKeyV2SQLQuery, options)
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
+	var limit, offset int
+	if options.Limit != 0 {
+		limit = options.Limit
+		offset = options.Offset
+	}
 	apiKeys := make([]*proto.APIKey, 0, limit)
 	for rows.Next() {
 		apiKey := proto.APIKey{}
@@ -315,8 +314,8 @@ func (s *accountStorage) ListAPIKeys(
 	}
 	nextOffset := offset + len(apiKeys)
 	var totalCount int64
-	countQuery := fmt.Sprintf(selectAPIKeyV2CountSQLQuery, whereSQL)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAPIKeyV2CountSQLQuery, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/account/storage/v2/mock/storage.go
+++ b/pkg/account/storage/v2/mock/storage.go
@@ -206,9 +206,9 @@ func (mr *MockAccountStorageMockRecorder) GetSystemAdminAccountV2(ctx, email any
 }
 
 // ListAPIKeys mocks base method.
-func (m *MockAccountStorage) ListAPIKeys(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*account.APIKey, int, int64, error) {
+func (m *MockAccountStorage) ListAPIKeys(ctx context.Context, options *mysql.ListOptions) ([]*account.APIKey, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAPIKeys", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListAPIKeys", ctx, options)
 	ret0, _ := ret[0].([]*account.APIKey)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -217,9 +217,9 @@ func (m *MockAccountStorage) ListAPIKeys(ctx context.Context, whereParts []mysql
 }
 
 // ListAPIKeys indicates an expected call of ListAPIKeys.
-func (mr *MockAccountStorageMockRecorder) ListAPIKeys(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockAccountStorageMockRecorder) ListAPIKeys(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAPIKeys", reflect.TypeOf((*MockAccountStorage)(nil).ListAPIKeys), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAPIKeys", reflect.TypeOf((*MockAccountStorage)(nil).ListAPIKeys), ctx, options)
 }
 
 // ListAccountsV2 mocks base method.

--- a/pkg/account/storage/v2/sql/api_key_v2/select_api_key_v2.sql
+++ b/pkg/account/storage/v2/sql/api_key_v2/select_api_key_v2.sql
@@ -12,4 +12,3 @@ SELECT
 FROM
     api_key
 LEFT JOIN environment_v2 ON api_key.environment_id = environment_v2.id
-%s %s %s

--- a/pkg/account/storage/v2/sql/api_key_v2/select_api_key_v2_count.sql
+++ b/pkg/account/storage/v2/sql/api_key_v2/select_api_key_v2_count.sql
@@ -3,4 +3,3 @@ SELECT
 FROM
     api_key
 LEFT JOIN environment_v2 ON api_key.environment_id = environment_v2.id
-%s

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -42,12 +42,7 @@ type AccountStorage interface {
 	GetAPIKeyByAPIKey(ctx context.Context, apiKey string, environmentID string) (*domain.APIKey, error)
 	GetEnvironmentAPIKey(ctx context.Context, apiKey string) (*domain.EnvironmentAPIKey, error)
 	ListAllEnvironmentAPIKeys(ctx context.Context) ([]*domain.EnvironmentAPIKey, error)
-	ListAPIKeys(
-		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
-	) ([]*proto.APIKey, int, int64, error)
+	ListAPIKeys(ctx context.Context, options *mysql.ListOptions) ([]*proto.APIKey, int, int64, error)
 }
 
 type accountStorage struct {


### PR DESCRIPTION
This pull request refactors the `ListAPIKeys` functionality in the `pkg/account` package to improve code maintainability and simplify query construction. The changes replace the use of multiple parameters for query filters and options with a single `mysql.ListOptions` struct, affecting both the main implementation and associated test cases.
