### PR TITLE
test: fix flaky e2e boolean string handling test

### DIFF
--- a/test/e2e/gateway/api_test.go
+++ b/test/e2e/gateway/api_test.go
@@ -202,162 +202,197 @@ func TestHTTPBooleanStringHandling(t *testing.T) {
 	// boolean strings sent from the Android SDK via HTTP requests,
 	// specifically the userAttributesUpdated field in get_evaluations API
 
+	client := newFeatureClient(t)
+	defer client.Close()
+	uuid := newUUID(t)
+	tag := fmt.Sprintf("%s-tag-%s", prefixTestName, uuid)
+	userID := newUserID(t, uuid)
+	featureID := newFeatureID(t, uuid)
+	cmd := newCreateFeatureCommand(featureID)
+	createFeature(t, client, cmd)
+	addTag(t, tag, featureID, client)
+	enableFeature(t, featureID, client)
+	// Update feature flag cache
+	updateFeatueFlagCache(t)
+
 	testCases := []struct {
 		name        string
 		description string
-		requestBody map[string]interface{}
+		requestBody func(uuid, tag, userID string) map[string]interface{}
 	}{
 		{
 			name:        "boolean_string_true_lowercase",
 			description: "userAttributesUpdated as 'true' string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationsId": "test-evaluations-id",
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "true",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationsId": fmt.Sprintf("test-evaluations-id-%s", uuid),
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "true",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_false_lowercase",
 			description: "userAttributesUpdated as 'false' string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "false",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "false",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_true_titlecase",
 			description: "userAttributesUpdated as 'True' string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "True",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "True",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_false_titlecase",
 			description: "userAttributesUpdated as 'False' string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "False",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "False",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_true_uppercase",
 			description: "userAttributesUpdated as 'TRUE' string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "TRUE",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "TRUE",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_false_uppercase",
 			description: "userAttributesUpdated as 'FALSE' string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "FALSE",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "FALSE",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_numeric_1",
 			description: "userAttributesUpdated as '1' string (true)",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "1",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "1",
+					},
+				}
 			},
 		},
 		{
 			name:        "boolean_string_numeric_0",
 			description: "userAttributesUpdated as '0' string (false)",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "0",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "0",
+					},
+				}
 			},
 		},
 		{
 			name:        "empty_user_evaluation_condition",
 			description: "Empty user evaluation condition object",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{},
+				}
 			},
 		},
 		{
 			name:        "null_user_data",
 			description: "User data is null with boolean string",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id":   "test-user-id",
-					"data": nil,
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": "false",
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id":   userID,
+						"data": nil,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": "false",
+					},
+				}
 			},
 		},
 		{
 			name:        "actual_boolean_value",
 			description: "userAttributesUpdated as actual boolean (not string)",
-			requestBody: map[string]interface{}{
-				"tag": "test-tag",
-				"user": map[string]interface{}{
-					"id": "test-user-id",
-				},
-				"userEvaluationCondition": map[string]interface{}{
-					"evaluatedAt":           time.Now().Unix() - 60,
-					"userAttributesUpdated": true, // actual boolean
-				},
+			requestBody: func(uuid, tag, userID string) map[string]interface{} {
+				return map[string]interface{}{
+					"tag": tag,
+					"user": map[string]interface{}{
+						"id": userID,
+					},
+					"userEvaluationCondition": map[string]interface{}{
+						"evaluatedAt":           time.Now().Unix() - 60,
+						"userAttributesUpdated": true, // actual boolean
+					},
+				}
 			},
 		},
 	}
@@ -366,9 +401,8 @@ func TestHTTPBooleanStringHandling(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
 			// Make the HTTP request - should succeed for all cases
-			response := util.GetEvaluationsRaw(t, tc.requestBody, *gatewayAddr, *apiKeyPath)
+			response := util.GetEvaluationsRaw(t, tc.requestBody(uuid, tag, userID), *gatewayAddr, *apiKeyPath)
 
 			// Verify we got a valid response (no error occurred)
 			assert.NotNil(t, response, "Response should not be nil for test case: %s", tc.description)


### PR DESCRIPTION
Error log:

```sh
=== CONT  TestHTTPBooleanStringHandling/boolean_string_false_uppercase
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"13298090430196981890", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130806", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/actual_boolean_value
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"13298090430196981890", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/null_user_data
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"13298090430196981890", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/empty_user_evaluation_condition
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"13152072191500085605", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/boolean_string_numeric_0
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"13152072191500085605", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/boolean_string_numeric_1
--- PASS: TestGrpcGetEvaluation (3.59s)
=== CONT  TestHTTPBooleanStringHandling/boolean_string_true_titlecase
=== NAME  TestHTTPBooleanStringHandling/boolean_string_numeric_1
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"13152072191500085605", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/boolean_string_true_uppercase
=== NAME  TestHTTPBooleanStringHandling/boolean_string_true_titlecase
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"11807928611137478314", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/boolean_string_false_titlecase
=== NAME  TestHTTPBooleanStringHandling/boolean_string_true_uppercase
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"11807928611137478314", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== CONT  TestHTTPBooleanStringHandling/boolean_string_false_lowercase
=== NAME  TestHTTPBooleanStringHandling/boolean_string_false_titlecase
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"11807928611137478314", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
=== NAME  TestHTTPBooleanStringHandling/boolean_string_false_lowercase
    api_test.go:371: Failed to unmarshal response: json: cannot unmarshal string into Go struct field Reason.evaluations.evaluations.reason.type of type feature.Reason_Type, data: {"state":"FULL", "evaluations":{"id":"11807928611137478314", "evaluations":[{"id":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8:1:test-user-id", "featureId":"e2e-test-16188104694-feature-id-c710f04f-764e-4147-9a74-988983c830e8", "featureVersion":1, "userId":"test-user-id", "variationId":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "variation":{"id":"31fb70c7-d15b-4ae0-896d-e9e486d1d5e1", "value":"B", "name":"Variation B", "description":""}, "reason":{"type":"OFF_VARIATION", "ruleId":""}, "variationValue":"B", "variationName":"Variation B"}], "createdAt":"1752130807", "archivedFeatureIds":["e2e-test-16188104694-feature-id-2d20e5ec-79ad-45c5-8b01-2bfe0229feb2", "e2e-test-16188104694-feature-id-40ca01e4-11d6-4b6a-849b-6b9efa0ca464", "e2e-test-16188104694-feature-id-8f2f49da-e34b-4a8b-8e84-fb9eb1ae4f15", "e2e-test-16188104694-feature-id-cc19d240-70f7-45a2-9e51-778f9f6bc79e", "e2e-test-16188104694-feature-id-d2196eb9-76d4-4422-99cb-5b4ebd39a029"], "forceUpdate":true}, "userEvaluationsId":"14440634603203325333"}
--- FAIL: TestHTTPBooleanStringHandling (0.00s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_true_lowercase (0.39s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_false_uppercase (0.14s)
    --- FAIL: TestHTTPBooleanStringHandling/actual_boolean_value (0.14s)
    --- FAIL: TestHTTPBooleanStringHandling/null_user_data (0.13s)
    --- FAIL: TestHTTPBooleanStringHandling/empty_user_evaluation_condition (0.13s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_numeric_0 (0.15s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_numeric_1 (0.13s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_true_titlecase (0.13s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_true_uppercase (0.13s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_false_titlecase (0.14s)
    --- FAIL: TestHTTPBooleanStringHandling/boolean_string_false_lowercase (0.13s)
```