### PR TITLE
[WIP]refactor: add GRPC's ErrorInfo when an error occurs related to ApiKey

### DIFF
--- a/pkg/account/api/api_key.go
+++ b/pkg/account/api/api_key.go
@@ -73,14 +73,10 @@ func (s *AccountService) CreateAPIKey(
 				zap.String("environmentId", req.EnvironmentId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		handler, err := command.NewAPIKeyCommandHandler(
@@ -99,14 +95,12 @@ func (s *AccountService) CreateAPIKey(
 	})
 	if err != nil {
 		if errors.Is(err, v2as.ErrAPIKeyAlreadyExists) {
-			dt, err := statusAlreadyExists.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusAlreadyExists, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.AlreadyExistsError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to create api key",
@@ -115,14 +109,10 @@ func (s *AccountService) CreateAPIKey(
 				zap.String("environmentId", req.EnvironmentId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	return &proto.CreateAPIKeyResponse{
 		ApiKey: key.APIKey,
@@ -154,14 +144,10 @@ func (s *AccountService) createAPIKeyNoCommand(
 				zap.String("maintainer", req.Maintainer),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
@@ -169,14 +155,12 @@ func (s *AccountService) createAPIKeyNoCommand(
 	})
 	if err != nil {
 		if errors.Is(err, v2as.ErrAPIKeyAlreadyExists) {
-			dt, err := statusAlreadyExists.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusAlreadyExists, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.AlreadyExistsError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to create api key",
@@ -188,14 +172,10 @@ func (s *AccountService) createAPIKeyNoCommand(
 				zap.String("maintainer", req.Maintainer),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 
 	prev := &domain.APIKey{}
@@ -275,14 +255,12 @@ func (s *AccountService) ChangeAPIKeyName(
 		req.Command,
 	); err != nil {
 		if err == v2as.ErrAPIKeyNotFound || err == v2as.ErrAPIKeyUnexpectedAffectedRows {
-			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusNotFound, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to change api key name",
@@ -293,14 +271,10 @@ func (s *AccountService) ChangeAPIKeyName(
 				zap.String("name", req.Command.Name),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	return &proto.ChangeAPIKeyNameResponse{}, nil
 }
@@ -337,14 +311,12 @@ func (s *AccountService) EnableAPIKey(
 		req.Command,
 	); err != nil {
 		if err == v2as.ErrAPIKeyNotFound || err == v2as.ErrAPIKeyUnexpectedAffectedRows {
-			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusNotFound, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to enable api key",
@@ -354,14 +326,10 @@ func (s *AccountService) EnableAPIKey(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	return &proto.EnableAPIKeyResponse{}, nil
 }
@@ -398,14 +366,12 @@ func (s *AccountService) DisableAPIKey(
 		req.Command,
 	); err != nil {
 		if errors.Is(err, v2as.ErrAPIKeyNotFound) || errors.Is(err, v2as.ErrAPIKeyUnexpectedAffectedRows) {
-			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusNotFound, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to disable api key",
@@ -415,14 +381,10 @@ func (s *AccountService) DisableAPIKey(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	return &proto.DisableAPIKeyResponse{}, nil
 }
@@ -458,26 +420,20 @@ func (s *AccountService) GetAPIKey(ctx context.Context, req *proto.GetAPIKeyRequ
 		return nil, err
 	}
 	if req.Id == "" {
-		dt, err := statusMissingAPIKeyID.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusMissingAPIKeyID, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_id"),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	apiKey, err := s.accountStorage.GetAPIKey(ctx, req.Id, req.EnvironmentId)
 	if err != nil {
 		if errors.Is(err, v2as.ErrAPIKeyNotFound) {
-			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusNotFound, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to get api key",
@@ -487,14 +443,10 @@ func (s *AccountService) GetAPIKey(ctx context.Context, req *proto.GetAPIKeyRequ
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	if apiKey == nil {
 		s.logger.Error(
@@ -526,14 +478,12 @@ func (s *AccountService) ListAPIKeys(
 		return nil, err
 	}
 	if req.OrganizationId == "" {
-		dt, err := statusInvalidListAPIKeyRequest.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInvalidListAPIKeyRequest, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "organization_id"),
+		}, map[string]string{
+			"field": "organization_id",
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	whereParts := []mysql.WherePart{}
 	whereParts = append(whereParts, mysql.NewFilter("environment_v2.organization_id", "=", req.OrganizationId))
@@ -565,14 +515,10 @@ func (s *AccountService) ListAPIKeys(
 	}
 	offset, err := strconv.Atoi(cursor)
 	if err != nil {
-		dt, err := statusInvalidCursor.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInvalidCursor, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "cursor"),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	apiKeys, nextCursor, totalCount, err := s.accountStorage.ListAPIKeys(
 		ctx,
@@ -589,14 +535,10 @@ func (s *AccountService) ListAPIKeys(
 				zap.String("environmentId", req.EnvironmentId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 
 	// for security, obfuscate the returned key
@@ -633,14 +575,10 @@ func (s *AccountService) newAPIKeyListOrders(
 	case proto.ListAPIKeysRequest_STATE:
 		column = "api_key.disabled"
 	default:
-		dt, err := statusInvalidOrderBy.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInvalidOrderBy, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "order_by"),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	direction := mysql.OrderDirectionAsc
 	if orderDirection == proto.ListAPIKeysRequest_DESC {
@@ -659,26 +597,18 @@ func (s *AccountService) GetEnvironmentAPIKey(
 		return nil, err
 	}
 	if req.ApiKey == "" {
-		dt, err := statusMissingAPIKeyID.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusMissingAPIKeyID, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_id"),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	envAPIKey, err := s.accountStorage.GetEnvironmentAPIKey(ctx, req.ApiKey)
 	if err != nil {
 		if errors.Is(err, v2as.ErrAPIKeyNotFound) {
-			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusNotFound, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to get environment api key",
@@ -687,14 +617,10 @@ func (s *AccountService) GetEnvironmentAPIKey(
 				zap.String("apiKey", req.ApiKey),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	// for security, obfuscate the returned key
 	shadowLen := int(float64(len(envAPIKey.ApiKey.ApiKey)) * apiKeyShadowPercentage)
@@ -749,14 +675,12 @@ func (s *AccountService) UpdateAPIKey(
 	})
 	if err != nil {
 		if errors.Is(err, v2as.ErrAPIKeyNotFound) {
-			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
+			return nil, NewError(statusNotFound, &errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),
+			}, map[string]string{
+				"field": "apiKey",
 			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
 		}
 		s.logger.Error(
 			"Failed to update api key",
@@ -766,14 +690,10 @@ func (s *AccountService) UpdateAPIKey(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
+		return nil, NewError(statusInternal, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalize(locale.InternalServerError),
 		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
 	}
 	e, err := domainevent.NewEvent(
 		editor,

--- a/pkg/account/api/api_key_test.go
+++ b/pkg/account/api/api_key_test.go
@@ -48,12 +48,10 @@ func TestCreateAPIKeyMySQL(t *testing.T) {
 	})
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
 		})
-		require.NoError(t, err)
-		return st.Err()
 	}
 
 	patterns := []struct {
@@ -135,12 +133,10 @@ func TestCreateAPIKeyMySQLNoCommand(t *testing.T) {
 	})
 	localizer := locale.NewLocalizer(ctx)
 	createError := func(status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
 		})
-		require.NoError(t, err)
-		return st.Err()
 	}
 
 	patterns := []struct {
@@ -224,13 +220,11 @@ func TestChangeAPIKeyNameMySQL(t *testing.T) {
 		"accept-language": []string{"ja"},
 	})
 	localizer := locale.NewLocalizer(ctx)
-	createError := func(status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+	createError := func(status *gstatus.Status, msg string, anotherDetailData ...map[string]string) error {
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
-		})
-		require.NoError(t, err)
-		return st.Err()
+		}, anotherDetailData...)
 	}
 
 	patterns := []struct {
@@ -271,7 +265,9 @@ func TestChangeAPIKeyNameMySQL(t *testing.T) {
 					Name: "",
 				},
 			},
-			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError)),
+			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError), map[string]string{
+				"field": "apiKey",
+			}),
 		},
 		{
 			desc: "errInternal",
@@ -341,13 +337,11 @@ func TestEnableAPIKeyMySQL(t *testing.T) {
 		"accept-language": []string{"ja"},
 	})
 	localizer := locale.NewLocalizer(ctx)
-	createError := func(status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+	createError := func(status *gstatus.Status, msg string, anotherDetailData ...map[string]string) error {
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
-		})
-		require.NoError(t, err)
-		return st.Err()
+		}, anotherDetailData...)
 	}
 
 	patterns := []struct {
@@ -386,7 +380,9 @@ func TestEnableAPIKeyMySQL(t *testing.T) {
 				Id:      "id",
 				Command: &accountproto.EnableAPIKeyCommand{},
 			},
-			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError)),
+			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError), map[string]string{
+				"field": "apiKey",
+			}),
 		},
 		{
 			desc: "errInternal",
@@ -452,13 +448,11 @@ func TestDisableAPIKeyMySQL(t *testing.T) {
 		"accept-language": []string{"ja"},
 	})
 	localizer := locale.NewLocalizer(ctx)
-	createError := func(status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+	createError := func(status *gstatus.Status, msg string, anotherDetailData ...map[string]string) error {
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
-		})
-		require.NoError(t, err)
-		return st.Err()
+		}, anotherDetailData...)
 	}
 
 	patterns := []struct {
@@ -497,7 +491,9 @@ func TestDisableAPIKeyMySQL(t *testing.T) {
 				Id:      "id",
 				Command: &accountproto.DisableAPIKeyCommand{},
 			},
-			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError)),
+			expectedErr: createError(statusNotFound, localizer.MustLocalize(locale.NotFoundError), map[string]string{
+				"field": "apiKey",
+			}),
 		},
 		{
 			desc: "errInternal",
@@ -557,13 +553,11 @@ func TestGetAPIKeyMySQL(t *testing.T) {
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
-	createError := func(localizer locale.Localizer, status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+	createError := func(localizer locale.Localizer, status *gstatus.Status, msg string, anotherDetailData ...map[string]string) error {
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
-		})
-		require.NoError(t, err)
-		return st.Err()
+		}, anotherDetailData...)
 	}
 
 	patterns := []struct {
@@ -591,7 +585,9 @@ func TestGetAPIKeyMySQL(t *testing.T) {
 			},
 			req: &accountproto.GetAPIKeyRequest{Id: "id"},
 			getExpectedErr: func(localizer locale.Localizer) error {
-				return createError(localizer, statusNotFound, localizer.MustLocalize(locale.NotFoundError))
+				return createError(localizer, statusNotFound, localizer.MustLocalize(locale.NotFoundError), map[string]string{
+					"field": "apiKey",
+				})
 			},
 		},
 		{
@@ -694,12 +690,10 @@ func TestListAPIKeysMySQL(t *testing.T) {
 	defer mockController.Finish()
 
 	createError := func(localizer locale.Localizer, status *gstatus.Status, msg string) error {
-		st, err := status.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(status, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: msg,
 		})
-		require.NoError(t, err)
-		return st.Err()
 	}
 
 	patterns := []struct {

--- a/pkg/account/api/validation.go
+++ b/pkg/account/api/validation.go
@@ -38,110 +38,78 @@ func verifyEmailFormat(email string) bool {
 
 func validateCreateAPIKeyRequest(req *accountproto.CreateAPIKeyRequest, localizer locale.Localizer) error {
 	if req.Command.Name == "" {
-		dt, err := statusMissingAPIKeyName.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusMissingAPIKeyName, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_name"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	return nil
 }
 
 func validateCreateAPIKeyRequestNoCommand(req *accountproto.CreateAPIKeyRequest, localizer locale.Localizer) error {
 	if req.Name == "" {
-		dt, err := statusMissingAPIKeyName.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusMissingAPIKeyName, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_name"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	if req.Maintainer != "" && !verifyEmailFormat(req.Maintainer) {
-		dt, err := statusInvalidEmail.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusInvalidEmail, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "maintainer"),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		},
+			map[string]string{
+				"field": "maintainer",
+			},
+		)
 	}
 	return nil
 }
 
 func validateChangeAPIKeyNameRequest(req *accountproto.ChangeAPIKeyNameRequest, localizer locale.Localizer) error {
 	if req.Id == "" {
-		dt, err := statusMissingAPIKeyID.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusMissingAPIKeyID, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_id"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	if req.Command == nil {
-		dt, err := statusNoCommand.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusNoCommand, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "command"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	return nil
 }
 
 func validateEnableAPIKeyRequest(req *accountproto.EnableAPIKeyRequest, localizer locale.Localizer) error {
 	if req.Id == "" {
-		dt, err := statusMissingAPIKeyID.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusMissingAPIKeyID, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_id"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	if req.Command == nil {
-		dt, err := statusNoCommand.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusNoCommand, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "command"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	return nil
 }
 
 func validateDisableAPIKeyRequest(req *accountproto.DisableAPIKeyRequest, localizer locale.Localizer) error {
 	if req.Id == "" {
-		dt, err := statusMissingAPIKeyID.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusMissingAPIKeyID, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "api_key_id"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	if req.Command == nil {
-		dt, err := statusNoCommand.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusNoCommand, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "command"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	return nil
 }
@@ -886,14 +854,10 @@ func validateDeleteSearchFilterRequest(
 
 func validateUpdateAPIKeyRequestNoCommand(req *accountproto.UpdateAPIKeyRequest, localizer locale.Localizer) error {
 	if req.Id == "" {
-		dt, err := statusMissingAPIKeyID.WithDetails(&errdetails.LocalizedMessage{
+		return NewError(statusMissingAPIKeyID, &errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.RequiredFieldTemplate, "id"),
 		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
 	}
 	return nil
 }


### PR DESCRIPTION
This pull request refactors error handling in the `AccountService` to simplify code and enhance error details. Specifically, it replaces the use of `status.WithDetails` with a new helper function, `NewError`, for creating structured errors. Additionally, it updates related unit tests to reflect these changes.

Relate of #1253
