### PR TITLE
fix: admin access only entities are not listing for owner users

### DIFF
--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -1195,9 +1195,10 @@ func (s *AccountService) ListAccountsV2(
 		return nil, err
 	}
 
-	// If not an organization admin or system admin, a user can only view accounts in their environments
+	// If not an organization admin or organization owner or system admin,
+	// a user can only view accounts in their environments
 	requestEnvironmentRoles := make([]*accountproto.AccountV2_EnvironmentRole, 0)
-	if editor.OrganizationRole != accountproto.AccountV2_Role_Organization_ADMIN && !editor.IsAdmin {
+	if editor.OrganizationRole == accountproto.AccountV2_Role_Organization_MEMBER {
 		requestEnvironmentRoles, err = s.constructEnvironmentRoles(req, editor)
 		if err != nil {
 			return nil, err

--- a/pkg/account/api/account.go
+++ b/pkg/account/api/account.go
@@ -204,7 +204,7 @@ func (s *AccountService) createAccountV2NoCommand(
 			if err != nil {
 				return err
 			}
-			// Store the event to publish after transaction
+			// Store the event to publish after the transaction commits to ensure consistency
 			createAccountEvent = updateAccountEvent
 			return nil
 		}
@@ -1195,8 +1195,7 @@ func (s *AccountService) ListAccountsV2(
 		return nil, err
 	}
 
-	// If not an organization admin or organization owner or system admin,
-	// a user can only view accounts in their environments
+	// Users with member role can only view accounts in the environments they have access to
 	requestEnvironmentRoles := make([]*accountproto.AccountV2_EnvironmentRole, 0)
 	if editor.OrganizationRole == accountproto.AccountV2_Role_Organization_MEMBER {
 		requestEnvironmentRoles, err = s.constructEnvironmentRoles(req, editor)

--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -495,10 +495,6 @@ func TestCreateAccountV2NoCommandMySQL(t *testing.T) {
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
 
-				s.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
-					gomock.Any(), gomock.Any(),
-				).Return(nil)
-
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().UpdateAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -418,7 +418,7 @@ func (s *AccountService) getMyOrganizations(
 		if accWithOrg.AccountV2.Disabled || accWithOrg.Organization.Disabled || accWithOrg.Organization.Archived {
 			continue
 		}
-		// If the user is an admin or owner, no need to filter environments.
+		// Add the organization if the account is an admin or owner.
 		// Otherwise, we check if the account is enabled in any environment in this organization.
 		if accWithOrg.AccountV2.OrganizationRole == accountproto.AccountV2_Role_Organization_ADMIN ||
 			accWithOrg.AccountV2.OrganizationRole == accountproto.AccountV2_Role_Organization_OWNER {

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -170,10 +170,11 @@ func (s *AccountService) GetMe(
 		return nil, err
 	}
 	var envRoles []*accountproto.ConsoleAccount_EnvironmentRole
-	if account.OrganizationRole == accountproto.AccountV2_Role_Organization_ADMIN {
-		envRoles = s.getAdminConsoleAccountEnvironmentRoles(environments, projects)
-	} else {
+	if account.OrganizationRole == accountproto.AccountV2_Role_Organization_MEMBER {
 		envRoles = s.getConsoleAccountEnvironmentRoles(account.EnvironmentRoles, environments, projects)
+	} else {
+		// If the user is an admin or owner, no need to filter environments.
+		envRoles = s.getAdminConsoleAccountEnvironmentRoles(environments, projects)
 	}
 
 	// update user last seen
@@ -417,9 +418,10 @@ func (s *AccountService) getMyOrganizations(
 		if accWithOrg.AccountV2.Disabled || accWithOrg.Organization.Disabled || accWithOrg.Organization.Archived {
 			continue
 		}
-		// If the account is an admin account, we append the organization.
+		// If the user is an admin or owner, no need to filter environments.
 		// Otherwise, we check if the account is enabled in any environment in this organization.
-		if accWithOrg.AccountV2.OrganizationRole == accountproto.AccountV2_Role_Organization_ADMIN {
+		if accWithOrg.AccountV2.OrganizationRole == accountproto.AccountV2_Role_Organization_ADMIN ||
+			accWithOrg.AccountV2.OrganizationRole == accountproto.AccountV2_Role_Organization_OWNER {
 			myOrgs = append(myOrgs, accWithOrg.Organization)
 			continue
 		}

--- a/pkg/account/api/api_key.go
+++ b/pkg/account/api/api_key.go
@@ -634,10 +634,7 @@ func (s *AccountService) getAllowedEnvironments(
 	editor *eventproto.Editor,
 ) []string {
 	filterEnvironmentIDs := make([]string, 0)
-	if editor.OrganizationRole == proto.AccountV2_Role_Organization_ADMIN || editor.IsAdmin {
-		// if the user is an admin, no need to filter environments.
-		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
-	} else {
+	if editor.OrganizationRole == proto.AccountV2_Role_Organization_MEMBER {
 		// only show API keys in allowed environments for member.
 		if len(reqEnvironmentIDs) > 0 {
 			for _, id := range reqEnvironmentIDs {
@@ -653,6 +650,9 @@ func (s *AccountService) getAllowedEnvironments(
 				filterEnvironmentIDs = append(filterEnvironmentIDs, e.EnvironmentId)
 			}
 		}
+	} else {
+		// if the user is an admin or owner, no need to filter environments.
+		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
 	}
 	return filterEnvironmentIDs
 }

--- a/pkg/account/domain/account.go
+++ b/pkg/account/domain/account.go
@@ -144,7 +144,8 @@ func (a *AccountV2) Update(
 	if len(environmentRoles) > 0 {
 		updated.EnvironmentRoles = environmentRoles
 	}
-	if updated.OrganizationRole == proto.AccountV2_Role_Organization_ADMIN {
+	if updated.OrganizationRole == proto.AccountV2_Role_Organization_ADMIN ||
+		updated.OrganizationRole == proto.AccountV2_Role_Organization_OWNER {
 		updated.EnvironmentRoles = []*proto.AccountV2_EnvironmentRole{}
 	}
 	if isDisabled != nil {

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -771,10 +771,7 @@ func (s *NotificationService) getAllowedEnvironments(
 	editor *eventproto.Editor,
 ) []string {
 	filterEnvironmentIDs := make([]string, 0)
-	if editor.OrganizationRole == accountproto.AccountV2_Role_Organization_ADMIN || editor.IsAdmin {
-		// if the user is an admin, no need to filter environments.
-		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
-	} else {
+	if editor.OrganizationRole == accountproto.AccountV2_Role_Organization_MEMBER {
 		// only show API keys in allowed environments for member.
 		if len(reqEnvironmentIDs) > 0 {
 			for _, id := range reqEnvironmentIDs {
@@ -790,6 +787,9 @@ func (s *NotificationService) getAllowedEnvironments(
 				filterEnvironmentIDs = append(filterEnvironmentIDs, e.EnvironmentId)
 			}
 		}
+	} else {
+		// if the user is an admin or owner, no need to filter environments.
+		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
 	}
 	return filterEnvironmentIDs
 }

--- a/pkg/push/api/api.go
+++ b/pkg/push/api/api.go
@@ -1095,10 +1095,7 @@ func (s *PushService) getAllowedEnvironments(
 	editor *eventproto.Editor,
 ) []string {
 	filterEnvironmentIDs := make([]string, 0)
-	if editor.OrganizationRole == accountproto.AccountV2_Role_Organization_ADMIN || editor.IsAdmin {
-		// if the user is an admin, no need to filter environments.
-		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
-	} else {
+	if editor.OrganizationRole == accountproto.AccountV2_Role_Organization_MEMBER {
 		// only show API keys in allowed environments for member.
 		if len(reqEnvironmentIDs) > 0 {
 			for _, id := range reqEnvironmentIDs {
@@ -1114,6 +1111,9 @@ func (s *PushService) getAllowedEnvironments(
 				filterEnvironmentIDs = append(filterEnvironmentIDs, e.EnvironmentId)
 			}
 		}
+	} else {
+		// if the user is an admin or owner, no need to filter environments.
+		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
 	}
 	return filterEnvironmentIDs
 }

--- a/pkg/tag/api/api.go
+++ b/pkg/tag/api/api.go
@@ -645,10 +645,7 @@ func (s *TagService) getAllowedEnvironments(
 	editor *eventproto.Editor,
 ) []string {
 	filterEnvironmentIDs := make([]string, 0)
-	if editor.OrganizationRole == accproto.AccountV2_Role_Organization_ADMIN || editor.IsAdmin {
-		// if the user is an admin, no need to filter environments.
-		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
-	} else {
+	if editor.OrganizationRole == accproto.AccountV2_Role_Organization_MEMBER {
 		// only show API keys in allowed environments for member.
 		if len(reqEnvironmentIDs) > 0 {
 			for _, id := range reqEnvironmentIDs {
@@ -664,6 +661,9 @@ func (s *TagService) getAllowedEnvironments(
 				filterEnvironmentIDs = append(filterEnvironmentIDs, e.EnvironmentId)
 			}
 		}
+	} else {
+		// if the user is an admin or owner, no need to filter environments.
+		filterEnvironmentIDs = append(filterEnvironmentIDs, reqEnvironmentIDs...)
 	}
 	return filterEnvironmentIDs
 }


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2023 https://github.com/bucketeer-io/bucketeer/issues/2024 https://github.com/bucketeer-io/bucketeer/issues/2025

### Things done

- Fixed the issue not listing all accounts when the current user is the owner
- Fixed list environments, API keys, subscriptions, and Slack notifications not showing to an owner user
- Fixed unexpected affected rows when creating accounts 

