### PR TITLE
ci: fix permission error when pushing migration image

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -77,6 +77,7 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
+      packages: "write"
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -120,8 +121,8 @@ jobs:
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USER_NAME }}
-          password: ${{ secrets.GHCR_PAT }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push migration image to GHCR
         if:  ${{ needs.setup.outputs.MIGRATION_REQUIRED == 'true' }}
         run: |


### PR DESCRIPTION
Changed it to use GITHUB_TOKEN instead, like when publishing the [helm chart](https://github.com/bucketeer-io/bucketeer/blob/main/.github/workflows/publish_chart.yaml#L68).