### PR TITLE
feat: add pprof debug option

### DIFF
--- a/docker-compose/compose.yml
+++ b/docker-compose/compose.yml
@@ -121,6 +121,8 @@ services:
       - BUCKETEER_WEB_LOG_LEVEL=info
       - BUCKETEER_WEB_PROFILE=false
       - BUCKETEER_WEB_GCP_TRACE_ENABLED=false
+      - BUCKETEER_WEB_ENABLE_PPROF=false
+      - BUCKETEER_WEB_PPROF_ADDR=127.0.0.1:6060
       - BUCKETEER_WEB_USE_MYSQL=true
       - BUCKETEER_WEB_CLOUD_SERVICE=gcp
       - BUCKETEER_WEB_WEBHOOK_BASE_URL=https://localhost
@@ -204,6 +206,8 @@ services:
       - BUCKETEER_API_PROFILE=false
       - BUCKETEER_API_GCP_TRACE_ENABLED=false
       - BUCKETEER_API_TRACE_SAMPLING_PROBABILITY=0.0
+      - BUCKETEER_API_ENABLE_PPROF=false
+      - BUCKETEER_API_PPROF_ADDR=127.0.0.1:6060
     volumes:
       - ../tools/dev/cert/tls.crt:/usr/local/certs/service/tls.crt:ro
       - ../tools/dev/cert/tls.key:/usr/local/certs/service/tls.key:ro
@@ -270,6 +274,8 @@ services:
       - BUCKETEER_BATCH_LOG_LEVEL=info
       - BUCKETEER_BATCH_PROFILE=false
       - BUCKETEER_BATCH_GCP_TRACE_ENABLED=false
+      - BUCKETEER_BATCH_ENABLE_PPROF=false
+      - BUCKETEER_BATCH_PPROF_ADDR=127.0.0.1:6060
       - BUCKETEER_BATCH_STAN_MODEL_ID=y3qsnd7m
       - BUCKETEER_BATCH_STAN_HOST=httpstan
       - BUCKETEER_BATCH_STAN_PORT=8080
@@ -332,6 +338,8 @@ services:
       - BUCKETEER_SUBSCRIBER_LOG_LEVEL=info
       - BUCKETEER_SUBSCRIBER_PROFILE=false
       - BUCKETEER_SUBSCRIBER_GCP_TRACE_ENABLED=false
+      - BUCKETEER_SUBSCRIBER_ENABLE_PPROF=false
+      - BUCKETEER_SUBSCRIBER_PPROF_ADDR=127.0.0.1:6060
       - BUCKETEER_SUBSCRIBER_SUBSCRIBER_CONFIG=/usr/local/conf/subscribers.json
       - BUCKETEER_SUBSCRIBER_ON_DEMAND_SUBSCRIBER_CONFIG=/usr/local/conf/onDemandSubscribers.json
       - BUCKETEER_SUBSCRIBER_PROCESSORS_CONFIG=/usr/local/conf/processors.json

--- a/docker-compose/compose.yml
+++ b/docker-compose/compose.yml
@@ -121,8 +121,6 @@ services:
       - BUCKETEER_WEB_LOG_LEVEL=info
       - BUCKETEER_WEB_PROFILE=false
       - BUCKETEER_WEB_GCP_TRACE_ENABLED=false
-      - BUCKETEER_WEB_ENABLE_PPROF=false
-      - BUCKETEER_WEB_PPROF_ADDR=127.0.0.1:6060
       - BUCKETEER_WEB_USE_MYSQL=true
       - BUCKETEER_WEB_CLOUD_SERVICE=gcp
       - BUCKETEER_WEB_WEBHOOK_BASE_URL=https://localhost
@@ -145,6 +143,9 @@ services:
       - BUCKETEER_WEB_AUTOOPS_SERVICE=nginx:443
       - BUCKETEER_WEB_CODE_REFERENCE_SERVICE=nginx:443
       - BUCKETEER_WEB_DATA_WAREHOUSE_CONFIG_PATH=/usr/local/datawarehouse-config/datawarehouse.yaml
