### PR TITLE
fix: flag only updating the updated_at field

### DIFF
--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1107,7 +1107,7 @@ func (s *FeatureService) UpdateFeature(
 			feature.Feature,
 			// check require comment.
 			domainevent.WithComment(req.Comment),
-			domainevent.WithNewVersion(feature.Version),
+			domainevent.WithNewVersion(updated.Version),
 		)
 		if err != nil {
 			return err

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -3095,7 +3095,7 @@ func TestUpdateTagsGranular(t *testing.T) {
 			expectedFunc: func() *Feature {
 				return genF()
 			},
-			expectedErr: errors.New("feature: value not found"),
+			expectedErr: errors.New("feature: tag not found"),
 		},
 	}
 

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -23,24 +23,24 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	"github.com/bucketeer-io/bucketeer/proto/common"
-	"github.com/bucketeer-io/bucketeer/proto/feature"
-	proto "github.com/bucketeer-io/bucketeer/proto/feature"
+	ftproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
 func makeFeature(id string) *Feature {
 	return &Feature{
-		Feature: &proto.Feature{
+		Feature: &ftproto.Feature{
 			Id:            id,
 			Name:          "test feature",
 			Version:       1,
 			Enabled:       true,
 			CreatedAt:     time.Now().Unix(),
-			VariationType: feature.Feature_STRING,
-			Variations: []*proto.Variation{
+			VariationType: ftproto.Feature_STRING,
+			Variations: []*ftproto.Variation{
 				{
 					Id:          "variation-A",
 					Value:       "A",
@@ -60,7 +60,7 @@ func makeFeature(id string) *Feature {
 					Description: "Thing does C",
 				},
 			},
-			Targets: []*proto.Target{
+			Targets: []*ftproto.Target{
 				{
 					Variation: "variation-A",
 					Users: []string{
@@ -80,20 +80,20 @@ func makeFeature(id string) *Feature {
 					},
 				},
 			},
-			Rules: []*proto.Rule{
+			Rules: []*ftproto.Rule{
 				{
 					Id: "rule-1",
-					Strategy: &proto.Strategy{
-						Type: proto.Strategy_FIXED,
-						FixedStrategy: &proto.FixedStrategy{
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_FIXED,
+						FixedStrategy: &ftproto.FixedStrategy{
 							Variation: "variation-A",
 						},
 					},
-					Clauses: []*proto.Clause{
+					Clauses: []*ftproto.Clause{
 						{
 							Id:        "clause-1",
 							Attribute: "name",
-							Operator:  proto.Clause_EQUALS,
+							Operator:  ftproto.Clause_EQUALS,
 							Values: []string{
 								"user1",
 								"user2",
@@ -103,17 +103,17 @@ func makeFeature(id string) *Feature {
 				},
 				{
 					Id: "rule-2",
-					Strategy: &proto.Strategy{
-						Type: proto.Strategy_FIXED,
-						FixedStrategy: &proto.FixedStrategy{
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_FIXED,
+						FixedStrategy: &ftproto.FixedStrategy{
 							Variation: "variation-B",
 						},
 					},
-					Clauses: []*proto.Clause{
+					Clauses: []*ftproto.Clause{
 						{
 							Id:        "clause-2",
 							Attribute: "name",
-							Operator:  proto.Clause_EQUALS,
+							Operator:  ftproto.Clause_EQUALS,
 							Values: []string{
 								"user3",
 								"user4",
@@ -122,9 +122,9 @@ func makeFeature(id string) *Feature {
 					},
 				},
 			},
-			DefaultStrategy: &proto.Strategy{
-				Type: proto.Strategy_FIXED,
-				FixedStrategy: &proto.FixedStrategy{
+			DefaultStrategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{
 					Variation: "variation-B",
 				},
 			},
@@ -139,8 +139,8 @@ func TestNewFeature(t *testing.T) {
 		id                       string
 		name                     string
 		description              string
-		variationType            feature.Feature_VariationType
-		variations               []*feature.Variation
+		variationType            ftproto.Feature_VariationType
+		variations               []*ftproto.Variation
 		tags                     []string
 		defaultOnVariationIndex  int
 		defaultOffVariationIndex int
@@ -152,8 +152,8 @@ func TestNewFeature(t *testing.T) {
 			id:            "test-feature",
 			name:          "test feature",
 			description:   "test feature description",
-			variationType: feature.Feature_BOOLEAN,
-			variations: []*feature.Variation{
+			variationType: ftproto.Feature_BOOLEAN,
+			variations: []*ftproto.Variation{
 				{
 					Value:       "true",
 					Name:        "Variation A",
@@ -171,8 +171,8 @@ func TestNewFeature(t *testing.T) {
 			id:            "test-feature",
 			name:          "test feature",
 			description:   "test feature description",
-			variationType: feature.Feature_BOOLEAN,
-			variations: []*feature.Variation{
+			variationType: ftproto.Feature_BOOLEAN,
+			variations: []*ftproto.Variation{
 				{
 					Value:       "true",
 					Name:        "Variation A",
@@ -195,8 +195,8 @@ func TestNewFeature(t *testing.T) {
 			id:            "test-feature",
 			name:          "test feature",
 			description:   "test feature description",
-			variationType: feature.Feature_BOOLEAN,
-			variations: []*feature.Variation{
+			variationType: ftproto.Feature_BOOLEAN,
+			variations: []*ftproto.Variation{
 				{
 					Value:       "true",
 					Name:        "Variation A",
@@ -219,8 +219,8 @@ func TestNewFeature(t *testing.T) {
 			id:            "test-feature",
 			name:          "test feature",
 			description:   "test feature description",
-			variationType: feature.Feature_BOOLEAN,
-			variations: []*feature.Variation{
+			variationType: ftproto.Feature_BOOLEAN,
+			variations: []*ftproto.Variation{
 				{
 					Value:       "true",
 					Name:        "Variation A",
@@ -284,29 +284,29 @@ func TestAddVariation(t *testing.T) {
 	id2, _ := uuid.NewUUID()
 	patterns := []struct {
 		desc          string
-		variationType feature.Feature_VariationType
+		variationType ftproto.Feature_VariationType
 		id            string
 		name          string
 		value         string
 		description   string
 		expectedErr   error
-		variations    []*feature.Variation
+		variations    []*ftproto.Variation
 	}{
 		{
 			desc:          "fail: empty name",
-			variationType: feature.Feature_BOOLEAN,
+			variationType: ftproto.Feature_BOOLEAN,
 			id:            id1.String(),
 			name:          "",
 			value:         "true",
 			description:   "first variation",
 			expectedErr:   errVariationNameRequired,
-			variations: []*feature.Variation{
+			variations: []*ftproto.Variation{
 				{Id: id1.String(), Name: "v1", Value: "true", Description: "first variation"},
 			},
 		},
 		{
 			desc:          "fail: empty value",
-			variationType: feature.Feature_BOOLEAN,
+			variationType: ftproto.Feature_BOOLEAN,
 			id:            id1.String(),
 			name:          "v1",
 			value:         "",
@@ -315,19 +315,19 @@ func TestAddVariation(t *testing.T) {
 		},
 		{
 			desc:          "fail: duplicate value",
-			variationType: feature.Feature_BOOLEAN,
+			variationType: ftproto.Feature_BOOLEAN,
 			id:            id2.String(),
 			name:          "v2",
 			value:         "true", // same value as first variation
 			description:   "second variation",
 			expectedErr:   errVariationValueUnique,
-			variations: []*feature.Variation{
+			variations: []*ftproto.Variation{
 				{Id: id1.String(), Name: "v1", Value: "true", Description: "first variation"},
 			},
 		},
 		{
 			desc:          "success: valid variation",
-			variationType: feature.Feature_BOOLEAN,
+			variationType: ftproto.Feature_BOOLEAN,
 			id:            id1.String(),
 			name:          "v1",
 			value:         "true",
@@ -338,7 +338,7 @@ func TestAddVariation(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			t.Parallel()
-			f := &Feature{Feature: &feature.Feature{
+			f := &Feature{Feature: &ftproto.Feature{
 				VariationType: p.variationType,
 				Variations:    p.variations,
 			}}
@@ -561,19 +561,19 @@ func TestAddFixedStrategyRule(t *testing.T) {
 	patterns := []struct {
 		desc        string
 		id          string
-		strategy    *proto.Strategy
-		clauses     []*feature.Clause
+		strategy    *ftproto.Strategy
+		clauses     []*ftproto.Clause
 		expectedErr bool
 	}{
 		{
 			desc:     "fail: add rule with nil strategy",
 			id:       "rule-2",
 			strategy: nil,
-			clauses: []*feature.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
 					Attribute: "name",
-					Operator:  feature.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Values: []string{
 						"user1",
 					},
@@ -584,15 +584,15 @@ func TestAddFixedStrategyRule(t *testing.T) {
 		{
 			desc: "fail: add rule with nil clauses",
 			id:   "rule-3",
-			strategy: &proto.Strategy{
-				Type:          proto.Strategy_FIXED,
-				FixedStrategy: &proto.FixedStrategy{Variation: ""},
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: ""},
 			},
-			clauses: []*feature.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
 					Attribute: "name",
-					Operator:  feature.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Values: []string{
 						"user1",
 					},
@@ -603,15 +603,15 @@ func TestAddFixedStrategyRule(t *testing.T) {
 		{
 			desc: "success",
 			id:   "rule-3",
-			strategy: &proto.Strategy{
-				Type:          proto.Strategy_FIXED,
-				FixedStrategy: &proto.FixedStrategy{Variation: f.Variations[0].Id},
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: f.Variations[0].Id},
 			},
-			clauses: []*feature.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
 					Attribute: "name",
-					Operator:  feature.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Values: []string{
 						"user1",
 					},
@@ -621,7 +621,7 @@ func TestAddFixedStrategyRule(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		rule := &proto.Rule{
+		rule := &ftproto.Rule{
 			Id:       p.id,
 			Strategy: p.strategy,
 			Clauses:  p.clauses,
@@ -639,12 +639,12 @@ func TestAddRolloutStrategyRule(t *testing.T) {
 	id1, _ := uuid.NewUUID()
 	patterns := []struct {
 		desc        string
-		rule        *proto.Rule
+		rule        *ftproto.Rule
 		expectedErr bool
 	}{
 		{
 			desc: "fail: rule already exists",
-			rule: &feature.Rule{
+			rule: &ftproto.Rule{
 				Id:       "rule-2",
 				Strategy: nil,
 			},
@@ -652,12 +652,12 @@ func TestAddRolloutStrategyRule(t *testing.T) {
 		},
 		{
 			desc: "fail: variation not found",
-			rule: &feature.Rule{
+			rule: &ftproto.Rule{
 				Id: "rule-3",
-				Strategy: &proto.Strategy{
-					Type: proto.Strategy_ROLLOUT,
-					RolloutStrategy: &proto.RolloutStrategy{
-						Variations: []*proto.RolloutStrategy_Variation{
+				Strategy: &ftproto.Strategy{
+					Type: ftproto.Strategy_ROLLOUT,
+					RolloutStrategy: &ftproto.RolloutStrategy{
+						Variations: []*ftproto.RolloutStrategy_Variation{
 							{
 								Variation: f.Variations[0].Id,
 								Weight:    30000,
@@ -674,12 +674,12 @@ func TestAddRolloutStrategyRule(t *testing.T) {
 		},
 		{
 			desc: "success",
-			rule: &feature.Rule{
+			rule: &ftproto.Rule{
 				Id: "rule-3",
-				Strategy: &proto.Strategy{
-					Type: proto.Strategy_ROLLOUT,
-					RolloutStrategy: &proto.RolloutStrategy{
-						Variations: []*proto.RolloutStrategy_Variation{
+				Strategy: &ftproto.Strategy{
+					Type: ftproto.Strategy_ROLLOUT,
+					RolloutStrategy: &ftproto.RolloutStrategy{
+						Variations: []*ftproto.RolloutStrategy_Variation{
 							{
 								Variation: f.Variations[0].Id,
 								Weight:    30000,
@@ -691,10 +691,10 @@ func TestAddRolloutStrategyRule(t *testing.T) {
 						},
 					},
 				},
-				Clauses: []*proto.Clause{{
+				Clauses: []*ftproto.Clause{{
 					Id:        id1.String(),
 					Attribute: "name",
-					Operator:  proto.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Values: []string{
 						"user1",
 					},
@@ -717,13 +717,13 @@ func TestChangeRuleStrategyToFixed(t *testing.T) {
 	r := f.Rules[0]
 	rID := r.Id
 	vID := f.Variations[1].Id
-	expected := &proto.Strategy{
-		Type:          proto.Strategy_FIXED,
-		FixedStrategy: &proto.FixedStrategy{Variation: vID},
+	expected := &ftproto.Strategy{
+		Type:          ftproto.Strategy_FIXED,
+		FixedStrategy: &ftproto.FixedStrategy{Variation: vID},
 	}
 	patterns := []*struct {
 		ruleID   string
-		strategy *proto.Strategy
+		strategy *ftproto.Strategy
 		expected error
 	}{
 		{
@@ -733,17 +733,17 @@ func TestChangeRuleStrategyToFixed(t *testing.T) {
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.Strategy{
-				Type:          proto.Strategy_FIXED,
-				FixedStrategy: &proto.FixedStrategy{Variation: ""},
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: ""},
 			},
 			expected: errVariationNotFound,
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.Strategy{
-				Type:          proto.Strategy_FIXED,
-				FixedStrategy: &proto.FixedStrategy{Variation: "variation-D"},
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: "variation-D"},
 			},
 			expected: errVariationNotFound,
 		},
@@ -818,9 +818,9 @@ func TestChangeRuleToRolloutStrategy(t *testing.T) {
 	rID := r.Id
 	vID1 := f.Variations[0].Id
 	vID2 := f.Variations[1].Id
-	expected := &proto.Strategy{
-		Type: proto.Strategy_ROLLOUT,
-		RolloutStrategy: &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+	expected := &ftproto.Strategy{
+		Type: ftproto.Strategy_ROLLOUT,
+		RolloutStrategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 			{
 				Variation: vID1,
 				Weight:    30,
@@ -833,7 +833,7 @@ func TestChangeRuleToRolloutStrategy(t *testing.T) {
 	}
 	patterns := []*struct {
 		ruleID   string
-		strategy *proto.Strategy
+		strategy *ftproto.Strategy
 		expected error
 	}{
 		{
@@ -843,9 +843,9 @@ func TestChangeRuleToRolloutStrategy(t *testing.T) {
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.Strategy{
-				Type: proto.Strategy_ROLLOUT,
-				RolloutStrategy: &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 					{
 						Variation: "",
 						Weight:    30000,
@@ -860,9 +860,9 @@ func TestChangeRuleToRolloutStrategy(t *testing.T) {
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.Strategy{
-				Type: proto.Strategy_ROLLOUT,
-				RolloutStrategy: &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 					{
 						Variation: vID1,
 						Weight:    30000,
@@ -877,9 +877,9 @@ func TestChangeRuleToRolloutStrategy(t *testing.T) {
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.Strategy{
-				Type: proto.Strategy_ROLLOUT,
-				RolloutStrategy: &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 					{
 						Variation: vID1,
 						Weight:    30000,
@@ -1011,7 +1011,7 @@ func TestChangeClauseOperator(t *testing.T) {
 	patterns := []struct {
 		rule        string
 		clause      string
-		operator    proto.Clause_Operator
+		operator    ftproto.Clause_Operator
 		ruleIdx     int
 		idx         int
 		expectedErr error
@@ -1019,7 +1019,7 @@ func TestChangeClauseOperator(t *testing.T) {
 		{
 			rule:        "rule-1",
 			clause:      "clause-1",
-			operator:    proto.Clause_IN,
+			operator:    ftproto.Clause_IN,
 			ruleIdx:     0,
 			idx:         0,
 			expectedErr: nil,
@@ -1222,10 +1222,10 @@ func TestRemoveVariationUsingRolloutStrategy(t *testing.T) {
 	f := makeFeature("test-feature")
 	expected := "variation-D"
 	f.AddVariation(expected, "D", "Variation D", "Thing does D")
-	f.ChangeDefaultStrategy(&proto.Strategy{
-		Type: proto.Strategy_ROLLOUT,
-		RolloutStrategy: &proto.RolloutStrategy{
-			Variations: []*proto.RolloutStrategy_Variation{
+	f.ChangeDefaultStrategy(&ftproto.Strategy{
+		Type: ftproto.Strategy_ROLLOUT,
+		RolloutStrategy: &ftproto.RolloutStrategy{
+			Variations: []*ftproto.RolloutStrategy_Variation{
 				{
 					Variation: "variation-A",
 					Weight:    100000,
@@ -1352,7 +1352,7 @@ func TestChangeFixedStrategy(t *testing.T) {
 		},
 	}
 	for _, p := range patterns {
-		err := f.ChangeFixedStrategy(p.ruleID, &proto.FixedStrategy{Variation: p.variationID})
+		err := f.ChangeFixedStrategy(p.ruleID, &ftproto.FixedStrategy{Variation: p.variationID})
 		assert.Equal(t, p.expected, err)
 	}
 	if r.Strategy.FixedStrategy.Variation != vID {
@@ -1366,7 +1366,7 @@ func TestChangeRolloutStrategy(t *testing.T) {
 	rID := r.Id
 	vID1 := f.Variations[0].Id
 	vID2 := f.Variations[1].Id
-	expected := &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+	expected := &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 		{
 			Variation: vID1,
 			Weight:    30,
@@ -1378,17 +1378,17 @@ func TestChangeRolloutStrategy(t *testing.T) {
 	}}
 	patterns := []*struct {
 		ruleID   string
-		strategy *proto.RolloutStrategy
+		strategy *ftproto.RolloutStrategy
 		expected error
 	}{
 		{
 			ruleID:   "",
-			strategy: &proto.RolloutStrategy{},
+			strategy: &ftproto.RolloutStrategy{},
 			expected: errRuleNotFound,
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 				{
 					Variation: "",
 					Weight:    30,
@@ -1402,7 +1402,7 @@ func TestChangeRolloutStrategy(t *testing.T) {
 		},
 		{
 			ruleID: rID,
-			strategy: &proto.RolloutStrategy{Variations: []*proto.RolloutStrategy_Variation{
+			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 				{
 					Variation: vID1,
 					Weight:    30,
@@ -1451,8 +1451,8 @@ func TestIsStale(t *testing.T) {
 	}{
 		{
 			desc: "false",
-			feature: &Feature{Feature: &proto.Feature{
-				LastUsedInfo: &proto.FeatureLastUsedInfo{
+			feature: &Feature{Feature: &ftproto.Feature{
+				LastUsedInfo: &ftproto.FeatureLastUsedInfo{
 					LastUsedAt: t1.Unix(),
 				},
 			}},
@@ -1461,8 +1461,8 @@ func TestIsStale(t *testing.T) {
 		},
 		{
 			desc: "true",
-			feature: &Feature{Feature: &proto.Feature{
-				LastUsedInfo: &proto.FeatureLastUsedInfo{
+			feature: &Feature{Feature: &ftproto.Feature{
+				LastUsedInfo: &ftproto.FeatureLastUsedInfo{
 					LastUsedAt: t1.Unix(),
 				},
 			}},
@@ -1485,67 +1485,67 @@ func TestValidateVariationValue(t *testing.T) {
 	require.NoError(t, err)
 	patterns := []struct {
 		desc          string
-		variationType feature.Feature_VariationType
+		variationType ftproto.Feature_VariationType
 		value         string
 		expected      error
 	}{
 		{
 			desc:          "invalid bool",
-			variationType: feature.Feature_BOOLEAN,
+			variationType: ftproto.Feature_BOOLEAN,
 			value:         "hoge",
 			expected:      errVariationTypeUnmatched,
 		},
 		{
 			desc:          "empty string",
-			variationType: feature.Feature_JSON,
+			variationType: ftproto.Feature_JSON,
 			value:         "",
 			expected:      errVariationValueRequired,
 		},
 		{
 			desc:          "invalid number",
-			variationType: feature.Feature_NUMBER,
+			variationType: ftproto.Feature_NUMBER,
 			value:         `{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}`,
 			expected:      errVariationTypeUnmatched,
 		},
 		{
 			desc:          "invalid json",
-			variationType: feature.Feature_JSON,
+			variationType: ftproto.Feature_JSON,
 			value:         "true",
 			expected:      errVariationTypeUnmatched,
 		},
 		{
 			desc:          "valid bool",
-			variationType: feature.Feature_BOOLEAN,
+			variationType: ftproto.Feature_BOOLEAN,
 			value:         "true",
 			expected:      nil,
 		},
 		{
 			desc:          "valid number float",
-			variationType: feature.Feature_NUMBER,
+			variationType: ftproto.Feature_NUMBER,
 			value:         "1.23",
 			expected:      nil,
 		},
 		{
 			desc:          "valid number int",
-			variationType: feature.Feature_NUMBER,
+			variationType: ftproto.Feature_NUMBER,
 			value:         "123",
 			expected:      nil,
 		},
 		{
 			desc:          "valid json",
-			variationType: feature.Feature_JSON,
+			variationType: ftproto.Feature_JSON,
 			value:         `{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}`,
 			expected:      nil,
 		},
 		{
 			desc:          "valid json array",
-			variationType: feature.Feature_JSON,
+			variationType: ftproto.Feature_JSON,
 			value:         `[{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}]`,
 			expected:      nil,
 		},
 		{
 			desc:          "valid string",
-			variationType: feature.Feature_STRING,
+			variationType: ftproto.Feature_STRING,
 			value:         `{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}`,
 			expected:      nil,
 		},
@@ -1553,9 +1553,9 @@ func TestValidateVariationValue(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			t.Parallel()
-			f := &Feature{Feature: &feature.Feature{
+			f := &Feature{Feature: &ftproto.Feature{
 				VariationType: p.variationType,
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: v1.String(), Value: "value-1"},
 					{Id: v2.String(), Value: "value-2"},
 				},
@@ -1572,34 +1572,34 @@ func TestNewClonedFeature(t *testing.T) {
 		offVariationIndex int
 		expectedEnabled   bool
 		expectedVersion   int32
-		defaultStrategy   *feature.Strategy
-		rules             []*feature.Rule
+		defaultStrategy   *ftproto.Strategy
+		rules             []*ftproto.Rule
 	}{
 		{
 			maintainer:        "sample@example.com",
 			offVariationIndex: 2,
 			expectedEnabled:   false,
 			expectedVersion:   int32(1),
-			defaultStrategy: &proto.Strategy{
-				Type: proto.Strategy_FIXED,
-				FixedStrategy: &proto.FixedStrategy{
+			defaultStrategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{
 					Variation: "variation-B",
 				},
 			},
-			rules: []*proto.Rule{
+			rules: []*ftproto.Rule{
 				{
 					Id: "rule-1",
-					Strategy: &proto.Strategy{
-						Type: proto.Strategy_FIXED,
-						FixedStrategy: &proto.FixedStrategy{
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_FIXED,
+						FixedStrategy: &ftproto.FixedStrategy{
 							Variation: "variation-A",
 						},
 					},
-					Clauses: []*proto.Clause{
+					Clauses: []*ftproto.Clause{
 						{
 							Id:        "clause-1",
 							Attribute: "name",
-							Operator:  proto.Clause_EQUALS,
+							Operator:  ftproto.Clause_EQUALS,
 							Values: []string{
 								"user1",
 								"user2",
@@ -1609,17 +1609,17 @@ func TestNewClonedFeature(t *testing.T) {
 				},
 				{
 					Id: "rule-2",
-					Strategy: &proto.Strategy{
-						Type: proto.Strategy_FIXED,
-						FixedStrategy: &proto.FixedStrategy{
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_FIXED,
+						FixedStrategy: &ftproto.FixedStrategy{
 							Variation: "variation-B",
 						},
 					},
-					Clauses: []*proto.Clause{
+					Clauses: []*ftproto.Clause{
 						{
 							Id:        "clause-2",
 							Attribute: "name",
-							Operator:  proto.Clause_EQUALS,
+							Operator:  ftproto.Clause_EQUALS,
 							Values: []string{
 								"user3",
 								"user4",
@@ -1634,10 +1634,10 @@ func TestNewClonedFeature(t *testing.T) {
 			offVariationIndex: 2,
 			expectedEnabled:   false,
 			expectedVersion:   int32(1),
-			defaultStrategy: &proto.Strategy{
-				Type: proto.Strategy_ROLLOUT,
-				RolloutStrategy: &proto.RolloutStrategy{
-					Variations: []*proto.RolloutStrategy_Variation{
+			defaultStrategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{
 							Variation: "variation-A",
 							Weight:    100000,
@@ -1653,13 +1653,13 @@ func TestNewClonedFeature(t *testing.T) {
 					},
 				},
 			},
-			rules: []*proto.Rule{
+			rules: []*ftproto.Rule{
 				{
 					Id: "rule-1",
-					Strategy: &proto.Strategy{
-						Type: proto.Strategy_ROLLOUT,
-						RolloutStrategy: &proto.RolloutStrategy{
-							Variations: []*proto.RolloutStrategy_Variation{
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_ROLLOUT,
+						RolloutStrategy: &ftproto.RolloutStrategy{
+							Variations: []*ftproto.RolloutStrategy_Variation{
 								{
 									Variation: "variation-A",
 									Weight:    100000,
@@ -1678,10 +1678,10 @@ func TestNewClonedFeature(t *testing.T) {
 				},
 				{
 					Id: "rule-2",
-					Strategy: &proto.Strategy{
-						Type: proto.Strategy_ROLLOUT,
-						RolloutStrategy: &proto.RolloutStrategy{
-							Variations: []*proto.RolloutStrategy_Variation{
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_ROLLOUT,
+						RolloutStrategy: &ftproto.RolloutStrategy{
+							Variations: []*ftproto.RolloutStrategy_Variation{
 								{
 									Variation: "variation-A",
 									Weight:    100,
@@ -1716,7 +1716,7 @@ func TestNewClonedFeature(t *testing.T) {
 		for i := range actual.Variations {
 			assert.Equal(t, actual.Variations[i].Id, actual.Targets[i].Variation)
 		}
-		if actual.DefaultStrategy.Type == feature.Strategy_FIXED {
+		if actual.DefaultStrategy.Type == ftproto.Strategy_FIXED {
 			assert.Equal(t, actual.Variations[1].Id, actual.DefaultStrategy.FixedStrategy.Variation)
 		} else {
 			for i := range actual.Variations {
@@ -1726,7 +1726,7 @@ func TestNewClonedFeature(t *testing.T) {
 		assert.NotNil(t, actual.Prerequisites)
 		assert.Equal(t, len(actual.Prerequisites), 0)
 		for i := range actual.Rules {
-			if actual.Rules[i].Strategy.Type == feature.Strategy_FIXED {
+			if actual.Rules[i].Strategy.Type == ftproto.Strategy_FIXED {
 				assert.Equal(t, actual.Rules[i].Strategy.FixedStrategy.Variation, actual.Variations[i].Id)
 			} else {
 				for idx := range actual.Variations {
@@ -1748,24 +1748,24 @@ func TestResetSamplingSeed(t *testing.T) {
 func TestFeatureIDsDependsOn(t *testing.T) {
 	t.Parallel()
 	patterns := []struct {
-		feature  *feature.Feature
+		feature  *ftproto.Feature
 		expected []string
 	}{
 		{
-			feature:  &feature.Feature{},
+			feature:  &ftproto.Feature{},
 			expected: []string{},
 		},
 		{
-			feature: &feature.Feature{
-				Prerequisites: []*feature.Prerequisite{
+			feature: &ftproto.Feature{
+				Prerequisites: []*ftproto.Prerequisite{
 					{FeatureId: "feature-1"},
 				},
 			},
 			expected: []string{"feature-1"},
 		},
 		{
-			feature: &feature.Feature{
-				Prerequisites: []*feature.Prerequisite{
+			feature: &ftproto.Feature{
+				Prerequisites: []*ftproto.Prerequisite{
 					{FeatureId: "feature-1"},
 					{FeatureId: "feature-2"},
 				},
@@ -1773,11 +1773,11 @@ func TestFeatureIDsDependsOn(t *testing.T) {
 			expected: []string{"feature-1", "feature-2"},
 		},
 		{
-			feature: &feature.Feature{
-				Rules: []*feature.Rule{
+			feature: &ftproto.Feature{
+				Rules: []*ftproto.Rule{
 					{
-						Clauses: []*feature.Clause{
-							{Attribute: "feature-1", Operator: feature.Clause_FEATURE_FLAG},
+						Clauses: []*ftproto.Clause{
+							{Attribute: "feature-1", Operator: ftproto.Clause_FEATURE_FLAG},
 						},
 					},
 				},
@@ -1785,12 +1785,12 @@ func TestFeatureIDsDependsOn(t *testing.T) {
 			expected: []string{"feature-1"},
 		},
 		{
-			feature: &feature.Feature{
-				Rules: []*feature.Rule{
+			feature: &ftproto.Feature{
+				Rules: []*ftproto.Rule{
 					{
-						Clauses: []*feature.Clause{
-							{Attribute: "feature-1", Operator: feature.Clause_FEATURE_FLAG},
-							{Attribute: "feature-2", Operator: feature.Clause_FEATURE_FLAG},
+						Clauses: []*ftproto.Clause{
+							{Attribute: "feature-1", Operator: ftproto.Clause_FEATURE_FLAG},
+							{Attribute: "feature-2", Operator: ftproto.Clause_FEATURE_FLAG},
 						},
 					},
 				},
@@ -1798,14 +1798,14 @@ func TestFeatureIDsDependsOn(t *testing.T) {
 			expected: []string{"feature-1", "feature-2"},
 		},
 		{
-			feature: &feature.Feature{
-				Prerequisites: []*feature.Prerequisite{
+			feature: &ftproto.Feature{
+				Prerequisites: []*ftproto.Prerequisite{
 					{FeatureId: "feature-1"},
 				},
-				Rules: []*feature.Rule{
+				Rules: []*ftproto.Rule{
 					{
-						Clauses: []*feature.Clause{
-							{Attribute: "feature-2", Operator: feature.Clause_FEATURE_FLAG},
+						Clauses: []*ftproto.Clause{
+							{Attribute: "feature-2", Operator: ftproto.Clause_FEATURE_FLAG},
 						},
 					},
 				},
@@ -1825,16 +1825,16 @@ func TestValidateClauses(t *testing.T) {
 	id3, _ := uuid.NewUUID()
 	patterns := []struct {
 		desc     string
-		clauses  []*proto.Clause
+		clauses  []*ftproto.Clause
 		expected error
 	}{
 		{
 			desc: "success: 2 clauses",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
 					Attribute: "name",
-					Operator:  proto.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Values: []string{
 						"user1",
 						"user2",
@@ -1842,14 +1842,14 @@ func TestValidateClauses(t *testing.T) {
 				},
 				{
 					Id:       id2.String(),
-					Operator: proto.Clause_SEGMENT,
+					Operator: ftproto.Clause_SEGMENT,
 					Values: []string{
 						"value",
 					},
 				},
 				{
 					Id:        id3.String(),
-					Operator:  proto.Clause_FEATURE_FLAG,
+					Operator:  ftproto.Clause_FEATURE_FLAG,
 					Attribute: "feature-1",
 					Values: []string{
 						"true",
@@ -1860,16 +1860,16 @@ func TestValidateClauses(t *testing.T) {
 		},
 		{
 			desc:     "err: zero clause",
-			clauses:  []*proto.Clause{},
+			clauses:  []*ftproto.Clause{},
 			expected: fmt.Errorf("feature: rule must have at least one clause"),
 		},
 		{
 			desc: "err: id is empty",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        "",
 					Attribute: "name",
-					Operator:  proto.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Values:    []string{"user1"},
 				},
 			},
@@ -1877,10 +1877,10 @@ func TestValidateClauses(t *testing.T) {
 		},
 		{
 			desc: "err: compare missing attribute",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:       id1.String(),
-					Operator: proto.Clause_EQUALS,
+					Operator: ftproto.Clause_EQUALS,
 					Values: []string{
 						"user1",
 						"user2",
@@ -1891,10 +1891,10 @@ func TestValidateClauses(t *testing.T) {
 		},
 		{
 			desc: "err: compare missing values",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
-					Operator:  proto.Clause_EQUALS,
+					Operator:  ftproto.Clause_EQUALS,
 					Attribute: "name",
 				},
 			},
@@ -1902,10 +1902,10 @@ func TestValidateClauses(t *testing.T) {
 		},
 		{
 			desc: "err: segment attribute not empty",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
-					Operator:  proto.Clause_SEGMENT,
+					Operator:  ftproto.Clause_SEGMENT,
 					Attribute: "name",
 					Values: []string{
 						"user1",
@@ -1916,30 +1916,30 @@ func TestValidateClauses(t *testing.T) {
 		},
 		{
 			desc: "err: segment value empty",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:       id1.String(),
-					Operator: proto.Clause_SEGMENT,
+					Operator: ftproto.Clause_SEGMENT,
 				},
 			},
 			expected: errClauseValuesEmpty,
 		},
 		{
 			desc: "err: feature flag attribute empty",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:       id1.String(),
-					Operator: proto.Clause_FEATURE_FLAG,
+					Operator: ftproto.Clause_FEATURE_FLAG,
 				},
 			},
 			expected: errClauseAttributeEmpty,
 		},
 		{
 			desc: "err: feature flag values empty",
-			clauses: []*proto.Clause{
+			clauses: []*ftproto.Clause{
 				{
 					Id:        id1.String(),
-					Operator:  proto.Clause_FEATURE_FLAG,
+					Operator:  ftproto.Clause_FEATURE_FLAG,
 					Attribute: "feature-1",
 				},
 			},
@@ -1967,33 +1967,33 @@ func TestUpdate(t *testing.T) {
 		tags                *common.StringListValue
 		enabled             *wrapperspb.BoolValue
 		archived            *wrapperspb.BoolValue
-		defaultStrategy     *feature.Strategy
+		defaultStrategy     *ftproto.Strategy
 		offVariation        *wrapperspb.StringValue
 		resetSamplingSeed   bool
-		prerequisiteChanges []*feature.PrerequisiteChange
-		targetChanges       []*feature.TargetChange
-		ruleChanges         []*feature.RuleChange
-		variationChanges    []*feature.VariationChange
-		tagChanges          []*feature.TagChange
+		prerequisiteChanges []*ftproto.PrerequisiteChange
+		targetChanges       []*ftproto.TargetChange
+		ruleChanges         []*ftproto.RuleChange
+		variationChanges    []*ftproto.VariationChange
+		tagChanges          []*ftproto.TagChange
 		expected            *Feature
 		expectedErr         error
 	}{
 		{
 			desc: "success: no changes when updating with same values",
-			feature: &Feature{Feature: &feature.Feature{
+			feature: &Feature{Feature: &ftproto.Feature{
 				Name:        "test-feature",
 				Description: "test description",
 				Tags:        []string{"tag1"},
 				Enabled:     true,
 				Archived:    false,
-				DefaultStrategy: &feature.Strategy{
-					Type: feature.Strategy_FIXED,
-					FixedStrategy: &feature.FixedStrategy{
+				DefaultStrategy: &ftproto.Strategy{
+					Type: ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{
 						Variation: id1.String(),
 					},
 				},
 				OffVariation: id2.String(),
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: id1.String(), Name: "v1", Value: "true"},
 					{Id: id2.String(), Name: "v2", Value: "false"},
 				},
@@ -2003,121 +2003,130 @@ func TestUpdate(t *testing.T) {
 			tags:        &common.StringListValue{Values: []string{"tag1"}},
 			enabled:     wrapperspb.Bool(true),
 			archived:    wrapperspb.Bool(false),
-			defaultStrategy: &feature.Strategy{
-				Type: feature.Strategy_FIXED,
-				FixedStrategy: &feature.FixedStrategy{
+			defaultStrategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{
 					Variation: id1.String(),
 				},
 			},
 			offVariation: wrapperspb.String(id2.String()),
-			expected: &Feature{Feature: &feature.Feature{
+			expected: &Feature{Feature: &ftproto.Feature{
 				Name:        "test-feature",
 				Description: "test description",
 				Tags:        []string{"tag1"},
 				Enabled:     true,
 				Archived:    false,
-				DefaultStrategy: &feature.Strategy{
-					Type: feature.Strategy_FIXED,
-					FixedStrategy: &feature.FixedStrategy{
+				DefaultStrategy: &ftproto.Strategy{
+					Type: ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{
 						Variation: id1.String(),
 					},
 				},
 				OffVariation: id2.String(),
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: id1.String(), Name: "v1", Value: "true"},
 					{Id: id2.String(), Name: "v2", Value: "false"},
 				},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{},
+				Rules:         []*ftproto.Rule{},
 			}},
 		},
 		{
 			desc: "success: version incremented with full replacement fields",
-			feature: &Feature{Feature: &feature.Feature{
+			feature: &Feature{Feature: &ftproto.Feature{
 				Name:        "old-name",
 				Description: "old description",
 				Tags:        []string{"old-tag"},
 				Enabled:     false,
 				Archived:    false,
-				DefaultStrategy: &feature.Strategy{
-					Type: feature.Strategy_FIXED,
-					FixedStrategy: &feature.FixedStrategy{
+				DefaultStrategy: &ftproto.Strategy{
+					Type: ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{
 						Variation: id1.String(),
 					},
 				},
 				OffVariation: id2.String(),
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: id1.String(), Name: "v1", Value: "true"},
 					{Id: id2.String(), Name: "v2", Value: "false"},
 				},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{},
+				Rules:         []*ftproto.Rule{},
 			}},
 			name:        wrapperspb.String("new-name"),
 			description: wrapperspb.String("new description"),
 			tags:        &common.StringListValue{Values: []string{"new-tag"}},
 			enabled:     wrapperspb.Bool(true),
 			archived:    wrapperspb.Bool(false),
-			defaultStrategy: &feature.Strategy{
-				Type: feature.Strategy_FIXED,
-				FixedStrategy: &feature.FixedStrategy{
+			defaultStrategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{
 					Variation: id1.String(),
 				},
 			},
 			offVariation: wrapperspb.String(id1.String()),
-			expected: &Feature{Feature: &feature.Feature{
+			expected: &Feature{Feature: &ftproto.Feature{
 				Name:        "new-name",
 				Description: "new description",
 				Tags:        []string{"new-tag"},
 				Enabled:     true,
 				Archived:    false,
-				DefaultStrategy: &feature.Strategy{
-					Type: feature.Strategy_FIXED,
-					FixedStrategy: &feature.FixedStrategy{
+				DefaultStrategy: &ftproto.Strategy{
+					Type: ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{
 						Variation: id1.String(),
 					},
 				},
 				OffVariation: id1.String(),
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: id1.String(), Name: "v1", Value: "true"},
 					{Id: id2.String(), Name: "v2", Value: "false"},
 				},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{},
+				Rules:         []*ftproto.Rule{},
 			}},
 		},
 		{
 			desc: "success: granular updates for variations, rules, prerequisites, targets, and tags",
-			feature: &Feature{Feature: &feature.Feature{
+			feature: &Feature{Feature: &ftproto.Feature{
 				Name: "test-feature",
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: id1.String(), Name: "v1", Value: "true"},
 					{Id: id2.String(), Name: "v2", Value: "false"},
 				},
-				Targets: []*feature.Target{
+				Targets: []*ftproto.Target{
 					{Variation: id1.String(), Users: []string{}},
 					{Variation: id2.String(), Users: []string{}},
 				},
 			}},
-			variationChanges: []*feature.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Variation: &feature.Variation{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Variation: &ftproto.Variation{
 						Id:    id3.String(),
 						Name:  "v3",
 						Value: "new-value",
 					},
 				},
 			},
-			ruleChanges: []*feature.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Rule: &feature.Rule{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Rule: &ftproto.Rule{
 						Id: ruleID.String(),
-						Strategy: &feature.Strategy{
-							Type: feature.Strategy_FIXED,
-							FixedStrategy: &feature.FixedStrategy{
+						Strategy: &ftproto.Strategy{
+							Type: ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{
 								Variation: id1.String(),
 							},
 						},
-						Clauses: []*feature.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        id1.String(),
-								Operator:  feature.Clause_EQUALS,
+								Operator:  ftproto.Clause_EQUALS,
 								Values:    []string{"user1"},
 								Attribute: "name",
 							},
@@ -2125,64 +2134,64 @@ func TestUpdate(t *testing.T) {
 					},
 				},
 			},
-			prerequisiteChanges: []*feature.PrerequisiteChange{
+			prerequisiteChanges: []*ftproto.PrerequisiteChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Prerequisite: &feature.Prerequisite{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Prerequisite: &ftproto.Prerequisite{
 						FeatureId:   "feature-1",
 						VariationId: id1.String(),
 					},
 				},
 			},
-			targetChanges: []*feature.TargetChange{
+			targetChanges: []*ftproto.TargetChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Target: &feature.Target{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Target: &ftproto.Target{
 						Variation: id1.String(),
 						Users:     []string{"user1"},
 					},
 				},
 			},
-			tagChanges: []*feature.TagChange{
+			tagChanges: []*ftproto.TagChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
+					ChangeType: ftproto.ChangeType_CREATE,
 					Tag:        "new-tag",
 				},
 			},
-			expected: &Feature{Feature: &feature.Feature{
+			expected: &Feature{Feature: &ftproto.Feature{
 				Name: "test-feature",
 				Tags: []string{"new-tag"},
-				Variations: []*feature.Variation{
+				Variations: []*ftproto.Variation{
 					{Id: id1.String(), Name: "v1", Value: "true"},
 					{Id: id2.String(), Name: "v2", Value: "false"},
 					{Name: "v3", Value: "new-value"},
 				},
-				Rules: []*feature.Rule{
+				Rules: []*ftproto.Rule{
 					{
 						Id: ruleID.String(),
-						Strategy: &feature.Strategy{
-							Type: feature.Strategy_FIXED,
-							FixedStrategy: &feature.FixedStrategy{
+						Strategy: &ftproto.Strategy{
+							Type: ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{
 								Variation: id1.String(),
 							},
 						},
-						Clauses: []*feature.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        id1.String(),
-								Operator:  feature.Clause_EQUALS,
+								Operator:  ftproto.Clause_EQUALS,
 								Values:    []string{"user1"},
 								Attribute: "name",
 							},
 						},
 					},
 				},
-				Prerequisites: []*feature.Prerequisite{
+				Prerequisites: []*ftproto.Prerequisite{
 					{
 						FeatureId:   "feature-1",
 						VariationId: id1.String(),
 					},
 				},
-				Targets: []*feature.Target{
+				Targets: []*ftproto.Target{
 					{
 						Variation: id1.String(),
 						Users:     []string{"user1"},
@@ -2230,7 +2239,7 @@ func TestUpdate(t *testing.T) {
 
 			// Check variations
 			var createdVariationID string
-			hasVariationCreate := len(p.variationChanges) > 0 && p.variationChanges[0].ChangeType == feature.ChangeType_CREATE
+			hasVariationCreate := len(p.variationChanges) > 0 && p.variationChanges[0].ChangeType == ftproto.ChangeType_CREATE
 			if hasVariationCreate {
 				assert.Equal(t, len(p.expected.Variations), len(updated.Variations))
 				for i := range updated.Variations {
@@ -2240,7 +2249,11 @@ func TestUpdate(t *testing.T) {
 				}
 				createdVariationID = updated.Variations[len(updated.Variations)-1].Id
 			} else {
-				assert.Equal(t, p.expected.Variations, updated.Variations)
+				// Use proto.Equal for protobuf message comparison to avoid internal structure differences
+				assert.Equal(t, len(p.expected.Variations), len(updated.Variations), "Variations length should match")
+				for i := range p.expected.Variations {
+					assert.True(t, proto.Equal(p.expected.Variations[i], updated.Variations[i]), "Variation %d should be equal", i)
+				}
 			}
 
 			// Check targets
@@ -2257,11 +2270,21 @@ func TestUpdate(t *testing.T) {
 					assert.Equal(t, p.expected.Targets[i].Users, updated.Targets[i].Users)
 				}
 			} else {
-				assert.Equal(t, p.expected.Targets, updated.Targets)
+				// Use proto.Equal for protobuf message comparison
+				assert.Equal(t, len(p.expected.Targets), len(updated.Targets), "Targets length should match")
+				for i := range p.expected.Targets {
+					assert.True(t, proto.Equal(p.expected.Targets[i], updated.Targets[i]), "Target %d should be equal", i)
+				}
 			}
-			// Check prerequisites and rules
-			assert.Equal(t, p.expected.Prerequisites, updated.Prerequisites)
-			assert.Equal(t, p.expected.Rules, updated.Rules)
+			// Check prerequisites and rules using proto.Equal
+			assert.Equal(t, len(p.expected.Prerequisites), len(updated.Prerequisites), "Prerequisites length should match")
+			for i := range p.expected.Prerequisites {
+				assert.True(t, proto.Equal(p.expected.Prerequisites[i], updated.Prerequisites[i]), "Prerequisite %d should be equal", i)
+			}
+			assert.Equal(t, len(p.expected.Rules), len(updated.Rules), "Rules length should match")
+			for i := range p.expected.Rules {
+				assert.True(t, proto.Equal(p.expected.Rules[i], updated.Rules[i]), "Rule %d should be equal", i)
+			}
 		})
 	}
 }
@@ -2276,24 +2299,24 @@ func TestUpdatePrerequisitesGranular(t *testing.T) {
 	// Baseline feature with no prerequisites.
 	genF := func() *Feature {
 		return &Feature{
-			Feature: &proto.Feature{
+			Feature: &ftproto.Feature{
 				Id:            "i",
 				Name:          "n",
 				Description:   "d",
 				Archived:      false,
 				Enabled:       false,
 				Tags:          []string{"t1", "t2"},
-				VariationType: feature.Feature_BOOLEAN,
-				Variations: []*proto.Variation{
+				VariationType: ftproto.Feature_BOOLEAN,
+				Variations: []*ftproto.Variation{
 					{Id: v1.String(), Value: "true", Name: "n1", Description: "d1"},
 					{Id: v2.String(), Value: "false", Name: "n2", Description: "d2"},
 				},
-				Prerequisites: []*proto.Prerequisite{},
-				Targets:       []*proto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
-				Rules:         []*proto.Rule{},
-				DefaultStrategy: &proto.Strategy{
-					Type:          proto.Strategy_FIXED,
-					FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
+				Rules:         []*ftproto.Rule{},
+				DefaultStrategy: &ftproto.Strategy{
+					Type:          ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 				},
 				OffVariation: v1.String(),
 			},
@@ -2303,17 +2326,17 @@ func TestUpdatePrerequisitesGranular(t *testing.T) {
 	patterns := []struct {
 		desc                string
 		inputFunc           func() *Feature
-		prerequisiteChanges []*proto.PrerequisiteChange
+		prerequisiteChanges []*ftproto.PrerequisiteChange
 		expectedFunc        func() *Feature
 		expectedErr         error
 	}{
 		{
 			desc:      "Prerequisite Create - success",
 			inputFunc: genF,
-			prerequisiteChanges: []*proto.PrerequisiteChange{
+			prerequisiteChanges: []*ftproto.PrerequisiteChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Prerequisite: &proto.Prerequisite{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Prerequisite: &ftproto.Prerequisite{
 						FeatureId:   "f1",
 						VariationId: v1.String(),
 					},
@@ -2333,10 +2356,10 @@ func TestUpdatePrerequisitesGranular(t *testing.T) {
 				_ = f.AddPrerequisite("f1", v1.String())
 				return f
 			},
-			prerequisiteChanges: []*proto.PrerequisiteChange{
+			prerequisiteChanges: []*ftproto.PrerequisiteChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Prerequisite: &proto.Prerequisite{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Prerequisite: &ftproto.Prerequisite{
 						FeatureId:   "f1",
 						VariationId: v1.String(),
 					},
@@ -2353,10 +2376,10 @@ func TestUpdatePrerequisitesGranular(t *testing.T) {
 			inputFunc: func() *Feature {
 				return genF()
 			},
-			prerequisiteChanges: []*proto.PrerequisiteChange{
+			prerequisiteChanges: []*ftproto.PrerequisiteChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Prerequisite: &proto.Prerequisite{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Prerequisite: &ftproto.Prerequisite{
 						FeatureId:   "non-existent",
 						VariationId: v2.String(),
 					},
@@ -2372,10 +2395,10 @@ func TestUpdatePrerequisitesGranular(t *testing.T) {
 			inputFunc: func() *Feature {
 				return genF()
 			},
-			prerequisiteChanges: []*proto.PrerequisiteChange{
+			prerequisiteChanges: []*ftproto.PrerequisiteChange{
 				{
-					ChangeType: feature.ChangeType_DELETE,
-					Prerequisite: &proto.Prerequisite{
+					ChangeType: ftproto.ChangeType_DELETE,
+					Prerequisite: &ftproto.Prerequisite{
 						FeatureId:   "non-existent",
 						VariationId: v1.String(),
 					},
@@ -2411,27 +2434,27 @@ func TestUpdateTargetsGranular(t *testing.T) {
 
 	genF := func() *Feature {
 		return &Feature{
-			Feature: &proto.Feature{
+			Feature: &ftproto.Feature{
 				Id:            "i",
 				Name:          "n",
 				Description:   "d",
 				Archived:      false,
 				Enabled:       false,
 				Tags:          []string{"t1"},
-				VariationType: feature.Feature_BOOLEAN,
-				Variations: []*proto.Variation{
+				VariationType: ftproto.Feature_BOOLEAN,
+				Variations: []*ftproto.Variation{
 					{Id: v1.String(), Value: "true", Name: "n1", Description: "d1"},
 					{Id: v2.String(), Value: "false", Name: "n2", Description: "d2"},
 				},
-				Prerequisites: []*proto.Prerequisite{},
-				Targets: []*proto.Target{
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets: []*ftproto.Target{
 					{Variation: v1.String(), Users: []string{"u1"}},
 					{Variation: v2.String(), Users: []string{"u2"}},
 				},
-				Rules: []*proto.Rule{},
-				DefaultStrategy: &proto.Strategy{
-					Type:          proto.Strategy_FIXED,
-					FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+				Rules: []*ftproto.Rule{},
+				DefaultStrategy: &ftproto.Strategy{
+					Type:          ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 				},
 				OffVariation: v1.String(),
 			},
@@ -2441,17 +2464,17 @@ func TestUpdateTargetsGranular(t *testing.T) {
 	patterns := []struct {
 		desc          string
 		inputFunc     func() *Feature
-		targetChanges []*proto.TargetChange
+		targetChanges []*ftproto.TargetChange
 		expectedFunc  func() *Feature
 		expectedErr   error
 	}{
 		{
 			desc:      "Target Create - error: empty target fields",
 			inputFunc: genF,
-			targetChanges: []*proto.TargetChange{
+			targetChanges: []*ftproto.TargetChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Target:     &proto.Target{Variation: "", Users: []string{}},
+					ChangeType: ftproto.ChangeType_CREATE,
+					Target:     &ftproto.Target{Variation: "", Users: []string{}},
 				},
 			},
 			expectedFunc: func() *Feature {
@@ -2462,10 +2485,10 @@ func TestUpdateTargetsGranular(t *testing.T) {
 		{
 			desc:      "Target Update - error: target not found",
 			inputFunc: genF,
-			targetChanges: []*proto.TargetChange{
+			targetChanges: []*ftproto.TargetChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Target:     &proto.Target{Variation: "non-existent", Users: []string{"u-new"}},
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Target:     &ftproto.Target{Variation: "non-existent", Users: []string{"u-new"}},
 				},
 			},
 			expectedFunc: func() *Feature {
@@ -2476,10 +2499,10 @@ func TestUpdateTargetsGranular(t *testing.T) {
 		{
 			desc:      "Target Delete - error: target not found",
 			inputFunc: genF,
-			targetChanges: []*proto.TargetChange{
+			targetChanges: []*ftproto.TargetChange{
 				{
-					ChangeType: feature.ChangeType_DELETE,
-					Target:     &proto.Target{Variation: "non-existent"},
+					ChangeType: ftproto.ChangeType_DELETE,
+					Target:     &ftproto.Target{Variation: "non-existent"},
 				},
 			},
 			expectedFunc: func() *Feature {
@@ -2517,24 +2540,24 @@ func TestUpdateRulesGranular(t *testing.T) {
 	// genF returns a baseline Feature with no rules.
 	genF := func() *Feature {
 		return &Feature{
-			Feature: &proto.Feature{
+			Feature: &ftproto.Feature{
 				Id:            "i",
 				Name:          "n",
 				Description:   "d",
 				Archived:      false,
 				Enabled:       false,
 				Tags:          []string{"t1"},
-				VariationType: feature.Feature_BOOLEAN,
-				Variations: []*proto.Variation{
+				VariationType: ftproto.Feature_BOOLEAN,
+				Variations: []*ftproto.Variation{
 					{Id: v1.String(), Value: "true", Name: "n1", Description: "d1"},
 					{Id: v2.String(), Value: "false", Name: "n2", Description: "d2"},
 				},
-				Prerequisites: []*proto.Prerequisite{},
-				Targets:       []*proto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
-				Rules:         []*proto.Rule{},
-				DefaultStrategy: &proto.Strategy{
-					Type:          proto.Strategy_FIXED,
-					FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
+				Rules:         []*ftproto.Rule{},
+				DefaultStrategy: &ftproto.Strategy{
+					Type:          ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 				},
 				OffVariation: v1.String(),
 			},
@@ -2545,16 +2568,16 @@ func TestUpdateRulesGranular(t *testing.T) {
 	patterns := []struct {
 		desc         string
 		inputFunc    func() *Feature
-		ruleChanges  []*proto.RuleChange
+		ruleChanges  []*ftproto.RuleChange
 		expectedFunc func() *Feature
 		expectedErr  error
 	}{
 		{
 			desc:      "Rule Create - error: rule required",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
+					ChangeType: ftproto.ChangeType_CREATE,
 					Rule:       nil,
 				},
 			},
@@ -2564,17 +2587,17 @@ func TestUpdateRulesGranular(t *testing.T) {
 		{
 			desc:      "Rule Create - error: nil strategy",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Rule: &ftproto.Rule{
 						Id:       ruleID.String(),
 						Strategy: nil, // This should trigger errStrategyRequired
-						Clauses: []*proto.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        clauseID.String(),
 								Attribute: "attr",
-								Operator:  feature.Clause_EQUALS,
+								Operator:  ftproto.Clause_EQUALS,
 								Values:    []string{"val"},
 							},
 						},
@@ -2587,16 +2610,16 @@ func TestUpdateRulesGranular(t *testing.T) {
 		{
 			desc:      "Rule Create - error: no clauses",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Rule: &ftproto.Rule{
 						Id: ruleID.String(),
-						Strategy: &proto.Strategy{
-							Type:          feature.Strategy_FIXED,
-							FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+						Strategy: &ftproto.Strategy{
+							Type:          ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 						},
-						Clauses: []*proto.Clause{},
+						Clauses: []*ftproto.Clause{},
 					},
 				},
 			},
@@ -2606,20 +2629,20 @@ func TestUpdateRulesGranular(t *testing.T) {
 		{
 			desc:      "Rule Create - error: clause attribute not empty for SEGMENT operator",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Rule: &ftproto.Rule{
 						Id: ruleID.String(),
-						Strategy: &proto.Strategy{
-							Type:          feature.Strategy_FIXED,
-							FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+						Strategy: &ftproto.Strategy{
+							Type:          ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 						},
-						Clauses: []*proto.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        clauseID.String(),
 								Attribute: "non-empty", // Not allowed for SEGMENT operator
-								Operator:  feature.Clause_SEGMENT,
+								Operator:  ftproto.Clause_SEGMENT,
 								Values:    []string{"val"},
 							},
 						},
@@ -2632,20 +2655,20 @@ func TestUpdateRulesGranular(t *testing.T) {
 		{
 			desc:      "Rule Create - error: clause values empty for SEGMENT operator",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Rule: &ftproto.Rule{
 						Id: ruleID.String(),
-						Strategy: &proto.Strategy{
-							Type:          feature.Strategy_FIXED,
-							FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+						Strategy: &ftproto.Strategy{
+							Type:          ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 						},
-						Clauses: []*proto.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        clauseID.String(),
 								Attribute: "", // Correct for SEGMENT operator
-								Operator:  feature.Clause_SEGMENT,
+								Operator:  ftproto.Clause_SEGMENT,
 								Values:    []string{}, // Missing values
 							},
 						},
@@ -2658,20 +2681,20 @@ func TestUpdateRulesGranular(t *testing.T) {
 		{
 			desc:      "Rule Update - error: rule not found",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Rule: &ftproto.Rule{
 						Id: "non-existent",
-						Strategy: &proto.Strategy{
-							Type:          feature.Strategy_FIXED,
-							FixedStrategy: &proto.FixedStrategy{Variation: v2.String()},
+						Strategy: &ftproto.Strategy{
+							Type:          ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{Variation: v2.String()},
 						},
-						Clauses: []*proto.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        clauseID.String(),
 								Attribute: "attr",
-								Operator:  feature.Clause_EQUALS,
+								Operator:  ftproto.Clause_EQUALS,
 								Values:    []string{"val-updated"},
 							},
 						},
@@ -2686,37 +2709,37 @@ func TestUpdateRulesGranular(t *testing.T) {
 			inputFunc: func() *Feature {
 				f := genF()
 				// Pre-add a valid rule.
-				_ = f.AddRule(&proto.Rule{
+				_ = f.AddRule(&ftproto.Rule{
 					Id: ruleID.String(),
-					Strategy: &proto.Strategy{
-						Type:          feature.Strategy_FIXED,
-						FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+					Strategy: &ftproto.Strategy{
+						Type:          ftproto.Strategy_FIXED,
+						FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 					},
-					Clauses: []*proto.Clause{
+					Clauses: []*ftproto.Clause{
 						{
 							Id:        clauseID.String(),
 							Attribute: "attr",
-							Operator:  feature.Clause_EQUALS,
+							Operator:  ftproto.Clause_EQUALS,
 							Values:    []string{"val"},
 						},
 					},
 				})
 				return f
 			},
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Rule: &ftproto.Rule{
 						Id: ruleID.String(),
-						Strategy: &proto.Strategy{
-							Type:          feature.Strategy_FIXED,
-							FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+						Strategy: &ftproto.Strategy{
+							Type:          ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 						},
-						Clauses: []*proto.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        clauseID.String(),
 								Attribute: "", // empty attribute for non-SEGMENT operator not allowed
-								Operator:  feature.Clause_EQUALS,
+								Operator:  ftproto.Clause_EQUALS,
 								Values:    []string{"val-updated"},
 							},
 						},
@@ -2731,37 +2754,37 @@ func TestUpdateRulesGranular(t *testing.T) {
 			inputFunc: func() *Feature {
 				f := genF()
 				// Pre-add a valid rule.
-				_ = f.AddRule(&proto.Rule{
+				_ = f.AddRule(&ftproto.Rule{
 					Id: ruleID.String(),
-					Strategy: &proto.Strategy{
-						Type:          feature.Strategy_FIXED,
-						FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+					Strategy: &ftproto.Strategy{
+						Type:          ftproto.Strategy_FIXED,
+						FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 					},
-					Clauses: []*proto.Clause{
+					Clauses: []*ftproto.Clause{
 						{
 							Id:        clauseID.String(),
 							Attribute: "attr",
-							Operator:  feature.Clause_EQUALS,
+							Operator:  ftproto.Clause_EQUALS,
 							Values:    []string{"val"},
 						},
 					},
 				})
 				return f
 			},
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Rule: &proto.Rule{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Rule: &ftproto.Rule{
 						Id: ruleID.String(),
-						Strategy: &proto.Strategy{
-							Type:          feature.Strategy_FIXED,
-							FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+						Strategy: &ftproto.Strategy{
+							Type:          ftproto.Strategy_FIXED,
+							FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 						},
-						Clauses: []*proto.Clause{
+						Clauses: []*ftproto.Clause{
 							{
 								Id:        clauseID.String(),
 								Attribute: "attr",
-								Operator:  feature.Clause_EQUALS,
+								Operator:  ftproto.Clause_EQUALS,
 								Values:    []string{}, // empty values not allowed
 							},
 						},
@@ -2774,10 +2797,10 @@ func TestUpdateRulesGranular(t *testing.T) {
 		{
 			desc:      "Rule Delete - error: empty rule id",
 			inputFunc: genF,
-			ruleChanges: []*proto.RuleChange{
+			ruleChanges: []*ftproto.RuleChange{
 				{
-					ChangeType: feature.ChangeType_DELETE,
-					Rule:       &proto.Rule{Id: ""},
+					ChangeType: ftproto.ChangeType_DELETE,
+					Rule:       &ftproto.Rule{Id: ""},
 				},
 			},
 			expectedFunc: func() *Feature { return genF() },
@@ -2814,24 +2837,24 @@ func TestUpdateVariationsGranular(t *testing.T) {
 	// Baseline generator for JSON type.
 	genFJSON := func() *Feature {
 		return &Feature{
-			Feature: &proto.Feature{
+			Feature: &ftproto.Feature{
 				Id:            "i",
 				Name:          "n",
 				Description:   "d",
 				Archived:      false,
 				Enabled:       false,
 				Tags:          []string{"t1"},
-				VariationType: feature.Feature_JSON,
-				Variations: []*proto.Variation{
+				VariationType: ftproto.Feature_JSON,
+				Variations: []*ftproto.Variation{
 					{Id: v1.String(), Value: `{"key": "value1"}`, Name: "n1", Description: "d1"},
 					{Id: v2.String(), Value: `{"key": "value2"}`, Name: "n2", Description: "d2"},
 				},
-				Prerequisites: []*proto.Prerequisite{},
-				Targets:       []*proto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
-				Rules:         []*proto.Rule{},
-				DefaultStrategy: &proto.Strategy{
-					Type:          proto.Strategy_FIXED,
-					FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
+				Rules:         []*ftproto.Rule{},
+				DefaultStrategy: &ftproto.Strategy{
+					Type:          ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 				},
 				OffVariation: v1.String(),
 			},
@@ -2842,17 +2865,17 @@ func TestUpdateVariationsGranular(t *testing.T) {
 	patterns := []struct {
 		desc             string
 		inputFunc        func() *Feature
-		variationChanges []*proto.VariationChange
+		variationChanges []*ftproto.VariationChange
 		expectedFunc     func() *Feature
 		expectedErr      error
 	}{
 		{
 			desc:      "Variation Create - success",
 			inputFunc: genFJSON,
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
-					Variation: &proto.Variation{
+					ChangeType: ftproto.ChangeType_CREATE,
+					Variation: &ftproto.Variation{
 						Id:          v3.String(),
 						Value:       `{"key": "value3"}`,
 						Name:        "n3",
@@ -2863,14 +2886,14 @@ func TestUpdateVariationsGranular(t *testing.T) {
 			expectedFunc: func() *Feature {
 				f := genFJSON()
 				// Add the new variation directly
-				f.Variations = append(f.Variations, &proto.Variation{
+				f.Variations = append(f.Variations, &ftproto.Variation{
 					Id:          v3.String(),
 					Value:       `{"key": "value3"}`,
 					Name:        "n3",
 					Description: "d3",
 				})
 				// Add corresponding target for the new variation
-				f.Targets = append(f.Targets, &proto.Target{
+				f.Targets = append(f.Targets, &ftproto.Target{
 					Variation: v3.String(),
 					Users:     []string{},
 				})
@@ -2881,10 +2904,10 @@ func TestUpdateVariationsGranular(t *testing.T) {
 		{
 			desc:      "Variation Update - success",
 			inputFunc: genFJSON,
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Variation: &proto.Variation{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Variation: &ftproto.Variation{
 						Id:          v1.String(),
 						Value:       `{"key": "updated-value1"}`,
 						Name:        "n1-updated",
@@ -2911,10 +2934,10 @@ func TestUpdateVariationsGranular(t *testing.T) {
 				require.NoError(t, err)
 				return f
 			},
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_DELETE,
-					Variation:  &proto.Variation{Id: v3.String()},
+					ChangeType: ftproto.ChangeType_DELETE,
+					Variation:  &ftproto.Variation{Id: v3.String()},
 				},
 			},
 			expectedFunc: genFJSON,
@@ -2923,9 +2946,9 @@ func TestUpdateVariationsGranular(t *testing.T) {
 		{
 			desc:      "Variation Update - error: nil variation",
 			inputFunc: genFJSON,
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
+					ChangeType: ftproto.ChangeType_UPDATE,
 					Variation:  nil,
 				},
 			},
@@ -2935,10 +2958,10 @@ func TestUpdateVariationsGranular(t *testing.T) {
 		{
 			desc:      "Variation Update - error: empty name",
 			inputFunc: genFJSON,
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Variation: &proto.Variation{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Variation: &ftproto.Variation{
 						Id:          v1.String(),
 						Value:       `{"key": "value1"}`,
 						Name:        "",
@@ -2952,10 +2975,10 @@ func TestUpdateVariationsGranular(t *testing.T) {
 		{
 			desc:      "Variation Update - success: valid JSON object",
 			inputFunc: genFJSON,
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Variation: &proto.Variation{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Variation: &ftproto.Variation{
 						Id:          v1.String(),
 						Value:       `{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}`,
 						Name:        "n1-updated",
@@ -2976,10 +2999,10 @@ func TestUpdateVariationsGranular(t *testing.T) {
 		{
 			desc:      "Variation Update - success: valid JSON array",
 			inputFunc: genFJSON,
-			variationChanges: []*proto.VariationChange{
+			variationChanges: []*ftproto.VariationChange{
 				{
-					ChangeType: feature.ChangeType_UPDATE,
-					Variation: &proto.Variation{
+					ChangeType: ftproto.ChangeType_UPDATE,
+					Variation: &ftproto.Variation{
 						Id:          v1.String(),
 						Value:       `[{"foo":"foo","fee":20,"hoo": [1, "lee", null], "boo": true}]`,
 						Name:        "n1-updated",
@@ -3032,24 +3055,24 @@ func TestUpdateTagsGranular(t *testing.T) {
 	require.NoError(t, err)
 	genF := func() *Feature {
 		return &Feature{
-			Feature: &proto.Feature{
+			Feature: &ftproto.Feature{
 				Id:            "i",
 				Name:          "n",
 				Description:   "d",
 				Archived:      false,
 				Enabled:       false,
 				Tags:          []string{"t1", "t2"},
-				VariationType: feature.Feature_BOOLEAN,
-				Variations: []*proto.Variation{
+				VariationType: ftproto.Feature_BOOLEAN,
+				Variations: []*ftproto.Variation{
 					{Id: v1.String(), Value: "true", Name: "n1", Description: "d1"},
 					{Id: v2.String(), Value: "false", Name: "n2", Description: "d2"},
 				},
-				Prerequisites: []*proto.Prerequisite{},
-				Targets:       []*proto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
-				Rules:         []*proto.Rule{},
-				DefaultStrategy: &proto.Strategy{
-					Type:          proto.Strategy_FIXED,
-					FixedStrategy: &proto.FixedStrategy{Variation: v1.String()},
+				Prerequisites: []*ftproto.Prerequisite{},
+				Targets:       []*ftproto.Target{{Variation: v1.String()}, {Variation: v2.String()}},
+				Rules:         []*ftproto.Rule{},
+				DefaultStrategy: &ftproto.Strategy{
+					Type:          ftproto.Strategy_FIXED,
+					FixedStrategy: &ftproto.FixedStrategy{Variation: v1.String()},
 				},
 				OffVariation: v1.String(),
 			},
@@ -3059,20 +3082,20 @@ func TestUpdateTagsGranular(t *testing.T) {
 	patterns := []struct {
 		desc         string
 		inputFunc    func() *Feature
-		tagChanges   []*proto.TagChange
+		tagChanges   []*ftproto.TagChange
 		expectedFunc func() *Feature
 		expectedErr  error
 	}{
 		{
 			desc:      "Tag Create - error: duplicate create should not add duplicate",
 			inputFunc: genF,
-			tagChanges: []*proto.TagChange{
+			tagChanges: []*ftproto.TagChange{
 				{
-					ChangeType: feature.ChangeType_CREATE,
+					ChangeType: ftproto.ChangeType_CREATE,
 					Tag:        "new-tag",
 				},
 				{
-					ChangeType: feature.ChangeType_CREATE,
+					ChangeType: ftproto.ChangeType_CREATE,
 					Tag:        "new-tag",
 				},
 			},
@@ -3086,9 +3109,9 @@ func TestUpdateTagsGranular(t *testing.T) {
 		{
 			desc:      "Tag Delete - error: tag not found",
 			inputFunc: genF,
-			tagChanges: []*proto.TagChange{
+			tagChanges: []*ftproto.TagChange{
 				{
-					ChangeType: feature.ChangeType_DELETE,
+					ChangeType: ftproto.ChangeType_DELETE,
 					Tag:        "non-existent-tag",
 				},
 			},
@@ -3125,31 +3148,31 @@ func TestValidateStrategy(t *testing.T) {
 	t.Parallel()
 	id1, _ := uuid.NewUUID()
 	id2, _ := uuid.NewUUID()
-	variations := []*feature.Variation{
+	variations := []*ftproto.Variation{
 		{Id: id1.String(), Value: "true", Name: "n1", Description: "d1"},
 		{Id: id2.String(), Value: "false", Name: "n2", Description: "d2"},
 	}
 	tests := []struct {
 		desc        string
-		strategy    *feature.Strategy
-		variations  []*feature.Variation
+		strategy    *ftproto.Strategy
+		variations  []*ftproto.Variation
 		expectedErr error
 	}{
 		{
 			desc: "success: fixed strategy",
-			strategy: &feature.Strategy{
-				Type:          feature.Strategy_FIXED,
-				FixedStrategy: &feature.FixedStrategy{Variation: id1.String()},
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: id1.String()},
 			},
 			variations:  variations,
 			expectedErr: nil,
 		},
 		{
 			desc: "success: rollout strategy",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
 				},
@@ -3165,19 +3188,19 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: fixed strategy with non-existent variation",
-			strategy: &feature.Strategy{
-				Type:          feature.Strategy_FIXED,
-				FixedStrategy: &feature.FixedStrategy{Variation: "non-existent"},
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: "non-existent"},
 			},
 			variations:  variations,
 			expectedErr: errVariationNotFound,
 		},
 		{
 			desc: "fail: rollout strategy with non-existent variation",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: "non-existent", Weight: 100},
 					},
 				},
@@ -3187,7 +3210,7 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: unsupported strategy type",
-			strategy: &feature.Strategy{
+			strategy: &ftproto.Strategy{
 				Type: 999,
 			},
 			variations:  variations,
@@ -3195,27 +3218,27 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: fixed strategy is nil",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_FIXED,
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_FIXED,
 			},
 			variations:  variations,
 			expectedErr: ErrRuleStrategyCannotBeEmpty,
 		},
 		{
 			desc: "fail: rollout strategy is nil",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
 			},
 			variations:  variations,
 			expectedErr: ErrRuleStrategyCannotBeEmpty,
 		},
 		{
 			desc: "fail: both strategies are set",
-			strategy: &feature.Strategy{
-				Type:          feature.Strategy_FIXED,
-				FixedStrategy: &feature.FixedStrategy{Variation: id1.String()},
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type:          ftproto.Strategy_FIXED,
+				FixedStrategy: &ftproto.FixedStrategy{Variation: id1.String()},
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
 				},
@@ -3225,14 +3248,14 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "success: rollout strategy with valid audience",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 50},
 						{Variation: id2.String(), Weight: 50},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       50,
 						DefaultVariation: id1.String(),
 					},
@@ -3243,13 +3266,13 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "success: rollout strategy with 0% audience",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       0,
 						DefaultVariation: "",
 					},
@@ -3260,13 +3283,13 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "success: rollout strategy with 100% audience",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       100,
 						DefaultVariation: "",
 					},
@@ -3277,13 +3300,13 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: audience percentage below 0",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       -1,
 						DefaultVariation: id1.String(),
 					},
@@ -3294,13 +3317,13 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: audience percentage above 100",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       101,
 						DefaultVariation: id1.String(),
 					},
@@ -3311,13 +3334,13 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: audience percentage between 1-99 without default variation",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       50,
 						DefaultVariation: "",
 					},
@@ -3328,13 +3351,13 @@ func TestValidateStrategy(t *testing.T) {
 		},
 		{
 			desc: "fail: audience with non-existent default variation",
-			strategy: &feature.Strategy{
-				Type: feature.Strategy_ROLLOUT,
-				RolloutStrategy: &feature.RolloutStrategy{
-					Variations: []*feature.RolloutStrategy_Variation{
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
 						{Variation: id1.String(), Weight: 100},
 					},
-					Audience: &feature.Audience{
+					Audience: &ftproto.Audience{
 						Percentage:       50,
 						DefaultVariation: "non-existent",
 					},

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -27,10 +27,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
-var (
-	ErrTagNotFound = errors.New("feature: tag not found")
-)
-
 // Update returns a new Feature with the updated values.
 func (f *Feature) Update(
 	name, description *wrapperspb.StringValue,
@@ -350,11 +346,6 @@ func (f *Feature) applyGranularChanges(
 	return nil
 }
 
-// New functions for Update method that handle timestamp updates intelligently
-// These functions only update the timestamp when actual changes occur
-// TODO: Remove these duplicate functions once old console is deprecated
-
-// updateEnable enables the feature only if it's not already enabled
 func (f *Feature) updateEnable() error {
 	if !f.Enabled {
 		f.Enabled = true
@@ -362,7 +353,6 @@ func (f *Feature) updateEnable() error {
 	return nil
 }
 
-// updateDisable disables the feature only if it's not already disabled
 func (f *Feature) updateDisable() error {
 	if f.Enabled {
 		f.Enabled = false
@@ -370,7 +360,6 @@ func (f *Feature) updateDisable() error {
 	return nil
 }
 
-// updateArchive archives the feature only if it's not already archived
 func (f *Feature) updateArchive() error {
 	if !f.Archived {
 		f.Archived = true
@@ -378,7 +367,6 @@ func (f *Feature) updateArchive() error {
 	return nil
 }
 
-// updateUnarchive unarchives the feature only if it's not already unarchived
 func (f *Feature) updateUnarchive() error {
 	if f.Archived {
 		f.Archived = false
@@ -386,7 +374,6 @@ func (f *Feature) updateUnarchive() error {
 	return nil
 }
 
-// updateAddVariation adds a variation, updating timestamp only if successful
 func (f *Feature) updateAddVariation(id, value, name, description string) error {
 	if id == "" {
 		return errVariationIDRequired
@@ -413,7 +400,6 @@ func (f *Feature) updateAddVariation(id, value, name, description string) error 
 	return nil
 }
 
-// updateChangeVariation changes a variation only if it actually differs
 func (f *Feature) updateChangeVariation(variation *feature.Variation) error {
 	if variation == nil {
 		return errVariationRequired
@@ -436,7 +422,6 @@ func (f *Feature) updateChangeVariation(variation *feature.Variation) error {
 	return nil
 }
 
-// updateRemoveVariation removes a variation, updating timestamp only if successful
 func (f *Feature) updateRemoveVariation(id string) error {
 	if len(f.Variations) == 1 {
 		return errVariationInUse
@@ -452,7 +437,6 @@ func (f *Feature) updateRemoveVariation(id string) error {
 	return nil
 }
 
-// updateAddPrerequisite adds a prerequisite, updating timestamp only if successful
 func (f *Feature) updateAddPrerequisite(featureID, variationID string) error {
 	if err := validatePrerequisite(featureID, variationID); err != nil {
 		return err
@@ -467,7 +451,6 @@ func (f *Feature) updateAddPrerequisite(featureID, variationID string) error {
 	return nil
 }
 
-// updateChangePrerequisiteVariation changes a prerequisite variation only if it differs
 func (f *Feature) updateChangePrerequisiteVariation(featureID, variationID string) error {
 	if err := validatePrerequisite(featureID, variationID); err != nil {
 		return err
@@ -484,7 +467,6 @@ func (f *Feature) updateChangePrerequisiteVariation(featureID, variationID strin
 	return nil
 }
 
-// updateRemovePrerequisite removes a prerequisite, updating timestamp only if successful
 func (f *Feature) updateRemovePrerequisite(featureID string) error {
 	idx, err := f.findPrerequisiteIndex(featureID)
 	if err != nil {
@@ -494,7 +476,6 @@ func (f *Feature) updateRemovePrerequisite(featureID string) error {
 	return nil
 }
 
-// updateAddTargetUsers adds target users, updating timestamp only if users were actually added
 func (f *Feature) updateAddTargetUsers(target *feature.Target) error {
 	idx, err := f.findTarget(target.Variation)
 	if err != nil {
@@ -514,7 +495,6 @@ func (f *Feature) updateAddTargetUsers(target *feature.Target) error {
 	return nil
 }
 
-// updateRemoveTargetUsers removes target users, updating timestamp only if users were actually removed
 func (f *Feature) updateRemoveTargetUsers(target *feature.Target) error {
 	idx, err := f.findTarget(target.Variation)
 	if err != nil {
@@ -537,7 +517,6 @@ func (f *Feature) updateRemoveTargetUsers(target *feature.Target) error {
 	return nil
 }
 
-// updateAddRule adds a rule, updating timestamp only if successful
 func (f *Feature) updateAddRule(rule *feature.Rule) error {
 	if rule == nil {
 		return errRuleRequired
@@ -555,7 +534,6 @@ func (f *Feature) updateAddRule(rule *feature.Rule) error {
 	return nil
 }
 
-// updateChangeRule changes a rule only if it actually differs
 func (f *Feature) updateChangeRule(rule *feature.Rule) error {
 	if rule == nil {
 		return errRuleRequired
@@ -579,7 +557,6 @@ func (f *Feature) updateChangeRule(rule *feature.Rule) error {
 	return nil
 }
 
-// updateRemoveRule removes a rule, updating timestamp only if successful
 func (f *Feature) updateRemoveRule(id string) error {
 	idx, err := f.findRuleIndex(id)
 	if err != nil {
@@ -589,7 +566,6 @@ func (f *Feature) updateRemoveRule(id string) error {
 	return nil
 }
 
-// updateAddTag adds a tag, updating timestamp only if tag was actually added
 func (f *Feature) updateAddTag(tag string) error {
 	if slices.Contains(f.Tags, tag) {
 		return nil
@@ -598,19 +574,15 @@ func (f *Feature) updateAddTag(tag string) error {
 	return nil
 }
 
-// updateRemoveTag removes a tag, updating timestamp only if tag was actually removed
 func (f *Feature) updateRemoveTag(tag string) error {
 	index := slices.Index(f.Tags, tag)
 	if index == -1 {
-		return ErrTagNotFound
+		return errors.New("feature: tag not found")
 	}
 	f.Tags = slices.Delete(f.Tags, index, index+1)
 	return nil
 }
 
-// Helper functions to support the update methods
-
-// findRuleIndex finds the index of a rule by ID
 func (f *Feature) findRuleIndex(id string) (int, error) {
 	for i, rule := range f.Rules {
 		if rule.Id == id {
@@ -620,7 +592,6 @@ func (f *Feature) findRuleIndex(id string) (int, error) {
 	return -1, errRuleNotFound
 }
 
-// findPrerequisiteIndex finds the index of a prerequisite by feature ID
 func (f *Feature) findPrerequisiteIndex(featureID string) (int, error) {
 	for i, prereq := range f.Prerequisites {
 		if prereq.FeatureId == featureID {

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -1,0 +1,1657 @@
+// Copyright 2025 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/bucketeer-io/bucketeer/pkg/uuid"
+	"github.com/bucketeer-io/bucketeer/proto/common"
+	"github.com/bucketeer-io/bucketeer/proto/feature"
+)
+
+func TestUpdateNoTimestampChangeWithSameValues(t *testing.T) {
+	t.Parallel()
+
+	// Generate valid UUIDs for variations
+	v1, err := uuid.NewUUID()
+	require.NoError(t, err)
+	v2, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	// Create a feature with specific timestamp
+	fixedTimestamp := time.Now().Unix() - 3600 // 1 hour ago
+	original := &Feature{
+		Feature: &feature.Feature{
+			Id:          "test-feature",
+			Name:        "Test Feature",
+			Description: "Test Description",
+			Enabled:     true,
+			Archived:    false,
+			Version:     5,
+			UpdatedAt:   fixedTimestamp,
+			Variations: []*feature.Variation{
+				{Id: v1.String(), Name: "v1", Value: "true"},
+				{Id: v2.String(), Name: "v2", Value: "false"},
+			},
+			Targets: []*feature.Target{
+				{Variation: v1.String(), Users: []string{}},
+				{Variation: v2.String(), Users: []string{}},
+			},
+			DefaultStrategy: &feature.Strategy{
+				Type: feature.Strategy_FIXED,
+				FixedStrategy: &feature.FixedStrategy{
+					Variation: v1.String(),
+				},
+			},
+			OffVariation: v2.String(),
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		enabled  *wrapperspb.BoolValue
+		archived *wrapperspb.BoolValue
+		desc     string
+	}{
+		{
+			name:     "enabled same value true",
+			enabled:  wrapperspb.Bool(true),  // same as original
+			archived: wrapperspb.Bool(false), // same as original
+			desc:     "Should not update timestamp when enabled=true (same as original)",
+		},
+		{
+			name:     "enabled same value false",
+			enabled:  wrapperspb.Bool(false), // different from original
+			archived: wrapperspb.Bool(false), // same as original
+			desc:     "Should update timestamp when enabled=false (different from original)",
+		},
+		{
+			name:     "archived same value false",
+			enabled:  wrapperspb.Bool(true),  // same as original
+			archived: wrapperspb.Bool(false), // same as original
+			desc:     "Should not update timestamp when archived=false (same as original)",
+		},
+		{
+			name:     "archived same value true",
+			enabled:  wrapperspb.Bool(true), // same as original
+			archived: wrapperspb.Bool(true), // different from original
+			desc:     "Should update timestamp when archived=true (different from original)",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create fresh copy of original for each test
+			testFeature := &Feature{
+				Feature: &feature.Feature{
+					Id:          original.Id,
+					Name:        original.Name,
+					Description: original.Description,
+					Enabled:     original.Enabled,
+					Archived:    original.Archived,
+					Version:     original.Version,
+					UpdatedAt:   original.UpdatedAt,
+					Variations:  original.Variations,
+					Targets:     original.Targets,
+					DefaultStrategy: &feature.Strategy{
+						Type: feature.Strategy_FIXED,
+						FixedStrategy: &feature.FixedStrategy{
+							Variation: original.DefaultStrategy.FixedStrategy.Variation,
+						},
+					},
+					OffVariation: original.OffVariation,
+				},
+			}
+
+			// Update with the test values
+			updated, err := testFeature.Update(
+				nil,         // name
+				nil,         // description
+				nil,         // tags
+				tc.enabled,  // enabled
+				tc.archived, // archived
+				nil,         // defaultStrategy
+				nil,         // offVariation
+				false,       // resetSamplingSeed
+				nil,         // prerequisiteChanges
+				nil,         // targetChanges
+				nil,         // ruleChanges
+				nil,         // variationChanges
+				nil,         // tagChanges
+			)
+
+			require.NoError(t, err)
+
+			// Determine if values are changing
+			enabledChanging := tc.enabled != nil && tc.enabled.Value != original.Enabled
+			archivedChanging := tc.archived != nil && tc.archived.Value != original.Archived
+			shouldHaveChanges := enabledChanging || archivedChanging
+
+			if shouldHaveChanges {
+				// Should have changes - version should increment and timestamp should update
+				assert.Equal(t, original.Version+1, updated.Version, tc.desc)
+				assert.NotEqual(t, original.UpdatedAt, updated.UpdatedAt, tc.desc)
+				assert.True(t, updated.UpdatedAt > original.UpdatedAt, tc.desc)
+
+				// Values should be updated
+				if tc.enabled != nil {
+					assert.Equal(t, tc.enabled.Value, updated.Enabled, tc.desc)
+				}
+				if tc.archived != nil {
+					assert.Equal(t, tc.archived.Value, updated.Archived, tc.desc)
+				}
+			} else {
+				// Should not have changes - version and timestamp should remain the same
+				assert.Equal(t, original.Version, updated.Version, tc.desc)
+				assert.Equal(t, original.UpdatedAt, updated.UpdatedAt, tc.desc)
+
+				// Values should remain the same
+				assert.Equal(t, original.Enabled, updated.Enabled, tc.desc)
+				assert.Equal(t, original.Archived, updated.Archived, tc.desc)
+			}
+		})
+	}
+}
+
+func TestUpdateWithIdenticalDefaultStrategy(t *testing.T) {
+	t.Parallel()
+
+	// Generate valid UUIDs for variations
+	v1, err := uuid.NewUUID()
+	require.NoError(t, err)
+	v2, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	// Create a feature with rollout strategy
+	fixedTimestamp := time.Now().Unix() - 3600 // 1 hour ago
+	original := &Feature{
+		Feature: &feature.Feature{
+			Id:        "test-feature",
+			Name:      "Test Feature",
+			Enabled:   true,
+			Version:   10,
+			UpdatedAt: fixedTimestamp,
+			Variations: []*feature.Variation{
+				{Id: v1.String(), Name: "v1", Value: "20"},
+				{Id: v2.String(), Name: "v2", Value: "30"},
+			},
+			Targets: []*feature.Target{
+				{Variation: v1.String(), Users: []string{}},
+				{Variation: v2.String(), Users: []string{}},
+			},
+			DefaultStrategy: &feature.Strategy{
+				Type: feature.Strategy_ROLLOUT,
+				RolloutStrategy: &feature.RolloutStrategy{
+					Variations: []*feature.RolloutStrategy_Variation{
+						{Variation: v1.String(), Weight: 40000},
+						{Variation: v2.String(), Weight: 60000},
+					},
+				},
+			},
+			OffVariation: v2.String(),
+		},
+	}
+
+	// Update with identical default strategy
+	identicalStrategy := &feature.Strategy{
+		Type: feature.Strategy_ROLLOUT,
+		RolloutStrategy: &feature.RolloutStrategy{
+			Variations: []*feature.RolloutStrategy_Variation{
+				{Variation: v1.String(), Weight: 40000},
+				{Variation: v2.String(), Weight: 60000},
+			},
+		},
+	}
+
+	updated, err := original.Update(
+		nil,                            // name
+		nil,                            // description
+		nil,                            // tags
+		wrapperspb.Bool(true),          // enabled (same as original)
+		nil,                            // archived
+		identicalStrategy,              // defaultStrategy (identical to original)
+		wrapperspb.String(v2.String()), // offVariation (same as original)
+		false,                          // resetSamplingSeed
+		nil,                            // prerequisiteChanges
+		nil,                            // targetChanges
+		nil,                            // ruleChanges
+		nil,                            // variationChanges
+		nil,                            // tagChanges
+	)
+
+	require.NoError(t, err)
+
+	// Should not have changes - version and timestamp should remain the same
+	assert.Equal(t, original.Version, updated.Version, "Version should not increment when no actual changes")
+	assert.Equal(t, original.UpdatedAt, updated.UpdatedAt, "Timestamp should not change when no actual changes")
+
+	// Values should remain the same
+	assert.Equal(t, original.Enabled, updated.Enabled)
+	assert.Equal(t, original.DefaultStrategy.RolloutStrategy.Variations, updated.DefaultStrategy.RolloutStrategy.Variations)
+	assert.Equal(t, original.OffVariation, updated.OffVariation)
+}
+
+func TestUpdateEnable(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		expectedFunc func() *Feature
+	}{
+		{
+			desc: "enable when already enabled - no-op",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = true
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = true
+				return f
+			},
+		},
+		{
+			desc: "enable when disabled - should enable",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = false
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = true
+				return f
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateEnable()
+			require.NoError(t, err)
+			expected := p.expectedFunc()
+			assert.Equal(t, expected.Enabled, actual.Enabled)
+		})
+	}
+}
+
+func TestUpdateDisable(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		expectedFunc func() *Feature
+	}{
+		{
+			desc: "disable when already disabled - no-op",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = false
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = false
+				return f
+			},
+		},
+		{
+			desc: "disable when enabled - should disable",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = true
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Enabled = false
+				return f
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateDisable()
+			require.NoError(t, err)
+			expected := p.expectedFunc()
+			assert.Equal(t, expected.Enabled, actual.Enabled)
+		})
+	}
+}
+
+func TestUpdateArchive(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		expectedFunc func() *Feature
+	}{
+		{
+			desc: "archive when already archived - no-op",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = true
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = true
+				return f
+			},
+		},
+		{
+			desc: "archive when not archived - should archive",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = false
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = true
+				return f
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateArchive()
+			require.NoError(t, err)
+			expected := p.expectedFunc()
+			assert.Equal(t, expected.Archived, actual.Archived)
+		})
+	}
+}
+
+func TestUpdateUnarchive(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		expectedFunc func() *Feature
+	}{
+		{
+			desc: "unarchive when already unarchived - no-op",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = false
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = false
+				return f
+			},
+		},
+		{
+			desc: "unarchive when archived - should unarchive",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = true
+				return f
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Archived = false
+				return f
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateUnarchive()
+			require.NoError(t, err)
+			expected := p.expectedFunc()
+			assert.Equal(t, expected.Archived, actual.Archived)
+		})
+	}
+}
+
+func TestUpdateAddVariation(t *testing.T) {
+	newV, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		id           string
+		value        string
+		name         string
+		description  string
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - add new variation",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			id:          newV.String(),
+			value:       "new-value",
+			name:        "new-name",
+			description: "new-description",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Variations = append(f.Variations, &feature.Variation{
+					Id:          newV.String(),
+					Value:       "new-value",
+					Name:        "new-name",
+					Description: "new-description",
+				})
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - empty id",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			id:          "",
+			value:       "new-value",
+			name:        "new-name",
+			description: "new-description",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationIDRequired,
+		},
+		{
+			desc: "error - empty value",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			id:          newV.String(),
+			value:       "",
+			name:        "new-name",
+			description: "new-description",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationValueRequired,
+		},
+		{
+			desc: "error - empty name",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			id:          newV.String(),
+			value:       "new-value",
+			name:        "",
+			description: "new-description",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationNameRequired,
+		},
+		{
+			desc: "error - duplicate variation id",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				return f
+			},
+			id:          "variation-A", // Using existing variation ID from makeFeature
+			value:       "new-value",
+			name:        "new-name",
+			description: "new-description",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationValueUnique,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateAddVariation(p.id, p.value, p.name, p.description)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := p.expectedFunc()
+				assert.Equal(t, len(expected.Variations), len(actual.Variations))
+				if len(actual.Variations) > 0 {
+					lastVar := actual.Variations[len(actual.Variations)-1]
+					assert.Equal(t, p.id, lastVar.Id)
+					assert.Equal(t, p.value, lastVar.Value)
+					assert.Equal(t, p.name, lastVar.Name)
+					assert.Equal(t, p.description, lastVar.Description)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateChangeVariation(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		variation    *feature.Variation
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - change variation",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			variation: &feature.Variation{
+				Id:          "variation-A", // Using existing variation ID from makeFeature
+				Value:       "updated-value",
+				Name:        "updated-name",
+				Description: "updated-description",
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Variations[0].Value = "updated-value"
+				f.Variations[0].Name = "updated-name"
+				f.Variations[0].Description = "updated-description"
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "no change - same variation",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				return f
+			},
+			variation: &feature.Variation{
+				Id:          "variation-A",  // Using existing variation ID from makeFeature
+				Value:       "A",            // Original value from makeFeature
+				Name:        "Variation A",  // Original name from makeFeature
+				Description: "Thing does A", // Original description from makeFeature
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - nil variation",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			variation: nil,
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationRequired,
+		},
+		{
+			desc: "error - empty name",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			variation: &feature.Variation{
+				Id:          "variation-A", // Using existing variation ID from makeFeature
+				Value:       "updated-value",
+				Name:        "",
+				Description: "updated-description",
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationNameRequired,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateChangeVariation(p.variation)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				if p.variation != nil {
+					idx, findErr := actual.findVariationIndex(p.variation.Id)
+					require.NoError(t, findErr)
+					if p.desc == "success - change variation" {
+						assert.Equal(t, p.variation.Value, actual.Variations[idx].Value)
+						assert.Equal(t, p.variation.Name, actual.Variations[idx].Name)
+						assert.Equal(t, p.variation.Description, actual.Variations[idx].Description)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateAddTargetUsers(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		target       *feature.Target
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - add new users",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     []string{"new-user1", "new-user2"},
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Targets[0].Users = []string{"user1", "new-user1", "new-user2"} // makeFeature creates user1 initially
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "no-op - add existing users",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				return f // makeFeature already has user1 in variation-A
+			},
+			target: &feature.Target{
+				Variation: "variation-A",     // Using existing variation ID from makeFeature
+				Users:     []string{"user1"}, // user1 already exists in makeFeature
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				return f // No change expected
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - nil users",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     nil,
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errTargetUsersRequired,
+		},
+		{
+			desc: "error - empty user",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     []string{""},
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errTargetUserRequired,
+		},
+		{
+			desc: "error - target not found",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			target: &feature.Target{
+				Variation: "non-existent",
+				Users:     []string{"user1"},
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errTargetNotFound,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateAddTargetUsers(p.target)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				idx, findErr := actual.findTarget(p.target.Variation)
+				require.NoError(t, findErr)
+				expected := p.expectedFunc()
+				expectedIdx, expectedFindErr := expected.findTarget(p.target.Variation)
+				require.NoError(t, expectedFindErr)
+				assert.ElementsMatch(t, expected.Targets[expectedIdx].Users, actual.Targets[idx].Users)
+			}
+		})
+	}
+}
+
+func TestUpdateRemoveTargetUsers(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		target       *feature.Target
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - remove existing users",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Targets[0].Users = []string{"user1", "user2", "user3"}
+				return f
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     []string{"user1", "user3"},
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Targets[0].Users = []string{"user2"}
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "no-op - remove non-existent users",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Targets[0].Users = []string{"user1"}
+				return f
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     []string{"user2"},
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Targets[0].Users = []string{"user1"}
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - nil users",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     nil,
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errTargetUsersRequired,
+		},
+		{
+			desc: "error - empty user",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			target: &feature.Target{
+				Variation: "variation-A", // Using existing variation ID from makeFeature
+				Users:     []string{""},
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errTargetUserRequired,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateRemoveTargetUsers(p.target)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				idx, findErr := actual.findTarget(p.target.Variation)
+				require.NoError(t, findErr)
+				expected := p.expectedFunc()
+				expectedIdx, expectedFindErr := expected.findTarget(p.target.Variation)
+				require.NoError(t, expectedFindErr)
+				assert.ElementsMatch(t, expected.Targets[expectedIdx].Users, actual.Targets[idx].Users)
+			}
+		})
+	}
+}
+
+func TestUpdateAddRule(t *testing.T) {
+	ruleID, err := uuid.NewUUID()
+	require.NoError(t, err)
+	clauseID, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		rule         *feature.Rule
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - add new rule",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			rule: &feature.Rule{
+				Id: ruleID.String(),
+				Strategy: &feature.Strategy{
+					Type:          feature.Strategy_FIXED,
+					FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+				},
+				Clauses: []*feature.Clause{
+					{
+						Id:        clauseID.String(),
+						Attribute: "attr",
+						Operator:  feature.Clause_EQUALS,
+						Values:    []string{"val"},
+					},
+				},
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Rules = append(f.Rules, &feature.Rule{
+					Id: ruleID.String(),
+					Strategy: &feature.Strategy{
+						Type:          feature.Strategy_FIXED,
+						FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+					},
+					Clauses: []*feature.Clause{
+						{
+							Id:        clauseID.String(),
+							Attribute: "attr",
+							Operator:  feature.Clause_EQUALS,
+							Values:    []string{"val"},
+						},
+					},
+				})
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - nil rule",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			rule: nil,
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errRuleRequired,
+		},
+		{
+			desc: "error - nil strategy",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			rule: &feature.Rule{
+				Id:       ruleID.String(),
+				Strategy: nil,
+				Clauses: []*feature.Clause{
+					{
+						Id:        clauseID.String(),
+						Attribute: "attr",
+						Operator:  feature.Clause_EQUALS,
+						Values:    []string{"val"},
+					},
+				},
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errStrategyRequired,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateAddRule(p.rule)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := p.expectedFunc()
+				assert.Equal(t, len(expected.Rules), len(actual.Rules))
+				if len(actual.Rules) > 0 && p.rule != nil {
+					lastRule := actual.Rules[len(actual.Rules)-1]
+					assert.Equal(t, p.rule.Id, lastRule.Id)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateChangeRule(t *testing.T) {
+	ruleID, err := uuid.NewUUID()
+	require.NoError(t, err)
+	clauseID, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		rule         *feature.Rule
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - change rule",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Rules = append(f.Rules, &feature.Rule{
+					Id: ruleID.String(),
+					Strategy: &feature.Strategy{
+						Type:          feature.Strategy_FIXED,
+						FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+					},
+					Clauses: []*feature.Clause{
+						{
+							Id:        clauseID.String(),
+							Attribute: "attr",
+							Operator:  feature.Clause_EQUALS,
+							Values:    []string{"val"},
+						},
+					},
+				})
+				return f
+			},
+			rule: &feature.Rule{
+				Id: ruleID.String(),
+				Strategy: &feature.Strategy{
+					Type:          feature.Strategy_FIXED,
+					FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+				},
+				Clauses: []*feature.Clause{
+					{
+						Id:        clauseID.String(),
+						Attribute: "attr",
+						Operator:  feature.Clause_EQUALS,
+						Values:    []string{"updated-val"},
+					},
+				},
+			},
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Rules = append(f.Rules, &feature.Rule{
+					Id: ruleID.String(),
+					Strategy: &feature.Strategy{
+						Type:          feature.Strategy_FIXED,
+						FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+					},
+					Clauses: []*feature.Clause{
+						{
+							Id:        clauseID.String(),
+							Attribute: "attr",
+							Operator:  feature.Clause_EQUALS,
+							Values:    []string{"updated-val"},
+						},
+					},
+				})
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - nil rule",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			rule: nil,
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errRuleRequired,
+		},
+		{
+			desc: "error - rule not found",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			rule: &feature.Rule{
+				Id: "non-existent",
+				Strategy: &feature.Strategy{
+					Type:          feature.Strategy_FIXED,
+					FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+				},
+				Clauses: []*feature.Clause{
+					{
+						Id:        clauseID.String(),
+						Attribute: "attr",
+						Operator:  feature.Clause_EQUALS,
+						Values:    []string{"val"},
+					},
+				},
+			},
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errRuleNotFound,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateChangeRule(p.rule)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				if p.rule != nil {
+					idx, findErr := actual.findRuleIndex(p.rule.Id)
+					require.NoError(t, findErr)
+					assert.Equal(t, p.rule.Id, actual.Rules[idx].Id)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateRemoveRule(t *testing.T) {
+	ruleID, err := uuid.NewUUID()
+	require.NoError(t, err)
+	clauseID, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		ruleID       string
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - remove existing rule",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Rules = append(f.Rules, &feature.Rule{
+					Id: ruleID.String(),
+					Strategy: &feature.Strategy{
+						Type:          feature.Strategy_FIXED,
+						FixedStrategy: &feature.FixedStrategy{Variation: "variation-A"}, // Using existing variation ID from makeFeature
+					},
+					Clauses: []*feature.Clause{
+						{
+							Id:        clauseID.String(),
+							Attribute: "attr",
+							Operator:  feature.Clause_EQUALS,
+							Values:    []string{"val"},
+						},
+					},
+				})
+				return f
+			},
+			ruleID: ruleID.String(),
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - rule not found",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			ruleID: "non-existent",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errRuleNotFound,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateRemoveRule(p.ruleID)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := p.expectedFunc()
+				assert.Equal(t, len(expected.Rules), len(actual.Rules))
+			}
+		})
+	}
+}
+
+func TestUpdateAddPrerequisite(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		featureID    string
+		variationID  string
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - add new prerequisite",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			featureID:   "feature-1",
+			variationID: "variation-1",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-1",
+				})
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - empty feature ID",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			featureID:   "",
+			variationID: "variation-1",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errFeatureIDRequired,
+		},
+		{
+			desc: "error - empty variation ID",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			featureID:   "feature-1",
+			variationID: "",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errVariationIDRequired,
+		},
+		{
+			desc: "error - prerequisite already exists",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-1",
+				})
+				return f
+			},
+			featureID:   "feature-1",
+			variationID: "variation-2",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errPrerequisiteAlreadyExists,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateAddPrerequisite(p.featureID, p.variationID)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := p.expectedFunc()
+				assert.Equal(t, len(expected.Prerequisites), len(actual.Prerequisites))
+				if len(actual.Prerequisites) > 0 {
+					lastPrereq := actual.Prerequisites[len(actual.Prerequisites)-1]
+					assert.Equal(t, p.featureID, lastPrereq.FeatureId)
+					assert.Equal(t, p.variationID, lastPrereq.VariationId)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateChangePrerequisiteVariation(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		featureID    string
+		variationID  string
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - change prerequisite variation",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-1",
+				})
+				return f
+			},
+			featureID:   "feature-1",
+			variationID: "variation-2",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-2",
+				})
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "no-op - same prerequisite variation",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-1",
+				})
+				return f
+			},
+			featureID:   "feature-1",
+			variationID: "variation-1",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-1",
+				})
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - prerequisite not found",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			featureID:   "non-existent",
+			variationID: "variation-1",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errPrerequisiteNotFound,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateChangePrerequisiteVariation(p.featureID, p.variationID)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				if p.expectedErr == nil {
+					idx, findErr := actual.findPrerequisiteIndex(p.featureID)
+					require.NoError(t, findErr)
+					assert.Equal(t, p.variationID, actual.Prerequisites[idx].VariationId)
+				}
+			}
+		})
+	}
+}
+
+func TestUpdateRemovePrerequisite(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		featureID    string
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - remove existing prerequisite",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Prerequisites = append(f.Prerequisites, &feature.Prerequisite{
+					FeatureId:   "feature-1",
+					VariationId: "variation-1",
+				})
+				return f
+			},
+			featureID: "feature-1",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - prerequisite not found",
+			inputFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			featureID: "non-existent",
+			expectedFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedErr: errPrerequisiteNotFound,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateRemovePrerequisite(p.featureID)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := p.expectedFunc()
+				assert.Equal(t, len(expected.Prerequisites), len(actual.Prerequisites))
+			}
+		})
+	}
+}
+
+func TestUpdateAddTag(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		tag          string
+		expectedFunc func() *Feature
+	}{
+		{
+			desc: "success - add new tag",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1"}
+				return f
+			},
+			tag: "tag2",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1", "tag2"}
+				return f
+			},
+		},
+		{
+			desc: "no-op - add existing tag",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1"}
+				return f
+			},
+			tag: "tag1",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1"}
+				return f
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateAddTag(p.tag)
+			require.NoError(t, err)
+			expected := p.expectedFunc()
+			assert.ElementsMatch(t, expected.Tags, actual.Tags)
+		})
+	}
+}
+
+func TestUpdateRemoveTag(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		inputFunc    func() *Feature
+		tag          string
+		expectedFunc func() *Feature
+		expectedErr  error
+	}{
+		{
+			desc: "success - remove existing tag",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1", "tag2"}
+				return f
+			},
+			tag: "tag1",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag2"}
+				return f
+			},
+			expectedErr: nil,
+		},
+		{
+			desc: "error - remove non-existent tag",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1"}
+				return f
+			},
+			tag: "tag2",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1"}
+				return f
+			},
+			expectedErr: ErrTagNotFound,
+		},
+		{
+			desc: "success - remove last tag",
+			inputFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{"tag1"}
+				return f
+			},
+			tag: "tag1",
+			expectedFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.Tags = []string{}
+				return f
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			actual := p.inputFunc()
+			err := actual.updateRemoveTag(p.tag)
+			if p.expectedErr != nil {
+				assert.Equal(t, p.expectedErr, err)
+			} else {
+				require.NoError(t, err)
+				expected := p.expectedFunc()
+				assert.ElementsMatch(t, expected.Tags, actual.Tags)
+			}
+		})
+	}
+}
+
+func TestUpdateCompleteNoChangesScenario(t *testing.T) {
+	t.Parallel()
+
+	// Create a comprehensive feature with all possible fields set
+	v1, err := uuid.NewUUID()
+	require.NoError(t, err)
+	v2, err := uuid.NewUUID()
+	require.NoError(t, err)
+	ruleID, err := uuid.NewUUID()
+	require.NoError(t, err)
+	clauseID, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	fixedTimestamp := time.Now().Unix() - 3600 // 1 hour ago
+	originalVersion := int32(10)
+
+	originalFeature := &Feature{
+		Feature: &feature.Feature{
+			Id:            "comprehensive-test-feature",
+			Name:          "Comprehensive Test Feature",
+			Description:   "A feature with all possible fields set",
+			Tags:          []string{"tag1", "tag2", "tag3"},
+			Enabled:       true,
+			Archived:      false,
+			Version:       originalVersion,
+			UpdatedAt:     fixedTimestamp,
+			VariationType: feature.Feature_BOOLEAN,
+			Variations: []*feature.Variation{
+				{Id: v1.String(), Name: "v1", Value: "true", Description: "First variation"},
+				{Id: v2.String(), Name: "v2", Value: "false", Description: "Second variation"},
+			},
+			Targets: []*feature.Target{
+				{Variation: v1.String(), Users: []string{"user1", "user2"}},
+				{Variation: v2.String(), Users: []string{"user3"}},
+			},
+			Rules: []*feature.Rule{
+				{
+					Id: ruleID.String(),
+					Strategy: &feature.Strategy{
+						Type:          feature.Strategy_FIXED,
+						FixedStrategy: &feature.FixedStrategy{Variation: v1.String()},
+					},
+					Clauses: []*feature.Clause{
+						{
+							Id:        clauseID.String(),
+							Attribute: "user_type",
+							Operator:  feature.Clause_EQUALS,
+							Values:    []string{"premium"},
+						},
+					},
+				},
+			},
+			Prerequisites: []*feature.Prerequisite{
+				{FeatureId: "prerequisite-feature-1", VariationId: v1.String()},
+			},
+			DefaultStrategy: &feature.Strategy{
+				Type: feature.Strategy_ROLLOUT,
+				RolloutStrategy: &feature.RolloutStrategy{
+					Variations: []*feature.RolloutStrategy_Variation{
+						{Variation: v1.String(), Weight: 30000},
+						{Variation: v2.String(), Weight: 70000},
+					},
+				},
+			},
+			OffVariation: v2.String(),
+			SamplingSeed: "test-sampling-seed",
+		},
+	}
+
+	// Call Update with IDENTICAL values to all current fields
+	updated, err := originalFeature.Update(
+		// Basic fields - all identical to original
+		wrapperspb.String("Comprehensive Test Feature"),                   // name - same
+		wrapperspb.String("A feature with all possible fields set"),       // description - same
+		&common.StringListValue{Values: []string{"tag1", "tag2", "tag3"}}, // tags - same order
+		wrapperspb.Bool(true),  // enabled - same
+		wrapperspb.Bool(false), // archived - same
+		&feature.Strategy{ // defaultStrategy - identical
+			Type: feature.Strategy_ROLLOUT,
+			RolloutStrategy: &feature.RolloutStrategy{
+				Variations: []*feature.RolloutStrategy_Variation{
+					{Variation: v1.String(), Weight: 30000},
+					{Variation: v2.String(), Weight: 70000},
+				},
+			},
+		},
+		wrapperspb.String(v2.String()), // offVariation - same
+		false,                          // resetSamplingSeed - no reset
+
+		// Granular changes - all empty (no changes)
+		nil, // prerequisiteChanges - no changes
+		nil, // targetChanges - no changes
+		nil, // ruleChanges - no changes
+		nil, // variationChanges - no changes
+		nil, // tagChanges - no changes
+	)
+
+	require.NoError(t, err)
+
+	// CRITICAL ASSERTIONS: Version and timestamp should NOT change
+	assert.Equal(t, originalVersion, updated.Version, "Version should NOT increment when no actual changes occur")
+	assert.Equal(t, fixedTimestamp, updated.UpdatedAt, "UpdatedAt should NOT change when no actual changes occur")
+
+	// Verify all field values remain exactly the same
+	assert.Equal(t, originalFeature.Id, updated.Id)
+	assert.Equal(t, originalFeature.Name, updated.Name)
+	assert.Equal(t, originalFeature.Description, updated.Description)
+	assert.ElementsMatch(t, originalFeature.Tags, updated.Tags)
+	assert.Equal(t, originalFeature.Enabled, updated.Enabled)
+	assert.Equal(t, originalFeature.Archived, updated.Archived)
+	assert.Equal(t, originalFeature.OffVariation, updated.OffVariation)
+	assert.Equal(t, originalFeature.SamplingSeed, updated.SamplingSeed)
+
+	// Deep comparison of complex fields
+	assert.Equal(t, originalFeature.Variations, updated.Variations)
+	assert.Equal(t, originalFeature.Targets, updated.Targets)
+	assert.Equal(t, originalFeature.Rules, updated.Rules)
+	assert.Equal(t, originalFeature.Prerequisites, updated.Prerequisites)
+
+	// Compare default strategy
+	assert.True(t, compareStrategies(originalFeature.DefaultStrategy, updated.DefaultStrategy),
+		"Default strategy should remain identical")
+}
+
+// TestUpdateWithActualChangesIncrementsVersionAndTimestamp verifies the opposite scenario
+func TestUpdateWithActualChangesIncrementsVersionAndTimestamp(t *testing.T) {
+	t.Parallel()
+
+	v1, err := uuid.NewUUID()
+	require.NoError(t, err)
+	v2, err := uuid.NewUUID()
+	require.NoError(t, err)
+
+	fixedTimestamp := time.Now().Unix() - 3600 // 1 hour ago
+	originalVersion := int32(5)
+
+	originalFeature := &Feature{
+		Feature: &feature.Feature{
+			Id:          "test-feature",
+			Name:        "Original Name",
+			Description: "Original Description",
+			Enabled:     false,
+			Archived:    false,
+			Version:     originalVersion,
+			UpdatedAt:   fixedTimestamp,
+			Variations: []*feature.Variation{
+				{Id: v1.String(), Name: "v1", Value: "true"},
+				{Id: v2.String(), Name: "v2", Value: "false"},
+			},
+			Targets: []*feature.Target{
+				{Variation: v1.String(), Users: []string{}},
+				{Variation: v2.String(), Users: []string{}},
+			},
+		},
+	}
+
+	// Make an actual change (different name)
+	updated, err := originalFeature.Update(
+		wrapperspb.String("Updated Name"), // CHANGED - different from original
+		nil, nil, nil, nil, nil, nil, false, nil, nil, nil, nil, nil,
+	)
+
+	require.NoError(t, err)
+
+	// CRITICAL ASSERTIONS: Version and timestamp SHOULD change
+	assert.Equal(t, originalVersion+1, updated.Version, "Version should increment when actual changes occur")
+	assert.NotEqual(t, fixedTimestamp, updated.UpdatedAt, "UpdatedAt should change when actual changes occur")
+	assert.True(t, updated.UpdatedAt > fixedTimestamp, "UpdatedAt should be more recent")
+
+	// Verify the change took effect
+	assert.Equal(t, "Updated Name", updated.Name)
+}

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -15,6 +15,7 @@
 package domain
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -1450,7 +1451,7 @@ func TestUpdateRemoveTag(t *testing.T) {
 				f.Tags = []string{"tag1"}
 				return f
 			},
-			expectedErr: ErrTagNotFound,
+			expectedErr: errors.New("feature: tag not found"),
 		},
 		{
 			desc: "success - remove last tag",

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
@@ -1603,7 +1604,7 @@ func TestUpdateCompleteNoChangesScenario(t *testing.T) {
 	assert.Equal(t, originalFeature.Prerequisites, updated.Prerequisites)
 
 	// Compare default strategy
-	assert.True(t, compareStrategies(originalFeature.DefaultStrategy, updated.DefaultStrategy),
+	assert.True(t, proto.Equal(originalFeature.DefaultStrategy, updated.DefaultStrategy),
 		"Default strategy should remain identical")
 }
 


### PR DESCRIPTION
When the console sends in the flag update API, the `enabled` and `archived` fields, the new update logic still uses old functions from the old UI, which updates the `updated_at` when setting those fields. So, even if the boolean value is the same, because the `updated_at` was updated, MySQL saves with no issues, causing an incorrect state in the audit logs with only the `updated_at`.

If the console tries to send those two fields without changing the current state, it will return the following error, so we can know there is something wrong next time.


```sh
{"code":2, "message":"feature: unexpected affected rows", "details":[]}
```

### Problem
- Shallow Copy Bug: `copier.Copy` caused modifications to the updated feature to also modify the original feature, making copier.Copy always sees them as identical. Preventing version increments even when changes occurred
- Unnecessary Updates: Identical values (e.g., enabled: true when already enabled) incorrectly incremented version/timestamp
- Inconsistent Serialization: Empty slices showed as null vs [] between API responses and audit logs

### Solution
- Use copier.CopyWithOption(..., DeepCopy: true) for proper feature isolation
- Use proto.Equal() to detect actual changes and only update version/timestamp when needed
- Standardize empty slices as [] for consistent JSON serialization
- Fix audit log events to use updated.Version instead of feature.Version