### PR TITLE
fix: variation deletion not deleting references in targets, rules, and default strategy

### DIFF
--- a/pkg/feature/api/error.go
+++ b/pkg/feature/api/error.go
@@ -127,6 +127,10 @@ var (
 		codes.FailedPrecondition,
 		"feature: can't change or remove this variation because it is used as a prerequsite",
 	)
+	statusVariationInUseByOtherFeatures = gstatus.New(
+		codes.FailedPrecondition,
+		"feature: can't remove this variation because it is used as a prerequisite or rule in other features",
+	)
 	statusInvalidPrerequisite                     = gstatus.New(codes.FailedPrecondition, "feature: invalid prerequisite")
 	statusProgressiveRolloutWaitingOrRunningState = gstatus.New(
 		codes.FailedPrecondition,

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1057,6 +1057,11 @@ func (s *FeatureService) UpdateFeature(
 			)
 			return dt.Err()
 		}
+
+		// Clean up any orphaned variation references BEFORE validation
+		// This fixes data corruption from the historical variation deletion bug
+		feature.CleanupOrphanedVariationReferences()
+
 		updated, err := feature.Update(
 			req.Name,
 			req.Description,
@@ -1711,6 +1716,11 @@ func (s *FeatureService) updateFeature(
 			)
 			return err
 		}
+
+		// Clean up any orphaned variation references BEFORE validation
+		// This fixes data corruption from the historical variation deletion bug
+		feature.CleanupOrphanedVariationReferences()
+
 		handler, err = command.NewFeatureCommandHandler(editor, feature, environmentId, comment)
 		if err != nil {
 			return err
@@ -2092,6 +2102,11 @@ func (s *FeatureService) UpdateFeatureTargeting(
 			}
 		}
 		feature := &domain.Feature{Feature: f}
