### PR TITLE
deps: upgrade golangci-lint to v2

### DIFF
--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -178,6 +178,6 @@ jobs:
           go-version-file: 'go.mod'
           cache: true
       - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0
       - name: Lint
         run: make lint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,36 +1,54 @@
+version: "2"
 run:
   tests: false
-linters-settings:
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/bucketeer-io/bucketeer
-  goheader:
-    # template does not contains the comment indicator '//' or '/*' '*/'
-    template: |-
-      Copyright {{mod-year-range}} The Bucketeer Authors.
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-          http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
 linters:
-  disable-all: true
+  default: none
   enable:
     - errcheck
     - goheader
-    - gosimple
     - govet
     - ineffassign
-    - typecheck
+    - lll
+    - staticcheck
     - unused
+  settings:
+    goheader:
+      template: |-
+        Copyright {{mod-year-range}} The Bucketeer Authors.
+
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
     - gofmt
     - goimports
-    - lll
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/bucketeer-io/bucketeer
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,8 @@ linters:
         WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
         See the License for the specific language governing permissions and
         limitations under the License.
+    staticcheck:
+      checks: ["all", "-SA1019", "-ST1003","-ST1012"] # ignore deprecated, ignore poorly chosen identifier and ignore poorly chosen name for error variable
   exclusions:
     generated: lax
     presets:
@@ -34,10 +36,6 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
-    paths:
-      - third_party$
-      - builtin$
-      - examples$
 formatters:
   enable:
     - gofmt
