### PR TITLE
feat(ui/dashboard): add status and has a flag as a rule filter options

### DIFF
--- a/ui/dashboard/src/@api/features/features-fetch.ts
+++ b/ui/dashboard/src/@api/features/features-fetch.ts
@@ -3,6 +3,7 @@ import pickBy from 'lodash/pickBy';
 import { CollectionParams, FeatureCollection } from '@types';
 import { isNotEmpty } from 'utils/data-type';
 import { stringifyParams } from 'utils/search-params';
+import { StatusFilterType } from 'pages/feature-flags/types';
 
 export interface FeaturesFetcherParams extends CollectionParams {
   environmentId: string;
@@ -12,6 +13,8 @@ export interface FeaturesFetcherParams extends CollectionParams {
   enabled?: boolean;
   hasPrerequisites?: boolean;
   tags?: string[];
+  status?: StatusFilterType;
+  hasFeatureFlagAsRule?: boolean;
 }
 
 export const featuresFetcher = async (

--- a/ui/dashboard/src/pages/feature-flags/collection-layout/grid-view-collection.tsx
+++ b/ui/dashboard/src/pages/feature-flags/collection-layout/grid-view-collection.tsx
@@ -153,7 +153,7 @@ const GridViewCollection = ({
                 </div>
                 <Popover
                   options={compact([
-                    searchOptions.status === 'ARCHIVED'
+                    searchOptions.tab === 'ARCHIVED'
                       ? {
                           label: `${t('unarchive-flag')}`,
                           icon: IconArchiveOutlined,

--- a/ui/dashboard/src/pages/feature-flags/collection-loader/index.tsx
+++ b/ui/dashboard/src/pages/feature-flags/collection-loader/index.tsx
@@ -100,7 +100,9 @@ const CollectionLoader = ({
           filters?.hasExperiment ??
           filters?.hasPrerequisites ??
           filters?.maintainer ??
-          filters?.tags
+          filters?.tags ??
+          filters?.status ??
+          filters?.hasFeatureFlagAsRule
       )}
       searchQuery={filters?.searchQuery}
       onClear={onClearFilters}

--- a/ui/dashboard/src/pages/feature-flags/collection-loader/use-fetch-flags.ts
+++ b/ui/dashboard/src/pages/feature-flags/collection-loader/use-fetch-flags.ts
@@ -1,6 +1,7 @@
 import { useQueryFeatures } from '@queries/features';
 import { LIST_PAGE_SIZE } from 'constants/app';
 import { CollectionStatusType, OrderBy, OrderDirection } from '@types';
+import { StatusFilterType } from '../types';
 
 export const useFetchFlags = ({
   page = 1,
@@ -14,7 +15,9 @@ export const useFetchFlags = ({
   enabled,
   hasPrerequisites,
   tags,
-  status
+  tab,
+  status,
+  hasFeatureFlagAsRule
 }: {
   environmentId: string;
   pageSize?: number;
@@ -27,7 +30,9 @@ export const useFetchFlags = ({
   enabled?: boolean;
   hasPrerequisites?: boolean;
   tags?: string[];
-  status: CollectionStatusType;
+  tab: CollectionStatusType;
+  status?: StatusFilterType;
+  hasFeatureFlagAsRule?: boolean;
 }) => {
   const cursor = (page - 1) * LIST_PAGE_SIZE;
 
@@ -41,10 +46,12 @@ export const useFetchFlags = ({
       environmentId,
       maintainer,
       enabled,
-      archived: status === 'ARCHIVED',
+      archived: tab === 'ARCHIVED',
       hasExperiment,
       hasPrerequisites,
-      tags
+      tags,
+      status,
+      hasFeatureFlagAsRule
     }
   });
 };

--- a/ui/dashboard/src/pages/feature-flags/overview/index.tsx
+++ b/ui/dashboard/src/pages/feature-flags/overview/index.tsx
@@ -1,18 +1,17 @@
 import { FunctionComponent } from 'react';
 import { useTranslation } from 'i18n';
-import { ExperimentStatus, FeatureCountByStatus } from '@types';
+import { FeatureCountByStatus } from '@types';
 import { cn } from 'utils/style';
 import { IconActiveFlags, IconInactiveFlags, IconTotalFlags } from '@icons';
 import OverviewCard, { OverviewIconColor } from 'elements/overview-card';
-import { SummaryType } from '../types';
+import { StatusFilterType } from '../types';
 
 interface OverviewOption {
   titleKey: string;
   countKey?: keyof FeatureCountByStatus;
   color: OverviewIconColor;
   icon: FunctionComponent;
-  summaryFilterValue: SummaryType;
-  filterValues: ExperimentStatus[];
+  filterValue: StatusFilterType | undefined;
 }
 
 const overviewOptions: OverviewOption[] = [
@@ -21,38 +20,32 @@ const overviewOptions: OverviewOption[] = [
     countKey: 'total',
     color: 'brand',
     icon: IconTotalFlags,
-    summaryFilterValue: 'TOTAL',
-    filterValues: []
+    filterValue: undefined
   },
   {
     titleKey: 'feature-flags.active-flags',
     countKey: 'active',
     color: 'green',
     icon: IconActiveFlags,
-    summaryFilterValue: 'ACTIVE',
-    filterValues: []
+    filterValue: StatusFilterType.ACTIVE
   },
   {
     titleKey: 'feature-flags.inactive-flags',
     countKey: 'inactive',
     color: 'yellow',
     icon: IconInactiveFlags,
-    summaryFilterValue: 'INACTIVE',
-    filterValues: []
+    filterValue: StatusFilterType.NO_ACTIVITY
   }
 ];
 
 const Overview = ({
   summary,
-  filterBySummary,
+  statusFilter,
   onChangeFilters
 }: {
   summary?: FeatureCountByStatus;
-  filterBySummary?: SummaryType;
-  onChangeFilters: (
-    statuses: ExperimentStatus[],
-    summaryFilterValue: SummaryType
-  ) => void;
+  statusFilter?: StatusFilterType;
+  onChangeFilters: (filterValue: StatusFilterType | undefined) => void;
 }) => {
   const { t } = useTranslation(['table']);
 
@@ -69,12 +62,9 @@ const Overview = ({
             color={item.color}
             icon={item.icon}
             className={cn('border border-transparent', {
-              'border-gray-300':
-                filterBySummary && item.summaryFilterValue === filterBySummary
+              'border-gray-300': item.filterValue === statusFilter
             })}
-            onClick={() =>
-              onChangeFilters(item.filterValues, item.summaryFilterValue)
-            }
+            onClick={() => onChangeFilters(item.filterValue)}
           />
         ))}
       </div>

--- a/ui/dashboard/src/pages/feature-flags/page-content.tsx
+++ b/ui/dashboard/src/pages/feature-flags/page-content.tsx
@@ -41,7 +41,7 @@ const PageContent = ({
     page: 1,
     orderBy: 'CREATED_AT',
     orderDirection: 'DESC',
-    status: 'ACTIVE',
+    tab: 'ACTIVE',
     ...searchFilters
   } as FlagFilters;
 
@@ -53,7 +53,9 @@ const PageContent = ({
       'hasPrerequisites',
       'maintainer',
       'enabled',
-      'tags'
+      'tags',
+      'status',
+      'hasFeatureFlagAsRule'
     ];
     const count = filterKeys.reduce((acc, curr) => {
       if (isNotEmpty(filters[curr as keyof FlagFilters])) ++acc;
@@ -83,7 +85,9 @@ const PageContent = ({
       enabled: undefined,
       archived: undefined,
       tags: undefined,
-      status: 'ACTIVE'
+      tab: 'ACTIVE',
+      status: undefined,
+      hasFeatureFlagAsRule: undefined
     });
     onCloseFilterModal();
   }, [filters]);
@@ -105,14 +109,22 @@ const PageContent = ({
         enabled: undefined,
         archived: undefined,
         tags: undefined,
-        status: 'ACTIVE'
+        tab: 'ACTIVE'
       });
     }
   }, [location]);
 
   return (
     <PageLayout.Content>
-      <Overview summary={summary} onChangeFilters={() => {}} />
+      <Overview
+        summary={summary}
+        statusFilter={filters?.status}
+        onChangeFilters={status =>
+          onChangeFilters({
+            status
+          })
+        }
+      />
       <Filter
         action={
           <>
@@ -142,13 +154,13 @@ const PageContent = ({
       )}
       <Tabs
         className="flex-1 flex h-full flex-col mt-6"
-        value={filters.status}
+        value={filters.tab}
         onValueChange={value => {
-          const status = value as CollectionStatusType;
+          const tab = value as CollectionStatusType;
           onChangeFilters({
             searchQuery: '',
-            status,
-            archived: status === 'ARCHIVED' || undefined
+            tab,
+            archived: tab === 'ARCHIVED' || undefined
           });
         }}
       >
@@ -159,7 +171,7 @@ const PageContent = ({
           </TabsList>
         )}
 
-        <TabsContent value={filters.status} className="pb-6">
+        <TabsContent value={filters.tab} className="pb-6">
           <TableListContainer>
             <CollectionLoader
               filters={filters}

--- a/ui/dashboard/src/pages/feature-flags/types.ts
+++ b/ui/dashboard/src/pages/feature-flags/types.ts
@@ -7,7 +7,13 @@ export type FlagActionType =
   | 'CLONE'
   | 'ACTIVE'
   | 'INACTIVE';
-export type SummaryType = 'TOTAL' | 'ACTIVE' | 'INACTIVE';
+
+export enum StatusFilterType {
+  NEW = 'NEW',
+  ACTIVE = 'ACTIVE',
+  NO_ACTIVITY = 'NO_ACTIVITY',
+  UNKNOWN = 'UNKNOWN'
+}
 
 export interface FlagFilters {
   page: number;
@@ -15,7 +21,7 @@ export interface FlagFilters {
   orderDirection: OrderDirection;
   archived?: boolean;
   searchQuery: string;
-  status: CollectionStatusType;
+  tab: CollectionStatusType;
   environmentId: string;
   pageSize?: number;
   maintainer?: string;
@@ -23,6 +29,8 @@ export interface FlagFilters {
   enabled?: boolean;
   hasPrerequisites?: boolean;
   tags?: string[];
+  status?: StatusFilterType;
+  hasFeatureFlagAsRule?: boolean;
 }
 
 export enum FeatureActivityStatus {


### PR DESCRIPTION
Add the new filters to the flag list page.
- Status (Active, Inactive, and New)
- Has a flag as a rule (Yes or No)

For the Status, I want you to also add template filters on the cards at the top of the page.

Fix #1869 