### PR TITLE
feat(ui/dashboard): restrict the environment list when creating fcm and slack notifications

### DIFF
--- a/ui/dashboard/src/@api/notification/notifications-fetcher.ts
+++ b/ui/dashboard/src/@api/notification/notifications-fetcher.ts
@@ -6,6 +6,7 @@ import { stringifyParams } from 'utils/search-params';
 
 export interface NotificationsFetcherParams extends CollectionParams {
   environmentId?: string;
+  environmentIds?: string[];
   organizationId: string;
 }
 

--- a/ui/dashboard/src/@api/push/pushes-fetcher.ts
+++ b/ui/dashboard/src/@api/push/pushes-fetcher.ts
@@ -7,6 +7,7 @@ import { stringifyParams } from 'utils/search-params';
 export interface PushesFetcherParams extends CollectionParams {
   environmentId?: string;
   organizationId?: string;
+  environmentIds?: string[];
 }
 
 export const pushesFetcher = async (

--- a/ui/dashboard/src/auth/utils.ts
+++ b/ui/dashboard/src/auth/utils.ts
@@ -72,3 +72,10 @@ export const getEnvironmentsByProjectId = (
     .filter(role => role.environment.projectId === projectId)
     .map(role => role.environment);
 };
+
+export const getEditorEnvironmentIds = (account: ConsoleAccount): string[] => {
+  const ids = account.environmentRoles
+    .filter(item => item.role === 'Environment_EDITOR')
+    .map(item => item.environment.id);
+  return ids;
+};

--- a/ui/dashboard/src/pages/notifications/collection-loader/index.tsx
+++ b/ui/dashboard/src/pages/notifications/collection-loader/index.tsx
@@ -1,5 +1,5 @@
 import { SortingState } from '@tanstack/react-table';
-import { getCurrentEnvironment, useAuth } from 'auth';
+import { getCurrentEnvironment, getEditorEnvironmentIds, useAuth } from 'auth';
 import { sortingListFields } from 'constants/collection';
 import { Notification } from '@types';
 import { isNotEmpty } from 'utils/data-type';
@@ -29,6 +29,7 @@ const CollectionLoader = ({
   const columns = useColumns({ onActions });
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
+  const editorEnvironmentIds = getEditorEnvironmentIds(consoleAccount!);
 
   const {
     data: collection,
@@ -37,6 +38,7 @@ const CollectionLoader = ({
     isError
   } = useFetchNotifications({
     ...filters,
+    environmentIds: editorEnvironmentIds,
     organizationId: currentEnvironment.organizationId
   });
 

--- a/ui/dashboard/src/pages/notifications/collection-loader/use-fetch-notifications.ts
+++ b/ui/dashboard/src/pages/notifications/collection-loader/use-fetch-notifications.ts
@@ -10,6 +10,7 @@ export const useFetchNotifications = ({
   orderDirection,
   disabled,
   environmentId,
+  environmentIds,
   organizationId
 }: {
   pageSize?: number;
@@ -19,6 +20,7 @@ export const useFetchNotifications = ({
   orderDirection?: OrderDirection;
   disabled?: boolean;
   environmentId?: string;
+  environmentIds?: string[];
   organizationId: string;
 }) => {
   const cursor = (page - 1) * LIST_PAGE_SIZE;
@@ -32,6 +34,7 @@ export const useFetchNotifications = ({
       searchKeyword: searchQuery,
       disabled,
       environmentId,
+      environmentIds,
       organizationId
     }
   });

--- a/ui/dashboard/src/pages/pushes/collection-layout/data-collection.tsx
+++ b/ui/dashboard/src/pages/pushes/collection-layout/data-collection.tsx
@@ -60,6 +60,7 @@ export const useColumns = ({
     {
       accessorKey: 'tags',
       header: `${t('tags')}`,
+      enableSorting: false,
       size: 350,
       cell: ({ row }) => {
         const push = row.original;

--- a/ui/dashboard/src/pages/pushes/collection-loader/index.tsx
+++ b/ui/dashboard/src/pages/pushes/collection-loader/index.tsx
@@ -1,5 +1,5 @@
 import { SortingState } from '@tanstack/react-table';
-import { getCurrentEnvironment, useAuth } from 'auth';
+import { getCurrentEnvironment, getEditorEnvironmentIds, useAuth } from 'auth';
 import { sortingListFields } from 'constants/collection';
 import { Push } from '@types';
 import { isNotEmpty } from 'utils/data-type';
@@ -29,6 +29,7 @@ const CollectionLoader = ({
 }) => {
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
+  const editorEnvironmentIds = getEditorEnvironmentIds(consoleAccount!);
 
   const { data: tagCollection, isLoading: isLoadingTags } = useFetchTags({
     organizationId: currentEnvironment.organizationId,
@@ -45,6 +46,7 @@ const CollectionLoader = ({
     isError
   } = useFetchPushes({
     ...filters,
+    environmentIds: editorEnvironmentIds,
     organizationId: currentEnvironment.organizationId
   });
 

--- a/ui/dashboard/src/pages/pushes/collection-loader/use-fetch-pushes.ts
+++ b/ui/dashboard/src/pages/pushes/collection-loader/use-fetch-pushes.ts
@@ -9,7 +9,8 @@ export const useFetchPushes = ({
   searchQuery,
   orderDirection,
   disabled,
-  organizationId
+  organizationId,
+  environmentIds
 }: {
   pageSize?: number;
   page?: number;
@@ -18,6 +19,7 @@ export const useFetchPushes = ({
   orderDirection?: OrderDirection;
   disabled?: boolean;
   organizationId?: string;
+  environmentIds?: string[];
 } = {}) => {
   const cursor = (page - 1) * LIST_PAGE_SIZE;
 
@@ -29,7 +31,8 @@ export const useFetchPushes = ({
       orderDirection,
       searchKeyword: searchQuery,
       disabled,
-      organizationId
+      organizationId,
+      environmentIds
     }
   });
 };


### PR DESCRIPTION
For the FCM and Slack Create pages, I need to change the implementation of the environment list.
We must check the environment_roles from the local storage (retrieved by the get_me API), and create a list of environments where the user has the Editor role instead of calling the list_environments API, which includes all environments even if the user doesn't belong to them.

Currently, if the user tries to create using an environment he doesn't belong to, the request will fail.

Fix #1870 