+      # pprof settings
+      - BUCKETEER_WEB_ENABLE_PPROF=${BUCKETEER_WEB_ENABLE_PPROF:-false}
+      - BUCKETEER_WEB_PPROF_ADDR=${BUCKETEER_WEB_PPROF_ADDR:-127.0.0.1:6060}
     volumes:
       - ../tools/dev/cert/tls.crt:/usr/local/certs/service/tls.crt:ro
       - ../tools/dev/cert/tls.key:/usr/local/certs/service/tls.key:ro
@@ -206,8 +207,9 @@ services:
       - BUCKETEER_API_PROFILE=false
       - BUCKETEER_API_GCP_TRACE_ENABLED=false
       - BUCKETEER_API_TRACE_SAMPLING_PROBABILITY=0.0
-      - BUCKETEER_API_ENABLE_PPROF=false
-      - BUCKETEER_API_PPROF_ADDR=127.0.0.1:6060
+     # pprof settings
+      - BUCKETEER_API_ENABLE_PPROF=${BUCKETEER_API_ENABLE_PPROF:-false}
+      - BUCKETEER_API_PPROF_ADDR=${BUCKETEER_API_PPROF_ADDR:-127.0.0.1:6060}
     volumes:
       - ../tools/dev/cert/tls.crt:/usr/local/certs/service/tls.crt:ro
       - ../tools/dev/cert/tls.key:/usr/local/certs/service/tls.key:ro
@@ -274,11 +276,12 @@ services:
       - BUCKETEER_BATCH_LOG_LEVEL=info
       - BUCKETEER_BATCH_PROFILE=false
       - BUCKETEER_BATCH_GCP_TRACE_ENABLED=false
-      - BUCKETEER_BATCH_ENABLE_PPROF=false
-      - BUCKETEER_BATCH_PPROF_ADDR=127.0.0.1:6060
       - BUCKETEER_BATCH_STAN_MODEL_ID=y3qsnd7m
       - BUCKETEER_BATCH_STAN_HOST=httpstan
       - BUCKETEER_BATCH_STAN_PORT=8080
+      # pprof settings
+      - BUCKETEER_BATCH_ENABLE_PPROF=${BUCKETEER_BATCH_ENABLE_PPROF:-false}
+      - BUCKETEER_BATCH_PPROF_ADDR=${BUCKETEER_BATCH_PPROF_ADDR:-127.0.0.1:6060}
     volumes:
       - ../tools/dev/cert/tls.crt:/usr/local/certs/service/tls.crt:ro
       - ../tools/dev/cert/tls.key:/usr/local/certs/service/tls.key:ro
@@ -338,12 +341,13 @@ services:
       - BUCKETEER_SUBSCRIBER_LOG_LEVEL=info
       - BUCKETEER_SUBSCRIBER_PROFILE=false
       - BUCKETEER_SUBSCRIBER_GCP_TRACE_ENABLED=false
-      - BUCKETEER_SUBSCRIBER_ENABLE_PPROF=false
-      - BUCKETEER_SUBSCRIBER_PPROF_ADDR=127.0.0.1:6060
       - BUCKETEER_SUBSCRIBER_SUBSCRIBER_CONFIG=/usr/local/conf/subscribers.json
       - BUCKETEER_SUBSCRIBER_ON_DEMAND_SUBSCRIBER_CONFIG=/usr/local/conf/onDemandSubscribers.json
       - BUCKETEER_SUBSCRIBER_PROCESSORS_CONFIG=/usr/local/conf/processors.json
       - BUCKETEER_SUBSCRIBER_ON_DEMAND_PROCESSORS_CONFIG=/usr/local/conf/onDemandProcessors.json
+      # pprof settings
+      - BUCKETEER_SUBSCRIBER_ENABLE_PPROF=${BUCKETEER_SUBSCRIBER_ENABLE_PPROF:-false}
+      - BUCKETEER_SUBSCRIBER_PPROF_ADDR=${BUCKETEER_SUBSCRIBER_PPROF_ADDR:-127.0.0.1:6060}
     volumes:
       - ../tools/dev/cert/tls.crt:/usr/local/certs/service/tls.crt:ro
       - ../tools/dev/cert/tls.key:/usr/local/certs/service/tls.key:ro