+
+		// Clean up any orphaned variation references BEFORE validation
+		// This fixes data corruption from the historical variation deletion bug
+		feature.CleanupOrphanedVariationReferences()
+
 		handler, err = command.NewFeatureCommandHandler(
 			editor,
 			feature,

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -114,12 +114,13 @@ func (s *FeatureService) GetFeature(
 		return nil, dt.Err()
 	}
 
+	// TEMPORARY: Clean up any orphaned variation references before returning to UI
 	// Clean up any orphaned variation references before returning to UI
 	// This prevents the UI from seeing corrupted data and sending it back in update requests
 	cleanupResult := feature.CleanupOrphanedVariationReferences()
 	if cleanupResult.Changed {
 		s.logger.Warn(
-			"Cleaned up orphaned variation references in feature during get",
+			"Cleaned up orphaned variation references in feature during get (temporary migration)",
 			log.FieldsFromImcomingContext(ctx).AddFields(
 				zap.String("featureId", req.Id),
 				zap.String("environmentId", req.EnvironmentId),
@@ -222,13 +223,15 @@ func (s *FeatureService) GetFeatures(
 		return nil, dt.Err()
 	}
 
+	// TEMPORARY: Clean up any orphaned variation references before returning to UI
 	// Clean up any orphaned variation references before returning to UI
+	// This prevents the UI from seeing corrupted data and sending it back in update requests
 	for _, f := range features {
 		domainFeature := &domain.Feature{Feature: f}
 		cleanupResult := domainFeature.CleanupOrphanedVariationReferences()
 		if cleanupResult.Changed {
 			s.logger.Warn(
-				"Cleaned up orphaned variation references in feature during get multiple",
+				"Cleaned up orphaned variation references in feature during get multiple (temporary migration)",
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.String("featureId", f.Id),
 					zap.String("environmentId", req.EnvironmentId),
@@ -327,13 +330,14 @@ func (s *FeatureService) ListFeatures(
 		return nil, statusInternal.Err()
 	}
 
-	// Clean up any orphaned variation references before returning to UI
+	// TEMPORARY: Clean up any orphaned variation references before returning to UI
+	// This prevents the UI from seeing corrupted data and sending it back in update requests
 	for _, f := range features {
 		domainFeature := &domain.Feature{Feature: f}
 		cleanupResult := domainFeature.CleanupOrphanedVariationReferences()
 		if cleanupResult.Changed {
 			s.logger.Warn(
-				"Cleaned up orphaned variation references in feature during list",
+				"Cleaned up orphaned variation references in feature during list (temporary migration)",
 				log.FieldsFromImcomingContext(ctx).AddFields(
 					zap.String("featureId", f.Id),
 					zap.String("environmentId", req.EnvironmentId),

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -1240,6 +1240,10 @@ func (s *FeatureService) UpdateFeature(
 		if err := domain.ValidateFeatureDependencies(tgts); err != nil {
 			return err
 		}
+		// Validate that variations being deleted are not used in other features
+		if err := validateVariationDeletion(req.VariationChanges, features, req.Id, localizer); err != nil {
+			return err
+		}
 		updatedpb = updated.Feature
 		event, err = domainevent.NewEvent(
 			editor,

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -135,7 +135,7 @@ func (s *FeatureService) GetFeature(
 
 	// TEMPORARY: Ensure all variations are present in rollout strategies during reads
 	// This fixes existing data corruption from the historical AddVariation bug
-	// TODO: Remove this after most existing corrupted data is fixed (estimated 2-3 months)
+	// TODO: Remove this after DB migration is complete
 	migrationResult := feature.EnsureVariationsInStrategies()
 	if migrationResult.Changed {
 		s.logger.Warn(
@@ -246,7 +246,7 @@ func (s *FeatureService) GetFeatures(
 
 		// TEMPORARY: Ensure all variations are present in rollout strategies during reads
 		// This fixes existing data corruption from the historical AddVariation bug
-		// TODO: Remove this after most existing corrupted data is fixed (estimated 2-3 months)
+		// TODO: Remove this after DB migration is complete
 		migrationResult := domainFeature.EnsureVariationsInStrategies()
 		if migrationResult.Changed {
 			s.logger.Warn(
@@ -352,7 +352,7 @@ func (s *FeatureService) ListFeatures(
 
 		// TEMPORARY: Ensure all variations are present in rollout strategies during reads
 		// This fixes existing data corruption from the historical AddVariation bug
-		// TODO: Remove this after most existing corrupted data is fixed (estimated 2-3 months)
+		// TODO: Remove this after DB migration is complete
 		migrationResult := domainFeature.EnsureVariationsInStrategies()
 		if migrationResult.Changed {
 			s.logger.Warn(

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -116,7 +116,21 @@ func (s *FeatureService) GetFeature(
 
 	// Clean up any orphaned variation references before returning to UI
 	// This prevents the UI from seeing corrupted data and sending it back in update requests
-	feature.CleanupOrphanedVariationReferences()
+	cleanupResult := feature.CleanupOrphanedVariationReferences()
+	if cleanupResult.Changed {
+		s.logger.Warn(
+			"Cleaned up orphaned variation references in feature during get",
+			log.FieldsFromImcomingContext(ctx).AddFields(
+				zap.String("featureId", req.Id),
+				zap.String("environmentId", req.EnvironmentId),
+				zap.Int("orphanedTargets", cleanupResult.OrphanedTargets),
+				zap.Int("orphanedRules", cleanupResult.OrphanedRules),
+				zap.Int("orphanedDefault", cleanupResult.OrphanedDefault),
+				zap.Bool("orphanedOffVar", cleanupResult.OrphanedOffVar),
+				zap.Strings("orphanedVariationIDs", cleanupResult.OrphanedVariationIDs),
+			)...,
+		)
+	}
 
 	if err := s.setLastUsedInfosToFeatureByChunk(
 		ctx,
@@ -194,7 +208,21 @@ func (s *FeatureService) GetFeatures(
 	// Clean up any orphaned variation references before returning to UI
 	for _, f := range features {
 		domainFeature := &domain.Feature{Feature: f}
-		domainFeature.CleanupOrphanedVariationReferences()
+		cleanupResult := domainFeature.CleanupOrphanedVariationReferences()
+		if cleanupResult.Changed {
+			s.logger.Warn(
+				"Cleaned up orphaned variation references in feature during get multiple",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.String("featureId", f.Id),
+					zap.String("environmentId", req.EnvironmentId),
+					zap.Int("orphanedTargets", cleanupResult.OrphanedTargets),
+					zap.Int("orphanedRules", cleanupResult.OrphanedRules),
+					zap.Int("orphanedDefault", cleanupResult.OrphanedDefault),
+					zap.Bool("orphanedOffVar", cleanupResult.OrphanedOffVar),
+					zap.Strings("orphanedVariationIDs", cleanupResult.OrphanedVariationIDs),
+				)...,
+			)
+		}
 	}
 
 	return &featureproto.GetFeaturesResponse{Features: features}, nil
@@ -268,7 +296,21 @@ func (s *FeatureService) ListFeatures(
 	// Clean up any orphaned variation references before returning to UI
 	for _, f := range features {
 		domainFeature := &domain.Feature{Feature: f}
-		domainFeature.CleanupOrphanedVariationReferences()
+		cleanupResult := domainFeature.CleanupOrphanedVariationReferences()
+		if cleanupResult.Changed {
+			s.logger.Warn(
+				"Cleaned up orphaned variation references in feature during list",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.String("featureId", f.Id),
+					zap.String("environmentId", req.EnvironmentId),
+					zap.Int("orphanedTargets", cleanupResult.OrphanedTargets),
+					zap.Int("orphanedRules", cleanupResult.OrphanedRules),
+					zap.Int("orphanedDefault", cleanupResult.OrphanedDefault),
+					zap.Bool("orphanedOffVar", cleanupResult.OrphanedOffVar),
+					zap.Strings("orphanedVariationIDs", cleanupResult.OrphanedVariationIDs),
+				)...,
+			)
+		}
 	}
 
 	return &featureproto.ListFeaturesResponse{
@@ -1079,7 +1121,21 @@ func (s *FeatureService) UpdateFeature(
 
 		// Clean up any orphaned variation references BEFORE validation
 		// This fixes data corruption from the historical variation deletion bug
-		feature.CleanupOrphanedVariationReferences()
+		cleanupResult := feature.CleanupOrphanedVariationReferences()
+		if cleanupResult.Changed {
+			s.logger.Warn(
+				"Cleaned up orphaned variation references in feature during update",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.String("featureId", req.Id),
+					zap.String("environmentId", req.EnvironmentId),
+					zap.Int("orphanedTargets", cleanupResult.OrphanedTargets),
+					zap.Int("orphanedRules", cleanupResult.OrphanedRules),
+					zap.Int("orphanedDefault", cleanupResult.OrphanedDefault),
+					zap.Bool("orphanedOffVar", cleanupResult.OrphanedOffVar),
+					zap.Strings("orphanedVariationIDs", cleanupResult.OrphanedVariationIDs),
+				)...,
+			)
+		}
 
 		updated, err := feature.Update(
 			req.Name,
@@ -1738,7 +1794,21 @@ func (s *FeatureService) updateFeature(
 
 		// Clean up any orphaned variation references BEFORE validation
 		// This fixes data corruption from the historical variation deletion bug
-		feature.CleanupOrphanedVariationReferences()
+		cleanupResult := feature.CleanupOrphanedVariationReferences()
+		if cleanupResult.Changed {
+			s.logger.Warn(
+				"Cleaned up orphaned variation references in feature during details update",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.String("featureId", id),
+					zap.String("environmentId", environmentId),
+					zap.Int("orphanedTargets", cleanupResult.OrphanedTargets),
+					zap.Int("orphanedRules", cleanupResult.OrphanedRules),
+					zap.Int("orphanedDefault", cleanupResult.OrphanedDefault),
+					zap.Bool("orphanedOffVar", cleanupResult.OrphanedOffVar),
+					zap.Strings("orphanedVariationIDs", cleanupResult.OrphanedVariationIDs),
+				)...,
+			)
+		}
 
 		handler, err = command.NewFeatureCommandHandler(editor, feature, environmentId, comment)
 		if err != nil {
@@ -2124,7 +2194,21 @@ func (s *FeatureService) UpdateFeatureTargeting(
 
 		// Clean up any orphaned variation references BEFORE validation
 		// This fixes data corruption from the historical variation deletion bug
-		feature.CleanupOrphanedVariationReferences()
+		cleanupResult := feature.CleanupOrphanedVariationReferences()
+		if cleanupResult.Changed {
+			s.logger.Warn(
+				"Cleaned up orphaned variation references in feature during targeting update",
+				log.FieldsFromImcomingContext(ctx).AddFields(
+					zap.String("featureId", req.Id),
+					zap.String("environmentId", req.EnvironmentId),
+					zap.Int("orphanedTargets", cleanupResult.OrphanedTargets),
+					zap.Int("orphanedRules", cleanupResult.OrphanedRules),
+					zap.Int("orphanedDefault", cleanupResult.OrphanedDefault),
+					zap.Bool("orphanedOffVar", cleanupResult.OrphanedOffVar),
+					zap.Strings("orphanedVariationIDs", cleanupResult.OrphanedVariationIDs),
+				)...,
+			)
+		}
 
 		handler, err = command.NewFeatureCommandHandler(
 			editor,

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -113,6 +113,11 @@ func (s *FeatureService) GetFeature(
 		}
 		return nil, dt.Err()
 	}
+
+	// Clean up any orphaned variation references before returning to UI
+	// This prevents the UI from seeing corrupted data and sending it back in update requests
+	feature.CleanupOrphanedVariationReferences()
+
 	if err := s.setLastUsedInfosToFeatureByChunk(
 		ctx,
 		[]*featureproto.Feature{feature.Feature},
@@ -185,6 +190,13 @@ func (s *FeatureService) GetFeatures(
 		}
 		return nil, dt.Err()
 	}
+
+	// Clean up any orphaned variation references before returning to UI
+	for _, f := range features {
+		domainFeature := &domain.Feature{Feature: f}
+		domainFeature.CleanupOrphanedVariationReferences()
+	}
+
 	return &featureproto.GetFeaturesResponse{Features: features}, nil
 }
 
@@ -252,6 +264,13 @@ func (s *FeatureService) ListFeatures(
 		)
 		return nil, statusInternal.Err()
 	}
+
+	// Clean up any orphaned variation references before returning to UI
+	for _, f := range features {
+		domainFeature := &domain.Feature{Feature: f}
+		domainFeature.CleanupOrphanedVariationReferences()
+	}
+
 	return &featureproto.ListFeaturesResponse{
 		Features:             features,
 		Cursor:               cursor,

--- a/pkg/feature/api/validation.go
+++ b/pkg/feature/api/validation.go
@@ -1093,7 +1093,7 @@ func (s *FeatureService) validateFeatureVariationsCommand(
 	cmd command.Command,
 	localizer locale.Localizer,
 ) error {
-	switch cmd.(type) {
+	switch c := cmd.(type) {
 	case *featureproto.AddVariationCommand:
 		if err := s.checkProgressiveRolloutInProgress(ctx, environmentID, f.Id, localizer); err != nil {
 			return err
@@ -1103,7 +1103,7 @@ func (s *FeatureService) validateFeatureVariationsCommand(
 		if err := s.checkProgressiveRolloutInProgress(ctx, environmentID, f.Id, localizer); err != nil {
 			return err
 		}
-		return validateRemoveVariationCommand(cmd.(*featureproto.RemoveVariationCommand), fs, f, localizer)
+		return validateRemoveVariationCommand(c, fs, f, localizer)
 	case *featureproto.ChangeVariationValueCommand:
 		return validateVariationCommand(fs, f, localizer)
 	default:
@@ -1182,7 +1182,12 @@ func validateVariationCommand(fs []*featureproto.Feature, tgt *featureproto.Feat
 }
 
 // validateRemoveVariationCommand validates that a specific variation can be safely removed
-func validateRemoveVariationCommand(cmd *featureproto.RemoveVariationCommand, fs []*featureproto.Feature, tgt *featureproto.Feature, localizer locale.Localizer) error {
+func validateRemoveVariationCommand(
+	cmd *featureproto.RemoveVariationCommand,
+	fs []*featureproto.Feature,
+	tgt *featureproto.Feature,
+	localizer locale.Localizer,
+) error {
 	// Find the variation being removed to get its value
 	var deletedVariationValue string
 	for _, variation := range tgt.Variations {

--- a/pkg/feature/api/validation.go
+++ b/pkg/feature/api/validation.go
@@ -1231,6 +1231,10 @@ func validateRemoveVariationCommand(
 		deletedVariations[cmd.Id] = "" // Empty value, but we'll check keys for prerequisites
 	}
 
+	if len(deletedVariations) == 0 {
+		return nil // No variations being deleted
+	}
+
 	if err := featuredomain.ValidateVariationUsage(dependentFeaturesSlice, tgt.Id, deletedVariations); err != nil {
 		if errors.Is(err, featuredomain.ErrVariationInUse) {
 			// Use the legacy error status for RemoveVariationCommand for backward compatibility

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -700,6 +700,9 @@ func (f *Feature) RemoveVariation(id string) error {
 }
 
 func (f *Feature) validateRemoveVariation(id string) error {
+	if len(f.Variations) <= 2 {
+		return errVariationsMustHaveAtLeastTwoVariations
+	}
 	if f.OffVariation == id {
 		return errVariationInUse
 	}

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -1290,12 +1290,11 @@ func ValidateVariationUsage(
 		for _, rule := range f.Rules {
 			for _, clause := range rule.Clauses {
 				if clause.Operator == feature.Clause_FEATURE_FLAG && clause.Attribute == targetFeatureID {
-					// Check if clause values match any deleted variation values
+					// FEATURE_FLAG clause values contain variation IDs, not values
+					// We should check if any clause values match deleted variation IDs
 					for _, clValue := range clause.Values {
-						for _, delValue := range deletedVariations {
-							if clValue == delValue {
-								return ErrVariationInUse
-							}
+						if _, found := deletedVariations[clValue]; found {
+							return ErrVariationInUse
 						}
 					}
 				}

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -1447,7 +1447,7 @@ func TestRemoveVariationMultipleInstancesInRollout(t *testing.T) {
 			Variations: []*ftproto.RolloutStrategy_Variation{
 				{
 					Variation: "variation-A",
-					Weight:    100000,
+					Weight:    50000,
 				},
 				{
 					Variation: expected,

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -2198,6 +2198,39 @@ func TestValidateVariationUsage(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			desc: "error: detailed FEATURE_FLAG rule test",
+			features: []*ftproto.Feature{
+				{
+					Id: "feature-A",
+					Variations: []*ftproto.Variation{
+						{Id: "var-true", Value: "true"},
+						{Id: "var-false", Value: "false"},
+					},
+				},
+				{
+					Id: "feature-B",
+					Rules: []*ftproto.Rule{
+						{
+							Id: "test-rule",
+							Clauses: []*ftproto.Clause{
+								{
+									Id:        "test-clause",
+									Operator:  ftproto.Clause_FEATURE_FLAG,
+									Attribute: "feature-A",      // References feature being updated
+									Values:    []string{"true"}, // References the value we're deleting
+								},
+							},
+						},
+					},
+				},
+			},
+			targetFeatureID: "feature-A",
+			deletedVariations: map[string]string{
+				"var-true": "true", // Deleting variation with value "true"
+			},
+			expected: ErrVariationInUse,
+		},
 	}
 
 	for _, p := range patterns {

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -823,11 +823,11 @@ func TestChangeRuleToRolloutStrategy(t *testing.T) {
 		RolloutStrategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 			{
 				Variation: vID1,
-				Weight:    30,
+				Weight:    30000,
 			},
 			{
 				Variation: vID2,
-				Weight:    70,
+				Weight:    70000,
 			},
 		}},
 	}
@@ -1559,11 +1559,11 @@ func TestChangeRolloutStrategy(t *testing.T) {
 	expected := &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 		{
 			Variation: vID1,
-			Weight:    30,
+			Weight:    30000,
 		},
 		{
 			Variation: vID2,
-			Weight:    70,
+			Weight:    70000,
 		},
 	}}
 	patterns := []*struct {
@@ -1581,11 +1581,11 @@ func TestChangeRolloutStrategy(t *testing.T) {
 			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 				{
 					Variation: "",
-					Weight:    30,
+					Weight:    30000,
 				},
 				{
 					Variation: vID2,
-					Weight:    70,
+					Weight:    70000,
 				},
 			}},
 			expected: errVariationNotFound,
@@ -1595,11 +1595,11 @@ func TestChangeRolloutStrategy(t *testing.T) {
 			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
 				{
 					Variation: vID1,
-					Weight:    30,
+					Weight:    30000,
 				},
 				{
 					Variation: "",
-					Weight:    70,
+					Weight:    70000,
 				},
 			}},
 			expected: errVariationNotFound,
@@ -1613,6 +1613,50 @@ func TestChangeRolloutStrategy(t *testing.T) {
 			ruleID:   rID,
 			strategy: expected,
 			expected: nil,
+		},
+		{
+			ruleID: rID,
+			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
+				{
+					Variation: vID1,
+					Weight:    30000, // 30%
+				},
+				{
+					Variation: vID2,
+					Weight:    40000, // 40%
+				},
+				// Total: 70000 (70%) - invalid!
+			}},
+			expected: ErrInvalidVariationWeightTotal,
+		},
+		{
+			ruleID: rID,
+			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
+				{
+					Variation: vID1,
+					Weight:    60000, // 60%
+				},
+				{
+					Variation: vID2,
+					Weight:    50000, // 50%
+				},
+				// Total: 110000 (110%) - invalid!
+			}},
+			expected: ErrInvalidVariationWeightTotal,
+		},
+		{
+			ruleID: rID,
+			strategy: &ftproto.RolloutStrategy{Variations: []*ftproto.RolloutStrategy_Variation{
+				{
+					Variation: vID1,
+					Weight:    30, // Old test format - invalid!
+				},
+				{
+					Variation: vID2,
+					Weight:    70, // Old test format - invalid!
+				},
+			}},
+			expected: ErrInvalidVariationWeightTotal,
 		},
 	}
 	for _, p := range patterns {
@@ -3363,7 +3407,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 				},
 			},
@@ -3442,8 +3486,8 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 50},
-						{Variation: id2.String(), Weight: 50},
+						{Variation: id1.String(), Weight: 50000},
+						{Variation: id2.String(), Weight: 50000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       50,
@@ -3460,7 +3504,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       0,
@@ -3477,7 +3521,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       100,
@@ -3494,7 +3538,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       -1,
@@ -3511,7 +3555,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       101,
@@ -3528,7 +3572,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       50,
@@ -3545,7 +3589,7 @@ func TestValidateStrategy(t *testing.T) {
 				Type: ftproto.Strategy_ROLLOUT,
 				RolloutStrategy: &ftproto.RolloutStrategy{
 					Variations: []*ftproto.RolloutStrategy_Variation{
-						{Variation: id1.String(), Weight: 100},
+						{Variation: id1.String(), Weight: 100000},
 					},
 					Audience: &ftproto.Audience{
 						Percentage:       50,
@@ -3555,6 +3599,66 @@ func TestValidateStrategy(t *testing.T) {
 			},
 			variations:  variations,
 			expectedErr: ErrDefaultVariationNotFound,
+		},
+		{
+			desc: "fail: rollout strategy weights sum less than 100000",
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
+						{Variation: id1.String(), Weight: 30000}, // 30%
+						{Variation: id2.String(), Weight: 40000}, // 40%
+						// Total: 70000 (70%) - invalid!
+					},
+				},
+			},
+			variations:  variations,
+			expectedErr: ErrInvalidVariationWeightTotal,
+		},
+		{
+			desc: "fail: rollout strategy weights sum more than 100000",
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
+						{Variation: id1.String(), Weight: 60000}, // 60%
+						{Variation: id2.String(), Weight: 50000}, // 50%
+						// Total: 110000 (110%) - invalid!
+					},
+				},
+			},
+			variations:  variations,
+			expectedErr: ErrInvalidVariationWeightTotal,
+		},
+		{
+			desc: "fail: rollout strategy weights zero total",
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
+						{Variation: id1.String(), Weight: 0},
+						{Variation: id2.String(), Weight: 0},
+						// Total: 0 (0%) - invalid!
+					},
+				},
+			},
+			variations:  variations,
+			expectedErr: ErrInvalidVariationWeightTotal,
+		},
+		{
+			desc: "fail: rollout strategy weights using old test values",
+			strategy: &ftproto.Strategy{
+				Type: ftproto.Strategy_ROLLOUT,
+				RolloutStrategy: &ftproto.RolloutStrategy{
+					Variations: []*ftproto.RolloutStrategy_Variation{
+						{Variation: id1.String(), Weight: 30}, // Old test format
+						{Variation: id2.String(), Weight: 70}, // Old test format
+						// Total: 100 instead of 100000 - invalid!
+					},
+				},
+			},
+			variations:  variations,
+			expectedErr: ErrInvalidVariationWeightTotal,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -2057,8 +2057,8 @@ func TestValidateVariationUsage(t *testing.T) {
 	t.Parallel()
 
 	variationID1 := "variation-1"
+	variationID2 := "variation-2"
 	variationValue1 := "true"
-	variationValue2 := "false"
 
 	patterns := []struct {
 		desc              string
@@ -2115,7 +2115,7 @@ func TestValidateVariationUsage(t *testing.T) {
 			expected: ErrVariationInUse,
 		},
 		{
-			desc: "error: other feature has FEATURE_FLAG rule using deleted variation value",
+			desc: "error: other feature has FEATURE_FLAG rule using deleted variation ID",
 			features: []*ftproto.Feature{
 				{
 					Id: "feature-2",
@@ -2125,7 +2125,7 @@ func TestValidateVariationUsage(t *testing.T) {
 								{
 									Operator:  ftproto.Clause_FEATURE_FLAG,
 									Attribute: "feature-1",
-									Values:    []string{variationValue1},
+									Values:    []string{variationID1}, // Fixed: Use variation ID, not value
 								},
 							},
 						},
@@ -2175,7 +2175,7 @@ func TestValidateVariationUsage(t *testing.T) {
 			expected: nil,
 		},
 		{
-			desc: "success: different variation value in FEATURE_FLAG rule",
+			desc: "success: different variation ID in FEATURE_FLAG rule",
 			features: []*ftproto.Feature{
 				{
 					Id: "feature-2",
@@ -2185,7 +2185,7 @@ func TestValidateVariationUsage(t *testing.T) {
 								{
 									Operator:  ftproto.Clause_FEATURE_FLAG,
 									Attribute: "feature-1",
-									Values:    []string{variationValue2}, // Different value
+									Values:    []string{variationID2}, // Fixed: Different variation ID
 								},
 							},
 						},
@@ -2217,8 +2217,8 @@ func TestValidateVariationUsage(t *testing.T) {
 								{
 									Id:        "test-clause",
 									Operator:  ftproto.Clause_FEATURE_FLAG,
-									Attribute: "feature-A",      // References feature being updated
-									Values:    []string{"true"}, // References the value we're deleting
+									Attribute: "feature-A",          // References feature being updated
+									Values:    []string{"var-true"}, // Fixed: Use variation ID, not value
 								},
 							},
 						},

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -468,7 +468,7 @@ func (f *Feature) updateValidateRemoveVariation(id string) error {
 		return errVariationsMustHaveAtLeastTwoVariations
 	}
 	if f.OffVariation == id {
-		return errVariationInUse
+		return ErrVariationInUse
 	}
 	// Check if the individual targeting has any users
 	idx, err := f.updateFindTarget(id)
@@ -476,13 +476,13 @@ func (f *Feature) updateValidateRemoveVariation(id string) error {
 		return err
 	}
 	if len(f.Targets[idx].Users) > 0 {
-		return errVariationInUse
+		return ErrVariationInUse
 	}
 	if strategyContainsVariation(id, f.Feature.DefaultStrategy) {
-		return errVariationInUse
+		return ErrVariationInUse
 	}
 	if f.updateRulesContainsVariation(id) {
-		return errVariationInUse
+		return ErrVariationInUse
 	}
 	return nil
 }

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -397,6 +397,8 @@ func (f *Feature) updateAddVariation(id, value, name, description string) error 
 		Description: description,
 	})
 	f.addTarget(id)
+	f.updateAddVariationToRules(id)
+	f.updateAddVariationToDefaultStrategy(id)
 	return nil
 }
 
@@ -695,4 +697,25 @@ func (f *Feature) findPrerequisiteIndex(featureID string) (int, error) {
 		}
 	}
 	return -1, errPrerequisiteNotFound
+}
+
+func (f *Feature) updateAddVariationToRules(variationID string) {
+	for _, rule := range f.Rules {
+		if rule.Strategy.Type == feature.Strategy_ROLLOUT {
+			f.updateAddVariationToRolloutStrategy(rule.Strategy.RolloutStrategy, variationID)
+		}
+	}
+}
+
+func (f *Feature) updateAddVariationToDefaultStrategy(variationID string) {
+	if f.DefaultStrategy != nil && f.DefaultStrategy.Type == feature.Strategy_ROLLOUT {
+		f.updateAddVariationToRolloutStrategy(f.DefaultStrategy.RolloutStrategy, variationID)
+	}
+}
+
+func (f *Feature) updateAddVariationToRolloutStrategy(strategy *feature.RolloutStrategy, variationID string) {
+	strategy.Variations = append(strategy.Variations, &feature.RolloutStrategy_Variation{
+		Variation: variationID,
+		Weight:    0,
+	})
 }

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -423,9 +423,6 @@ func (f *Feature) updateChangeVariation(variation *feature.Variation) error {
 }
 
 func (f *Feature) updateRemoveVariation(id string) error {
-	if len(f.Variations) == 1 {
-		return errVariationInUse
-	}
 	idx, err := f.updateFindVariationIndex(id)
 	if err != nil {
 		return err
@@ -465,6 +462,9 @@ func (f *Feature) updateFindTarget(id string) (int, error) {
 
 // updateValidateRemoveVariation validates that a variation can be safely removed
 func (f *Feature) updateValidateRemoveVariation(id string) error {
+	if len(f.Variations) <= 2 {
+		return errVariationsMustHaveAtLeastTwoVariations
+	}
 	if f.OffVariation == id {
 		return errVariationInUse
 	}

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -426,15 +426,111 @@ func (f *Feature) updateRemoveVariation(id string) error {
 	if len(f.Variations) == 1 {
 		return errVariationInUse
 	}
-	idx, err := f.findVariationIndex(id)
+	idx, err := f.updateFindVariationIndex(id)
 	if err != nil {
 		return err
 	}
-	if err := f.validateRemoveVariation(id); err != nil {
+	if err := f.updateValidateRemoveVariation(id); err != nil {
 		return err
 	}
+	// Clean up references to this variation before removing it
+	if err = f.updateRemoveTarget(id); err != nil {
+		return err
+	}
+	f.updateRemoveVariationFromRules(id)
+	f.updateRemoveVariationFromDefaultStrategy(id)
 	f.Variations = slices.Delete(f.Variations, idx, idx+1)
 	return nil
+}
+
+// updateFindVariationIndex finds the index of the variation with the specified ID
+func (f *Feature) updateFindVariationIndex(id string) (int, error) {
+	for i := range f.Variations {
+		if f.Variations[i].Id == id {
+			return i, nil
+		}
+	}
+	return -1, errVariationNotFound
+}
+
+// updateFindTarget finds the index of the target with the specified variation ID
+func (f *Feature) updateFindTarget(id string) (int, error) {
+	for i := range f.Targets {
+		if f.Targets[i].Variation == id {
+			return i, nil
+		}
+	}
+	return -1, errTargetNotFound
+}
+
+// updateValidateRemoveVariation validates that a variation can be safely removed
+func (f *Feature) updateValidateRemoveVariation(id string) error {
+	if f.OffVariation == id {
+		return errVariationInUse
+	}
+	// Check if the individual targeting has any users
+	idx, err := f.updateFindTarget(id)
+	if err != nil {
+		return err
+	}
+	if len(f.Targets[idx].Users) > 0 {
+		return errVariationInUse
+	}
+	if strategyContainsVariation(id, f.Feature.DefaultStrategy) {
+		return errVariationInUse
+	}
+	if f.updateRulesContainsVariation(id) {
+		return errVariationInUse
+	}
+	return nil
+}
+
+// updateRulesContainsVariation checks if any rule contains the specified variation
+func (f *Feature) updateRulesContainsVariation(id string) bool {
+	for _, r := range f.Feature.Rules {
+		if ok := strategyContainsVariation(id, r.Strategy); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// updateRemoveTarget removes the target entry for the specified variation
+func (f *Feature) updateRemoveTarget(variationID string) error {
+	idx, err := f.updateFindTarget(variationID)
+	if err != nil {
+		return err
+	}
+	f.Targets = slices.Delete(f.Targets, idx, idx+1)
+	return nil
+}
+
+// updateRemoveVariationFromRules removes the variation from all rollout strategies in rules
+func (f *Feature) updateRemoveVariationFromRules(variationID string) {
+	for _, rule := range f.Rules {
+		if rule.Strategy.Type == feature.Strategy_ROLLOUT {
+			f.updateRemoveVariationFromRolloutStrategy(rule.Strategy.RolloutStrategy, variationID)
+		}
+	}
+}
+
+// updateRemoveVariationFromDefaultStrategy removes the variation from the default strategy if it's a rollout
+func (f *Feature) updateRemoveVariationFromDefaultStrategy(variationID string) {
+	if f.DefaultStrategy != nil && f.DefaultStrategy.Type == feature.Strategy_ROLLOUT {
+		f.updateRemoveVariationFromRolloutStrategy(f.DefaultStrategy.RolloutStrategy, variationID)
+	}
+}
+
+// updateRemoveVariationFromRolloutStrategy removes all instances of the variation from a rollout strategy
+func (f *Feature) updateRemoveVariationFromRolloutStrategy(strategy *feature.RolloutStrategy, variationID string) {
+	// Remove all instances of the variation, regardless of weight
+	filteredVariations := make([]*feature.RolloutStrategy_Variation, 0, len(strategy.Variations))
+	for _, v := range strategy.Variations {
+		if v.Variation != variationID {
+			filteredVariations = append(filteredVariations, v)
+		}
+	}
+	strategy.Variations = filteredVariations
 }
 
 func (f *Feature) updateAddPrerequisite(featureID, variationID string) error {

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -16,6 +16,7 @@ package domain
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -1781,6 +1782,63 @@ func TestUpdateRemoveVariationComprehensiveCleanup(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUpdateRemoveVariationMinimumVariationConstraint(t *testing.T) {
+	t.Parallel()
+
+	// Test case 1: Feature with exactly 3 variations - should allow removal (leaves 2)
+	f := makeFeature("test-feature")
+	// makeFeature creates 3 variations: A, B, C
+	// Remove variation-C (which has users, so we need to remove them first)
+	f.Targets[2].Users = []string{} // Remove users from variation-C
+
+	patterns := []*struct {
+		id       string
+		expected error
+	}{
+		{
+			id:       "variation-C",
+			expected: nil, // Should succeed - leaves 2 variations
+		},
+	}
+
+	for i, p := range patterns {
+		err := f.updateRemoveVariation(p.id)
+		des := fmt.Sprintf("index: %d", i)
+		assert.Equal(t, p.expected, err, des)
+	}
+
+	// Verify we now have 2 variations
+	if len(f.Variations) != 2 {
+		t.Fatalf("Expected 2 variations after removal, got %d", len(f.Variations))
+	}
+
+	// Test case 2: Now try to remove another variation - should fail (would leave 1)
+	patterns2 := []*struct {
+		id       string
+		expected error
+	}{
+		{
+			id:       "variation-A",
+			expected: errVariationsMustHaveAtLeastTwoVariations, // Should fail - would leave 1 variation
+		},
+		{
+			id:       "variation-B",
+			expected: errVariationsMustHaveAtLeastTwoVariations, // Should fail - would leave 1 variation
+		},
+	}
+
+	for i, p := range patterns2 {
+		err := f.updateRemoveVariation(p.id)
+		des := fmt.Sprintf("constraint_test_index: %d", i)
+		assert.Equal(t, p.expected, err, des)
+	}
+
+	// Verify we still have 2 variations (removal should have failed)
+	if len(f.Variations) != 2 {
+		t.Fatalf("Expected 2 variations after failed removal attempts, got %d", len(f.Variations))
 	}
 }
 

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -1883,7 +1883,7 @@ func TestUpdateRemoveVariationComprehensiveCleanup(t *testing.T) {
 				return makeFeature("test-feature")
 			},
 			variationID: "variation-C", // Has users in target
-			expectedErr: errVariationInUse,
+			expectedErr: ErrVariationInUse,
 		},
 		{
 			desc: "error - minimum variation constraint",
@@ -2021,7 +2021,7 @@ func TestUpdateRemoveVariationMultipleRulesCleanup(t *testing.T) {
 							Variations: []*ftproto.RolloutStrategy_Variation{
 								{
 									Variation: "variation-A",
-									Weight:    50000,
+									Weight:    100000,
 								},
 								{
 									Variation: expected,
@@ -2049,7 +2049,7 @@ func TestUpdateRemoveVariationMultipleRulesCleanup(t *testing.T) {
 							Variations: []*ftproto.RolloutStrategy_Variation{
 								{
 									Variation: "variation-B",
-									Weight:    70000,
+									Weight:    100000,
 								},
 								{
 									Variation: expected,

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -1732,6 +1732,18 @@ func TestUpdateRemoveVariationComprehensiveCleanup(t *testing.T) {
 			variationID: "variation-C", // Has users in target
 			expectedErr: errVariationInUse,
 		},
+		{
+			desc: "error - minimum variation constraint",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Remove one variation to get down to exactly 2 variations
+				f.Targets[2].Users = []string{}        // Remove users from variation-C
+				f.updateRemoveVariation("variation-C") // This should succeed, leaving 2 variations
+				return f
+			},
+			variationID: "variation-A", // Try to remove when only 2 variations remain
+			expectedErr: errVariationsMustHaveAtLeastTwoVariations,
+		},
 	}
 
 	for _, p := range patterns {

--- a/pkg/feature/domain/migration.go
+++ b/pkg/feature/domain/migration.go
@@ -32,7 +32,7 @@ type VariationCleanupResult struct {
 
 // CleanupOrphanedVariationReferences removes references to variations that no longer exist.
 // This fixes data corruption caused by the incomplete variation deletion bug.
-// TODO: Remove this function after 6 months (around July 2025) when all corrupted data is cleaned up
+// TODO: Remove this after the DB migration is complete
 func (f *Feature) CleanupOrphanedVariationReferences() VariationCleanupResult {
 	result := VariationCleanupResult{
 		OrphanedVariationIDs: []string{},
@@ -134,7 +134,7 @@ func (f *Feature) CleanupOrphanedVariationReferences() VariationCleanupResult {
 }
 
 // CleanupOrphanedVariationReferencesSimple provides backward compatibility
-// TODO: Remove this after updating all call sites to use detailed version
+// TODO: Remove this after ensuring all call sites use the detailed version of
 func (f *Feature) CleanupOrphanedVariationReferencesSimple() bool {
 	result := f.CleanupOrphanedVariationReferences()
 	return result.Changed
@@ -231,7 +231,7 @@ func (f *Feature) EnsureVariationsInStrategies() VariationMigrationResult {
 		if rule.Strategy != nil &&
 			rule.Strategy.Type == feature.Strategy_ROLLOUT &&
 			rule.Strategy.RolloutStrategy != nil {
-			// TODO: Remove this after updating all call sites to use detailed version
+			// TODO: Remove this after ensuring all call sites use the detailed version of
 			added := f.ensureVariationsInRolloutStrategy(rule.Strategy.RolloutStrategy, validVariationIDs)
 			result.AddedToRules += added
 			if added > 0 {

--- a/pkg/feature/domain/migration.go
+++ b/pkg/feature/domain/migration.go
@@ -133,13 +133,6 @@ func (f *Feature) CleanupOrphanedVariationReferences() VariationCleanupResult {
 	return result
 }
 
-// CleanupOrphanedVariationReferencesSimple provides backward compatibility
-// TODO: Remove this after ensuring all call sites use the detailed version of
-func (f *Feature) CleanupOrphanedVariationReferencesSimple() bool {
-	result := f.CleanupOrphanedVariationReferences()
-	return result.Changed
-}
-
 // ValidateVariationReferences checks if a feature has orphaned variation references.
 // Returns a list of orphaned variation IDs found.
 func (f *Feature) ValidateVariationReferences() []string {
@@ -311,10 +304,4 @@ func (f *Feature) ensureVariationsInRolloutStrategy(
 
 	strategy.Variations = newStrategyVariations
 	return len(strategy.Variations) - originalCount
-}
-
-// EnsureVariationsInStrategiesSimple is a convenience wrapper that returns only a boolean
-func (f *Feature) EnsureVariationsInStrategiesSimple() bool {
-	result := f.EnsureVariationsInStrategies()
-	return result.Changed
 }

--- a/pkg/feature/domain/migration.go
+++ b/pkg/feature/domain/migration.go
@@ -1,0 +1,163 @@
+// Copyright 2025 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"time"
+
+	"github.com/bucketeer-io/bucketeer/proto/feature"
+)
+
+// CleanupOrphanedVariationReferences removes references to variations that no longer exist.
+// This fixes data corruption caused by the incomplete variation deletion bug.
+func (f *Feature) CleanupOrphanedVariationReferences() bool {
+	if f == nil || f.Feature == nil {
+		return false
+	}
+
+	changed := false
+	validVariationIDs := make(map[string]bool)
+
+	// Build map of valid variation IDs
+	for _, v := range f.Variations {
+		validVariationIDs[v.Id] = true
+	}
+
+	// 1. Clean up orphaned targets
+	validTargets := make([]*feature.Target, 0, len(f.Targets))
+	for _, target := range f.Targets {
+		if validVariationIDs[target.Variation] {
+			validTargets = append(validTargets, target)
+		} else {
+			changed = true
+		}
+	}
+	f.Targets = validTargets
+
+	// 2. Clean up orphaned variations in rules
+	for _, rule := range f.Rules {
+		if rule.Strategy != nil && rule.Strategy.Type == feature.Strategy_ROLLOUT && rule.Strategy.RolloutStrategy != nil {
+			validRolloutVariations := make(
+				[]*feature.RolloutStrategy_Variation,
+				0,
+				len(rule.Strategy.RolloutStrategy.Variations),
+			)
+			for _, v := range rule.Strategy.RolloutStrategy.Variations {
+				if validVariationIDs[v.Variation] {
+					validRolloutVariations = append(validRolloutVariations, v)
+				} else {
+					changed = true
+				}
+			}
+			rule.Strategy.RolloutStrategy.Variations = validRolloutVariations
+		}
+	}
+
+	// 3. Clean up orphaned variations in default strategy
+	if f.DefaultStrategy != nil &&
+		f.DefaultStrategy.Type == feature.Strategy_ROLLOUT &&
+		f.DefaultStrategy.RolloutStrategy != nil {
+		validDefaultVariations := make(
+			[]*feature.RolloutStrategy_Variation,
+			0,
+			len(f.DefaultStrategy.RolloutStrategy.Variations),
+		)
+		for _, v := range f.DefaultStrategy.RolloutStrategy.Variations {
+			if validVariationIDs[v.Variation] {
+				validDefaultVariations = append(validDefaultVariations, v)
+			} else {
+				changed = true
+			}
+		}
+		f.DefaultStrategy.RolloutStrategy.Variations = validDefaultVariations
+	}
+
+	// 4. Check if OffVariation still exists
+	if f.OffVariation != "" && !validVariationIDs[f.OffVariation] {
+		// Reset to second available variation, fallback to first if only one exists
+		if len(f.Variations) > 1 {
+			f.OffVariation = f.Variations[1].Id
+			changed = true
+		} else if len(f.Variations) > 0 {
+			f.OffVariation = f.Variations[0].Id
+			changed = true
+		}
+	}
+
+	// Update timestamp if any changes were made
+	if changed {
+		f.UpdatedAt = time.Now().Unix()
+	}
+
+	return changed
+}
+
+// ValidateVariationReferences checks if a feature has orphaned variation references.
+// Returns a list of orphaned variation IDs found.
+func (f *Feature) ValidateVariationReferences() []string {
+	if f == nil || f.Feature == nil {
+		return nil
+	}
+
+	validVariationIDs := make(map[string]bool)
+	orphanedVariations := make(map[string]bool)
+
+	// Build map of valid variation IDs
+	for _, v := range f.Variations {
+		validVariationIDs[v.Id] = true
+	}
+
+	// Check targets for orphaned references
+	for _, target := range f.Targets {
+		if !validVariationIDs[target.Variation] {
+			orphanedVariations[target.Variation] = true
+		}
+	}
+
+	// Check rules for orphaned references
+	for _, rule := range f.Rules {
+		if rule.Strategy != nil && rule.Strategy.Type == feature.Strategy_ROLLOUT && rule.Strategy.RolloutStrategy != nil {
+			for _, v := range rule.Strategy.RolloutStrategy.Variations {
+				if !validVariationIDs[v.Variation] {
+					orphanedVariations[v.Variation] = true
+				}
+			}
+		}
+	}
+
+	// Check default strategy for orphaned references
+	if f.DefaultStrategy != nil &&
+		f.DefaultStrategy.Type == feature.Strategy_ROLLOUT &&
+		f.DefaultStrategy.RolloutStrategy != nil {
+		for _, v := range f.DefaultStrategy.RolloutStrategy.Variations {
+			if !validVariationIDs[v.Variation] {
+				orphanedVariations[v.Variation] = true
+			}
+		}
+	}
+
+	// Check OffVariation
+	if f.OffVariation != "" && !validVariationIDs[f.OffVariation] {
+		orphanedVariations[f.OffVariation] = true
+	}
+
+	// Convert map to slice
+	result := make([]string, 0, len(orphanedVariations))
+	for variationID := range orphanedVariations {
+		result = append(result, variationID)
+	}
+
+	return result
+}

--- a/pkg/feature/domain/migration_test.go
+++ b/pkg/feature/domain/migration_test.go
@@ -1,0 +1,363 @@
+// Copyright 2025 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ftproto "github.com/bucketeer-io/bucketeer/proto/feature"
+)
+
+func TestValidateVariationReferences(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc                string
+		setupFunc           func() *Feature
+		expectedOrphanedIDs []string
+	}{
+		{
+			desc: "no orphaned references",
+			setupFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedOrphanedIDs: []string{},
+		},
+		{
+			desc: "orphaned target reference",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Add orphaned target
+				f.Targets = append(f.Targets, &ftproto.Target{
+					Variation: "orphaned-variation-1",
+					Users:     []string{"user1"},
+				})
+				return f
+			},
+			expectedOrphanedIDs: []string{"orphaned-variation-1"},
+		},
+		{
+			desc: "orphaned variation in rule rollout strategy",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Add rule with orphaned variation
+				rule := &ftproto.Rule{
+					Id: "test-rule",
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_ROLLOUT,
+						RolloutStrategy: &ftproto.RolloutStrategy{
+							Variations: []*ftproto.RolloutStrategy_Variation{
+								{
+									Variation: "variation-A", // Valid
+									Weight:    50000,
+								},
+								{
+									Variation: "orphaned-variation-2", // Orphaned
+									Weight:    0,
+								},
+							},
+						},
+					},
+					Clauses: []*ftproto.Clause{
+						{
+							Id:        "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+							Attribute: "user_id",
+							Operator:  ftproto.Clause_EQUALS,
+							Values:    []string{"user-1"},
+						},
+					},
+				}
+				f.Rules = []*ftproto.Rule{rule}
+				return f
+			},
+			expectedOrphanedIDs: []string{"orphaned-variation-2"},
+		},
+		{
+			desc: "orphaned variation in default strategy",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Set default strategy with orphaned variation
+				f.DefaultStrategy = &ftproto.Strategy{
+					Type: ftproto.Strategy_ROLLOUT,
+					RolloutStrategy: &ftproto.RolloutStrategy{
+						Variations: []*ftproto.RolloutStrategy_Variation{
+							{
+								Variation: "variation-A", // Valid
+								Weight:    100000,
+							},
+							{
+								Variation: "orphaned-variation-3", // Orphaned
+								Weight:    0,
+							},
+						},
+					},
+				}
+				return f
+			},
+			expectedOrphanedIDs: []string{"orphaned-variation-3"},
+		},
+		{
+			desc: "orphaned OffVariation",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.OffVariation = "orphaned-off-variation"
+				return f
+			},
+			expectedOrphanedIDs: []string{"orphaned-off-variation"},
+		},
+		{
+			desc: "multiple orphaned references",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+
+				// Orphaned target
+				f.Targets = append(f.Targets, &ftproto.Target{
+					Variation: "orphaned-1",
+					Users:     []string{"user1"},
+				})
+
+				// Orphaned in rule
+				rule := &ftproto.Rule{
+					Id: "test-rule",
+					Strategy: &ftproto.Strategy{
+						Type: ftproto.Strategy_ROLLOUT,
+						RolloutStrategy: &ftproto.RolloutStrategy{
+							Variations: []*ftproto.RolloutStrategy_Variation{
+								{
+									Variation: "orphaned-2",
+									Weight:    0,
+								},
+							},
+						},
+					},
+					Clauses: []*ftproto.Clause{
+						{
+							Id:        "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+							Attribute: "user_id",
+							Operator:  ftproto.Clause_EQUALS,
+							Values:    []string{"user-1"},
+						},
+					},
+				}
+				f.Rules = []*ftproto.Rule{rule}
+
+				// Orphaned in default strategy
+				f.DefaultStrategy = &ftproto.Strategy{
+					Type: ftproto.Strategy_ROLLOUT,
+					RolloutStrategy: &ftproto.RolloutStrategy{
+						Variations: []*ftproto.RolloutStrategy_Variation{
+							{
+								Variation: "orphaned-3",
+								Weight:    0,
+							},
+						},
+					},
+				}
+
+				return f
+			},
+			expectedOrphanedIDs: []string{"orphaned-1", "orphaned-2", "orphaned-3"},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			f := p.setupFunc()
+
+			orphanedIDs := f.ValidateVariationReferences()
+
+			// Convert to map for easier comparison (order doesn't matter)
+			expectedMap := make(map[string]bool)
+			for _, id := range p.expectedOrphanedIDs {
+				expectedMap[id] = true
+			}
+
+			actualMap := make(map[string]bool)
+			for _, id := range orphanedIDs {
+				actualMap[id] = true
+			}
+
+			assert.Equal(t, expectedMap, actualMap, "Orphaned variation IDs don't match")
+		})
+	}
+}
+
+func TestCleanupOrphanedVariationReferences(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc            string
+		setupFunc       func() *Feature
+		expectedChanged bool
+		verifyFunc      func(*testing.T, *Feature)
+	}{
+		{
+			desc: "no cleanup needed",
+			setupFunc: func() *Feature {
+				return makeFeature("test-feature")
+			},
+			expectedChanged: false,
+			verifyFunc: func(t *testing.T, f *Feature) {
+				// Should remain unchanged
+				assert.Equal(t, 3, len(f.Variations))
+				assert.Equal(t, 3, len(f.Targets))
+			},
+		},
+		{
+			desc: "cleanup orphaned target",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Add orphaned target
+				f.Targets = append(f.Targets, &ftproto.Target{
+					Variation: "orphaned-variation",
+					Users:     []string{"user1"},
+				})
+				return f
+			},
+			expectedChanged: true,
+			verifyFunc: func(t *testing.T, f *Feature) {
+				// Orphaned target should be removed
+				assert.Equal(t, 3, len(f.Targets))
+				for _, target := range f.Targets {
+					assert.NotEqual(t, "orphaned-variation", target.Variation)
+				}
+			},
+		},
+		{
+			desc: "cleanup orphaned variation in rule",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Clear existing rules and add one with orphaned variation
+				f.Rules = []*ftproto.Rule{
+					{
+						Id: "test-rule",
+						Strategy: &ftproto.Strategy{
+							Type: ftproto.Strategy_ROLLOUT,
+							RolloutStrategy: &ftproto.RolloutStrategy{
+								Variations: []*ftproto.RolloutStrategy_Variation{
+									{
+										Variation: "variation-A", // Valid
+										Weight:    50000,
+									},
+									{
+										Variation: "orphaned-variation", // Orphaned
+										Weight:    0,
+									},
+								},
+							},
+						},
+						Clauses: []*ftproto.Clause{
+							{
+								Id:        "0efe416e-2fd2-4996-b5c3-194f05444f1f",
+								Attribute: "user_id",
+								Operator:  ftproto.Clause_EQUALS,
+								Values:    []string{"user-1"},
+							},
+						},
+					},
+				}
+				return f
+			},
+			expectedChanged: true,
+			verifyFunc: func(t *testing.T, f *Feature) {
+				// Orphaned variation should be removed from rule
+				assert.Equal(t, 1, len(f.Rules))
+				rule := f.Rules[0]
+				assert.Equal(t, 1, len(rule.Strategy.RolloutStrategy.Variations))
+				assert.Equal(t, "variation-A", rule.Strategy.RolloutStrategy.Variations[0].Variation)
+			},
+		},
+		{
+			desc: "cleanup orphaned variation in default strategy",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Set default strategy with orphaned variation
+				f.DefaultStrategy = &ftproto.Strategy{
+					Type: ftproto.Strategy_ROLLOUT,
+					RolloutStrategy: &ftproto.RolloutStrategy{
+						Variations: []*ftproto.RolloutStrategy_Variation{
+							{
+								Variation: "variation-A", // Valid
+								Weight:    100000,
+							},
+							{
+								Variation: "orphaned-variation", // Orphaned
+								Weight:    0,
+							},
+						},
+					},
+				}
+				return f
+			},
+			expectedChanged: true,
+			verifyFunc: func(t *testing.T, f *Feature) {
+				// Orphaned variation should be removed from default strategy
+				assert.Equal(t, 1, len(f.DefaultStrategy.RolloutStrategy.Variations))
+				assert.Equal(t, "variation-A", f.DefaultStrategy.RolloutStrategy.Variations[0].Variation)
+			},
+		},
+		{
+			desc: "cleanup orphaned OffVariation",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				f.OffVariation = "orphaned-off-variation"
+				return f
+			},
+			expectedChanged: true,
+			verifyFunc: func(t *testing.T, f *Feature) {
+				// OffVariation should be reset to second valid variation
+				assert.Equal(t, "variation-B", f.OffVariation)
+			},
+		},
+		{
+			desc: "cleanup orphaned OffVariation with only one variation",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// Keep only one variation
+				f.Variations = f.Variations[:1]
+				f.OffVariation = "orphaned-off-variation"
+				return f
+			},
+			expectedChanged: true,
+			verifyFunc: func(t *testing.T, f *Feature) {
+				// OffVariation should fallback to first variation when only one exists
+				assert.Equal(t, "variation-A", f.OffVariation)
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			f := p.setupFunc()
+
+			initialTime := f.UpdatedAt
+			changed := f.CleanupOrphanedVariationReferences()
+
+			assert.Equal(t, p.expectedChanged, changed, "Changed flag doesn't match expected")
+
+			if changed {
+				assert.Greater(t, f.UpdatedAt, initialTime, "UpdatedAt should be updated when changes are made")
+			} else {
+				assert.Equal(t, initialTime, f.UpdatedAt, "UpdatedAt should not change when no changes are made")
+			}
+
+			p.verifyFunc(t, f)
+		})
+	}
+}

--- a/pkg/feature/domain/migration_test.go
+++ b/pkg/feature/domain/migration_test.go
@@ -347,11 +347,11 @@ func TestCleanupOrphanedVariationReferences(t *testing.T) {
 			f := p.setupFunc()
 
 			initialTime := f.UpdatedAt
-			changed := f.CleanupOrphanedVariationReferences()
+			result := f.CleanupOrphanedVariationReferences()
 
-			assert.Equal(t, p.expectedChanged, changed, "Changed flag doesn't match expected")
+			assert.Equal(t, p.expectedChanged, result.Changed, "Changed flag doesn't match expected")
 
-			if changed {
+			if result.Changed {
 				assert.Greater(t, f.UpdatedAt, initialTime, "UpdatedAt should be updated when changes are made")
 			} else {
 				assert.Equal(t, initialTime, f.UpdatedAt, "UpdatedAt should not change when no changes are made")

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/default-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/default-rule/index.tsx
@@ -17,7 +17,6 @@ import VariationLabel from 'elements/variation-label';
 import { DefaultRuleSchema, TargetingSchema } from '../form-schema';
 import Strategy from '../segment-rule/strategy';
 import { VariationOption } from '../segment-rule/variation';
-import { getDefaultRolloutStrategy } from '../utils';
 import DefaultRuleRollout from './rollout';
 
 const DefaultRule = ({
@@ -33,13 +32,11 @@ const DefaultRule = ({
 }) => {
   const { t } = useTranslation(['form']);
 
-  const { control, watch, setFocus, setValue } =
-    useFormContext<TargetingSchema>();
+  const { control, watch, setFocus } = useFormContext<TargetingSchema>();
 
   const commonName = 'defaultRule';
   const defaultRule = watch(commonName);
   const manualStrategy = watch('defaultRule.manualStrategy');
-  const defaultRolloutStrategy = getDefaultRolloutStrategy(feature);
 
   const variationOptions: VariationOption[] = useMemo(() => {
     const variations = feature.variations.map((item, index) => ({
@@ -56,12 +53,6 @@ const DefaultRule = ({
         type: StrategyType.MANUAL,
         icon: IconPercentage
       }
-      // {
-      //   label: t('common:source-type.progressive-rollout'),
-      //   value: StrategyType.ROLLOUT,
-      //   type: StrategyType.ROLLOUT,
-      //   icon: IconCircleDashed
-      // }
     ];
   }, [feature]);
 
@@ -81,18 +72,12 @@ const DefaultRule = ({
         currentOption: value,
         fixedStrategy: {
           variation: isFixed ? value : ''
-        },
-        rolloutStrategy: isFixed ? [] : defaultRolloutStrategy
+        }
+        // rolloutStrategy: isFixed ? [] : defaultRolloutStrategy
       });
       if (!isFixed) {
         let timerId: NodeJS.Timeout | null = null;
         if (timerId) clearTimeout(timerId);
-        defaultRolloutStrategy.forEach((_, index) =>
-          setValue(
-            `${commonName}.${isRollout ? 'rolloutStrategy' : 'manualStrategy'}.${index}.weight`,
-            0
-          )
-        );
         timerId = setTimeout(
           () =>
             setFocus(

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/default-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/default-rule/index.tsx
@@ -73,7 +73,6 @@ const DefaultRule = ({
         fixedStrategy: {
           variation: isFixed ? value : ''
         }
-        // rolloutStrategy: isFixed ? [] : defaultRolloutStrategy
       });
       if (!isFixed) {
         let timerId: NodeJS.Timeout | null = null;

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
@@ -151,7 +151,10 @@ export const handleCreateDefaultValues = (feature: Feature) => {
     segmentRules,
     defaultRule: {
       ..._defaultStrategy,
-      type: defaultStrategy?.type,
+      type:
+        defaultStrategy?.type === StrategyType.FIXED
+          ? StrategyType.FIXED
+          : StrategyType.MANUAL,
       currentOption:
         defaultStrategy?.type === StrategyType.FIXED
           ? defaultStrategy?.fixedStrategy?.variation


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2037

There was a bug when adding and removing variations. When adding, it wasn't adding the new variation to the Rules and Default Strategy, and when removing, it wasn't deleting from the targets, rules, and default strategy, causing a different state in the DB.

I have implemented a temporary migration in the API so the user can use the console as soon as possible. However, we will probably need a DB-level migration, and it will take some time to do it carefully.

Also, I found another issue when deleting a variation used in another Flag as a prerequisite or a rule. After deleting, the prerequisite and rule show empty for the variation ID value. This will also need a migration.

- Fixed variation not being added to Rules and Default Strategy
- Fixed variation not being removed from Targets, Rules, and Default Strategy
- Fixed the percentage validation on UI
- Implemented a validation for variation deletion to check if it is in use in other Flags as a prerequisite or a rule
- Implemented a temporary migration when reading and writing flags directly in the API
