### PR TITLE
fix(ui/dashboard): sidebar not updating when clicking on the bucketeer logo

### DIFF
--- a/ui/dashboard/src/components/navigation/index.tsx
+++ b/ui/dashboard/src/components/navigation/index.tsx
@@ -139,7 +139,7 @@ const Navigation = ({ onClickNavLink }: { onClickNavLink: () => void }) => {
   return (
     <div className="fixed h-screen w-[248px] bg-primary-500 z-50 py-8 px-6">
       <div className="flex flex-col size-full relative overflow-hidden">
-        <Link to={ROUTING.PAGE_PATH_ROOT}>
+        <Link to={ROUTING.PAGE_PATH_ROOT} onClick={onCloseSetting}>
           <img src={logo} alt="Bucketer" />
         </Link>
 


### PR DESCRIPTION
When the user is in the organization settings menu, clicking on the Bucketeer logo redirects to the flag list page, but it doesn't update the sidebar.

Fix #1871 