### PR TITLE
chore: change the ttl of UserAttributeKeys to config management

### DIFF
--- a/manifests/bucketeer/charts/batch/values.dev.yaml
+++ b/manifests/bucketeer/charts/batch/values.dev.yaml
@@ -228,7 +228,7 @@ processors:
     flushSize: 100
     flushInterval: 10
     writeCacheInterval: 10
-    userAttributeTTLDay: 1
+    userAttributeKeyTtl: 3600 # 1 hour
   segmentUserPersister:
     domainEventProject: bucketeer-test
     domainEventTopic: domain

--- a/manifests/bucketeer/charts/batch/values.dev.yaml
+++ b/manifests/bucketeer/charts/batch/values.dev.yaml
@@ -228,6 +228,7 @@ processors:
     flushSize: 100
     flushInterval: 10
     writeCacheInterval: 10
+    userAttributeTTLDay: 1
   segmentUserPersister:
     domainEventProject: bucketeer-test
     domainEventTopic: domain

--- a/manifests/bucketeer/charts/subscriber/values.yaml
+++ b/manifests/bucketeer/charts/subscriber/values.yaml
@@ -232,7 +232,7 @@ processors:
     flushSize: 100
     flushInterval: 10
     writeCacheInterval: 10
-    userAttributeTTLDay: 1
+    userAttributeKeyTtl: 604800 # 7 days
   segmentUserPersister:
     domainEventProject:
     domainEventTopic:

--- a/manifests/bucketeer/charts/subscriber/values.yaml
+++ b/manifests/bucketeer/charts/subscriber/values.yaml
@@ -232,6 +232,7 @@ processors:
     flushSize: 100
     flushInterval: 10
     writeCacheInterval: 10
+    userAttributeTTLDay: 1
   segmentUserPersister:
     domainEventProject:
     domainEventTopic:

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -489,7 +489,7 @@ subscriber:
       flushSize: 10
       flushInterval: 5
       writeCacheInterval: 10
-      userAttributeTTLDay: 1
+      userAttributeKeyTtl: 3600 # 1 hour
     segmentUserPersister:
       domainEventProject: bucketeer-test
       domainEventTopic: domain

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -489,6 +489,7 @@ subscriber:
       flushSize: 10
       flushInterval: 5
       writeCacheInterval: 10
+      userAttributeTTLDay: 1
     segmentUserPersister:
       domainEventProject: bucketeer-test
       domainEventTopic: domain

--- a/pkg/cache/v3/mock/user.go
+++ b/pkg/cache/v3/mock/user.go
@@ -11,6 +11,7 @@ package mock
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "go.uber.org/mock/gomock"
 
@@ -56,7 +57,7 @@ func (mr *MockUserAttributesCacheMockRecorder) GetUserAttributeKeyAll(environmen
 }
 
 // Put mocks base method.
-func (m *MockUserAttributesCache) Put(userAttributes *user.UserAttributes, ttl int) error {
+func (m *MockUserAttributesCache) Put(userAttributes *user.UserAttributes, ttl time.Duration) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Put", userAttributes, ttl)
 	ret0, _ := ret[0].(error)

--- a/pkg/cache/v3/mock/user.go
+++ b/pkg/cache/v3/mock/user.go
@@ -56,15 +56,15 @@ func (mr *MockUserAttributesCacheMockRecorder) GetUserAttributeKeyAll(environmen
 }
 
 // Put mocks base method.
-func (m *MockUserAttributesCache) Put(userAttributes *user.UserAttributes, ttlDay int) error {
+func (m *MockUserAttributesCache) Put(userAttributes *user.UserAttributes, ttl int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", userAttributes, ttlDay)
+	ret := m.ctrl.Call(m, "Put", userAttributes, ttl)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockUserAttributesCacheMockRecorder) Put(userAttributes, ttlDay any) *gomock.Call {
+func (mr *MockUserAttributesCacheMockRecorder) Put(userAttributes, ttl any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockUserAttributesCache)(nil).Put), userAttributes, ttlDay)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockUserAttributesCache)(nil).Put), userAttributes, ttl)
 }

