### PR TITLE
fix: auto operation not incrementing flag version

### DIFF
--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -1666,6 +1666,8 @@ func (s *AutoOpsService) ExecuteAutoOps(
 			feature,
 			s.logger,
 			localizer,
+			s.publisher,
+			editor,
 		); err != nil {
 			s.logger.Error(
 				"Failed to execute auto ops rule operation",
@@ -1824,6 +1826,8 @@ func (s *AutoOpsService) executeAutoOpsNoCommand(
 			feature,
 			s.logger,
 			localizer,
+			s.publisher,
+			editor,
 		); err != nil {
 			s.logger.Error(
 				"Failed to execute auto ops rule operation",


### PR DESCRIPTION
Fix: https://github.com/bucketeer-io/bucketeer/issues/2051

When the auto operation is triggered, the flag version is not incremented, which will not update the SDK client cache because the user evaluation ID is based on the feature_id, feature_version, and user_id.

### Things done

- Fixed flag version not being incremented when the auto operation updates a flag
- Fixed audit log not being created when the flag is updated by an auto operation