### PR TITLE
chore: add custom JSON unmarshaler for boolean string compatibility

### DIFF
--- a/pkg/rpc/gateway/gateway.go
+++ b/pkg/rpc/gateway/gateway.go
@@ -157,7 +157,7 @@ func (m *BooleanConversionMarshaler) convertStringBooleansRecursive(data interfa
 
 // stringToBool converts string boolean values to actual booleans
 func stringToBool(s string) (bool, bool) {
-	if val, ok := stringBoolMap[strings.ToLower(s)]; ok {
+	if val, ok := stringBoolMap[strings.ToLower(strings.TrimSpace(s))]; ok {
 		return val, true
 	}
 	return false, false

--- a/pkg/rpc/gateway/gateway.go
+++ b/pkg/rpc/gateway/gateway.go
@@ -41,7 +41,9 @@ type customJSONPb struct {
 }
 
 // Unmarshal implements the custom unmarshaling logic
-// TODO: This is a temporary solution until the Android SDK is updated to use the correct boolean type
+// TODO: This is a temporary custom JSON unmarshaler to handle boolean fields sent as strings from the Android SDK.
+// This addresses a compatibility issue that arose after switching from Envoy JSON transcoder to gRPC-Gateway.
+// Reference: https://github.com/bucketeer-io/android-client-sdk/pull/230
 func (c *customJSONPb) Unmarshal(data []byte, v interface{}) error {
 	// First try to unmarshal with the default protojson unmarshaler
 	err := c.JSONPb.Unmarshal(data, v)

--- a/pkg/rpc/gateway/gateway_test.go
+++ b/pkg/rpc/gateway/gateway_test.go
@@ -289,26 +289,3 @@ func TestBooleanConversionMarshaler_Integration(t *testing.T) {
 		})
 	}
 }
-
-func TestShouldProcessRequest(t *testing.T) {
-	tests := []struct {
-		name string
-		path string
-		want bool
-	}{
-		{"exact match get_evaluations", "/get_evaluations", true},
-		{"exact match v1 gateway", "/v1/gateway/evaluations", true},
-		{"contains get_evaluations", "/api/get_evaluations/test", true},
-		{"contains v1 gateway", "/api/v1/gateway/evaluations/test", true},
-		{"no match", "/api/other/endpoint", false},
-		{"empty path", "", false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := shouldProcessRequest(tt.path); got != tt.want {
-				t.Errorf("shouldProcessRequest(%q) = %v, want %v", tt.path, got, tt.want)
-			}
-		})
-	}
-}

