### PR TITLE
deps: remove unminimize and add minimal man deps for dev container

### DIFF
--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -7,10 +7,6 @@ ENV LANG="C.UTF-8" \
     SHELL=/bin/bash \
     DOCKER_BUILDKIT=1
 
-# Restore man command
-RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && yes | unminimize 2>&1
-
 # Install packages in optimized order for better layer caching
 RUN apt-get update \
     && apt-get upgrade -y \
@@ -29,6 +25,13 @@ RUN apt-get update \
         zip \
         rsync \
         moreutils \
+        # Minimal man support
+        man-db \
+        manpages \
+        manpages-dev \
+        groff-base \
+        less \
+        locales \
     && add-apt-repository universe \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Summary

This PR removes the `unminimize` step and inlines the minimal set of packages needed for `man` into the existing **Install packages in optimized order for better layer caching** block. Functionality is unchanged (man pages are available), but the image now builds reliably in non-interactive environments.

### Motivation

Our current devcontainer build fails in BuildKit/CI because `unminimize` expects an interactive TTY and exits with a non-zero code. From the Docker Build summary:

```
process "/bin/sh -c apt-get update && export DEBIAN_FRONTEND=noninteractive \
    && yes | unminimize 2>&1" did not complete successfully: exit code: 123
```

Replacing `unminimize` eliminates this non-interactive failure mode while keeping the intended outcome (having `man` available).
