### PR TITLE
fix: mysql no rows error when using pagination

### DIFF
--- a/pkg/account/storage/v2/account.go
+++ b/pkg/account/storage/v2/account.go
@@ -355,7 +355,7 @@ func (s *accountStorage) ListAccountsV2(
 	}
 	nextOffset := offset + len(accounts)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countAccountsV2SQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countAccountsV2SQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/account/storage/v2/account.go
+++ b/pkg/account/storage/v2/account.go
@@ -355,8 +355,12 @@ func (s *accountStorage) ListAccountsV2(
 	}
 	nextOffset := offset + len(accounts)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countAccountsV2SQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countAccountsV2SQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countAccountsV2SQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/account/storage/v2/account.go
+++ b/pkg/account/storage/v2/account.go
@@ -355,12 +355,8 @@ func (s *accountStorage) ListAccountsV2(
 	}
 	nextOffset := offset + len(accounts)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countAccountsV2SQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countAccountsV2SQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countAccountsV2SQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/account/storage/v2/api_key.go
+++ b/pkg/account/storage/v2/api_key.go
@@ -314,7 +314,7 @@ func (s *accountStorage) ListAPIKeys(
 	}
 	nextOffset := offset + len(apiKeys)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAPIKeyV2CountSQLQuery, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(selectAPIKeyV2CountSQLQuery, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/account/storage/v2/api_key.go
+++ b/pkg/account/storage/v2/api_key.go
@@ -314,12 +314,8 @@ func (s *accountStorage) ListAPIKeys(
 	}
 	nextOffset := offset + len(apiKeys)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, selectAPIKeyV2CountSQLQuery+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, selectAPIKeyV2CountSQLQuery).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAPIKeyV2CountSQLQuery, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/account/storage/v2/api_key.go
+++ b/pkg/account/storage/v2/api_key.go
@@ -314,8 +314,12 @@ func (s *accountStorage) ListAPIKeys(
 	}
 	nextOffset := offset + len(apiKeys)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAPIKeyV2CountSQLQuery, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, selectAPIKeyV2CountSQLQuery+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, selectAPIKeyV2CountSQLQuery).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/admin_audit_log.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log.go
@@ -162,7 +162,7 @@ func (s *adminAuditLogStorage) ListAdminAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAdminAuditLogV2CountSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(selectAdminAuditLogV2CountSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/auditlog/storage/v2/admin_audit_log.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log.go
@@ -162,12 +162,8 @@ func (s *adminAuditLogStorage) ListAdminAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, selectAdminAuditLogV2CountSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, selectAdminAuditLogV2CountSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAdminAuditLogV2CountSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/admin_audit_log.go
+++ b/pkg/auditlog/storage/v2/admin_audit_log.go
@@ -162,8 +162,12 @@ func (s *adminAuditLogStorage) ListAdminAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAdminAuditLogV2CountSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, selectAdminAuditLogV2CountSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, selectAdminAuditLogV2CountSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -195,8 +195,12 @@ func (s *auditLogStorage) ListAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAuditLogV2CountSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, selectAuditLogV2CountSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, selectAuditLogV2CountSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -195,7 +195,7 @@ func (s *auditLogStorage) ListAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAuditLogV2CountSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(selectAuditLogV2CountSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/auditlog/storage/v2/audit_log.go
+++ b/pkg/auditlog/storage/v2/audit_log.go
@@ -195,12 +195,8 @@ func (s *auditLogStorage) ListAuditLogs(
 	}
 	nextOffset := offset + len(auditLogs)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, selectAuditLogV2CountSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, selectAuditLogV2CountSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAuditLogV2CountSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/autoops/storage/v2/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/progressive_rollout.go
@@ -191,7 +191,7 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	}
 	nextOffset := offset + len(progressiveRollouts)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countOpsProgressiveRolloutsSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countOpsProgressiveRolloutsSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/autoops/storage/v2/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/progressive_rollout.go
@@ -191,12 +191,8 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	}
 	nextOffset := offset + len(progressiveRollouts)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countOpsProgressiveRolloutsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countOpsProgressiveRolloutsSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countOpsProgressiveRolloutsSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/autoops/storage/v2/progressive_rollout.go
+++ b/pkg/autoops/storage/v2/progressive_rollout.go
@@ -191,8 +191,12 @@ func (s *progressiveRolloutStorage) ListProgressiveRollouts(
 	}
 	nextOffset := offset + len(progressiveRollouts)
 	var totalCount int64