--- a/pkg/cache/v3/mock/user.go
+++ b/pkg/cache/v3/mock/user.go
@@ -56,15 +56,15 @@ func (mr *MockUserAttributesCacheMockRecorder) GetUserAttributeKeyAll(environmen
 }
 
 // Put mocks base method.
-func (m *MockUserAttributesCache) Put(userAttributes *user.UserAttributes) error {
+func (m *MockUserAttributesCache) Put(userAttributes *user.UserAttributes, ttlDay int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Put", userAttributes)
+	ret := m.ctrl.Call(m, "Put", userAttributes, ttlDay)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Put indicates an expected call of Put.
-func (mr *MockUserAttributesCacheMockRecorder) Put(userAttributes any) *gomock.Call {
+func (mr *MockUserAttributesCacheMockRecorder) Put(userAttributes, ttlDay any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockUserAttributesCache)(nil).Put), userAttributes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockUserAttributesCache)(nil).Put), userAttributes, ttlDay)
 }

--- a/pkg/cache/v3/user.go
+++ b/pkg/cache/v3/user.go
@@ -26,9 +26,8 @@ import (
 )
 
 const (
-	userAttributeKind       = "user_attr"
-	userAttributesMaxSize   = int64(100)
-	defalutUserAttributeTTL = 7 * 24 * 60 * 60 // 7 days
+	userAttributeKind     = "user_attr"
+	userAttributesMaxSize = int64(100)
 )
 
 type UserAttributesCache interface {
@@ -92,11 +91,7 @@ func (u *userAttributesCache) Put(userAttributes *userproto.UserAttributes, ttl 
 		for _, value := range attribute.Values {
 			pipe.SAdd(key, value)
 		}
-		setTTL := defalutUserAttributeTTL
-		if ttl > 0 {
-			setTTL = ttl
-		}
-		pipe.Expire(key, time.Duration(setTTL)*time.Second)
+		pipe.Expire(key, time.Duration(ttl)*time.Second)
 	}
 	_, err := pipe.Exec()
 	if err != nil {

--- a/pkg/cache/v3/user.go
+++ b/pkg/cache/v3/user.go
@@ -32,7 +32,7 @@ const (
 
 type UserAttributesCache interface {
 	GetUserAttributeKeyAll(environmentId string) ([]string, error)
-	Put(userAttributes *userproto.UserAttributes, ttl int) error
+	Put(userAttributes *userproto.UserAttributes, ttl time.Duration) error
 }
 
 type userAttributesCache struct {
@@ -81,7 +81,7 @@ func (u *userAttributesCache) GetUserAttributeKeyAll(environmentId string) ([]st
 	return attributeKeys, nil
 }
 
-func (u *userAttributesCache) Put(userAttributes *userproto.UserAttributes, ttl int) error {
+func (u *userAttributesCache) Put(userAttributes *userproto.UserAttributes, ttl time.Duration) error {
 	if userAttributes == nil {
 		return errors.New("user attributes is nil")
 	}
@@ -91,7 +91,7 @@ func (u *userAttributesCache) Put(userAttributes *userproto.UserAttributes, ttl 
 		for _, value := range attribute.Values {
 			pipe.SAdd(key, value)
 		}
-		pipe.Expire(key, time.Duration(ttl)*time.Second)
+		pipe.Expire(key, ttl)
 	}
 	_, err := pipe.Exec()
 	if err != nil {

--- a/pkg/cache/v3/user.go
+++ b/pkg/cache/v3/user.go
@@ -28,7 +28,7 @@ import (
 const (
 	userAttributeKind       = "user_attr"
 	userAttributesMaxSize   = int64(100)
-	defalutUserAttributeTTL = 30 * 24 * 60 * 60 // 30 days
+	defalutUserAttributeTTL = 7 * 24 * 60 * 60 // 7 days
 )
 
 type UserAttributesCache interface {

--- a/pkg/cache/v3/user_test.go
+++ b/pkg/cache/v3/user_test.go
@@ -123,22 +123,6 @@ func TestPutUserAttributesCache(t *testing.T) {
 			expectedErr: errors.New("user attributes is nil"),
 		},
 		{
-			desc: "success_with_default_ttl",
-			setup: func(uac *userAttributesCache, pipe *redismock.MockPipeClient) {
-				for _, attr := range userAttrs.UserAttributes {
-					key := fmt.Sprintf("%s:%s:%s", testEnvironmentId, userAttributeKind, attr.Key)
-					for _, v := range attr.Values {
-						pipe.EXPECT().SAdd(key, v)
-					}
-					pipe.EXPECT().Expire(key, defalutUserAttributeTTL*time.Second)
-				}
-				pipe.EXPECT().Exec().Return(nil, nil)
-			},
-			input:       userAttrs,
-			ttlDay:      0,
-			expectedErr: nil,
-		},
-		{
 			desc: "success_with_custom_ttl",
 			setup: func(uac *userAttributesCache, pipe *redismock.MockPipeClient) {
 				customTTL := 7
@@ -163,7 +147,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, defalutUserAttributeTTL*time.Second)
+					pipe.EXPECT().Expire(key, -1*time.Second)
 				}
 				pipe.EXPECT().Exec().Return(nil, nil)
 			},
@@ -179,7 +163,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, defalutUserAttributeTTL*time.Second)
+					pipe.EXPECT().Expire(key, 0*time.Second)
 				}
 				pipe.EXPECT().Exec().Return(nil, errors.New("exec error"))
 			},

--- a/pkg/cache/v3/user_test.go
+++ b/pkg/cache/v3/user_test.go
@@ -130,7 +130,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, defalutUserAttributeTTLDay*24*time.Hour)
+					pipe.EXPECT().Expire(key, defalutUserAttributeTTL*time.Second)
 				}
 				pipe.EXPECT().Exec().Return(nil, nil)
 			},
@@ -147,7 +147,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, time.Duration(customTTL)*24*time.Hour)
+					pipe.EXPECT().Expire(key, time.Duration(customTTL)*time.Second)
 				}
 				pipe.EXPECT().Exec().Return(nil, nil)
 			},
