### PR TITLE
fix: duplicate metrics collector registration attempted

### DIFF
--- a/pkg/storage/v2/bigquery/querier/metrics.go
+++ b/pkg/storage/v2/bigquery/querier/metrics.go
@@ -17,6 +17,7 @@ package querier
 import (
 	"errors"
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,6 +41,7 @@ const (
 )
 
 var (
+	registerOnce   sync.Once
 	handledCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -96,8 +98,10 @@ func getCodeFromError(err error) string {
 }
 
 func registerMetrics(r metrics.Registerer) {
-	r.MustRegister(
-		handledCounter,
-		handledHistogram,
-	)
+	registerOnce.Do(func() {
+		r.MustRegister(
+			handledCounter,
+			handledHistogram,
+		)
+	})
 }

--- a/pkg/storage/v2/bigquery/writer/metrics.go
+++ b/pkg/storage/v2/bigquery/writer/metrics.go
@@ -15,6 +15,7 @@
 package writer
 
 import (
+	"sync"
 	"time"
 
 	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
@@ -41,6 +42,7 @@ const (
 )
 
 var (
+	registerOnce   sync.Once
 	handledCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: "bucketeer",
@@ -104,8 +106,10 @@ func getCodeFromError(err error) string {
 }
 
 func RegisterMetrics(r metrics.Registerer) {
-	r.MustRegister(
-		handledCounter,
-		handledHistogram,
-	)
+	registerOnce.Do(func() {
+		r.MustRegister(
+			handledCounter,
+			handledHistogram,
+		)
+	})
 }

--- a/pkg/storage/v2/bigquery/writer/metrics_test.go
+++ b/pkg/storage/v2/bigquery/writer/metrics_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/bigquery/storage/apiv1/storagepb"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -172,4 +173,25 @@ func TestGetCodeFromError(t *testing.T) {
 			assert.Equal(t, p.expected, actual, "%s", p.desc)
 		})
 	}
+}
+
+func TestRegisterMetrics(t *testing.T) {
+	t.Parallel()
+
+	// Create a new registry to avoid interfering with other tests
+	registry := prometheus.NewRegistry()
+
+	// Test that RegisterMetrics can be called multiple times without panic
+	// This should not panic due to the sync.Once protection
+	assert.NotPanics(t, func() {
+		RegisterMetrics(registry)
+	})
+
+	assert.NotPanics(t, func() {
+		RegisterMetrics(registry)
+	})
+
+	assert.NotPanics(t, func() {
+		RegisterMetrics(registry)
+	})
 }

--- a/pkg/subscriber/cmd/server/server.go
+++ b/pkg/subscriber/cmd/server/server.go
@@ -38,7 +38,6 @@ import (
 	redisv3 "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
 	"github.com/bucketeer-io/bucketeer/pkg/rest"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc/client"
-	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/writer"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/pkg/subscriber"
 	"github.com/bucketeer-io/bucketeer/pkg/subscriber/processor"
@@ -480,7 +479,6 @@ func (s *server) registerPubSubProcessorMap(
 	logger *zap.Logger,
 ) (*processor.PubSubProcessors, error) {
 	processors := processor.NewPubSubProcessors(registerer)
-	writer.RegisterMetrics(registerer)
 
 	processorsConfigBytes, err := os.ReadFile(*s.processorsConfig)
 	if err != nil {


### PR DESCRIPTION
Fix the panic error.
The subscriber creates multiple queriers and writers for evaluation and goal events in the same processor, which causes it to panic. So, I implemented the `RegisterOnce`, which we already use in some places similar to this.

```sh
panic: duplicate metrics collector registration attempted

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*Registry).MustRegister(...)
	/home/runner/work/bucketeer/bucketeer/vendor/github.com/prometheus/client_golang/prometheus/registry.go:406
github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/writer.RegisterMetrics(...)
	/home/runner/work/bucketeer/bucketeer/pkg/storage/v2/bigquery/writer/metrics.go:107
github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/writer.NewWriter({0x1dc5950, 0xc000c84af0}, {0xc000c8a348, 0x11}, {0xc000c24e80, 0xd}, {0x1a7d7e5, 0x10}, {0x1dda7c0, 0xc0000160f0}, ...)
	/home/runner/work/bucketeer/bucketeer/pkg/storage/v2/bigquery/writer/client.go:88 +0x251
github.com/bucketeer-io/bucketeer/pkg/subscriber/processor.NewEvalEventWriter({0x1dc5950, 0xc000c84af0}, 0xc0009dcf00, {0x1dd81f8, 0xc000ef4600}, {0x1dbe598, 0xc0010a0c20}, {0xc000c8a348, 0x11}, {0xc000c24e80, ...}, ...)
	/home/runner/work/bucketeer/bucketeer/pkg/subscriber/processor/evaluation_events_dwh.go:99 +0x29c
github.com/bucketeer-io/bucketeer/pkg/subscriber/processor.NewEventsDWHPersister({0x1dc5950, 0xc000c84af0}, {0x17c2e40?, 0xc000a00a50?}, {0x1dcd260, 0xc000f34078}, {0x1de1eb0, 0xc0010a3a70}, {0x1de1eb0, 0xc00100c0c0}, ...)
	/home/runner/work/bucketeer/bucketeer/pkg/subscriber/processor/events_dwh_persister.go:186 +0xcbc
github.com/bucketeer-io/bucketeer/pkg/subscriber/cmd/server.(*server).registerPubSubProcessorMap(0xc0009e1b00, {0x1dc5950, 0xc000c84af0}, {0x1dde9a0, 0xc000883560}, {0x1dcd260, 0xc000f34078}, {0x1de1eb0, 0xc00100c0c0}, {0x1de1eb0, ...}, ...)
	/home/runner/work/bucketeer/bucketeer/pkg/subscriber/cmd/server/server.go:584 +0xf4d
github.com/bucketeer-io/bucketeer/pkg/subscriber/cmd/server.(*server).Run(0xc0009e1b00, {0x1dc5950, 0xc000c84af0}, {0x1dc8840, 0xc000b4ab80}, 0xc0009dcf00)
	/home/runner/work/bucketeer/bucketeer/pkg/subscriber/cmd/server/server.go:322 +0xfbc
github.com/bucketeer-io/bucketeer/pkg/cli.(*App).Run(0xc000b33200)
	/home/runner/work/bucketeer/bucketeer/pkg/cli/app.go:163 +0x19a5
main.main()
	/home/runner/work/bucketeer/bucketeer/cmd/subscriber/subscriber.go:33 +0x76
```