### PR TITLE
ci: fix node version in push image workflow

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -37,7 +37,7 @@ env:
   GHCR_REGISTRY: ghcr.io/bucketeer-io
   GAR_REGISTRY: asia-docker.pkg.dev
   GO_BUILD_CONCURRENCY: 4 # Set the same number of apps to build.
-  NODE_VERSION: "22.1"
+  NODE_VERSION: "22.12.0"
 
 
 jobs:


### PR DESCRIPTION
Reference: https://github.com/bucketeer-io/bucketeer/actions/runs/16560060717/job/46828083672