### PR TITLE
refactor: notificationAPI related error handling in Notification package

### DIFF
--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	AccountPackageName = "account"
+	AccountPackageName      = "account"
 	NotificationPackageName = "notification"
 
 	invalidTypeUnknown        = "unknown"

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -22,6 +22,7 @@ import (
 
 const (
 	AccountPackageName = "account"
+	NotificationPackageName = "notification"
 
 	invalidTypeUnknown        = "unknown"
 	invalidTypeEmpty          = "empty"

--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	"github.com/bucketeer-io/bucketeer/pkg/notification/command"
@@ -55,14 +56,7 @@ func (s *NotificationService) CreateAdminSubscription(
 				zap.Any("recipient", req.Command.Recipient),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
@@ -95,14 +89,7 @@ func (s *NotificationService) CreateAdminSubscription(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	if errs := s.publishDomainEvents(ctx, handler.Events()); len(errs) > 0 {
 		s.logger.Error(
@@ -111,14 +98,7 @@ func (s *NotificationService) CreateAdminSubscription(
 				zap.Any("errors", errs),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &notificationproto.CreateAdminSubscriptionResponse{}, nil
 }
@@ -407,14 +387,7 @@ func (s *NotificationService) updateAdminSubscription(
 				zap.String("id", id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	if errs := s.publishDomainEvents(ctx, handler.Events()); len(errs) > 0 {
 		s.logger.Error(
@@ -424,14 +397,7 @@ func (s *NotificationService) updateAdminSubscription(
 				zap.String("id", id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -484,14 +450,7 @@ func (s *NotificationService) DeleteAdminSubscription(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	if errs := s.publishDomainEvents(ctx, handler.Events()); len(errs) > 0 {
 		s.logger.Error(
@@ -501,14 +460,7 @@ func (s *NotificationService) DeleteAdminSubscription(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &notificationproto.DeleteAdminSubscriptionResponse{}, nil
 }
@@ -587,14 +539,7 @@ func (s *NotificationService) GetAdminSubscription(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &notificationproto.GetAdminSubscriptionResponse{Subscription: subscription.Subscription}, nil
 }
@@ -794,14 +739,7 @@ func (s *NotificationService) listAdminSubscriptionsMySQL(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, "", 0, statusInternal.Err()
-		}
-		return nil, "", 0, dt.Err()
+		return nil, "", 0, api.NewGRPCStatus(err).Err()
 	}
 	return subscriptions, strconv.Itoa(nextCursor), totalCount, nil
 }

--- a/pkg/notification/api/api.go
+++ b/pkg/notification/api/api.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	accountclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	v2 "github.com/bucketeer-io/bucketeer/pkg/notification/storage/v2"
@@ -123,14 +124,7 @@ func (s *NotificationService) checkSystemAdminRole(
 				"Failed to check role",
 				log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil
@@ -198,14 +192,7 @@ func (s *NotificationService) checkEnvironmentRole(
 					zap.String("environmentId", environmentId),
 				)...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil
@@ -269,14 +256,7 @@ func (s *NotificationService) checkOrganizationRole(
 					zap.String("organizationID", organizationID),
 				)...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil

--- a/pkg/notification/api/error.go
+++ b/pkg/notification/api/error.go
@@ -30,7 +30,8 @@ var (
 	statusSourceTypesRequired = api.NewGRPCStatus(err.NewErrorInvalidArgEmpty(
 		err.NotificationPackageName,
 		"notification types must be specified",
-		"notification_types"))
+		"notification_types",
+	))
 	statusUnknownRecipient = api.NewGRPCStatus(
 		err.NewErrorInvalidArgUnknown(err.NotificationPackageName, "unknown recipient", "recipient"),
 	)

--- a/pkg/notification/api/error.go
+++ b/pkg/notification/api/error.go
@@ -15,36 +15,55 @@
 package api
 
 import (
-	"google.golang.org/grpc/codes"
-	gstatus "google.golang.org/grpc/status"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
+	err "github.com/bucketeer-io/bucketeer/pkg/error"
 )
 
 var (
-	statusInternal            = gstatus.New(codes.Internal, "notification: internal")
-	statusIDRequired          = gstatus.New(codes.InvalidArgument, "notification: id must be specified")
-	statusNameRequired        = gstatus.New(codes.InvalidArgument, "notification: name must be specified")
-	statusSourceTypesRequired = gstatus.New(
-		codes.InvalidArgument,
-		"notification: notification types must be specified",
+	statusInternal   = api.NewGRPCStatus(err.NewErrorInternal(err.NotificationPackageName, "internal"))
+	statusIDRequired = api.NewGRPCStatus(
+		err.NewErrorInvalidArgEmpty(err.NotificationPackageName, "id must be specified", "id"),
 	)
-	statusUnknownRecipient  = gstatus.New(codes.InvalidArgument, "notification: unknown recipient")
-	statusRecipientRequired = gstatus.New(
-		codes.InvalidArgument,
-		"notification: recipient must be specified",
+	statusNameRequired = api.NewGRPCStatus(
+		err.NewErrorInvalidArgEmpty(err.NotificationPackageName, "name must be specified", "name"),
 	)
-	statusSlackRecipientRequired = gstatus.New(
-		codes.InvalidArgument,
-		"notification: slack recipient must be specified",
+	statusSourceTypesRequired = api.NewGRPCStatus(err.NewErrorInvalidArgEmpty(
+		err.NotificationPackageName,
+		"notification types must be specified",
+		"notification_types"))
+	statusUnknownRecipient = api.NewGRPCStatus(
+		err.NewErrorInvalidArgUnknown(err.NotificationPackageName, "unknown recipient", "recipient"),
 	)
-	statusSlackRecipientWebhookURLRequired = gstatus.New(
-		codes.InvalidArgument,
-		"notification: webhook URL must be specified",
+	statusRecipientRequired = api.NewGRPCStatus(err.NewErrorInvalidArgEmpty(
+		err.NotificationPackageName,
+		"recipient must be specified",
+		"recipient",
+	))
+	statusSlackRecipientRequired = api.NewGRPCStatus(err.NewErrorInvalidArgEmpty(
+		err.NotificationPackageName,
+		"slack recipient must be specified",
+		"slack_recipient",
+	))
+	statusSlackRecipientWebhookURLRequired = api.NewGRPCStatus(err.NewErrorInvalidArgEmpty(
+		err.NotificationPackageName,
+		"webhook URL must be specified",
+		"webhook_url",
+	))
+	statusInvalidCursor = api.NewGRPCStatus(
+		err.NewErrorInvalidArgNotMatchFormat(err.NotificationPackageName, "cursor is invalid", "cursor"),
 	)
-	statusInvalidCursor    = gstatus.New(codes.InvalidArgument, "notification: cursor is invalid")
-	statusNoCommand        = gstatus.New(codes.InvalidArgument, "notification: no command")
-	statusInvalidOrderBy   = gstatus.New(codes.InvalidArgument, "environment: order_by is invalid")
-	statusNotFound         = gstatus.New(codes.NotFound, "notification: not found")
-	statusAlreadyExists    = gstatus.New(codes.AlreadyExists, "notification: already exists")
-	statusUnauthenticated  = gstatus.New(codes.Unauthenticated, "notification: unauthenticated")
-	statusPermissionDenied = gstatus.New(codes.PermissionDenied, "notification: permission denied")
+	statusNoCommand = api.NewGRPCStatus(
+		err.NewErrorInvalidArgEmpty(err.NotificationPackageName, "no command", "command"),
+	)
+	statusInvalidOrderBy = api.NewGRPCStatus(
+		err.NewErrorInvalidArgNotMatchFormat(err.NotificationPackageName, "order_by is invalid", "order_by"),
+	)
+	statusNotFound      = api.NewGRPCStatus(err.NewErrorNotFound(err.NotificationPackageName, "not found", "id"))
+	statusAlreadyExists = api.NewGRPCStatus(
+		err.NewErrorAlreadyExists(err.NotificationPackageName, "already exists"),
+	)
+	statusUnauthenticated  = api.NewGRPCStatus(err.NewErrorUnauthenticated(err.NotificationPackageName, "unauthenticated"))
+	statusPermissionDenied = api.NewGRPCStatus(
+		err.NewErrorPermissionDenied(err.NotificationPackageName, "permission denied"),
+	)
 )

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	domainevent "github.com/bucketeer-io/bucketeer/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
@@ -73,14 +74,7 @@ func (s *NotificationService) CreateSubscription(
 				zap.Any("recipient", req.Command.Recipient),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	var handler command.Handler = command.NewEmptySubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
@@ -113,14 +107,7 @@ func (s *NotificationService) CreateSubscription(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	if errs := s.publishDomainEvents(ctx, handler.Events()); len(errs) > 0 {
 		s.logger.Error(
@@ -130,14 +117,7 @@ func (s *NotificationService) CreateSubscription(
 				zap.String("environmentId", req.EnvironmentId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &notificationproto.CreateSubscriptionResponse{}, nil
 }
@@ -167,14 +147,7 @@ func (s *NotificationService) createSubscriptionNoCommand(
 				zap.Any("recipient", req.Recipient),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		return s.subscriptionStorage.CreateSubscription(contextWithTx, subscription, req.EnvironmentId)
@@ -196,14 +169,7 @@ func (s *NotificationService) createSubscriptionNoCommand(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 
 	event, err := domainevent.NewEvent(
@@ -434,14 +400,7 @@ func (s *NotificationService) updateSubscription(
 				zap.String("id", id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	if errs := s.publishDomainEvents(ctx, handler.Events()); len(errs) > 0 {
 		s.logger.Error(
@@ -452,14 +411,7 @@ func (s *NotificationService) updateSubscription(
 				zap.String("id", id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -526,14 +478,7 @@ func (s *NotificationService) updateSubscriptionMySQLNoCommand(
 				zap.String("environmentID", environmentID),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 
 	err = s.domainEventPublisher.Publish(ctx, event)
@@ -614,14 +559,7 @@ func (s *NotificationService) DeleteSubscription(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 
 	err = s.domainEventPublisher.Publish(ctx, event)
@@ -692,14 +630,7 @@ func (s *NotificationService) GetSubscription(
 				zap.String("id", req.Id),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &notificationproto.GetSubscriptionResponse{Subscription: subscription.Subscription}, nil
 }
@@ -966,14 +897,7 @@ func (s *NotificationService) listSubscriptionsMySQL(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, "", 0, statusInternal.Err()
-		}
-		return nil, "", 0, dt.Err()
+		return nil, "", 0, api.NewGRPCStatus(err).Err()
 	}
 	return subscriptions, strconv.Itoa(nextCursor), totalCount, nil
 }

--- a/pkg/notification/command/command.go
+++ b/pkg/notification/command/command.go
@@ -16,13 +16,13 @@ package command
 
 import (
 	"context"
-	"errors"
 
+	err "github.com/bucketeer-io/bucketeer/pkg/error"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 )
 
 var (
-	errUnknownCommand = errors.New("command: unknown command")
+	errUnknownCommand = err.NewErrorInvalidArgUnknown(err.NotificationPackageName, "unknown command", "command")
 )
 
 type Command interface{}

--- a/pkg/notification/domain/subscription.go
+++ b/pkg/notification/domain/subscription.go
@@ -38,7 +38,10 @@ var (
 		"notification types must have at least one",
 		"notification_types",
 	)
-	ErrSourceTypeNotFound          = err.NewErrorNotFound(err.NotificationPackageName, "notification not found", "notification_type")
+	ErrSourceTypeNotFound = err.NewErrorNotFound(
+		err.NotificationPackageName,
+		"notification not found", "notification_type",
+	)
 	ErrAlreadyEnabled              = err.NewErrorAlreadyExists(err.NotificationPackageName, "already enabled")
 	ErrAlreadyDisabled             = err.NewErrorAlreadyExists(err.NotificationPackageName, "already disabled")
 	ErrCannotUpdateFeatureFlagTags = err.NewErrorNotFound(

--- a/pkg/notification/domain/subscription.go
+++ b/pkg/notification/domain/subscription.go
@@ -17,24 +17,35 @@ package domain
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"sort"
 	"time"
 
 	"github.com/jinzhu/copier"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	err "github.com/bucketeer-io/bucketeer/pkg/error"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
 )
 
 var (
-	ErrUnknownRecipient              = errors.New("subscription: unknown recipient")
-	ErrSourceTypesMustHaveAtLeastOne = errors.New("subscription: notification types must have at least one")
-	ErrSourceTypeNotFound            = errors.New("subscription: notification not found")
-	ErrAlreadyEnabled                = errors.New("subscription: already enabled")
-	ErrAlreadyDisabled               = errors.New("subscription: already disabled")
-	ErrCannotUpdateFeatureFlagTags   = errors.New(
-		"subscription: cannot update the feature flag tags when there is feature source type")
+	ErrUnknownRecipient = err.NewErrorInvalidArgUnknown(
+		err.NotificationPackageName,
+		"unknown recipient",
+		"recipient",
+	)
+	ErrSourceTypesMustHaveAtLeastOne = err.NewErrorInvalidArgNotMatchFormat(
+		"subscription",
+		"notification types must have at least one",
+		"notification_types",
+	)
+	ErrSourceTypeNotFound          = err.NewErrorNotFound("subscription", "notification not found", "notification_type")
+	ErrAlreadyEnabled              = err.NewErrorAlreadyExists("subscription", "already enabled")
+	ErrAlreadyDisabled             = err.NewErrorAlreadyExists("subscription", "already disabled")
+	ErrCannotUpdateFeatureFlagTags = err.NewErrorNotFound(
+		"subscription",
+		"cannot update the feature flag tags when there is feature source type",
+		"feature_source_type",
+	)
 )
 
 type Subscription struct {

--- a/pkg/notification/domain/subscription.go
+++ b/pkg/notification/domain/subscription.go
@@ -34,15 +34,15 @@ var (
 		"recipient",
 	)
 	ErrSourceTypesMustHaveAtLeastOne = err.NewErrorInvalidArgNotMatchFormat(
-		"subscription",
+		err.NotificationPackageName,
 		"notification types must have at least one",
 		"notification_types",
 	)
-	ErrSourceTypeNotFound          = err.NewErrorNotFound("subscription", "notification not found", "notification_type")
-	ErrAlreadyEnabled              = err.NewErrorAlreadyExists("subscription", "already enabled")
-	ErrAlreadyDisabled             = err.NewErrorAlreadyExists("subscription", "already disabled")
+	ErrSourceTypeNotFound          = err.NewErrorNotFound(err.NotificationPackageName, "notification not found", "notification_type")
+	ErrAlreadyEnabled              = err.NewErrorAlreadyExists(err.NotificationPackageName, "already enabled")
+	ErrAlreadyDisabled             = err.NewErrorAlreadyExists(err.NotificationPackageName, "already disabled")
 	ErrCannotUpdateFeatureFlagTags = err.NewErrorNotFound(
-		"subscription",
+		err.NotificationPackageName,
 		"cannot update the feature flag tags when there is feature source type",
 		"feature_source_type",
 	)

--- a/pkg/notification/storage/v2/admin_subscription.go
+++ b/pkg/notification/storage/v2/admin_subscription.go
@@ -18,17 +18,27 @@ package v2
 import (
 	"context"
 	_ "embed"
-	"errors"
 
+	err "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
 )
 
 var (
-	ErrAdminSubscriptionAlreadyExists          = errors.New("subscription: admin subscription already exists")
-	ErrAdminSubscriptionNotFound               = errors.New("subscription: admin subscription not found")
-	ErrAdminSubscriptionUnexpectedAffectedRows = errors.New("subscription: admin subscription unexpected affected rows")
+	ErrAdminSubscriptionAlreadyExists = err.NewErrorAlreadyExists(
+		err.NotificationPackageName,
+		"admin subscription already exists",
+	)
+	ErrAdminSubscriptionNotFound = err.NewErrorNotFound(
+		err.NotificationPackageName,
+		"admin subscription not found",
+		"admin_subscription",
+	)
+	ErrAdminSubscriptionUnexpectedAffectedRows = err.NewErrorUnexpectedAffectedRows(
+		err.NotificationPackageName,
+		"admin subscription unexpected affected rows",
+	)
 
 	//go:embed sql/admin_subscription/insert_admin_subscription_v2.sql
 	insertAdminSubscriptionV2SQLQuery string

--- a/pkg/notification/storage/v2/subscription.go
+++ b/pkg/notification/storage/v2/subscription.go
@@ -20,15 +20,26 @@ import (
 	_ "embed"
 	"errors"
 
+	err "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/notification/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	proto "github.com/bucketeer-io/bucketeer/proto/notification"
 )
 
 var (
-	ErrSubscriptionAlreadyExists          = errors.New("subscription: subscription already exists")
-	ErrSubscriptionNotFound               = errors.New("subscription: subscription not found")
-	ErrSubscriptionUnexpectedAffectedRows = errors.New("subscription: subscription unexpected affected rows")
+	ErrSubscriptionAlreadyExists = err.NewErrorAlreadyExists(
+		err.NotificationPackageName,
+		"subscription already exists",
+	)
+	ErrSubscriptionNotFound = err.NewErrorNotFound(
+		err.NotificationPackageName,
+		"subscription not found",
+		"subscription",
+	)
+	ErrSubscriptionUnexpectedAffectedRows = err.NewErrorUnexpectedAffectedRows(
+		err.NotificationPackageName,
+		"subscription unexpected affected rows",
+	)
 
 	//go:embed sql/subscription/insert_subscription_v2.sql
 	insertSubscriptionV2SQLQuery string


### PR DESCRIPTION
This pull request refactors error handling in the `notification` package to standardize and simplify the way gRPC errors are constructed and returned. Instead of manually building detailed error responses with localized messages, the code now uses a centralized utility (`api.NewGRPCStatus`) and new error constructors from the shared `error` package. This change improves consistency, maintainability, and clarity of error handling across notification service APIs.

I have also standardized the process of assigning ErrorInfo to GRPCStatus for each error via api.NewGRPCStatus.
This ErrorInfo will be used when moving i18n to the frontend(https://github.com/bucketeer-io/bucketeer/issues/1253), and we plan to generate error messages etc. based on this information on the frontend.