### PR TITLE
chore: add metrics registerer to event writers and persisters

### DIFF
--- a/pkg/subscriber/cmd/server/server.go
+++ b/pkg/subscriber/cmd/server/server.go
@@ -590,6 +590,7 @@ func (s *server) registerPubSubProcessorMap(
 			exClient,
 			ftClient,
 			processor.EvaluationCountEventDWHPersisterName,
+			registerer,
 			logger,
 		)
 		if err != nil {
@@ -609,6 +610,7 @@ func (s *server) registerPubSubProcessorMap(
 			exClient,
 			ftClient,
 			processor.GoalCountEventDWHPersisterName,
+			registerer,
 			logger,
 		)
 		if err != nil {

--- a/pkg/subscriber/processor/evaluation_events_dwh.go
+++ b/pkg/subscriber/processor/evaluation_events_dwh.go
@@ -26,6 +26,7 @@ import (
 
 	cachev3 "github.com/bucketeer-io/bucketeer/pkg/cache/v3"
 	ec "github.com/bucketeer-io/bucketeer/pkg/experiment/client"
+	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/writer"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/subscriber/storage"
@@ -63,6 +64,7 @@ func NewEvalEventWriter(
 	project, ds string,
 	size int,
 	location *time.Location,
+	registerer metrics.Registerer,
 	options ...EvalEventWriterOption,
 ) (Writer, error) {
 	var option EvalEventWriterOption
@@ -101,6 +103,7 @@ func NewEvalEventWriter(
 		evaluationEventTable,
 		evt.ProtoReflect().Descriptor(),
 		writer.WithLogger(l),
+		writer.WithMetrics(registerer),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/subscriber/processor/events_dwh_persister.go
+++ b/pkg/subscriber/processor/events_dwh_persister.go
@@ -28,6 +28,7 @@ import (
 	experimentclient "github.com/bucketeer-io/bucketeer/pkg/experiment/client"
 	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
+	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
 	redisv3 "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
@@ -94,6 +95,7 @@ func NewEventsDWHPersister(
 	exClient experimentclient.Client,
 	ftClient featureclient.Client,
 	persisterName string,
+	registerer metrics.Registerer,
 	logger *zap.Logger,
 ) (subscriber.PubSubProcessor, error) {
 	jsonConfig, ok := config.(map[string]interface{})
@@ -190,6 +192,7 @@ func NewEventsDWHPersister(
 			dataset,
 			bigQueryBatchSize,
 			location,
+			registerer,
 			evalOptions...,
 		)
 		if err != nil {
@@ -236,6 +239,7 @@ func NewEventsDWHPersister(
 			persistentRedisClient,
 			time.Duration(e.eventsDWHPersisterConfig.MaxRetryGoalEventPeriod)*time.Second,
 			time.Duration(e.eventsDWHPersisterConfig.RetryGoalEventInterval)*time.Second,
+			registerer,
 			goalOptions...,
 		)
 		if err != nil {

--- a/pkg/subscriber/processor/goal_events_dwh.go
+++ b/pkg/subscriber/processor/goal_events_dwh.go
@@ -28,6 +28,7 @@ import (
 	ecstorage "github.com/bucketeer-io/bucketeer/pkg/eventcounter/storage/v2"
 	ec "github.com/bucketeer-io/bucketeer/pkg/experiment/client"
 	ft "github.com/bucketeer-io/bucketeer/pkg/feature/client"
+	"github.com/bucketeer-io/bucketeer/pkg/metrics"
 	redisv3 "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
 	bqquerier "github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/querier"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/writer"
@@ -77,6 +78,7 @@ func NewGoalEventWriter(
 	redisClient redisv3.Client,
 	maxRetryGoalEventPeriod time.Duration,
 	retryGoalEventInterval time.Duration,
+	registerer metrics.Registerer,
 	options ...GoalEventWriterOption,
 ) (Writer, error) {
 	var option GoalEventWriterOption
@@ -130,6 +132,7 @@ func NewGoalEventWriter(
 		goalEventTable,
 		evt.ProtoReflect().Descriptor(),
 		writer.WithLogger(logger),
+		writer.WithMetrics(registerer),
 	)
 	if err != nil {
 		return nil, err
@@ -139,6 +142,7 @@ func NewGoalEventWriter(
 		project,
 		bigQueryDataLocation,
 		bqquerier.WithLogger(logger),
+		bqquerier.WithMetrics(registerer),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We can't collect BigQuery metrics now, so added metrics registerer to event writers and persisters.