@@ -163,7 +163,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, defalutUserAttributeTTLDay*24*time.Hour)
+					pipe.EXPECT().Expire(key, defalutUserAttributeTTL*time.Second)
 				}
 				pipe.EXPECT().Exec().Return(nil, nil)
 			},
@@ -179,7 +179,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, defalutUserAttributeTTLDay*24*time.Hour)
+					pipe.EXPECT().Expire(key, defalutUserAttributeTTL*time.Second)
 				}
 				pipe.EXPECT().Exec().Return(nil, errors.New("exec error"))
 			},

--- a/pkg/cache/v3/user_test.go
+++ b/pkg/cache/v3/user_test.go
@@ -125,13 +125,12 @@ func TestPutUserAttributesCache(t *testing.T) {
 		{
 			desc: "success_with_custom_ttl",
 			setup: func(uac *userAttributesCache, pipe *redismock.MockPipeClient) {
-				customTTL := 7
 				for _, attr := range userAttrs.UserAttributes {
 					key := fmt.Sprintf("%s:%s:%s", testEnvironmentId, userAttributeKind, attr.Key)
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, time.Duration(customTTL)*time.Second)
+					pipe.EXPECT().Expire(key, time.Duration(7))
 				}
 				pipe.EXPECT().Exec().Return(nil, nil)
 			},
@@ -147,7 +146,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 					for _, v := range attr.Values {
 						pipe.EXPECT().SAdd(key, v)
 					}
-					pipe.EXPECT().Expire(key, -1*time.Second)
+					pipe.EXPECT().Expire(key, time.Duration(-1))
 				}
 				pipe.EXPECT().Exec().Return(nil, nil)
 			},

