### PR TITLE
fix: race condition when creating tags

### DIFF
--- a/pkg/tag/storage/mock/tag.go
+++ b/pkg/tag/storage/mock/tag.go
@@ -72,6 +72,21 @@ func (mr *MockTagStorageMockRecorder) GetTag(ctx, id, environmentId any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTag", reflect.TypeOf((*MockTagStorage)(nil).GetTag), ctx, id, environmentId)
 }
 
+// GetTagByName mocks base method.
+func (m *MockTagStorage) GetTagByName(ctx context.Context, name, environmentId string, entityType tag.Tag_EntityType) (*domain.Tag, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTagByName", ctx, name, environmentId, entityType)
+	ret0, _ := ret[0].(*domain.Tag)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTagByName indicates an expected call of GetTagByName.
+func (mr *MockTagStorageMockRecorder) GetTagByName(ctx, name, environmentId, entityType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTagByName", reflect.TypeOf((*MockTagStorage)(nil).GetTagByName), ctx, name, environmentId, entityType)
+}
+
 // ListAllEnvironmentTags mocks base method.
 func (m *MockTagStorage) ListAllEnvironmentTags(ctx context.Context) ([]*tag.EnvironmentTag, error) {
 	m.ctrl.T.Helper()

--- a/pkg/tag/storage/sql/select_tag_by_name.sql
+++ b/pkg/tag/storage/sql/select_tag_by_name.sql
@@ -1,0 +1,16 @@
+SELECT 
+    tag.id,
+    tag.name,
+    tag.created_at,
+    tag.updated_at,
+    tag.entity_type,
+    tag.environment_id,
+    env.name as environment_name
+FROM
+    tag
+JOIN
+    environment_v2 env ON tag.environment_id = env.id
+WHERE
+    tag.name = ? AND
+    tag.environment_id = ? AND
+    tag.entity_type = ?


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/1927

This should fix the e2e test.
Also, when upserting an existing tag, it was sending the domain event using the incorrect ID and created_at. I fixed it, too.

```sh
=== NAME  TestUpsertAndListTag
    tag_test.go:85: Different create time. Expected: id:"140b2d6e-8b89-4b65-9227-6977112add8d" name:"e2e-test-16028583074-tag-5aaec30f-41da-4338-92fe-a9e07caf7e97" created_at:1751468519 updated_at:1751468519 entity_type:FEATURE_FLAG environment_id:"e2e" environment_name:"E2E environment"
        , Actual: id:"8d8bdcd6-69ff-4bc5-8760-9f40be155641" name:"e2e-test-16028583074-tag-5aaec30f-41da-4338-92fe-a9e07caf7e97" created_at:1751468524 updated_at:1751468524 entity_type:FEATURE_FLAG environment_id:"e2e" environment_name:"E2E environment"
--- FAIL: TestUpsertAndListTag (6.85s)
```