-	countQuery, whereArgs := mysql.ConstructQueryAndWhereArgs(countOpsProgressiveRolloutsSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, whereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countOpsProgressiveRolloutsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countOpsProgressiveRolloutsSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/environment/storage/v2/environment.go
+++ b/pkg/environment/storage/v2/environment.go
@@ -193,8 +193,12 @@ func (s *environmentStorage) ListEnvironmentsV2(
 	}
 	nextOffset := offset + len(environments)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countEnvironmentsSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countEnvironmentsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countEnvironmentsSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/environment/storage/v2/environment.go
+++ b/pkg/environment/storage/v2/environment.go
@@ -193,7 +193,7 @@ func (s *environmentStorage) ListEnvironmentsV2(
 	}
 	nextOffset := offset + len(environments)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countEnvironmentsSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countEnvironmentsSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/environment/storage/v2/environment.go
+++ b/pkg/environment/storage/v2/environment.go
@@ -193,12 +193,8 @@ func (s *environmentStorage) ListEnvironmentsV2(
 	}
 	nextOffset := offset + len(environments)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countEnvironmentsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countEnvironmentsSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countEnvironmentsSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/environment/storage/v2/organization.go
+++ b/pkg/environment/storage/v2/organization.go
@@ -232,12 +232,8 @@ func (s *organizationStorage) ListOrganizations(
 	}
 	nextOffset := offset + len(organizations)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countOrganizationsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countOrganizationsSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countOrganizationsSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/environment/storage/v2/organization.go
+++ b/pkg/environment/storage/v2/organization.go
@@ -232,8 +232,12 @@ func (s *organizationStorage) ListOrganizations(
 	}
 	nextOffset := offset + len(organizations)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countOrganizationsSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countOrganizationsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countOrganizationsSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/environment/storage/v2/organization.go
+++ b/pkg/environment/storage/v2/organization.go
@@ -232,7 +232,7 @@ func (s *organizationStorage) ListOrganizations(
 	}
 	nextOffset := offset + len(organizations)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countOrganizationsSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countOrganizationsSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/environment/storage/v2/project.go
+++ b/pkg/environment/storage/v2/project.go
@@ -234,12 +234,8 @@ func (s *projectStorage) ListProjects(
 	}
 	nextOffset := offset + len(projects)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countProjectsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countProjectsSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countProjectsSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/environment/storage/v2/project.go
+++ b/pkg/environment/storage/v2/project.go
@@ -234,7 +234,7 @@ func (s *projectStorage) ListProjects(
 	}
 	nextOffset := offset + len(projects)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countProjectsSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countProjectsSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/environment/storage/v2/project.go
+++ b/pkg/environment/storage/v2/project.go
@@ -234,8 +234,12 @@ func (s *projectStorage) ListProjects(
 	}
 	nextOffset := offset + len(projects)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countProjectsSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countProjectsSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countProjectsSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/experiment/storage/v2/experiment.go
+++ b/pkg/experiment/storage/v2/experiment.go
@@ -246,7 +246,7 @@ func (s *experimentStorage) ListExperiments(
 	}
 	nextOffset := offset + len(experiments)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countExperimentSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countExperimentSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/experiment/storage/v2/experiment.go
+++ b/pkg/experiment/storage/v2/experiment.go
@@ -246,12 +246,8 @@ func (s *experimentStorage) ListExperiments(
 	}
 	nextOffset := offset + len(experiments)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countExperimentSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countExperimentSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countExperimentSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/experiment/storage/v2/experiment.go
+++ b/pkg/experiment/storage/v2/experiment.go
@@ -246,10 +246,12 @@ func (s *experimentStorage) ListExperiments(
 	}
 	nextOffset := offset + len(experiments)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countExperimentSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(
-		&totalCount,
-	)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countExperimentSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countExperimentSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/feature/storage/v2/flag_trigger.go
+++ b/pkg/feature/storage/v2/flag_trigger.go
@@ -250,12 +250,8 @@ func (f flagTriggerStorage) ListFlagTriggers(
 	}
 	nextOffset := offset + len(flagTriggers)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = f.qe.QueryRowContext(ctx, countFlagTriggersSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = f.qe.QueryRowContext(ctx, countFlagTriggersSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countFlagTriggersSQL, options)
+	err = f.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/feature/storage/v2/flag_trigger.go
+++ b/pkg/feature/storage/v2/flag_trigger.go
@@ -251,8 +251,7 @@ func (f flagTriggerStorage) ListFlagTriggers(
 	nextOffset := offset + len(flagTriggers)
 	var totalCount int64
 	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countFlagTriggersSQL, options)
-	err = f.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
-	if err != nil {
+	if err := f.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount); err != nil {
 		return nil, 0, 0, err
 	}
 	return flagTriggers, nextOffset, totalCount, nil

--- a/pkg/feature/storage/v2/flag_trigger.go
+++ b/pkg/feature/storage/v2/flag_trigger.go
@@ -250,8 +250,13 @@ func (f flagTriggerStorage) ListFlagTriggers(
 	}
 	nextOffset := offset + len(flagTriggers)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countFlagTriggersSQL, options)
-	if err := f.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount); err != nil {
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = f.qe.QueryRowContext(ctx, countFlagTriggersSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = f.qe.QueryRowContext(ctx, countFlagTriggersSQL).Scan(&totalCount)
+	}
+	if err != nil {
 		return nil, 0, 0, err
 	}
 	return flagTriggers, nextOffset, totalCount, nil

--- a/pkg/feature/storage/v2/flag_trigger.go
+++ b/pkg/feature/storage/v2/flag_trigger.go
@@ -250,7 +250,7 @@ func (f flagTriggerStorage) ListFlagTriggers(
 	}
 	nextOffset := offset + len(flagTriggers)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countFlagTriggersSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countFlagTriggersSQL, options)
 	if err := f.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount); err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -190,7 +190,10 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAdminSubscriptionV2CountSQLQuery, options)
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(
+		selectAdminSubscriptionV2CountSQLQuery,
+		options,
+	)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -190,15 +190,8 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(
-			ctx,
-			selectAdminSubscriptionV2CountSQLQuery+whereQuery,
-			countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, selectAdminSubscriptionV2CountSQLQuery).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectAdminSubscriptionV2CountSQLQuery, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -190,7 +190,7 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(
 		selectAdminSubscriptionV2CountSQLQuery,
 		options,
 	)

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -190,8 +190,15 @@ func (s *adminSubscriptionStorage) ListAdminSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countQueryWhereArgs := mysql.ConstructQueryAndWhereArgs(selectAdminSubscriptionV2CountSQLQuery, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countQueryWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(
+			ctx,
+			selectAdminSubscriptionV2CountSQLQuery+whereQuery,
+			countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, selectAdminSubscriptionV2CountSQLQuery).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -216,7 +216,7 @@ func (s *subscriptionStorage) ListSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(
 		selectSubscriptionV2CountSQLQuery,
 		options,
 	)

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -218,5 +218,8 @@ func (s *subscriptionStorage) ListSubscriptions(
 	var totalCount int64
 	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectSubscriptionV2CountSQLQuery, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if err != nil {
+		return nil, 0, 0, err
+	}
 	return subscriptions, nextOffset, totalCount, nil
 }

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -216,8 +216,12 @@ func (s *subscriptionStorage) ListSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countQueryWhereArgs := mysql.ConstructQueryAndWhereArgs(selectSubscriptionV2CountSQLQuery, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countQueryWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, selectSubscriptionV2CountSQLQuery+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, selectSubscriptionV2CountSQLQuery).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -216,14 +216,7 @@ func (s *subscriptionStorage) ListSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, selectSubscriptionV2CountSQLQuery+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, selectSubscriptionV2CountSQLQuery).Scan(&totalCount)
-	}
-	if err != nil {
-		return nil, 0, 0, err
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectSubscriptionV2CountSQLQuery, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	return subscriptions, nextOffset, totalCount, nil
 }

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -216,7 +216,10 @@ func (s *subscriptionStorage) ListSubscriptions(
 	}
 	nextOffset := offset + len(subscriptions)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(selectSubscriptionV2CountSQLQuery, options)
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(
+		selectSubscriptionV2CountSQLQuery,
+		options,
+	)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/push/storage/v2/push.go
+++ b/pkg/push/storage/v2/push.go
@@ -180,7 +180,7 @@ func (s *pushStorage) ListPushes(
 	}
 	nextOffset := offset + len(pushes)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countPushesSQL, options)