--- a/docker-compose/env.default
+++ b/docker-compose/env.default
@@ -16,3 +16,13 @@ export BUCKETEER_VERSION=localenv
 # export BUCKETEER_API_VERSION=localenv
 # export BUCKETEER_BATCH_VERSION=localenv
 # export BUCKETEER_SUBSCRIBER_VERSION=localenv
+
+# Uncomment and modify to use different on/off and addresses for specific services
+# export BUCKETEER_API_ENABLE_PPROF=false
+# export BUCKETEER_API_PPROF_ADDR=127.0.0.1:6060
+# export BUCKETEER_WEB_ENABLE_PPROF=false
+# export BUCKETEER_WEB_PPROF_ADDR=127.0.0.1:6060
+# export BUCKETEER_BATCH_ENABLE_PPROF=false
+# export BUCKETEER_BATCH_PPROF_ADDR=127.0.0.1:6060
+# export BUCKETEER_SUBSCRIBER_ENABLE_PPROF=false
+# export BUCKETEER_SUBSCRIBER_PPROF_ADDR=127.0.0.1:6060

--- a/manifests/bucketeer/charts/api/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/api/templates/deployment.yaml
@@ -109,6 +109,10 @@ spec:
               value: "{{ .Values.env.metricsPort }}"
             - name: BUCKETEER_API_LOG_LEVEL
               value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_API_ENABLE_PPROF
+              value: "{{ .Values.env.enablePprof }}"
+            - name: BUCKETEER_API_PPROF_ADDR
+              value: "{{ .Values.env.pprofAddr }}"
             - name: BUCKETEER_API_TRACE_SAMPLING_PROBABILITY
               value: "{{ .Values.env.traceSamplingProbability }}"
             - name: BUCKETEER_API_PUBSUB_TYPE

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -7,6 +7,8 @@ env:
   project:
   gcpEnabled: true
   profile: true
+  enablePprof: false
+  pprofAddr: 127.0.0.1:6060
   pubsubEmulatorHost:
   goalTopic:
   evaluationTopic:

--- a/manifests/bucketeer/charts/batch/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/batch/templates/deployment.yaml
@@ -119,6 +119,10 @@ spec:
               value: "{{ .Values.env.webURL }}"
             - name: BUCKETEER_BATCH_LOG_LEVEL
               value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_BATCH_ENABLE_PPROF
+              value: "{{ .Values.env.enablePprof }}"
+            - name: BUCKETEER_BATCH_PPROF_ADDR
+              value: "{{ .Values.env.pprofAddr }}"
             - name: BUCKETEER_BATCH_REFRESH_INTERVAL
               value: "{{ .Values.env.refreshInterval }}"
             - name: BUCKETEER_BATCH_GRPC_GATEWAY_PORT

--- a/manifests/bucketeer/charts/batch/values.yaml
+++ b/manifests/bucketeer/charts/batch/values.yaml
@@ -10,6 +10,8 @@ env:
   project:
   profile: true
   gcpEnabled: true
+  enablePprof: false
+  pprofAddr: 127.0.0.1:6060
   mysqlUser:
   mysqlPass:
   mysqlHost:

--- a/manifests/bucketeer/charts/subscriber/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/subscriber/templates/deployment.yaml
@@ -105,6 +105,10 @@ spec:
               value: "{{ .Values.env.webURL }}"
             - name: BUCKETEER_SUBSCRIBER_LOG_LEVEL
               value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_SUBSCRIBER_ENABLE_PPROF
+              value: "{{ .Values.env.enablePprof }}"
+            - name: BUCKETEER_SUBSCRIBER_PPROF_ADDR
+              value: "{{ .Values.env.pprofAddr }}"
             - name: BUCKETEER_SUBSCRIBER_REFRESH_INTERVAL
               value: "{{ .Values.env.refreshInterval }}"
             - name: BUCKETEER_SUBSCRIBER_PORT

--- a/manifests/bucketeer/charts/subscriber/values.yaml
+++ b/manifests/bucketeer/charts/subscriber/values.yaml
@@ -9,6 +9,8 @@ env:
   project:
   profile: true
   gcpEnabled: true
