### PR TITLE
fix: cannot update an existing member on the new console

### DIFF
--- a/pkg/account/domain/account.go
+++ b/pkg/account/domain/account.go
@@ -43,9 +43,8 @@ var (
 	)
 	statusEmailIsEmpty            = gstatus.New(codes.InvalidArgument, "account: email is empty")
 	statusInvalidEmail            = gstatus.New(codes.InvalidArgument, "account: invalid email format")
-	statusFirstNameIsEmpty        = gstatus.New(codes.InvalidArgument, "account: first name is empty")
+	statusFullNameIsEmpty         = gstatus.New(codes.InvalidArgument, "account: full name is empty")
 	statusInvalidFirstName        = gstatus.New(codes.InvalidArgument, "account: invalid first name format")
-	statusLastNameIsEmpty         = gstatus.New(codes.InvalidArgument, "account: last name is empty")
 	statusInvalidLastName         = gstatus.New(codes.InvalidArgument, "account: invalid last name format")
 	statusLanguageIsEmpty         = gstatus.New(codes.InvalidArgument, "account: language is empty")
 	statusInvalidOrganizationRole = gstatus.New(codes.InvalidArgument, "account: invalid organization role")
@@ -364,6 +363,9 @@ func (a *AccountV2) resetDefaultFilter(targetFilter proto.FilterTargetType, envi
 }
 
 func (a *AccountV2) GetAccountFullName() string {
+	if a.FirstName == "" && a.LastName == "" {
+		return a.Name
+	}
 	if a.FirstName == "" {
 		return a.LastName
 	}
@@ -383,16 +385,18 @@ func validate(a *AccountV2) error {
 	if !emailRegex.MatchString(a.Email) {
 		return statusInvalidEmail.Err()
 	}
-	if a.FirstName == "" {
-		return statusFirstNameIsEmpty.Err()
+	// If both first name and last name are empty, the name field must not be empty
+	if a.FirstName == "" && a.LastName == "" {
+		if a.Name == "" {
+			return statusFullNameIsEmpty.Err()
+		}
 	}
-	if len(a.FirstName) > maxAccountNameLength {
+	// Validate first name length if it's provided
+	if a.FirstName != "" && len(a.FirstName) > maxAccountNameLength {
 		return statusInvalidFirstName.Err()
 	}
-	if a.LastName == "" {
-		return statusLastNameIsEmpty.Err()
-	}
-	if len(a.LastName) > maxAccountNameLength {
+	// Validate last name length if it's provided
+	if a.LastName != "" && len(a.LastName) > maxAccountNameLength {
 		return statusInvalidLastName.Err()
 	}
 	if a.Language == "" {

--- a/pkg/account/domain/account.go
+++ b/pkg/account/domain/account.go
@@ -387,6 +387,7 @@ func validate(a *AccountV2) error {
 	}
 	// If both first name and last name are empty, the name field must not be empty
 	if a.FirstName == "" && a.LastName == "" {
+		// TODO: This should be removed after the new console is released and the migration is completed
 		if a.Name == "" {
 			return statusFullNameIsEmpty.Err()
 		}

--- a/ui/dashboard/src/@locales/ja/common.json
+++ b/ui/dashboard/src/@locales/ja/common.json
@@ -172,7 +172,7 @@
   "conversion-rate": "コンバージョン率",
   "variations": "バリエーション",
   "experiments": "エクスペリメント",
-  "finished": "完了",
+  "finished": "終了",
   "flag": "フラグ",
   "goal": "ゴール",
   "goals-connected": "接続されたゴール",

--- a/ui/dashboard/src/@locales/ja/form.json
+++ b/ui/dashboard/src/@locales/ja/form.json
@@ -170,7 +170,7 @@
     "kill-switch-operation": "キルスイッチオペレーション",
     "enable-operation": "オペレーションを有効化",
     "schedule-operation": "スケジュールオペレーション",
-    "progress-information": "進行状況情報",
+    "progress-information": "進行状況",
     "stopped-at": "{{stoppedAt}}に停止",
     "user": "ユーザー",
     "progress-goal-value": "ゴール: <b>{{value}}</b>",


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/1943

Due to schema changes for the new console, the old members in the account table don't have the first and last names, which are being validated in the new API for the new console.
So, I changed the validation to allow the update if the `name` field is not empty.