### PR TITLE
refactor: change ListTags to utilize ListOptions

### DIFF
--- a/pkg/feature/api/tag_test.go
+++ b/pkg/feature/api/tag_test.go
@@ -68,7 +68,7 @@ func TestListTagsMySQL(t *testing.T) {
 			desc: "errInternal",
 			setup: func(fs *FeatureService) {
 				fs.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().ListTags(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return(nil, 0, int64(0), errors.New("test"))
 			},
 			input:       &featureproto.ListTagsRequest{EnvironmentId: environmentId},
@@ -79,7 +79,7 @@ func TestListTagsMySQL(t *testing.T) {
 			desc: "success",
 			setup: func(fs *FeatureService) {
 				fs.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().ListTags(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*tagproto.Tag{}, 0, int64(0), nil)
 			},
 			input: &featureproto.ListTagsRequest{

--- a/pkg/tag/api/api_test.go
+++ b/pkg/tag/api/api_test.go
@@ -168,7 +168,7 @@ func TestListTagsMySQL(t *testing.T) {
 			service: createTagService(mockController),
 			setup: func(s *TagService) {
 				s.tagStorage.(*tagstoragemock.MockTagStorage).EXPECT().ListTags(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(),
 				).Return([]*proto.Tag{
 					{
 						Id:            "tag-0",

--- a/pkg/tag/storage/mock/tag.go
+++ b/pkg/tag/storage/mock/tag.go
@@ -88,9 +88,9 @@ func (mr *MockTagStorageMockRecorder) ListAllEnvironmentTags(ctx any) *gomock.Ca
 }
 
 // ListTags mocks base method.
-func (m *MockTagStorage) ListTags(ctx context.Context, whereParts []mysql.WherePart, orders []*mysql.Order, limit, offset int) ([]*tag.Tag, int, int64, error) {
+func (m *MockTagStorage) ListTags(ctx context.Context, options *mysql.ListOptions) ([]*tag.Tag, int, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTags", ctx, whereParts, orders, limit, offset)
+	ret := m.ctrl.Call(m, "ListTags", ctx, options)
 	ret0, _ := ret[0].([]*tag.Tag)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(int64)
@@ -99,9 +99,9 @@ func (m *MockTagStorage) ListTags(ctx context.Context, whereParts []mysql.WhereP
 }
 
 // ListTags indicates an expected call of ListTags.
-func (mr *MockTagStorageMockRecorder) ListTags(ctx, whereParts, orders, limit, offset any) *gomock.Call {
+func (mr *MockTagStorageMockRecorder) ListTags(ctx, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockTagStorage)(nil).ListTags), ctx, whereParts, orders, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockTagStorage)(nil).ListTags), ctx, options)
 }
 
 // UpsertTag mocks base method.

--- a/pkg/tag/storage/sql/count_tags.sql
+++ b/pkg/tag/storage/sql/count_tags.sql
@@ -4,4 +4,3 @@ FROM
   tag
 JOIN
     environment_v2 env ON tag.environment_id = env.id
-%s

--- a/pkg/tag/storage/sql/select_tags.sql
+++ b/pkg/tag/storage/sql/select_tags.sql
@@ -10,4 +10,3 @@ FROM
     tag
 JOIN
     environment_v2 env ON tag.environment_id = env.id
-%s %s %s

--- a/pkg/tag/storage/tag.go
+++ b/pkg/tag/storage/tag.go
@@ -145,9 +145,14 @@ func (s *tagStorage) ListTags(
 		return nil, 0, 0, err
 	}
 	nextOffset := offset + len(tags)
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countTagsSQL, options)
 	var totalCount int64
-	if err := s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount); err != nil {
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countTagsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countTagsSQL).Scan(&totalCount)
+	}
+	if err != nil {
 		return nil, 0, 0, err
 	}
 	return tags, nextOffset, totalCount, nil

--- a/pkg/tag/storage/tag.go
+++ b/pkg/tag/storage/tag.go
@@ -146,12 +146,8 @@ func (s *tagStorage) ListTags(
 	}
 	nextOffset := offset + len(tags)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countTagsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countTagsSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countTagsSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/tag/storage/tag.go
+++ b/pkg/tag/storage/tag.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/tag/domain"
@@ -49,9 +48,7 @@ type TagStorage interface {
 	GetTag(ctx context.Context, id, environmentId string) (*domain.Tag, error)
 	ListTags(
 		ctx context.Context,
-		whereParts []mysql.WherePart,
-		orders []*mysql.Order,
-		limit, offset int,
+		options *mysql.ListOptions,
 	) ([]*proto.Tag, int, int64, error)
 	ListAllEnvironmentTags(ctx context.Context) ([]*proto.EnvironmentTag, error)
 	DeleteTag(ctx context.Context, id string) error
@@ -111,20 +108,20 @@ func (s *tagStorage) GetTag(ctx context.Context, id, environmentId string) (*dom
 
 func (s *tagStorage) ListTags(
 	ctx context.Context,
-	whereParts []mysql.WherePart,
-	orders []*mysql.Order,
-	limit, offset int,
+	options *mysql.ListOptions,
 ) ([]*proto.Tag, int, int64, error) {
-	whereSQL, whereArgs := mysql.ConstructWhereSQLString(whereParts)
-	orderBySQL := mysql.ConstructOrderBySQLString(orders)
-	limitOffsetSQL := mysql.ConstructLimitOffsetSQLString(limit, offset)
-	query := fmt.Sprintf(selectTagsSQL, whereSQL, orderBySQL, limitOffsetSQL)
+	query, whereArgs := mysql.ConstructQueryAndWhereArgs(selectTagsSQL, options)
 
 	rows, err := s.qe.QueryContext(ctx, query, whereArgs...)
 	if err != nil {
 		return nil, 0, 0, err
 	}
 	defer rows.Close()
+	var limit, offset int
+	if options != nil {
+		limit = options.Limit
+		offset = options.Offset
+	}
 	tags := make([]*proto.Tag, 0, limit)
 	for rows.Next() {
 		var entityType int32
@@ -148,9 +145,9 @@ func (s *tagStorage) ListTags(
 		return nil, 0, 0, err
 	}
 	nextOffset := offset + len(tags)
-	countQuery := fmt.Sprintf(countTagsSQL, whereSQL)
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countTagsSQL, options)
 	var totalCount int64
-	if err := s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount); err != nil {
+	if err := s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount); err != nil {
 		return nil, 0, 0, err
 	}
 	return tags, nextOffset, totalCount, nil


### PR DESCRIPTION
This pull request refactors the `ListTags` functionality across multiple components to adopt a new `mysql.ListOptions` structure, improving maintainability and consistency. The changes include updates to the `ListTags` method, its associated tests, and the SQL query construction logic.

relate of https://github.com/bucketeer-io/bucketeer/issues/1475