### PR TITLE
fix: apikey created by system admin cannot write data

### DIFF
--- a/pkg/role/role.go
+++ b/pkg/role/role.go
@@ -21,7 +21,6 @@ import (
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
-	accdomain "github.com/bucketeer-io/bucketeer/pkg/account/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/rpc"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
@@ -65,17 +64,10 @@ func CheckEnvironmentRole(
 	}
 	publicAPIEditor := getAPIKeyEditor(ctx)
 	if publicAPIEditor != nil && publicAPIEditor.Token != "" && token.IsSystemAdmin {
-		resp, err := getAccountFunc(publicAPIEditor.Maintainer)
-		if err != nil {
-			return nil, err
-		}
-		account := accdomain.AccountV2{AccountV2: resp}
 		return &eventproto.Editor{
-			Email:            publicAPIEditor.Maintainer,
-			Name:             account.GetAccountFullName(),
-			PublicApiEditor:  publicAPIEditor,
-			EnvironmentRoles: account.EnvironmentRoles,
-			OrganizationRole: account.OrganizationRole,
+			Email:           publicAPIEditor.Maintainer,
+			Name:            publicAPIEditor.Name,
+			PublicApiEditor: publicAPIEditor,
 		}, nil
 	}
 
@@ -160,17 +152,10 @@ func CheckOrganizationRole(
 	}
 	publicAPIEditor := getAPIKeyEditor(ctx)
 	if publicAPIEditor != nil && publicAPIEditor.Token != "" && token.IsSystemAdmin {
-		resp, err := getAccountFunc(publicAPIEditor.Maintainer)
-		if err != nil {
-			return nil, err
-		}
-		account := accdomain.AccountV2{AccountV2: resp.Account}
 		return &eventproto.Editor{
-			Email:            publicAPIEditor.Maintainer,
-			Name:             account.GetAccountFullName(),
-			PublicApiEditor:  publicAPIEditor,
-			EnvironmentRoles: account.EnvironmentRoles,
-			OrganizationRole: account.OrganizationRole,
+			Email:           publicAPIEditor.Maintainer,
+			Name:            publicAPIEditor.Name,
+			PublicApiEditor: publicAPIEditor,
 		}, nil
 	}
 

--- a/pkg/role/role.go
+++ b/pkg/role/role.go
@@ -68,6 +68,7 @@ func CheckEnvironmentRole(
 			Email:           publicAPIEditor.Maintainer,
 			Name:            publicAPIEditor.Name,
 			PublicApiEditor: publicAPIEditor,
+			IsAdmin:         true,
 		}, nil
 	}
 
@@ -156,6 +157,7 @@ func CheckOrganizationRole(
 			Email:           publicAPIEditor.Maintainer,
 			Name:            publicAPIEditor.Name,
 			PublicApiEditor: publicAPIEditor,
+			IsAdmin:         true,
 		}, nil
 	}
 

--- a/pkg/role/role_test.go
+++ b/pkg/role/role_test.go
@@ -389,6 +389,7 @@ func TestCheckEnvironmentRole(t *testing.T) {
 					Maintainer: "apikey_maintainer@example.com",
 					Name:       "apikey_name",
 				},
+				IsAdmin: true,
 			},
 			expectedErr: nil,
 		},

--- a/pkg/role/role_test.go
+++ b/pkg/role/role_test.go
@@ -381,27 +381,13 @@ func TestCheckEnvironmentRole(t *testing.T) {
 			),
 			requiredRole:  accountproto.AccountV2_Role_Environment_EDITOR,
 			environmentID: "ns0",
-			getAccountFunc: func(email string) (*accountproto.AccountV2, error) {
-				return &accountproto.AccountV2{
-					Email: "apikey_maintainer@example.com",
-					EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
-						{EnvironmentId: "ns0", Role: accountproto.AccountV2_Role_Environment_EDITOR},
-					},
-					FirstName: "apikey",
-					LastName:  "maintainer",
-					Disabled:  false,
-				}, nil
-			},
 			expected: &eventproto.Editor{
 				Email: "apikey_maintainer@example.com",
-				Name:  "apikey maintainer",
+				Name:  "apikey_name",
 				PublicApiEditor: &eventproto.Editor_PublicAPIEditor{
 					Token:      "apikey_token",
 					Maintainer: "apikey_maintainer@example.com",
 					Name:       "apikey_name",
-				},
-				EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
-					{EnvironmentId: "ns0", Role: accountproto.AccountV2_Role_Environment_EDITOR},
 				},
 			},
 			expectedErr: nil,


### PR DESCRIPTION
To fix https://github.com/bucketeer-io/bucketeer/issues/2114

We only need to know who is the maintainer of the API key. Since the maintainer data is already being embedded inside the APIkey, there's no need to call get account again, avoid unwanted exception