--- a/pkg/cache/v3/user_test.go
+++ b/pkg/cache/v3/user_test.go
@@ -112,7 +112,7 @@ func TestPutUserAttributesCache(t *testing.T) {
 		desc        string
 		setup       func(*userAttributesCache, *redismock.MockPipeClient)
 		input       *userproto.UserAttributes
-		ttlDay      int
+		ttlDay      time.Duration
 		expectedErr error
 	}{
 		{

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -603,7 +603,7 @@ func (p *evaluationCountEventPersister) upsertUserAttributes(
 ) error {
 	if err := p.userAttributesCacher.Put(
 		userAttributes,
-		p.evaluationCountEventPersisterConfig.UserAttributeKeyTTL,
+		time.Duration(p.evaluationCountEventPersisterConfig.UserAttributeKeyTTL)*time.Second,
 	); err != nil {
 		p.logger.Error("Failed to save user attributes to cache",
 			zap.Error(err),

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -57,7 +57,7 @@ type EvaluationCountEventPersisterConfig struct {
 	FlushSize           int `json:"flushSize"`
 	FlushInterval       int `json:"flushInterval"`
 	WriteCacheInterval  int `json:"writeCacheInterval"`
-	UserAttributeTTLDay int `json:"userAttributeTTLDay"`
+	UserAttributeKeyTTL int `json:"userAttributeKeyTtl"`
 }
 
 type evaluationCountEventPersister struct {
@@ -603,7 +603,7 @@ func (p *evaluationCountEventPersister) upsertUserAttributes(
 ) error {
 	if err := p.userAttributesCacher.Put(
 		userAttributes,
-		p.evaluationCountEventPersisterConfig.UserAttributeTTLDay,
+		p.evaluationCountEventPersisterConfig.UserAttributeKeyTTL,
 	); err != nil {
 		p.logger.Error("Failed to save user attributes to cache",
 			zap.Error(err),

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -54,9 +54,10 @@ type environmentEventMap map[string]eventMap
 type userAttributesCache map[string]*userproto.UserAttributes
 
 type EvaluationCountEventPersisterConfig struct {
-	FlushSize          int `json:"flushSize"`
-	FlushInterval      int `json:"flushInterval"`
-	WriteCacheInterval int `json:"writeCacheInterval"`
+	FlushSize           int `json:"flushSize"`
+	FlushInterval       int `json:"flushInterval"`
+	WriteCacheInterval  int `json:"writeCacheInterval"`
+	UserAttributeTTLDay int `json:"userAttributeTTLDay"`
 }
 
 type evaluationCountEventPersister struct {
@@ -600,7 +601,10 @@ func (p *evaluationCountEventPersister) writeUserAttributes() {
 func (p *evaluationCountEventPersister) upsertUserAttributes(
 	userAttributes *userproto.UserAttributes,
 ) error {
-	if err := p.userAttributesCacher.Put(userAttributes); err != nil {
+	if err := p.userAttributesCacher.Put(
+		userAttributes,
+		p.evaluationCountEventPersisterConfig.UserAttributeTTLDay,
+	); err != nil {
 		p.logger.Error("Failed to save user attributes to cache",
 			zap.Error(err),
 			zap.String("environmentId", userAttributes.EnvironmentId),


### PR DESCRIPTION
This pull request introduces a new feature to support configurable TTL (Time-To-Live) for user attributes in the caching layer and updates related configurations and tests. The main changes include adding a `UserAttributeTTLDay` parameter, modifying the caching logic to use this parameter, and updating tests to validate the new functionality.

This PR allows you to change the storage period of `UserAttributeKeys` depending on the environment, improving the performance of e2e tests.
