### PR TITLE
fix: add EntityType value when getting tag list

### DIFF
--- a/pkg/tag/api/api.go
+++ b/pkg/tag/api/api.go
@@ -222,6 +222,7 @@ func (s *TagService) ListTags(
 		filters = append(filters, &mysql.FilterV2{
 			Column:   "tag.entity_type",
 			Operator: mysql.OperatorEqual,
+			Value:    req.EntityType,
 		})
 	}
 	orders, err := s.newListTagsOrdersMySQL(req.OrderBy, req.OrderDirection, localizer)


### PR DESCRIPTION
When addressing #1812, the code to specify the EntityType value was missing.