+	countQuery, countWhereArgs := mysql.ConstructCountQuery(countPushesSQL, options)
 	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err

--- a/pkg/push/storage/v2/push.go
+++ b/pkg/push/storage/v2/push.go
@@ -180,8 +180,12 @@ func (s *pushStorage) ListPushes(
 	}
 	nextOffset := offset + len(pushes)
 	var totalCount int64
-	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgs(countPushesSQL, options)
-	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
+	if options != nil {
+		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
+		err = s.qe.QueryRowContext(ctx, countPushesSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
+	} else {
+		err = s.qe.QueryRowContext(ctx, countPushesSQL).Scan(&totalCount)
+	}
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/push/storage/v2/push.go
+++ b/pkg/push/storage/v2/push.go
@@ -180,12 +180,8 @@ func (s *pushStorage) ListPushes(
 	}
 	nextOffset := offset + len(pushes)
 	var totalCount int64
-	if options != nil {
-		whereQuery, countWhereArgs := mysql.ConstructWhereSQLString(options.CreateWhereParts())
-		err = s.qe.QueryRowContext(ctx, countPushesSQL+whereQuery, countWhereArgs...).Scan(&totalCount)
-	} else {
-		err = s.qe.QueryRowContext(ctx, countPushesSQL).Scan(&totalCount)
-	}
+	countQuery, countWhereArgs := mysql.ConstructQueryAndWhereArgsOnlyUseWherePart(countPushesSQL, options)
+	err = s.qe.QueryRowContext(ctx, countQuery, countWhereArgs...).Scan(&totalCount)
 	if err != nil {
 		return nil, 0, 0, err
 	}

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -360,6 +360,20 @@ func ConstructQueryAndWhereArgs(baseQuery string, options *ListOptions) (query s
 	return
 }
 
+// ConstructQueryAndWhereArgsOnlyUseWherePart builds a query with only the WHERE part.
+// This Function is intended to be used when the purpose is
+// to generate a query that does not require any conditions other than the Where clause, such as "SELECT COUNT(1) FROM XXX".
+func ConstructQueryAndWhereArgsOnlyUseWherePart(
+	baseQuery string,
+	options *ListOptions,
+) (query string, whereArgs []interface{}) {
+	if options != nil {
+		whereQuery, whereArgs := ConstructWhereSQLString(options.CreateWhereParts())
+		return baseQuery + whereQuery, whereArgs
+	}
+	return baseQuery, []interface{}{}
+}
+
 type Orders struct {
 	Orders []*Order
 }

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -362,7 +362,8 @@ func ConstructQueryAndWhereArgs(baseQuery string, options *ListOptions) (query s
 
 // ConstructQueryAndWhereArgsOnlyUseWherePart builds a query with only the WHERE part.
 // This Function is intended to be used when the purpose is
-// to generate a query that does not require any conditions other than the Where clause, such as "SELECT COUNT(1) FROM XXX".
+// to generate a query that does not require any conditions other than the Where clause,
+// such as "SELECT COUNT(1) FROM XXX".
 func ConstructQueryAndWhereArgsOnlyUseWherePart(
 	baseQuery string,
 	options *ListOptions,

--- a/pkg/storage/v2/mysql/query.go
+++ b/pkg/storage/v2/mysql/query.go
@@ -360,16 +360,16 @@ func ConstructQueryAndWhereArgs(baseQuery string, options *ListOptions) (query s
 	return
 }
 
-// ConstructQueryAndWhereArgsOnlyUseWherePart builds a query with only the WHERE part.
-// This Function is intended to be used when the purpose is
-// to generate a query that does not require any conditions other than the Where clause,
-// such as "SELECT COUNT(1) FROM XXX".
-func ConstructQueryAndWhereArgsOnlyUseWherePart(
-	baseQuery string,
-	options *ListOptions,
-) (query string, whereArgs []interface{}) {
+// ConstructCountQuery builds a count query with optional filtering.
+// It takes a base count SQL query and ListOptions, and returns the complete query and its arguments.
+// The base SQL should be a valid COUNT query (e.g., "SELECT COUNT(1) FROM table").
+// Additional WHERE clauses from ListOptions will be appended to the base query.
+func ConstructCountQuery(baseQuery string, options *ListOptions) (query string, whereArgs []interface{}) {
 	if options != nil {
 		whereQuery, whereArgs := ConstructWhereSQLString(options.CreateWhereParts())
+		if whereArgs == nil {
+			whereArgs = []interface{}{}
+		}
 		return baseQuery + whereQuery, whereArgs
 	}
 	return baseQuery, []interface{}{}


### PR DESCRIPTION
This pull request addressed the following issue.
- Due to refactoring of ListOption, there was an issue with the query to get the total number, which caused the total number to be retrieved incorrectly.
- There was an issue where paging on the Auditlog list screen, etc. could not be displayed properly.

This pull request refactors multiple `List` methods across various storage modules to improve query construction for counting total records. The changes replace the use of `mysql.ConstructQueryAndWhereArgs` with a more flexible approach that directly appends `WHERE` clauses to the base SQL query when filtering options are provided. If no options are specified, the base query is executed without modification.
