### PR TITLE
chore: improve error log when saving audit logs

### DIFF
--- a/pkg/subscriber/processor/auditlog_persister.go
+++ b/pkg/subscriber/processor/auditlog_persister.go
@@ -164,7 +164,22 @@ func (a auditLogPersister) createAuditLogsMySQL(
 				subscriberHandledCounter.WithLabelValues(subscriberAuditLog, codes.NonRepeatableError.String()).Inc()
 				messages[i].Ack()
 			} else {
-				a.logger.Error("Failed to put audit logs", zap.Error(err))
+				var publicApiEditor string
+				if aud.Editor.PublicApiEditor != nil {
+					publicApiEditor = aud.Editor.PublicApiEditor.Maintainer
+				}
+				a.logger.Error("Failed to put audit logs",
+					zap.Error(err),
+					zap.String("entity_id", aud.EntityId),
+					zap.String("editor", aud.Editor.Email),
+					zap.String("public_api_editor", publicApiEditor),
+					zap.String("type", aud.Type.String()),
+					zap.Int("entity_data_size", len(aud.EntityData)),
+					zap.Int("previous_entity_data_size", len(aud.PreviousEntityData)),
+					zap.Any("entity_type", aud.EntityType),
+					zap.String("entity_data", aud.EntityData),
+					zap.String("previous_entity_data", aud.PreviousEntityData),
+				)
 				subscriberHandledCounter.WithLabelValues(subscriberAuditLog, codes.RepeatableError.String()).Inc()
 				messages[i].Nack()
 			}


### PR DESCRIPTION
I'm investigating the following error when saving the audit log.

```sh
ERROR 2025-07-15T02:18:13.876800485Z [resource.labels.containerName: subscriber] Failed to put audit logs
"error": "Error 1406 (22001): Data too long for column 'entity_data' at row 1"
```

### Resolution

The cause was that the user saved a very large list of user IDs in the individual targeting. So, when saving the entire feature object in the entity_data column exceeded the max limit of 64 KB.
I have asked the maintainer to use the user segment instead, and I have purged the message from PubSub since we are not going to support an entity larger than 64 KB at the moment.