### PR TITLE
chore: remove email verified validation when authenticating

### DIFF
--- a/pkg/auth/error.go
+++ b/pkg/auth/error.go
@@ -37,5 +37,4 @@ var (
 	StateMissingPassword          = gstatus.New(codes.InvalidArgument, "auth: missing password")
 	StatusAccessDenied            = gstatus.New(codes.PermissionDenied, "auth: access denied")
 	StatusInvalidOrganization     = gstatus.New(codes.InvalidArgument, "auth: invalid organization")
-	StatusEmailNotVerified        = gstatus.New(codes.FailedPrecondition, "auth: email not verified")
 )

--- a/pkg/environment/api/api.go
+++ b/pkg/environment/api/api.go
@@ -190,23 +190,6 @@ func (s *EnvironmentService) ExchangeDemoToken(
 		}
 		return nil, dt.Err()
 	}
-	if !userInfo.VerifiedEmail {
-		s.logger.Error("Email is not verified",
-			zap.String("email", userInfo.Email),
-			zap.Any("type", req.Type),
-			zap.String("code", req.Code),
-			zap.String("redirect_url", req.RedirectUrl),
-		)
-		dt, err := auth.StatusEmailNotVerified.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.Account),
-		})
-		if err != nil {
-			return nil, auth.StatusEmailNotVerified.Err()
-		}
-		return nil, dt.Err()
-	}
-
 	existedInSystem, err := s.checkEmailExistedInSystem(ctx, userInfo.Email, localizer)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We should not check the email, because most users are not verified. We could introduce this as optional in the future if required.