@@ -48,7 +46,3 @@ formatters:
         - github.com/bucketeer-io/bucketeer
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$
-      - examples$

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -415,12 +415,12 @@ func (s *AccountService) getMyOrganizations(
 	}
 	myOrgs := make([]*environmentproto.Organization, 0, len(accountsWithOrg))
 	for _, accWithOrg := range accountsWithOrg {
-		if accWithOrg.AccountV2.Disabled || accWithOrg.Organization.Disabled || accWithOrg.Organization.Archived {
+		if accWithOrg.AccountV2.Disabled || accWithOrg.Organization.Disabled || accWithOrg.Archived {
 			continue
 		}
 		// Add the organization if the account is an admin or owner.
 		// Otherwise, we check if the account is enabled in any environment in this organization.
-		if accWithOrg.AccountV2.OrganizationRole >= accountproto.AccountV2_Role_Organization_ADMIN {
+		if accWithOrg.OrganizationRole >= accountproto.AccountV2_Role_Organization_ADMIN {
 			myOrgs = append(myOrgs, accWithOrg.Organization)
 			continue
 		}
@@ -432,7 +432,7 @@ func (s *AccountService) getMyOrganizations(
 		// When the new console is ready, we will use the DisableAccount API instead,
 		// which will update the `disabled` column in the DB.
 		var enabled bool
-		for _, role := range accWithOrg.AccountV2.EnvironmentRoles {
+		for _, role := range accWithOrg.EnvironmentRoles {
 			if role.Role != accountproto.AccountV2_Role_Environment_UNASSIGNED {
 				enabled = true
 			}
@@ -449,7 +449,7 @@ func (s *AccountService) containsSystemAdminOrganization(
 	organizations []*domain.AccountWithOrganization,
 ) bool {
 	for _, org := range organizations {
-		if org.Organization.SystemAdmin {
+		if org.SystemAdmin {
 			return true
 		}
 	}

--- a/pkg/account/command/account_v2.go
+++ b/pkg/account/command/account_v2.go
@@ -223,11 +223,12 @@ func (h *accountV2CommandHandler) changeEnvironmentRoles(
 	ctx context.Context,
 	cmd *accountproto.ChangeAccountV2EnvironmentRolesCommand,
 ) error {
-	if cmd.WriteType == accountproto.ChangeAccountV2EnvironmentRolesCommand_WriteType_OVERRIDE {
+	switch cmd.WriteType {
+	case accountproto.ChangeAccountV2EnvironmentRolesCommand_WriteType_OVERRIDE:
 		if err := h.account.ChangeEnvironmentRole(cmd.Roles); err != nil {
 			return err
 		}
-	} else if cmd.WriteType == accountproto.ChangeAccountV2EnvironmentRolesCommand_WriteType_PATCH {
+	case accountproto.ChangeAccountV2EnvironmentRolesCommand_WriteType_PATCH:
 		if err := h.account.PatchEnvironmentRole(cmd.Roles); err != nil {
 			return err
 		}

--- a/pkg/account/domain/account.go
+++ b/pkg/account/domain/account.go
@@ -172,68 +172,68 @@ func (a *AccountV2) RemoveTeam(team string) error {
 }
 
 func (a *AccountV2) ChangeName(newName string) error {
-	a.AccountV2.Name = newName
+	a.Name = newName
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeFirstName(newFirstName string) error {
-	a.AccountV2.FirstName = newFirstName
+	a.FirstName = newFirstName
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeLastName(newLastName string) error {
-	a.AccountV2.LastName = newLastName
+	a.LastName = newLastName
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeLanguage(newLanguage string) error {
-	a.AccountV2.Language = newLanguage
+	a.Language = newLanguage
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeAvatarImageURL(url string) error {
-	a.AccountV2.AvatarImageUrl = url
+	a.AvatarImageUrl = url
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeAvatar(image []byte, fileType string) error {
-	a.AccountV2.AvatarImage = image
-	a.AccountV2.AvatarFileType = fileType
+	a.AvatarImage = image
+	a.AvatarFileType = fileType
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeTags(tags []string) error {
-	a.AccountV2.Tags = tags
+	a.Tags = tags
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeOrganizationRole(role proto.AccountV2_Role_Organization) error {
-	a.AccountV2.OrganizationRole = role
+	a.OrganizationRole = role
 	if role >= proto.AccountV2_Role_Organization_ADMIN {
-		a.AccountV2.EnvironmentRoles = []*proto.AccountV2_EnvironmentRole{}
+		a.EnvironmentRoles = []*proto.AccountV2_EnvironmentRole{}
 	}
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) ChangeEnvironmentRole(roles []*proto.AccountV2_EnvironmentRole) error {
-	a.AccountV2.EnvironmentRoles = roles
+	a.EnvironmentRoles = roles
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) PatchEnvironmentRole(patchRoles []*proto.AccountV2_EnvironmentRole) error {
 	for _, p := range patchRoles {
-		e := getEnvironmentRole(a.AccountV2.EnvironmentRoles, p.EnvironmentId)
+		e := getEnvironmentRole(a.EnvironmentRoles, p.EnvironmentId)
 		if e == nil {
-			a.AccountV2.EnvironmentRoles = append(a.AccountV2.EnvironmentRoles, p)
+			a.EnvironmentRoles = append(a.EnvironmentRoles, p)
 			continue
 		}
 		e.Role = p.Role
@@ -243,7 +243,7 @@ func (a *AccountV2) PatchEnvironmentRole(patchRoles []*proto.AccountV2_Environme
 }
 
 func (a *AccountV2) ChangeLastSeen(lastSeen int64) error {
-	a.AccountV2.LastSeen = lastSeen
+	a.LastSeen = lastSeen
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
@@ -258,13 +258,13 @@ func getEnvironmentRole(roles []*proto.AccountV2_EnvironmentRole, envID string) 
 }
 
 func (a *AccountV2) Enable() error {
-	a.AccountV2.Disabled = false
+	a.Disabled = false
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *AccountV2) Disable() error {
-	a.AccountV2.Disabled = true
+	a.Disabled = true
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
@@ -291,17 +291,17 @@ func (a *AccountV2) AddSearchFilter(
 		EnvironmentId:    environmentID,
 		DefaultFilter:    defaultFilter,
 	}
-	a.AccountV2.SearchFilters = append(a.AccountV2.SearchFilters, searchFilter)
+	a.SearchFilters = append(a.SearchFilters, searchFilter)
 	a.UpdatedAt = time.Now().Unix()
 	return searchFilter, nil
 }
 
 func (a *AccountV2) DeleteSearchFilter(id string) error {
-	for i, f := range a.AccountV2.SearchFilters {
+	for i, f := range a.SearchFilters {
 		if f.Id == id {
-			a.AccountV2.SearchFilters = append(a.AccountV2.SearchFilters[:i], a.AccountV2.SearchFilters[i+1:]...)
-			if len(a.AccountV2.SearchFilters) == 0 {
-				a.AccountV2.SearchFilters = nil
+			a.SearchFilters = append(a.SearchFilters[:i], a.SearchFilters[i+1:]...)
+			if len(a.SearchFilters) == 0 {
+				a.SearchFilters = nil
 			}
 			a.UpdatedAt = time.Now().Unix()
 			return nil
@@ -311,7 +311,7 @@ func (a *AccountV2) DeleteSearchFilter(id string) error {
 }
 
 func (a *AccountV2) ChangeSearchFilterName(id string, name string) error {
-	for _, f := range a.AccountV2.SearchFilters {
+	for _, f := range a.SearchFilters {
 		if f.Id == id {
 			f.Name = name
 			a.UpdatedAt = time.Now().Unix()
@@ -322,7 +322,7 @@ func (a *AccountV2) ChangeSearchFilterName(id string, name string) error {
 }
 
 func (a *AccountV2) ChangeSearchFilterQuery(id string, query string) error {
-	for _, f := range a.AccountV2.SearchFilters {
+	for _, f := range a.SearchFilters {
 		if f.Id == id {
 			f.Query = query
 			a.UpdatedAt = time.Now().Unix()
@@ -333,7 +333,7 @@ func (a *AccountV2) ChangeSearchFilterQuery(id string, query string) error {
 }
 
 func (a *AccountV2) ChangeDefaultSearchFilter(id string, defaultFilter bool) error {
-	for _, f := range a.AccountV2.SearchFilters {
+	for _, f := range a.SearchFilters {
 		if f.Id == id {
 			// Since there is only one default setting for a filter target, set the existing default to OFF.
 			if defaultFilter {
@@ -349,7 +349,7 @@ func (a *AccountV2) ChangeDefaultSearchFilter(id string, defaultFilter bool) err
 }
 
 func (a *AccountV2) resetDefaultFilter(targetFilter proto.FilterTargetType, environmentID string) {
-	for _, f := range a.AccountV2.SearchFilters {
+	for _, f := range a.SearchFilters {
 		if f.DefaultFilter &&
 			targetFilter == f.FilterTargetType &&
 			environmentID == f.EnvironmentId {

--- a/pkg/account/domain/api_key.go
+++ b/pkg/account/domain/api_key.go
@@ -60,19 +60,19 @@ func NewAPIKey(
 }
 
 func (a *APIKey) Rename(name string) error {
-	a.APIKey.Name = name
+	a.Name = name
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *APIKey) Enable() error {
-	a.APIKey.Disabled = false
+	a.Disabled = false
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (a *APIKey) Disable() error {
-	a.APIKey.Disabled = true
+	a.Disabled = true
 	a.UpdatedAt = time.Now().Unix()
 	return nil
 }

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -230,9 +230,10 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	}
 
 	// Add provider-specific options
-	if pubSubType == factory.Google {
+	switch pubSubType {
+	case factory.Google:
 		factoryOpts = append(factoryOpts, factory.WithProjectID(*s.project))
-	} else if pubSubType == factory.RedisStream {
+	case factory.RedisStream:
 		redisClient, err := redisv3.NewClient(
 			*s.pubSubRedisAddr,
 			redisv3.WithPoolSize(*s.pubSubRedisPoolSize),

--- a/pkg/auth/api/api.go
+++ b/pkg/auth/api/api.go
@@ -418,7 +418,7 @@ func (s *authService) SwitchOrganization(
 				zap.String("organizationID", newOrganizationID),
 			)
 		}
-		accountDomain.AccountV2.OrganizationId = newOrganizationID
+		accountDomain.OrganizationId = newOrganizationID
 		token, err := s.generateToken(
 			ctx,
 			accessToken.Email,
@@ -705,7 +705,7 @@ func (s *authService) generateToken(
 	}
 
 	// Use the account's organization ID
-	organizationID := accountDomain.AccountV2.OrganizationId
+	organizationID := accountDomain.OrganizationId
 
 	// Create access token
 	timeNow := time.Now()

--- a/pkg/autoops/api/api.go
+++ b/pkg/autoops/api/api.go
@@ -34,7 +34,6 @@ import (
 	domainevent "github.com/bucketeer-io/bucketeer/pkg/domainevent/domain"
 	experimentclient "github.com/bucketeer-io/bucketeer/pkg/experiment/client"
 	featureclient "github.com/bucketeer-io/bucketeer/pkg/feature/client"
-	ftstorage "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
 	v2fs "github.com/bucketeer-io/bucketeer/pkg/feature/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
@@ -1642,7 +1641,7 @@ func (s *AutoOpsService) ExecuteAutoOps(
 			}
 			return dt.Err()
 		}
-		ftStorage := ftstorage.NewFeatureStorage(tx)
+		ftStorage := v2fs.NewFeatureStorage(tx)
 		feature, err := ftStorage.GetFeature(contextWithTx, autoOpsRule.FeatureId, req.EnvironmentId)
 		if err != nil {
 			return err
@@ -1802,7 +1801,7 @@ func (s *AutoOpsService) executeAutoOpsNoCommand(
 			return dt.Err()
 		}
 
-		ftStorage := ftstorage.NewFeatureStorage(tx)
+		ftStorage := v2fs.NewFeatureStorage(tx)
 		feature, err := ftStorage.GetFeature(contextWithTx, autoOpsRule.FeatureId, req.EnvironmentId)
 		if err != nil {
 			return err

--- a/pkg/autoops/domain/auto_ops_rule.go
+++ b/pkg/autoops/domain/auto_ops_rule.go
@@ -92,7 +92,7 @@ func (a *AutoOpsRule) Update(
 	}
 
 	if autoOpsStatus != nil {
-		updated.AutoOpsRule.AutoOpsStatus = *autoOpsStatus
+		updated.AutoOpsStatus = *autoOpsStatus
 	}
 
 	if err := updated.changeClauses(
@@ -103,7 +103,7 @@ func (a *AutoOpsRule) Update(
 	}
 
 	now := time.Now().Unix()
-	updated.AutoOpsRule.UpdatedAt = now
+	updated.UpdatedAt = now
 	return updated, nil
 }
 
@@ -274,8 +274,8 @@ func (a *AutoOpsRule) SetStopped() {
 }
 
 func (a *AutoOpsRule) SetDeleted() {
-	a.AutoOpsRule.Deleted = true
-	a.AutoOpsRule.UpdatedAt = time.Now().Unix()
+	a.Deleted = true
+	a.UpdatedAt = time.Now().Unix()
 }
 
 func (a *AutoOpsRule) SetFinished() {
@@ -292,8 +292,8 @@ func (a *AutoOpsRule) IsStopped() bool {
 
 func (a *AutoOpsRule) SetAutoOpsStatus(status proto.AutoOpsStatus) {
 	now := time.Now().Unix()
-	a.AutoOpsRule.AutoOpsStatus = status
-	a.AutoOpsRule.UpdatedAt = now
+	a.AutoOpsStatus = status
+	a.UpdatedAt = now
 }
 
 func (a *AutoOpsRule) AddOpsEventRateClause(oerc *proto.OpsEventRateClause) (*proto.Clause, error) {
@@ -305,7 +305,7 @@ func (a *AutoOpsRule) AddOpsEventRateClause(oerc *proto.OpsEventRateClause) (*pr
 	if err != nil {
 		return nil, err
 	}
-	a.AutoOpsRule.UpdatedAt = time.Now().Unix()
+	a.UpdatedAt = time.Now().Unix()
 	return clause, nil
 }
 
@@ -320,7 +320,7 @@ func (a *AutoOpsRule) AddDatetimeClause(dc *proto.DatetimeClause) (*proto.Clause
 	if err != nil {
 		return nil, err
 	}
-	a.AutoOpsRule.UpdatedAt = time.Now().Unix()
+	a.UpdatedAt = time.Now().Unix()
 	return clause, nil
 }
 
@@ -334,7 +334,7 @@ func (a *AutoOpsRule) addClause(ac *any.Any, actionType proto.ActionType) (*prot
 		Clause:     ac,
 		ActionType: actionType,
 	}
-	a.AutoOpsRule.Clauses = append(a.AutoOpsRule.Clauses, clause)
+	a.Clauses = append(a.Clauses, clause)
 	return clause, nil
 }
 
@@ -365,7 +365,7 @@ func (a *AutoOpsRule) sortDatetimeClause() {
 	for _, c := range sortClauses {
 		newClauses = append(newClauses, c.clause)
 	}
-	a.AutoOpsRule.Clauses = newClauses
+	a.Clauses = newClauses
 }
 
 func (a *AutoOpsRule) ChangeOpsEventRateClause(id string, oerc *proto.OpsEventRateClause) error {
@@ -373,7 +373,7 @@ func (a *AutoOpsRule) ChangeOpsEventRateClause(id string, oerc *proto.OpsEventRa
 	if err != nil {
 		return err
 	}
-	a.AutoOpsRule.UpdatedAt = time.Now().Unix()
+	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
@@ -383,7 +383,7 @@ func (a *AutoOpsRule) ChangeDatetimeClause(id string, dc *proto.DatetimeClause) 
 	if err != nil {
 		return err
 	}
-	a.AutoOpsRule.UpdatedAt = time.Now().Unix()
+	a.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
@@ -406,7 +406,7 @@ func (a *AutoOpsRule) DeleteClause(id string) error {
 	if len(a.Clauses) <= 1 {
 		return errClauseEmpty
 	}
-	a.AutoOpsRule.UpdatedAt = time.Now().Unix()
+	a.UpdatedAt = time.Now().Unix()
 	var clauses []*proto.Clause
 	for i, c := range a.Clauses {
 		if c.Id == id {

--- a/pkg/autoops/domain/progressive_rollout.go
+++ b/pkg/autoops/domain/progressive_rollout.go
@@ -226,7 +226,7 @@ func (p *ProgressiveRollout) SetTriggeredAt(scheduleID string) error {
 	default:
 		return ErrProgressiveRolloutInvalidType
 	}
-	p.ProgressiveRollout.UpdatedAt = now
+	p.UpdatedAt = now
 	return nil
 }
 

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -53,7 +53,6 @@ import (
 	notificationclient "github.com/bucketeer-io/bucketeer/pkg/notification/client"
 	notificationsender "github.com/bucketeer-io/bucketeer/pkg/notification/sender"
 	"github.com/bucketeer-io/bucketeer/pkg/notification/sender/notifier"
-	"github.com/bucketeer-io/bucketeer/pkg/opsevent/batch/executor"
 	opsexecutor "github.com/bucketeer-io/bucketeer/pkg/opsevent/batch/executor"
 	pushclient "github.com/bucketeer-io/bucketeer/pkg/push/client"
 	redisv3 "github.com/bucketeer-io/bucketeer/pkg/redis/v3"
@@ -358,7 +357,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 
 	progressiveRolloutExecutor := opsexecutor.NewProgressiveRolloutExecutor(
 		autoOpsClient,
-		executor.WithLogger(logger),
+		opsexecutor.WithLogger(logger),
 	)
 
 	slackNotifier := notifier.NewSlackNotifier(*s.webURL)

--- a/pkg/batch/jobs/calculator/experiment_calculate.go
+++ b/pkg/batch/jobs/calculator/experiment_calculate.go
@@ -175,7 +175,7 @@ func (e *experimentCalculate) calculateExperimentWithLock(ctx context.Context,
 ) error {
 	locked, lockValue, err := e.experimentLock.Lock(ctx, env.Id, experiment.Id)
 	if err != nil {
-		return fmt.Errorf("Failed to acquire lock when calculating experiment. Error: %w", err)
+		return fmt.Errorf("failed to acquire lock when calculating experiment. Error: %w", err)
 	}
 	if !locked {
 		e.logger.Info("Experiment is being calculated by another instance",

--- a/pkg/batch/jobs/opsevent/progressove_rollout_watcher.go
+++ b/pkg/batch/jobs/opsevent/progressove_rollout_watcher.go
@@ -94,11 +94,11 @@ func (w *progressiveRolloutWatcher) listEnvironments(ctx context.Context) ([]*en
 	return resp.Environments, nil
 }
 
-func (s *progressiveRolloutWatcher) listProgressiveRollouts(
+func (w *progressiveRolloutWatcher) listProgressiveRollouts(
 	ctx context.Context,
 	environmentID string,
 ) ([]*aoproto.ProgressiveRollout, error) {
-	resp, err := s.aoClient.ListProgressiveRollouts(
+	resp, err := w.aoClient.ListProgressiveRollouts(
 		ctx,
 		&aoproto.ListProgressiveRolloutsRequest{
 			EnvironmentId: environmentID,

--- a/pkg/coderef/api/code_reference.go
+++ b/pkg/coderef/api/code_reference.go
@@ -133,8 +133,8 @@ func (s *CodeReferenceService) GetCodeReference(
 		}
 		return nil, dt.Err()
 	}
-	codeRef.CodeReference.SourceUrl = generateSourceURL(&codeRef.CodeReference)
-	codeRef.CodeReference.BranchUrl = generateBranchURL(&codeRef.CodeReference)
+	codeRef.SourceUrl = generateSourceURL(&codeRef.CodeReference)
+	codeRef.BranchUrl = generateBranchURL(&codeRef.CodeReference)
 	return &proto.GetCodeReferenceResponse{CodeReference: &codeRef.CodeReference}, nil
 }
 
@@ -224,8 +224,8 @@ func (s *CodeReferenceService) ListCodeReferences(
 	}
 	protoRefs := make([]*proto.CodeReference, 0, len(codeRefs))
 	for _, ref := range codeRefs {
-		ref.CodeReference.SourceUrl = generateSourceURL(&ref.CodeReference)
-		ref.CodeReference.BranchUrl = generateBranchURL(&ref.CodeReference)
+		ref.SourceUrl = generateSourceURL(&ref.CodeReference)
+		ref.BranchUrl = generateBranchURL(&ref.CodeReference)
 		protoRefs = append(protoRefs, &ref.CodeReference)
 	}
 	return &proto.ListCodeReferencesResponse{

--- a/pkg/coderef/storage/code_reference.go
+++ b/pkg/coderef/storage/code_reference.go
@@ -39,6 +39,10 @@ var (
 	deleteCodeReferenceSQL string
 )
 
+type contextKey string
+
+const transactionKey contextKey = "transaction"
+
 var (
 	ErrCodeReferenceNotFound               = errors.New("coderef: code reference not found")
 	ErrCodeReferenceUnexpectedAffectedRows = errors.New("coderef: code reference unexpected affected rows")

--- a/pkg/coderef/storage/storage.go
+++ b/pkg/coderef/storage/storage.go
@@ -35,5 +35,3 @@ type CodeReferenceStorage interface {
 	) ([]*domain.CodeReference, int, int64, error)
 	DeleteCodeReference(ctx context.Context, id string) error
 }
-
-const transactionKey = "transaction"

--- a/pkg/crypto/cloudkmscrypto.go
+++ b/pkg/crypto/cloudkmscrypto.go
@@ -17,13 +17,12 @@ package crypto
 import (
 	"context"
 
-	cloudkms "cloud.google.com/go/kms/apiv1"
 	kms "cloud.google.com/go/kms/apiv1"
 	kmsproto "google.golang.org/genproto/googleapis/cloud/kms/v1"
 )
 
 type cloudKMSCrypto struct {
-	client  *cloudkms.KeyManagementClient
+	client  *kms.KeyManagementClient
 	keyName string
 }
 

--- a/pkg/environment/api/api.go
+++ b/pkg/environment/api/api.go
@@ -28,7 +28,6 @@ import (
 
 	accountclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
 	accdomain "github.com/bucketeer-io/bucketeer/pkg/account/domain"
-	accstorage "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
 	v2acc "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
 	"github.com/bucketeer-io/bucketeer/pkg/auth"
 	"github.com/bucketeer-io/bucketeer/pkg/auth/google"
@@ -578,10 +577,10 @@ func (s *EnvironmentService) getAccountV2ByEnvironmentID(
 	email, environmentID string,
 	localizer locale.Localizer,
 ) (*accdomain.AccountV2, error) {
-	storage := accstorage.NewAccountStorage(s.mysqlClient)
+	storage := v2acc.NewAccountStorage(s.mysqlClient)
 	account, err := storage.GetAccountV2ByEnvironmentID(ctx, email, environmentID)
 	if err != nil {
-		if errors.Is(err, accstorage.ErrAccountNotFound) {
+		if errors.Is(err, v2acc.ErrAccountNotFound) {
 			dt, err := statusNotFound.WithDetails(&errdetails.LocalizedMessage{
 				Locale:  localizer.GetLocale(),
 				Message: localizer.MustLocalize(locale.NotFoundError),

--- a/pkg/environment/api/organization.go
+++ b/pkg/environment/api/organization.go
@@ -592,7 +592,7 @@ func (s *EnvironmentService) createOrganizationMySQL(
 	var envRoles []*accountproto.AccountV2_EnvironmentRole
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		// Check if there is already a system admin organization
-		if organization.Organization.SystemAdmin {
+		if organization.SystemAdmin {
 			org, err := s.orgStorage.GetSystemAdminOrganization(contextWithTx)
 			if err != nil {
 				return err
@@ -740,7 +740,7 @@ func (s *EnvironmentService) createOrganization(
 	localizer locale.Localizer,
 ) error {
 	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
-		if organization.Organization.SystemAdmin {
+		if organization.SystemAdmin {
 			org, err := s.orgStorage.GetSystemAdminOrganization(contextWithTx)
 			if err != nil {
 				return err

--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -36,7 +36,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
 	environmentproto "github.com/bucketeer-io/bucketeer/proto/environment"
-	evdomain "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 )
 
@@ -326,7 +325,7 @@ func (s *EnvironmentService) createProjectNoCommand(
 	if err != nil {
 		return nil, err
 	}
-	var domainEvent *evdomain.Event
+	var domainEvent *eventproto.Event
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context, tx mysql.Transaction) error {
 		storage := v2es.NewProjectStorage(tx)
 		domainEvent, err = s.newCreateDomainEvent(newProj.Project, editor)
@@ -433,7 +432,7 @@ func (s *EnvironmentService) reportCreateProjectRequestError(
 func (s *EnvironmentService) newCreateDomainEvent(
 	newProj *environmentproto.Project,
 	editor *eventproto.Editor,
-) (*evdomain.Event, error) {
+) (*eventproto.Event, error) {
 	event, err := domainevent.NewAdminEvent(
 		editor,
 		eventproto.Event_PROJECT,
@@ -909,7 +908,7 @@ func (s *EnvironmentService) updateProjectNoCommand(
 	localizer locale.Localizer,
 	editor *eventproto.Editor,
 ) (*environmentproto.UpdateProjectResponse, error) {
-	var domainEvent *evdomain.Event
+	var domainEvent *eventproto.Event
 	err := s.mysqlClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context, tx mysql.Transaction) error {
 		storage := v2es.NewProjectStorage(tx)
 		updated, err := project.Update(
@@ -1020,7 +1019,7 @@ func (s *EnvironmentService) newUpdateDomainEvent(
 	req *environmentproto.UpdateProjectRequest,
 	editor *eventproto.Editor,
 	localizer locale.Localizer,
-) (*evdomain.Event, error) {
+) (*eventproto.Event, error) {
 	event, err := domainevent.NewAdminEvent(
 		editor,
 		eventproto.Event_PROJECT,

--- a/pkg/environment/domain/environment.go
+++ b/pkg/environment/domain/environment.go
@@ -87,26 +87,26 @@ func (e *EnvironmentV2) Update(
 }
 
 func (e *EnvironmentV2) Rename(name string) {
-	e.EnvironmentV2.Name = name
-	e.EnvironmentV2.UpdatedAt = time.Now().Unix()
+	e.Name = name
+	e.UpdatedAt = time.Now().Unix()
 }
 
 func (e *EnvironmentV2) ChangeDescription(description string) {
-	e.EnvironmentV2.Description = description
-	e.EnvironmentV2.UpdatedAt = time.Now().Unix()
+	e.Description = description
+	e.UpdatedAt = time.Now().Unix()
 }
 
 func (e *EnvironmentV2) ChangeRequireComment(state bool) {
-	e.EnvironmentV2.RequireComment = state
-	e.EnvironmentV2.UpdatedAt = time.Now().Unix()
+	e.RequireComment = state
+	e.UpdatedAt = time.Now().Unix()
 }
 
 func (e *EnvironmentV2) SetArchived() {
-	e.EnvironmentV2.Archived = true
-	e.EnvironmentV2.UpdatedAt = time.Now().Unix()
+	e.Archived = true
+	e.UpdatedAt = time.Now().Unix()
 }
 
 func (e *EnvironmentV2) SetUnarchived() {
-	e.EnvironmentV2.Archived = false
-	e.EnvironmentV2.UpdatedAt = time.Now().Unix()
+	e.Archived = false
+	e.UpdatedAt = time.Now().Unix()
 }

--- a/pkg/environment/domain/organization.go
+++ b/pkg/environment/domain/organization.go
@@ -78,49 +78,49 @@ func (p *Organization) Update(
 }
 
 func (p *Organization) ChangeDescription(description string) {
-	p.Organization.Description = description
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Description = description
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Organization) ChangeOwnerEmail(ownerEmail string) {
-	p.Organization.OwnerEmail = ownerEmail
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.OwnerEmail = ownerEmail
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Organization) ChangeName(name string) {
-	p.Organization.Name = name
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Name = name
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Organization) Enable() {
-	p.Organization.Disabled = false
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Disabled = false
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Organization) Disable() error {
-	if p.Organization.SystemAdmin {
+	if p.SystemAdmin {
 		return ErrCannotDisableSystemAdmin
 	}
-	p.Organization.Disabled = true
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Disabled = true
+	p.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (p *Organization) Archive() error {
-	if p.Organization.SystemAdmin {
+	if p.SystemAdmin {
 		return ErrCannotArchiveSystemAdmin
 	}
-	p.Organization.Archived = true
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Archived = true
+	p.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (p *Organization) Unarchive() {
-	p.Organization.Archived = false
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Archived = false
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Organization) ConvertTrial() {
-	p.Organization.Trial = false
-	p.Organization.UpdatedAt = time.Now().Unix()
+	p.Trial = false
+	p.UpdatedAt = time.Now().Unix()
 }

--- a/pkg/environment/domain/project.go
+++ b/pkg/environment/domain/project.go
@@ -49,28 +49,28 @@ func NewProject(name, urlCode, description, creatorEmail, organizationID string,
 }
 
 func (p *Project) ChangeDescription(description string) {
-	p.Project.Description = description
-	p.Project.UpdatedAt = time.Now().Unix()
+	p.Description = description
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Project) Rename(name string) {
-	p.Project.Name = name
-	p.Project.UpdatedAt = time.Now().Unix()
+	p.Name = name
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Project) Enable() {
-	p.Project.Disabled = false
-	p.Project.UpdatedAt = time.Now().Unix()
+	p.Disabled = false
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Project) Disable() {
-	p.Project.Disabled = true
-	p.Project.UpdatedAt = time.Now().Unix()
+	p.Disabled = true
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Project) ConvertTrial() {
-	p.Project.Trial = false
-	p.Project.UpdatedAt = time.Now().Unix()
+	p.Trial = false
+	p.UpdatedAt = time.Now().Unix()
 }
 
 func (p *Project) Update(name, description *wrapperspb.StringValue) (*Project, error) {
@@ -84,6 +84,6 @@ func (p *Project) Update(name, description *wrapperspb.StringValue) (*Project, e
 	if description != nil {
 		updated.Description = description.Value
 	}
-	p.Project.UpdatedAt = time.Now().Unix()
+	p.UpdatedAt = time.Now().Unix()
 	return updated, nil
 }

--- a/pkg/experiment/domain/experiment.go
+++ b/pkg/experiment/domain/experiment.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	experimentproto "github.com/bucketeer-io/bucketeer/proto/experiment"
-	"github.com/bucketeer-io/bucketeer/proto/feature"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
 
@@ -85,7 +84,7 @@ func NewExperiment(
 	}, nil
 }
 
-func validateBaseVariation(v string, vs []*feature.Variation) bool {
+func validateBaseVariation(v string, vs []*featureproto.Variation) bool {
 	for i := range vs {
 		if vs[i].Id == v {
 			return true
@@ -123,11 +122,11 @@ func (e *Experiment) Update(
 	now := time.Now().Unix()
 
 	if name != nil {
-		updated.Experiment.Name = name.Value
+		updated.Name = name.Value
 	}
 
 	if description != nil {
-		updated.Experiment.Description = description.Value
+		updated.Description = description.Value
 	}
 
 	if startAt != nil && stopAt != nil {
@@ -135,12 +134,12 @@ func (e *Experiment) Update(
 		if err != nil {
 			return nil, err
 		}
-		updated.Experiment.StartAt = startAt.Value
-		updated.Experiment.StopAt = stopAt.Value
+		updated.StartAt = startAt.Value
+		updated.StopAt = stopAt.Value
 	}
 
 	if archived != nil {
-		updated.Experiment.Archived = archived.Value
+		updated.Archived = archived.Value
 	}
 
 	if status != nil {
@@ -192,8 +191,8 @@ func (e *Experiment) Start() error {
 	if e.StartAt > now {
 		return ErrExperimentBeforeStart
 	}
-	e.Experiment.Status = experimentproto.Experiment_RUNNING
-	e.Experiment.UpdatedAt = now
+	e.Status = experimentproto.Experiment_RUNNING
+	e.UpdatedAt = now
 	return nil
 }
 
@@ -205,8 +204,8 @@ func (e *Experiment) Finish() error {
 	if e.StopAt > now {
 		return ErrExperimentBeforeStop
 	}
-	e.Experiment.Status = experimentproto.Experiment_STOPPED
-	e.Experiment.UpdatedAt = now
+	e.Status = experimentproto.Experiment_STOPPED
+	e.UpdatedAt = now
 	return nil
 }
 
@@ -215,10 +214,10 @@ func (e *Experiment) Stop() error {
 		return ErrExperimentAlreadyStopped
 	}
 	now := time.Now().Unix()
-	e.Experiment.Stopped = true
-	e.Experiment.Status = experimentproto.Experiment_FORCE_STOPPED
-	e.Experiment.StoppedAt = now
-	e.Experiment.UpdatedAt = now
+	e.Stopped = true
+	e.Status = experimentproto.Experiment_FORCE_STOPPED
+	e.StoppedAt = now
+	e.UpdatedAt = now
 	return nil
 }
 
@@ -226,9 +225,9 @@ func (e *Experiment) ChangePeriod(startAt, stopAt int64) error {
 	if err := e.validatePeriod(startAt, stopAt); err != nil {
 		return err
 	}
-	e.Experiment.StartAt = startAt
-	e.Experiment.StopAt = stopAt
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.StartAt = startAt
+	e.StopAt = stopAt
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
@@ -246,13 +245,13 @@ func (e *Experiment) ChangeStartAt(startAt int64) error {
 	if err := e.validateStartAt(startAt); err != nil {
 		return err
 	}
-	e.Experiment.StartAt = startAt
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.StartAt = startAt
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (e *Experiment) validateStartAt(startAt int64) error {
-	if startAt >= e.Experiment.StopAt {
+	if startAt >= e.StopAt {
 		return ErrExperimentStartIsAfterStop
 	}
 	return nil
@@ -262,25 +261,25 @@ func (e *Experiment) ChangeStopAt(stopAt int64) error {
 	if err := e.validateStopAt(stopAt); err != nil {
 		return err
 	}
-	e.Experiment.StopAt = stopAt
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.StopAt = stopAt
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (e *Experiment) ChangeName(name string) error {
-	e.Experiment.Name = name
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.Name = name
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (e *Experiment) ChangeDescription(description string) error {
-	e.Experiment.Description = description
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.Description = description
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (e *Experiment) validateStopAt(stopAt int64) error {
-	if stopAt <= e.Experiment.StartAt {
+	if stopAt <= e.StartAt {
 		return ErrExperimentStopIsBeforeStart
 	}
 	if stopAt <= time.Now().Unix() {
@@ -290,14 +289,14 @@ func (e *Experiment) validateStopAt(stopAt int64) error {
 }
 
 func (e *Experiment) SetArchived() error {
-	e.Experiment.Archived = true
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.Archived = true
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (e *Experiment) SetDeleted() error {
-	e.Experiment.Deleted = true
-	e.Experiment.UpdatedAt = time.Now().Unix()
+	e.Deleted = true
+	e.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
@@ -318,13 +317,13 @@ func SyncGoalIDs(goalID string, goalIDs []string) (string, []string) {
 
 // IsNotFinished returns true if the status is either waiting or running.
 func (e *Experiment) IsNotFinished(t time.Time) bool {
-	if e.Experiment.Deleted {
+	if e.Deleted {
 		return false
 	}
-	if e.Experiment.StopAt <= t.Unix() {
+	if e.StopAt <= t.Unix() {
 		return false
 	}
-	if e.Experiment.StoppedAt <= t.Unix() {
+	if e.StoppedAt <= t.Unix() {
 		return false
 	}
 	return true

--- a/pkg/experiment/domain/goal.go
+++ b/pkg/experiment/domain/goal.go
@@ -53,38 +53,38 @@ func (g *Goal) Update(
 	}
 
 	if name != nil {
-		updated.Goal.Name = name.Value
+		updated.Name = name.Value
 	}
 	if description != nil {
-		updated.Goal.Description = description.Value
+		updated.Description = description.Value
 	}
 	if archived != nil {
-		updated.Goal.Archived = archived.Value
+		updated.Archived = archived.Value
 	}
-	updated.Goal.UpdatedAt = time.Now().Unix()
+	updated.UpdatedAt = time.Now().Unix()
 	return updated, nil
 }
 
 func (g *Goal) Rename(name string) error {
-	g.Goal.Name = name
-	g.Goal.UpdatedAt = time.Now().Unix()
+	g.Name = name
+	g.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (g *Goal) ChangeDescription(description string) error {
-	g.Goal.Description = description
-	g.Goal.UpdatedAt = time.Now().Unix()
+	g.Description = description
+	g.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (g *Goal) SetArchived() error {
-	g.Goal.Archived = true
-	g.Goal.UpdatedAt = time.Now().Unix()
+	g.Archived = true
+	g.UpdatedAt = time.Now().Unix()
 	return nil
 }
 
 func (g *Goal) SetDeleted() error {
-	g.Goal.Deleted = true
-	g.Goal.UpdatedAt = time.Now().Unix()
+	g.Deleted = true
+	g.UpdatedAt = time.Now().Unix()
 	return nil
 }

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -887,7 +887,7 @@ func (s *FeatureService) CreateFeature(
 	if err != nil {
 		return nil, err
 	}
-	var handler *command.FeatureCommandHandler = command.NewEmptyFeatureCommandHandler()
+	var handler = command.NewEmptyFeatureCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		if err := s.upsertTags(contextWithTx, req.Command.Tags, req.EnvironmentId); err != nil {
 			return err
@@ -1328,7 +1328,7 @@ func (s *FeatureService) UpdateFeatureDetails(
 	if err := s.validateEnvironmentSettings(ctx, req.EnvironmentId, req.Comment, localizer); err != nil {
 		return nil, err
 	}
-	var handler *command.FeatureCommandHandler = command.NewEmptyFeatureCommandHandler()
+	var handler = command.NewEmptyFeatureCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context, _ mysql.Transaction) error {
 		feature, err := s.featureStorage.GetFeature(ctxWithTx, req.Id, req.EnvironmentId)
 		if err != nil {
@@ -1847,7 +1847,7 @@ func (s *FeatureService) updateFeature(
 		}
 		return dt.Err()
 	}
-	var handler *command.FeatureCommandHandler = command.NewEmptyFeatureCommandHandler()
+	var handler = command.NewEmptyFeatureCommandHandler()
 
 	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		feature, err := s.featureStorage.GetFeature(contextWithTx, id, environmentId)
@@ -2031,7 +2031,7 @@ func (s *FeatureService) UpdateFeatureVariations(
 		}
 		commands = append(commands, cmd)
 	}
-	var handler *command.FeatureCommandHandler = command.NewEmptyFeatureCommandHandler()
+	handler := command.NewEmptyFeatureCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context, _ mysql.Transaction) error {
 		filters := []*mysql.FilterV2{
 			{
@@ -2211,7 +2211,7 @@ func (s *FeatureService) UpdateFeatureTargeting(
 	// Also:
 	// Normally each command should be usable alone (load the feature from the repository change it and save it).
 	// Also here because many commands are run sequentially they all expect the same version of the feature.
-	var handler *command.FeatureCommandHandler = command.NewEmptyFeatureCommandHandler()
+	handler := command.NewEmptyFeatureCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context, _ mysql.Transaction) error {
 		filters := []*mysql.FilterV2{
 			{
@@ -2670,7 +2670,7 @@ func (s *FeatureService) setLastUsedInfosToFeature(
 	}
 	for _, f := range fluiList {
 		for _, feature := range features {
-			if feature.Id == f.FeatureLastUsedInfo.FeatureId {
+			if feature.Id == f.FeatureId {
 				feature.LastUsedInfo = f.FeatureLastUsedInfo
 				break
 			}
@@ -3011,7 +3011,7 @@ func (s *FeatureService) CloneFeature(
 	if err != nil {
 		return nil, err
 	}
-	var handler *command.FeatureCommandHandler = command.NewEmptyFeatureCommandHandler()
+	handler := command.NewEmptyFeatureCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context, _ mysql.Transaction) error {
 		if err := s.featureStorage.CreateFeature(ctxWithTx, feature, req.Command.EnvironmentId); err != nil {
 			s.logger.Error(

--- a/pkg/feature/api/flag_trigger.go
+++ b/pkg/feature/api/flag_trigger.go
@@ -142,7 +142,7 @@ func (s *FeatureService) CreateFlagTrigger(
 		return nil, dt.Err()
 	}
 	triggerURL := s.generateTriggerURL(ctx, flagTrigger.Token, false)
-	flagTrigger.FlagTrigger.Token = ""
+	flagTrigger.Token = ""
 	return &featureproto.CreateFlagTriggerResponse{
 		FlagTrigger: flagTrigger.FlagTrigger,
 		Url:         triggerURL,
@@ -237,7 +237,7 @@ func (s *FeatureService) createFlagTriggerNoCommand(
 		return nil, dt.Err()
 	}
 	triggerURL := s.generateTriggerURL(ctx, flagTrigger.Token, false)
-	flagTrigger.FlagTrigger.Token = ""
+	flagTrigger.Token = ""
 
 	if err = s.domainPublisher.Publish(ctx, event); err != nil {
 		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
@@ -714,7 +714,7 @@ func (s *FeatureService) ResetFlagTrigger(
 		return nil, dt.Err()
 	}
 	triggerURL := s.generateTriggerURL(ctx, trigger.Token, false)
-	trigger.FlagTrigger.Token = ""
+	trigger.Token = ""
 	return &featureproto.ResetFlagTriggerResponse{
 		FlagTrigger: trigger.FlagTrigger,
 		Url:         triggerURL,
@@ -857,7 +857,7 @@ func (s *FeatureService) GetFlagTrigger(
 		return nil, err
 	}
 	triggerURL := s.generateTriggerURL(ctx, trigger.Token, true)
-	trigger.FlagTrigger.Token = ""
+	trigger.Token = ""
 	return &featureproto.GetFlagTriggerResponse{
 		FlagTrigger: trigger.FlagTrigger,
 		Url:         triggerURL,

--- a/pkg/feature/api/validation.go
+++ b/pkg/feature/api/validation.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 
 	"github.com/bucketeer-io/bucketeer/pkg/feature/command"
-	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
 	featuredomain "github.com/bucketeer-io/bucketeer/pkg/feature/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
@@ -1168,7 +1167,7 @@ func validateArchiveFeatureRequest(
 }
 
 func validateVariationCommand(fs []*featureproto.Feature, tgt *featureproto.Feature, localizer locale.Localizer) error {
-	if domain.HasFeaturesDependsOnTargets([]*featureproto.Feature{tgt}, fs) {
+	if featuredomain.HasFeaturesDependsOnTargets([]*featureproto.Feature{tgt}, fs) {
 		dt, err := statusInvalidChangingVariation.WithDetails(&errdetails.LocalizedMessage{
 			Locale:  localizer.GetLocale(),
 			Message: localizer.MustLocalizeWithTemplate(locale.InvalidArgumentError, "variation"),

--- a/pkg/feature/command/eventfactory.go
+++ b/pkg/feature/command/eventfactory.go
@@ -19,7 +19,6 @@ import (
 
 	domainevent "github.com/bucketeer-io/bucketeer/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/feature/domain"
-	domainproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	featureproto "github.com/bucketeer-io/bucketeer/proto/feature"
 )
@@ -35,7 +34,7 @@ type FeatureEventFactory struct {
 func (s *FeatureEventFactory) CreateEvent(
 	eventType eventproto.Event_Type,
 	event proto.Message,
-) (*domainproto.Event, error) {
+) (*eventproto.Event, error) {
 	var prev *featureproto.Feature
 	if s.previousFeature != nil && s.previousFeature.Feature != nil {
 		prev = s.previousFeature.Feature

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -728,7 +728,7 @@ func (f *Feature) validateRemoveVariation(id string) error {
 	if len(f.Targets[idx].Users) > 0 {
 		return ErrVariationInUse
 	}
-	if strategyContainsVariation(id, f.Feature.DefaultStrategy) {
+	if strategyContainsVariation(id, f.DefaultStrategy) {
 		return ErrVariationInUse
 	}
 	if f.rulesContainsVariation(id) {
@@ -738,7 +738,7 @@ func (f *Feature) validateRemoveVariation(id string) error {
 }
 
 func (f *Feature) rulesContainsVariation(id string) bool {
-	for _, r := range f.Feature.Rules {
+	for _, r := range f.Rules {
 		if ok := strategyContainsVariation(id, r.Strategy); ok {
 			return true
 		}
@@ -747,11 +747,12 @@ func (f *Feature) rulesContainsVariation(id string) bool {
 }
 
 func strategyContainsVariation(id string, strategy *feature.Strategy) bool {
-	if strategy.Type == feature.Strategy_FIXED {
+	switch strategy.Type {
+	case feature.Strategy_FIXED:
 		if strategy.FixedStrategy.Variation == id {
 			return true
 		}
-	} else if strategy.Type == feature.Strategy_ROLLOUT {
+	case feature.Strategy_ROLLOUT:
 		for _, v := range strategy.RolloutStrategy.Variations {
 			if v.Variation == id && v.Weight > 0 {
 				return true

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -478,7 +478,7 @@ func (f *Feature) updateValidateRemoveVariation(id string) error {
 	if len(f.Targets[idx].Users) > 0 {
 		return ErrVariationInUse
 	}
-	if strategyContainsVariation(id, f.Feature.DefaultStrategy) {
+	if strategyContainsVariation(id, f.DefaultStrategy) {
 		return ErrVariationInUse
 	}
 	if f.updateRulesContainsVariation(id) {
@@ -489,7 +489,7 @@ func (f *Feature) updateValidateRemoveVariation(id string) error {
 
 // updateRulesContainsVariation checks if any rule contains the specified variation
 func (f *Feature) updateRulesContainsVariation(id string) bool {
-	for _, r := range f.Feature.Rules {
+	for _, r := range f.Rules {
 		if ok := strategyContainsVariation(id, r.Strategy); ok {
 			return true
 		}

--- a/pkg/feature/domain/segment.go
+++ b/pkg/feature/domain/segment.go
@@ -63,8 +63,8 @@ func (s *Segment) UpdateSegment(
 }
 
 func (s *Segment) SetDeleted() error {
-	s.Segment.Deleted = true
-	s.Segment.UpdatedAt = time.Now().Unix()
+	s.Deleted = true
+	s.UpdatedAt = time.Now().Unix()
 	return nil
 }
 

--- a/pkg/locale/localizer.go
+++ b/pkg/locale/localizer.go
@@ -177,7 +177,7 @@ func init() {
 	for _, f := range files {
 		data, err := localizedata.ReadFile(fmt.Sprintf("localizedata/%s", f))
 		if err != nil {
-			panic(fmt.Errorf("Failed to load translation data: %s", f))
+			panic(fmt.Errorf("failed to load translation data: %s", f))
 		}
 		bundle.MustParseMessageFileBytes(data, f)
 	}

--- a/pkg/notification/api/admin_subscription.go
+++ b/pkg/notification/api/admin_subscription.go
@@ -58,7 +58,7 @@ func (s *NotificationService) CreateAdminSubscription(
 		)
 		return nil, api.NewGRPCStatus(err).Err()
 	}
-	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
+	var handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		if err := s.adminSubscriptionStorage.CreateAdminSubscription(contextWithTx, subscription); err != nil {
 			return err
@@ -349,7 +349,7 @@ func (s *NotificationService) updateAdminSubscription(
 	editor *eventproto.Editor,
 	localizer locale.Localizer,
 ) error {
-	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
+	var handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		subscription, err := s.adminSubscriptionStorage.GetAdminSubscription(contextWithTx, id)
 		if err != nil {
@@ -414,7 +414,7 @@ func (s *NotificationService) DeleteAdminSubscription(
 	if err := validateDeleteAdminSubscriptionRequest(req, localizer); err != nil {
 		return nil, err
 	}
-	var handler command.Handler = command.NewEmptyAdminSubscriptionCommandHandler()
+	var handler = command.NewEmptyAdminSubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		subscription, err := s.adminSubscriptionStorage.GetAdminSubscription(contextWithTx, req.Id)
 		if err != nil {

--- a/pkg/notification/api/api.go
+++ b/pkg/notification/api/api.go
@@ -32,7 +32,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/role"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
-	proto "github.com/bucketeer-io/bucketeer/proto/account"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	notificationproto "github.com/bucketeer-io/bucketeer/proto/notification"
 )
@@ -200,20 +199,23 @@ func (s *NotificationService) checkEnvironmentRole(
 
 func (s *NotificationService) checkOrganizationRole(
 	ctx context.Context,
-	requiredRole proto.AccountV2_Role_Organization,
+	requiredRole accountproto.AccountV2_Role_Organization,
 	organizationID string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckOrganizationRole(ctx, requiredRole, func(email string) (*proto.GetAccountV2Response, error) {
-		resp, err := s.accountClient.GetAccountV2(ctx, &proto.GetAccountV2Request{
-			Email:          email,
-			OrganizationId: organizationID,
+	editor, err := role.CheckOrganizationRole(
+		ctx,
+		requiredRole,
+		func(email string) (*accountproto.GetAccountV2Response, error) {
+			resp, err := s.accountClient.GetAccountV2(ctx, &accountproto.GetAccountV2Request{
+				Email:          email,
+				OrganizationId: organizationID,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
 		})
-		if err != nil {
-			return nil, err
-		}
-		return resp, nil
-	})
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:

--- a/pkg/notification/api/subscription.go
+++ b/pkg/notification/api/subscription.go
@@ -76,7 +76,7 @@ func (s *NotificationService) CreateSubscription(
 		)
 		return nil, api.NewGRPCStatus(err).Err()
 	}
-	var handler command.Handler = command.NewEmptySubscriptionCommandHandler()
+	handler := command.NewEmptySubscriptionCommandHandler()
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		if err := s.subscriptionStorage.CreateSubscription(contextWithTx, subscription, req.EnvironmentId); err != nil {
 			return err
@@ -362,7 +362,7 @@ func (s *NotificationService) updateSubscription(
 	editor *eventproto.Editor,
 	localizer locale.Localizer,
 ) error {
-	var handler command.Handler = command.NewEmptySubscriptionCommandHandler()
+	handler := command.NewEmptySubscriptionCommandHandler()
 	err := s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
 		subscription, err := s.subscriptionStorage.GetSubscription(contextWithTx, id, environmentId)
 		if err != nil {

--- a/pkg/notification/sender/notifier/slack.go
+++ b/pkg/notification/sender/notifier/slack.go
@@ -34,7 +34,6 @@ import (
 	notificationdomain "github.com/bucketeer-io/bucketeer/pkg/notification/domain"
 	domainproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	notificationproto "github.com/bucketeer-io/bucketeer/proto/notification"
-	"github.com/bucketeer-io/bucketeer/proto/notification/sender"
 	senderproto "github.com/bucketeer-io/bucketeer/proto/notification/sender"
 )
 
@@ -114,7 +113,7 @@ func (n *slackNotifier) Notify(
 
 func (n *slackNotifier) notify(
 	ctx context.Context,
-	notification *sender.Notification,
+	notification *senderproto.Notification,
 	slackRecipient *notificationproto.SlackChannelRecipient,
 	language notificationproto.Recipient_Language,
 ) error {
@@ -153,7 +152,7 @@ func (n *slackNotifier) newLocalizer(
 }
 
 func (n *slackNotifier) createMessage(
-	notification *sender.Notification,
+	notification *senderproto.Notification,
 	slackRecipient *notificationproto.SlackChannelRecipient,
 	localizer locale.Localizer,
 ) (*slack.WebhookMessage, error) {
@@ -168,19 +167,19 @@ func (n *slackNotifier) createMessage(
 }
 
 func (n *slackNotifier) createAttachment(
-	notification *sender.Notification,
+	notification *senderproto.Notification,
 	localizer locale.Localizer,
 ) (*slack.Attachment, error) {
 	switch notification.Type {
-	case sender.Notification_DomainEvent:
+	case senderproto.Notification_DomainEvent:
 		return n.createDomainEventAttachment(notification.DomainEventNotification, localizer)
-	case sender.Notification_FeatureStale:
+	case senderproto.Notification_FeatureStale:
 		return n.createFeatureStaleAttachment(notification.FeatureStaleNotification)
-	case sender.Notification_ExperimentRunning:
+	case senderproto.Notification_ExperimentRunning:
 		return n.createExperimentRunningAttachment(notification.ExperimentRunningNotification)
-	case sender.Notification_MauCount:
+	case senderproto.Notification_MauCount:
 		return n.createMAUCountAttachment(notification.MauCountNotification)
-	case sender.Notification_DemoOrganizationCreation:
+	case senderproto.Notification_DemoOrganizationCreation:
 		return n.createDemoOrganizationCreationAttachment(notification.DemoOrganizationCreationNotification)
 	}
 	return nil, ErrUnknownNotification

--- a/pkg/pubsub/factory/factory.go
+++ b/pkg/pubsub/factory/factory.go
@@ -156,7 +156,7 @@ func NewClient(ctx context.Context, opts ...Option) (Client, error) {
 	case RedisStream:
 		// Handle RedisStream type
 		if options.redisClient == nil {
-			return nil, fmt.Errorf("Redis client is required for Redis Stream")
+			return nil, fmt.Errorf("redis client is required for Redis Stream")
 		}
 		streamOpts := []redis.StreamOption{}
 		if options.metrics != nil {

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -205,7 +205,7 @@ func (c *Client) topic(id string) (*pubsub.Topic, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c.createTopicForEmulator(ctx, id)
-	topic := c.Client.Topic(id)
+	topic := c.Topic(id)
 	ok, err := topic.Exists(ctx)
 	if err != nil {
 		return nil, err
@@ -220,7 +220,7 @@ func (c *Client) topicInProject(topicID, projectID string) (*pubsub.Topic, error
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	c.createTopicForEmulator(ctx, topicID)
-	topic := c.Client.TopicInProject(topicID, projectID)
+	topic := c.TopicInProject(topicID, projectID)
 	ok, err := topic.Exists(ctx)
 	if err != nil {
 		return nil, err
@@ -234,14 +234,14 @@ func (c *Client) topicInProject(topicID, projectID string) (*pubsub.Topic, error
 // createTopicForEmulator create topic when using pubsub emulator.
 func (c *Client) createTopicForEmulator(ctx context.Context, id string) {
 	if emulator := os.Getenv("PUBSUB_EMULATOR_HOST"); emulator != "" {
-		_, _ = c.Client.CreateTopic(ctx, id)
+		_, _ = c.CreateTopic(ctx, id)
 	}
 }
 
 // TODO: add metrics
 func (c *Client) subscription(id, topicID string) (*pubsub.Subscription, error) {
-	sub := c.Client.Subscription(id)
-	topic := c.Client.Topic(topicID)
+	sub := c.Subscription(id)
+	topic := c.Topic(topicID)
 	var lastErr error
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
@@ -255,7 +255,7 @@ func (c *Client) subscription(id, topicID string) (*pubsub.Subscription, error) 
 		if ok {
 			return sub, nil
 		}
-		_, err = c.Client.CreateSubscription(ctx, id, pubsub.SubscriptionConfig{
+		_, err = c.CreateSubscription(ctx, id, pubsub.SubscriptionConfig{
 			Topic: topic,
 		})
 		if err == nil {
@@ -274,7 +274,7 @@ func (c *Client) subscription(id, topicID string) (*pubsub.Subscription, error) 
 }
 
 func (c *Client) SubscriptionExists(id string) (bool, error) {
-	sub := c.Client.Subscription(id)
+	sub := c.Subscription(id)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	exists, err := sub.Exists(ctx)
@@ -285,7 +285,7 @@ func (c *Client) SubscriptionExists(id string) (bool, error) {
 }
 
 func (c *Client) DeleteSubscription(id string) error {
-	sub := c.Client.Subscription(id)
+	sub := c.Subscription(id)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	return sub.Delete(ctx)

--- a/pkg/push/api/api.go
+++ b/pkg/push/api/api.go
@@ -42,7 +42,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/role"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
-	proto "github.com/bucketeer-io/bucketeer/proto/account"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	pushproto "github.com/bucketeer-io/bucketeer/proto/push"
 )
@@ -228,7 +227,7 @@ func (s *PushService) CreatePush(
 	}
 
 	// For security reasons we remove the service account from the API response
-	push.Push.FcmServiceAccount = ""
+	push.FcmServiceAccount = ""
 
 	return &pushproto.CreatePushResponse{
 		Push: push.Push,
@@ -372,7 +371,7 @@ func (s *PushService) createPushNoCommand(
 	}
 
 	// For security reasons we remove the service account from the API response
-	push.Push.FcmServiceAccount = ""
+	push.FcmServiceAccount = ""
 
 	return &pushproto.CreatePushResponse{
 		Push: push.Push,
@@ -843,7 +842,7 @@ func (s *PushService) GetPush(
 
 	if push.Push != nil {
 		// For security reasons we remove the service account from the API response
-		push.Push.FcmServiceAccount = ""
+		push.FcmServiceAccount = ""
 	}
 
 	return &pushproto.GetPushResponse{
@@ -1334,20 +1333,23 @@ func (s *PushService) checkEnvironmentRole(
 
 func (s *PushService) checkOrganizationRole(
 	ctx context.Context,
-	requiredRole proto.AccountV2_Role_Organization,
+	requiredRole accountproto.AccountV2_Role_Organization,
 	organizationID string,
 	localizer locale.Localizer,
 ) (*eventproto.Editor, error) {
-	editor, err := role.CheckOrganizationRole(ctx, requiredRole, func(email string) (*proto.GetAccountV2Response, error) {
-		resp, err := s.accountClient.GetAccountV2(ctx, &proto.GetAccountV2Request{
-			Email:          email,
-			OrganizationId: organizationID,
+	editor, err := role.CheckOrganizationRole(
+		ctx,
+		requiredRole,
+		func(email string) (*accountproto.GetAccountV2Response, error) {
+			resp, err := s.accountClient.GetAccountV2(ctx, &accountproto.GetAccountV2Request{
+				Email:          email,
+				OrganizationId: organizationID,
+			})
+			if err != nil {
+				return nil, err
+			}
+			return resp, nil
 		})
-		if err != nil {
-			return nil, err
-		}
-		return resp, nil
-	})
 	if err != nil {
 		switch status.Code(err) {
 		case codes.Unauthenticated:

--- a/pkg/storage/v2/mysql/client.go
+++ b/pkg/storage/v2/mysql/client.go
@@ -28,7 +28,10 @@ import (
 )
 
 const dsnParams = "collation=utf8mb4_bin"
-const transactionKey = "transaction"
+
+type contextKey string
+
+const transactionKey contextKey = "transaction"
 
 type options struct {
 	connMaxLifetime time.Duration

--- a/pkg/subscriber/on_demand_subscriber.go
+++ b/pkg/subscriber/on_demand_subscriber.go
@@ -215,9 +215,10 @@ func (s *onDemandSubscriber) createPubSubClient(ctx context.Context) error {
 	}
 
 	// Add provider-specific options
-	if pubSubType == factory.Google {
+	switch pubSubType {
+	case factory.Google:
 		factoryOpts = append(factoryOpts, factory.WithProjectID(s.configuration.Project))
-	} else if pubSubType == factory.RedisStream {
+	case factory.RedisStream:
 		// Create Redis client
 		redisClient, redisErr := createRedisClient(ctx, s.configuration.Configuration, s.logger, s.opts.metrics)
 		if redisErr != nil {

--- a/pkg/subscriber/processor/demo_organization_creation_notifier.go
+++ b/pkg/subscriber/processor/demo_organization_creation_notifier.go
@@ -27,7 +27,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller"
 	"github.com/bucketeer-io/bucketeer/pkg/pubsub/puller/codes"
 	"github.com/bucketeer-io/bucketeer/pkg/subscriber"
-	domainevent "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	domaineventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	notificationproto "github.com/bucketeer-io/bucketeer/proto/notification"
 	senderproto "github.com/bucketeer-io/bucketeer/proto/notification/sender"
@@ -117,7 +116,7 @@ func (d demoOrganizationCreationNotifier) handleMessage(msg *puller.Message) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if domainEvent.Type != domainevent.Event_DEMO_ORGANIZATION_CREATED {
+	if domainEvent.Type != domaineventproto.Event_DEMO_ORGANIZATION_CREATED {
 		subscriberHandledCounter.WithLabelValues(subscriberDemoOrganizationEvent, codes.OK.String()).Inc()
 		msg.Ack()
 		return
@@ -175,7 +174,7 @@ func (d demoOrganizationCreationNotifier) handleMessage(msg *puller.Message) {
 	msg.Ack()
 }
 
-func (d demoOrganizationCreationNotifier) unmarshalMessage(msg *puller.Message) (*domainevent.Event, error) {
+func (d demoOrganizationCreationNotifier) unmarshalMessage(msg *puller.Message) (*domaineventproto.Event, error) {
 	event := &domaineventproto.Event{}
 	err := proto.Unmarshal(msg.Data, event)
 	if err != nil {

--- a/pkg/subscriber/processor/evaluation_events_ops.go
+++ b/pkg/subscriber/processor/evaluation_events_ops.go
@@ -193,7 +193,7 @@ func (u *evalEvtUpdater) linkOpsRulesByFeatureID(
 		r := &aodomain.AutoOpsRule{AutoOpsRule: aor}
 		// Ignore already triggered ops rules
 		if aor.FeatureId == featureID &&
-			!(r.IsFinished() || r.IsStopped()) {
+			!r.IsFinished() && !r.IsStopped() {
 			rules = append(rules, aor)
 		}
 	}

--- a/pkg/subscriber/processor/segment_user_persister.go
+++ b/pkg/subscriber/processor/segment_user_persister.go
@@ -118,9 +118,10 @@ func NewSegmentUserPersister(
 	opts = append(opts, factory.WithPubSubType(pubSubType))
 	opts = append(opts, factory.WithLogger(logger))
 
-	if pubSubType == factory.Google {
+	switch pubSubType {
+	case factory.Google:
 		opts = append(opts, factory.WithProjectID(segmentPersisterConfig.Project))
-	} else if pubSubType == factory.RedisStream {
+	case factory.RedisStream:
 		// Create Redis client internally
 		redisClient, err := createRedisClientForSegmentPersister(ctx, segmentPersisterConfig, logger, registerer)
 		if err != nil {

--- a/pkg/subscriber/subscriber.go
+++ b/pkg/subscriber/subscriber.go
@@ -183,9 +183,10 @@ func (s pubSubSubscriber) createPuller(
 	}
 
 	// Add provider-specific options
-	if pubSubType == factory.Google {
+	switch pubSubType {
+	case factory.Google:
 		factoryOpts = append(factoryOpts, factory.WithProjectID(s.configuration.Project))
-	} else if pubSubType == factory.RedisStream {
+	case factory.RedisStream:
 		// Create Redis client
 		redisClient, redisErr := createRedisClient(ctx, s.configuration, s.logger, s.opts.metrics)
 		if redisErr != nil {

--- a/pkg/team/api/api.go
+++ b/pkg/team/api/api.go
@@ -26,7 +26,6 @@ import (
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	gstatus "google.golang.org/grpc/status"
 
 	accclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
@@ -39,7 +38,6 @@ import (
 	"github.com/bucketeer-io/bucketeer/pkg/team/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/team/storage"
 	accountproto "github.com/bucketeer-io/bucketeer/proto/account"
-	accproto "github.com/bucketeer-io/bucketeer/proto/account"
 	eventproto "github.com/bucketeer-io/bucketeer/proto/event/domain"
 	proto "github.com/bucketeer-io/bucketeer/proto/team"
 )
@@ -109,7 +107,7 @@ func (s *TeamService) CreateTeam(
 	localizer := locale.NewLocalizer(ctx)
 	editor, err := s.checkOrganizationRole(
 		ctx, req.OrganizationId,
-		accproto.AccountV2_Role_Organization_ADMIN, localizer)
+		accountproto.AccountV2_Role_Organization_ADMIN, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +250,7 @@ func (s *TeamService) DeleteTeam(
 	localizer := locale.NewLocalizer(ctx)
 	editor, err := s.checkOrganizationRole(
 		ctx, req.OrganizationId,
-		accproto.AccountV2_Role_Organization_ADMIN, localizer)
+		accountproto.AccountV2_Role_Organization_ADMIN, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -346,8 +344,8 @@ func (s *TeamService) DeleteTeam(
 func (s *TeamService) listAccountsFromOrganization(
 	ctx context.Context,
 	organizationID string,
-) ([]*accproto.AccountV2, error) {
-	resp, err := s.accountClient.ListAccountsV2(ctx, &accproto.ListAccountsV2Request{
+) ([]*accountproto.AccountV2, error) {
+	resp, err := s.accountClient.ListAccountsV2(ctx, &accountproto.ListAccountsV2Request{
 		OrganizationId: organizationID,
 	})
 	if err != nil {
@@ -396,7 +394,7 @@ func (s *TeamService) ListTeams(
 	localizer := locale.NewLocalizer(ctx)
 	_, err := s.checkOrganizationRole(
 		ctx, req.OrganizationId,
-		accproto.AccountV2_Role_Organization_MEMBER, localizer)
+		accountproto.AccountV2_Role_Organization_MEMBER, localizer)
 	if err != nil {
 		return nil, err
 	}
@@ -523,7 +521,7 @@ func (s *TeamService) checkOrganizationRole(
 		},
 	)
 	if err != nil {
-		switch status.Code(err) {
+		switch gstatus.Code(err) {
 		case codes.Unauthenticated:
 			s.logger.Error(
 				"Unauthenticated",


### PR DESCRIPTION
fix #2098

- Execute `golangci-lint migrate` and update config. 
ref: https://golangci-lint.run/docs/product/migration-guide/
- Fix lint errors.