+  enablePprof: false
+  pprofAddr: 127.0.0.1:6060
   mysqlUser:
   mysqlPass:
   mysqlHost:

--- a/manifests/bucketeer/charts/web/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/web/templates/deployment.yaml
@@ -163,6 +163,10 @@ spec:
               value: "{{ .Values.env.metricsPort }}"
             - name: BUCKETEER_WEB_LOG_LEVEL
               value: "{{ .Values.env.logLevel }}"
+            - name: BUCKETEER_WEB_ENABLE_PPROF
+              value: "{{ .Values.env.enablePprof }}"
+            - name: BUCKETEER_WEB_PPROF_ADDR
+              value: "{{ .Values.env.pprofAddr }}"
             - name: BUCKETEER_WEB_PUBSUB_TYPE
               value: "{{ .Values.global.pubsub.type }}"
             - name: BUCKETEER_WEB_PUBSUB_REDIS_SERVER_NAME

--- a/manifests/bucketeer/charts/web/values.yaml
+++ b/manifests/bucketeer/charts/web/values.yaml
@@ -9,6 +9,8 @@ env:
   bucketeerTestEnabled:
   demoSiteEnabled: false
   gcpEnabled: true
+  enablePprof: false
+  pprofAddr: 127.0.0.1:6060
   bigqueryQuerierEmulatorHost:
   pubsubEmulatorHost:
   project:

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -59,6 +59,8 @@ web:
     gcpEnabled: false
     cloudService: hcv
     profile: false
+    enablePprof: false
+    pprofAddr: 127.0.0.1:6060
     bucketeerTestEnabled: true
     bigqueryQuerierEmulatorHost: http://localenv-bq.default.svc.cluster.local:9050
     project: ${global.pubsub.project}
@@ -132,6 +134,8 @@ api:
   env:
     gcpEnabled: false
     profile: false
+    enablePprof: true
+    pprofAddr: 0.0.0.0:6060
     pubsubEmulatorHost: ${global.pubsub.emulatorHost}
     project: ${global.pubsub.project}
     goalTopic: goal
@@ -167,6 +171,8 @@ batch-server:
     project: bucketeer-test
     profile: false
     gcpEnabled: false
+    enablePprof: true
+    pprofAddr: 0.0.0.0:6060
     mysqlUser: bucketeer
     mysqlPass: bucketeer
     mysqlHost: localenv-mysql-headless.default.svc.cluster.local
@@ -287,6 +293,8 @@ subscriber:
     project: bucketeer-test
     profile: false
     gcpEnabled: false
+    enablePprof: true
+    pprofAddr: 0.0.0.0:6060
     mysqlUser: bucketeer
     mysqlPass: bucketeer
     mysqlHost: localenv-mysql-headless.default.svc.cluster.local

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -134,8 +134,8 @@ api:
   env:
     gcpEnabled: false
     profile: false
-    enablePprof: true
-    pprofAddr: 0.0.0.0:6060
+    enablePprof: false
+    pprofAddr: 127.0.0.1:6060
     pubsubEmulatorHost: ${global.pubsub.emulatorHost}
     project: ${global.pubsub.project}
     goalTopic: goal
@@ -171,8 +171,8 @@ batch-server:
     project: bucketeer-test
     profile: false
     gcpEnabled: false
-    enablePprof: true
-    pprofAddr: 0.0.0.0:6060
+    enablePprof: false
+    pprofAddr: 127.0.0.1:6060
     mysqlUser: bucketeer
     mysqlPass: bucketeer
     mysqlHost: localenv-mysql-headless.default.svc.cluster.local
@@ -293,8 +293,8 @@ subscriber:
     project: bucketeer-test
     profile: false
     gcpEnabled: false
-    enablePprof: true
-    pprofAddr: 0.0.0.0:6060
+    enablePprof: false
+    pprofAddr: 127.0.0.1:6060
     mysqlUser: bucketeer
     mysqlPass: bucketeer
     mysqlHost: localenv-mysql-headless.default.svc.cluster.local

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -18,8 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 
 	"cloud.google.com/go/profiler"