--- a/pkg/rpc/gateway/gateway_test.go
+++ b/pkg/rpc/gateway/gateway_test.go
@@ -1,0 +1,244 @@
+package gateway
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestCustomJSONPb_Unmarshal(t *testing.T) {
+	c := &customJSONPb{
+		JSONPb: runtime.JSONPb{
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: true,
+			},
+		},
+	}
+
+	tests := []struct {
+		name    string
+		input   []byte
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "success: boolean true",
+			input:   []byte("true"),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "success: string 'true'",
+			input:   []byte(`"true"`),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "success: string 'True'",
+			input:   []byte(`"True"`),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "success: string 'TRUE'",
+			input:   []byte(`"TRUE"`),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "success: string '1'",
+			input:   []byte(`"1"`),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "success: boolean false",
+			input:   []byte("false"),
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "success: string 'false'",
+			input:   []byte(`"false"`),
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "success: string 'False'",
+			input:   []byte(`"False"`),
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "success: string 'FALSE'",
+			input:   []byte(`"FALSE"`),
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "success: string '0'",
+			input:   []byte(`"0"`),
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "error: invalid boolean string",
+			input:   []byte(`"invalid"`),
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "error: invalid JSON",
+			input:   []byte(`{invalid json}`),
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "error: non-boolean value",
+			input:   []byte(`123`),
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got wrapperspb.BoolValue
+			err := c.Unmarshal(tt.input, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Unmarshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got.Value != tt.want {
+				t.Errorf("Unmarshal() got = %v, want %v", got.Value, tt.want)
+			}
+		})
+	}
+}
+
+func TestCustomJSONPb_Unmarshal_NestedStructures(t *testing.T) {
+	// Define a test message type for nested structures
+	type TestMessage struct {
+		BoolField1 bool                   `json:"boolField1"`
+		BoolField2 bool                   `json:"boolField2"`
+		Nested     map[string]bool        `json:"nested"`
+		Array      []bool                 `json:"array"`
+		Mixed      map[string]interface{} `json:"mixed"`
+	}
+
+	tests := []struct {
+		name    string
+		input   string
+		check   func(t *testing.T, data []byte)
+		wantErr bool
+	}{
+		{
+			name: "nested object with boolean strings",
+			input: `{
+				"boolField1": "true",
+				"boolField2": "false",
+				"nested": {
+					"key1": "TRUE",
+					"key2": "0"
+				}
+			}`,
+			check: func(t *testing.T, data []byte) {
+				var result map[string]interface{}
+				json.Unmarshal(data, &result)
+
+				// Check that boolean strings were converted
+				if result["boolField1"] != true {
+					t.Errorf("Expected boolField1 to be true, got %v", result["boolField1"])
+				}
+				if result["boolField2"] != false {
+					t.Errorf("Expected boolField2 to be false, got %v", result["boolField2"])
+				}
+
+				nested := result["nested"].(map[string]interface{})
+				if nested["key1"] != true {
+					t.Errorf("Expected nested.key1 to be true, got %v", nested["key1"])
+				}
+				if nested["key2"] != false {
+					t.Errorf("Expected nested.key2 to be false, got %v", nested["key2"])
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "array with boolean strings",
+			input: `{
+				"array": ["true", "false", "1", "0", "TRUE", "FALSE"]
+			}`,
+			check: func(t *testing.T, data []byte) {
+				var result map[string]interface{}
+				json.Unmarshal(data, &result)
+
+				array := result["array"].([]interface{})
+				expected := []bool{true, false, true, false, true, false}
+
+				for i, v := range array {
+					if v != expected[i] {
+						t.Errorf("Expected array[%d] to be %v, got %v", i, expected[i], v)
+					}
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "mixed types with boolean strings",
+			input: `{
+				"mixed": {
+					"bool1": "true",
+					"bool2": true,
+					"string": "not a boolean",
+					"number": 42,
+					"nested": {
+						"deepBool": "false"
+					}
+				}
+			}`,
+			check: func(t *testing.T, data []byte) {
+				var result map[string]interface{}
+				json.Unmarshal(data, &result)
+
+				mixed := result["mixed"].(map[string]interface{})
+				if mixed["bool1"] != true {
+					t.Errorf("Expected mixed.bool1 to be true, got %v", mixed["bool1"])
+				}
+				if mixed["bool2"] != true {
+					t.Errorf("Expected mixed.bool2 to be true, got %v", mixed["bool2"])
+				}
+				if mixed["string"] != "not a boolean" {
+					t.Errorf("Expected mixed.string to remain unchanged, got %v", mixed["string"])
+				}
+				if mixed["number"] != float64(42) {
+					t.Errorf("Expected mixed.number to be 42, got %v", mixed["number"])
+				}
+
+				nested := mixed["nested"].(map[string]interface{})
+				if nested["deepBool"] != false {
+					t.Errorf("Expected mixed.nested.deepBool to be false, got %v", nested["deepBool"])
+				}
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// First, let's see what the conversion produces
+			var rawData interface{}
+			json.Unmarshal([]byte(tt.input), &rawData)
+			convertBooleanStrings(rawData)
+			modifiedData, _ := json.Marshal(rawData)
+
+			// Run the check function on the modified data
+			if tt.check != nil {
+				tt.check(t, modifiedData)
+			}
+		})
+	}
+}

--- a/pkg/rpc/gateway/gateway_test.go
+++ b/pkg/rpc/gateway/gateway_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBooleanConversionMarshaler_PreprocessJSON(t *testing.T) {
+	t.Parallel()
 	marshaler := &BooleanConversionMarshaler{}
 
 	tests := []struct {
@@ -203,6 +204,7 @@ func TestBooleanConversionMarshaler_PreprocessJSON(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			// Test the preprocessJSON method
 			processedData := marshaler.preprocessJSON([]byte(tt.input))
 
@@ -215,6 +217,7 @@ func TestBooleanConversionMarshaler_PreprocessJSON(t *testing.T) {
 }
 
 func TestStringToBool(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name     string
 		input    string
@@ -236,6 +239,7 @@ func TestStringToBool(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			gotBool, gotOk := stringToBool(tt.input)
 			if gotBool != tt.wantBool {
 				t.Errorf("stringToBool() gotBool = %v, want %v", gotBool, tt.wantBool)
@@ -248,6 +252,7 @@ func TestStringToBool(t *testing.T) {
 }
 
 func TestBooleanConversionMarshaler_Integration(t *testing.T) {
+	t.Parallel()
 	marshaler := &BooleanConversionMarshaler{
 		JSONPb: runtime.JSONPb{
 			UnmarshalOptions: protojson.UnmarshalOptions{
@@ -283,6 +288,7 @@ func TestBooleanConversionMarshaler_Integration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			if tt.check != nil {
 				tt.check(t, marshaler)
 			}

--- a/test/e2e/gateway/api_test.go
+++ b/test/e2e/gateway/api_test.go
@@ -22,12 +22,13 @@ import (
 
 	"google.golang.org/protobuf/encoding/protojson"
 
+	"github.com/stretchr/testify/assert"
+
 	gwapi "github.com/bucketeer-io/bucketeer/pkg/api/api"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/client"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 	userproto "github.com/bucketeer-io/bucketeer/proto/user"
 	"github.com/bucketeer-io/bucketeer/test/e2e/util"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGetEvaluationsFeatureFlagEnabled(t *testing.T) {


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/1803

Related to https://github.com/bucketeer-io/android-client-sdk/pull/230

Add a temporary custom JSON unmarshaler to handle boolean fields sent as strings from the Android SDK. This addresses a compatibility issue that arose after switching from Envoy JSON transcoder to gRPC-Gateway.

Changes:
- Implement customJSONPb struct with custom Unmarshal method
- Support multiple boolean string representations ("true", "false", "1", "0", etc.)
- Handle nested JSON structures with recursive boolean string conversion
- Preserve original errors for invalid inputs
- Add comprehensive test coverage for all scenarios

The unmarshaler follows this logic:
1. First attempts at standard protobuf unmarshaling
2. If that fails, checks for boolean string representations
3. Recursively converts boolean strings in nested objects and arrays
4. Returns the original error for non-boolean invalid strings

Supported boolean string formats:
- True: "true", "True", "TRUE", "1"
- False: "false", "False", "FALSE", "0"

This is a temporary solution to maintain backward compatibility while the Android SDK is updated to send proper boolean types instead of strings.