@@ -71,6 +75,8 @@ func (a *App) Run() error {
 	logLevel := a.app.Flag("log-level", "The level of logging.").Default("info").Enum(log.Levels...)
 	profile := a.app.Flag("profile", "If true enables uploading the profiles to Stackdriver.").Default("true").Bool()
 	metricsPort := a.app.Flag("metrics-port", "Port to bind metrics server to.").Default("9002").Int()
+	enablePprof := a.app.Flag("enable-pprof", "Enable pprof debug endpoints at /debug/pprof/.").Default("false").Bool()
+	pprofPort := a.app.Flag("pprof-port", "Port to bind pprof server to.").Default("6060").Int()
 	traceSamplingProbability := a.app.Flag(
 		"trace-sampling-probability",
 		"How offten we send traces to exporters.",
@@ -120,6 +126,15 @@ func (a *App) Run() error {
 	)
 	defer metrics.Stop()
 	go metrics.Run() // nolint:errcheck
+
+	if *enablePprof {
+		go func() {
+			pprofAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(*pprofPort))
+			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+				logger.Error("Failed to start pprof server", zap.Error(err))
+			}
+		}()
+	}
 
 	if *gcpTraceEnabled {
 		sd, err := trace.NewStackdriverExporter(serviceName, a.version, logger)

--- a/pkg/cli/app.go
+++ b/pkg/cli/app.go
@@ -18,12 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
-	"strconv"
 	"syscall"
 
 	"cloud.google.com/go/profiler"
@@ -76,7 +74,7 @@ func (a *App) Run() error {
 	profile := a.app.Flag("profile", "If true enables uploading the profiles to Stackdriver.").Default("true").Bool()
 	metricsPort := a.app.Flag("metrics-port", "Port to bind metrics server to.").Default("9002").Int()
 	enablePprof := a.app.Flag("enable-pprof", "Enable pprof debug endpoints at /debug/pprof/.").Default("false").Bool()
-	pprofPort := a.app.Flag("pprof-port", "Port to bind pprof server to.").Default("6060").Int()
+	pprofAddr := a.app.Flag("pprof-addr", "Address to bind pprof server to.").Default("127.0.0.1:6060").String()
 	traceSamplingProbability := a.app.Flag(
 		"trace-sampling-probability",
 		"How offten we send traces to exporters.",
@@ -129,8 +127,7 @@ func (a *App) Run() error {
 
 	if *enablePprof {
 		go func() {
-			pprofAddr := net.JoinHostPort("127.0.0.1", strconv.Itoa(*pprofPort))
-			if err := http.ListenAndServe(pprofAddr, nil); err != nil {
+			if err := http.ListenAndServe(*pprofAddr, nil); err != nil {
 				logger.Error("Failed to start pprof server", zap.Error(err))
 			}
 		}()


### PR DESCRIPTION
fix #2105

### Overview
This PR implements pprof (Go profiler) debug endpoints for the Bucketeer application. This enables performance analysis and bottleneck identification in production and testing environments.

### Changes Made

#### New functionality in `pkg/cli/app.go`:

1. **New Command Line Flags**:
   - `--enable-pprof`: Enable pprof endpoints (default: `false`)
   - `--pprof-address`: Port number for pprof server (default: `127.0.0.1:6060`)

2. **Pprof Server Implementation**:
   ```go
   if *enablePprof {
       go func() {
           if err := http.ListenAndServe(*pprofAddr, nil); err != nil {
               logger.Error("Failed to start pprof server", zap.Error(err))
           }
       }()
   }
   ```

### Usage
```bash
# Start application with pprof enabled
   ./bin/api --enable-pprof=true --pprof-address=127.0.0.1:6060 [other-flags]
   ./bin/batch --enable-pprof=true --pprof-address=127.0.0.1:6060 [other-flags]
   ./bin/subscriber --enable-pprof=true --pprof-address=127.0.0.1:6060 [other-flags]
   ./bin/web --enable-pprof=true --pprof-address=127.0.0.1:6060 [other-flags]

# Access profiling data
curl http://127.0.0.1:6060/debug/pprof/
go tool pprof http://127.0.0.1:6060/debug/pprof/profile
```
