### PR TITLE
refactor: change error definition in EventCounter PKG and Environment PKG to Bucketeer error

### DIFF
--- a/pkg/api/api/grpc_status.go
+++ b/pkg/api/api/grpc_status.go
@@ -120,8 +120,6 @@ func convertErrorReason(errorType pkgErr.ErrorType) string {
 		return "UNEXPECTED_AFFECTED_ROWS"
 	case pkgErr.ErrorTypeInternal:
 		return "INTERNAL"
-	case pkgErr.ErrorTypeFailedPrecondition:
-		return "FAILED_PRECONDITION"
 	default:
 		return "UNKNOWN"
 	}
@@ -149,8 +147,6 @@ func convertStatusCode(errorType pkgErr.ErrorType) codes.Code {
 		return codes.Internal
 	case pkgErr.ErrorTypeInternal:
 		return codes.Internal
-	case pkgErr.ErrorTypeFailedPrecondition:
-		return codes.FailedPrecondition
 	default:
 		return codes.Unknown
 	}

--- a/pkg/api/api/grpc_status.go
+++ b/pkg/api/api/grpc_status.go
@@ -116,6 +116,8 @@ func convertErrorReason(errorType pkgErr.ErrorType) string {
 		return "UNEXPECTED_AFFECTED_ROWS"
 	case pkgErr.ErrorTypeInternal:
 		return "INTERNAL"
+	case pkgErr.ErrorTypeFailedPrecondition:
+		return "FAILED_PRECONDITION"
 	default:
 		return "UNKNOWN"
 	}
@@ -140,6 +142,8 @@ func convertStatusCode(errorType pkgErr.ErrorType) codes.Code {
 		return codes.Internal
 	case pkgErr.ErrorTypeInternal:
 		return codes.Internal
+	case pkgErr.ErrorTypeFailedPrecondition:
+		return codes.FailedPrecondition
 	default:
 		return codes.Unknown
 	}

--- a/pkg/environment/api/api.go
+++ b/pkg/environment/api/api.go
@@ -30,6 +30,7 @@ import (
 	accdomain "github.com/bucketeer-io/bucketeer/pkg/account/domain"
 	accstorage "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
 	v2acc "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	"github.com/bucketeer-io/bucketeer/pkg/auth"
 	"github.com/bucketeer-io/bucketeer/pkg/auth/google"
 	v2 "github.com/bucketeer-io/bucketeer/pkg/environment/storage/v2"
@@ -426,14 +427,7 @@ func (s *EnvironmentService) checkSystemAdminRole(
 				"Failed to check role",
 				log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil
@@ -488,14 +482,7 @@ func (s *EnvironmentService) checkOrganizationRole(
 				"Failed to check role",
 				log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil
@@ -560,14 +547,7 @@ func (s *EnvironmentService) checkOrganizationRoleByEnvironmentID(
 					zap.String("environmentID", environmentID),
 				)...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil
@@ -599,14 +579,7 @@ func (s *EnvironmentService) getAccountV2ByEnvironmentID(
 				zap.String("email", email),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return account, nil
 }

--- a/pkg/environment/api/environment_v2.go
+++ b/pkg/environment/api/environment_v2.go
@@ -24,6 +24,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	domainevent "github.com/bucketeer-io/bucketeer/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/command"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
@@ -70,14 +71,7 @@ func (s *EnvironmentService) GetEnvironmentV2(
 			}
 			return nil, dt.Err()
 		}
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.GetEnvironmentV2Response{
 		Environment: environment.EnvironmentV2,
@@ -185,14 +179,7 @@ func (s *EnvironmentService) ListEnvironmentsV2(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.ListEnvironmentsV2Response{
 		Environments: environments,
@@ -371,14 +358,7 @@ func (s *EnvironmentService) createEnvironmentV2NoCommand(
 			"Failed to create environment",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.CreateEnvironmentV2Response{
 		Environment: newEnvironment.EnvironmentV2,
@@ -536,14 +516,7 @@ func (s *EnvironmentService) createEnvironmentV2(
 			"Failed to create environment",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -633,14 +606,7 @@ func (s *EnvironmentService) updateEnvironmentV2NoCommand(
 			"Failed to update environment",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.UpdateEnvironmentV2Response{}, nil
 }
@@ -683,14 +649,7 @@ func (s *EnvironmentService) updateEnvironmentV2(
 			"Failed to update environment",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -815,14 +774,7 @@ func (s *EnvironmentService) ArchiveEnvironmentV2(
 			"Failed to archive environment",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.ArchiveEnvironmentV2Response{}, nil
 }
@@ -891,14 +843,7 @@ func (s *EnvironmentService) UnarchiveEnvironmentV2(
 			"Failed to unarchive environment",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.UnarchiveEnvironmentV2Response{}, nil
 }

--- a/pkg/environment/api/environment_v2_test.go
+++ b/pkg/environment/api/environment_v2_test.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
@@ -29,9 +28,11 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	acmock "github.com/bucketeer-io/bucketeer/pkg/account/client/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
 	v2es "github.com/bucketeer-io/bucketeer/pkg/environment/storage/v2"
 	storagemock "github.com/bucketeer-io/bucketeer/pkg/environment/storage/v2/mock"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -80,10 +81,10 @@ func TestGetEnvironmentV2(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.environmentStorage.(*storagemock.MockEnvironmentStorage).EXPECT().GetEnvironmentV2(
 					gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
+				).Return(nil, pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			id:          "id-1",
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -154,11 +155,11 @@ func TestListEnvironmentsV2(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.environmentStorage.(*storagemock.MockEnvironmentStorage).EXPECT().ListEnvironmentsV2(
 					gomock.Any(), gomock.Any(),
-				).Return(nil, 0, int64(0), errors.New("error"))
+				).Return(nil, 0, int64(0), pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			input:       &proto.ListEnvironmentsV2Request{},
 			expected:    nil,
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -361,12 +362,12 @@ func TestCreateEnvironmentV2(t *testing.T) {
 				}, nil)
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.CreateEnvironmentV2Request{
 				Command: &proto.CreateEnvironmentV2Command{Name: "name", UrlCode: "url-code", ProjectId: "project-id"},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success: require comment is true",
@@ -632,14 +633,14 @@ func TestCreateEnvironmentV2NoCommand(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.projectStorage.(*storagemock.MockProjectStorage).EXPECT().GetProject(
 					gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
+				).Return(nil, pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.CreateEnvironmentV2Request{
 				Name:      "name",
 				UrlCode:   "url-code",
 				ProjectId: "project-id",
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success: require comment is true",
@@ -789,13 +790,13 @@ func TestUpdateEnvironmentV2(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.UpdateEnvironmentV2Request{
 				Id:            "id02",
 				RenameCommand: &proto.RenameEnvironmentV2Command{Name: "name-1"},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -905,13 +906,13 @@ func TestUpdateEnvironmentV2NoCommand(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.UpdateEnvironmentV2Request{
 				Id:   "id02",
 				Name: wrapperspb.String("name-1"),
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -985,10 +986,10 @@ func TestArchiveEnvironmentV2(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req:         &proto.ArchiveEnvironmentV2Request{Id: "id02", Command: &proto.ArchiveEnvironmentV2Command{}},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -1068,10 +1069,10 @@ func TestUnarchiveEnvironmentV2(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req:         &proto.UnarchiveEnvironmentV2Request{Id: "id02", Command: &proto.UnarchiveEnvironmentV2Command{}},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",

--- a/pkg/environment/api/error.go
+++ b/pkg/environment/api/error.go
@@ -15,47 +15,109 @@
 package api
 
 import (
-	"google.golang.org/grpc/codes"
-	gstatus "google.golang.org/grpc/status"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 )
 
 var (
-	statusInternal      = gstatus.New(codes.Internal, "environment: internal")
-	statusNoCommand     = gstatus.New(codes.InvalidArgument, "environment: no command")
-	statusInvalidCursor = gstatus.New(codes.InvalidArgument, "environment: cursor is invalid")
+	statusInternal  = api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
+	statusNoCommand = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNil(pkgErr.EnvironmentPackageName, "no command", "command"))
+	statusInvalidCursor = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EnvironmentPackageName, "cursor is invalid", "cursor"))
 	// Essentially, the id field is required, but no validation is performed because some older services do not have ID.
 	//statusEnvironmentIDRequired = gstatus.New(codes.InvalidArgument, "environment: environment id must be specified")
-	statusEnvironmentNameRequired         = gstatus.New(codes.InvalidArgument, "environment: environment name must be specified") // nolint:lll
-	statusInvalidEnvironmentName          = gstatus.New(codes.InvalidArgument, "environment: invalid environment name")           // nolint:lll
-	statusInvalidEnvironmentUrlCode       = gstatus.New(codes.InvalidArgument, "environment: invalid environment url code")       // nolint:lll
-	statusProjectIDRequired               = gstatus.New(codes.InvalidArgument, "environment: project id must be specified")       // nolint:lll
-	statusProjectNameRequired             = gstatus.New(codes.InvalidArgument, "environment: project name must be specified")     // nolint:lll
-	statusInvalidProjectName              = gstatus.New(codes.InvalidArgument, "environment: invalid project name")               // nolint:lll
-	statusInvalidProjectUrlCode           = gstatus.New(codes.InvalidArgument, "environment: invalid project url code")           // nolint:lll
-	statusInvalidProjectCreatorEmail      = gstatus.New(codes.InvalidArgument, "environment: invalid project creator email")      // nolint:lll
-	statusInvalidOrganizationCreatorEmail = gstatus.New(codes.InvalidArgument, "environment: invalid organization creator email") // nolint:lll
-	statusInvalidOrderBy                  = gstatus.New(codes.InvalidArgument, "environment: order_by is invalid")                // nolint:lll
-	statusOrganizationIDRequired          = gstatus.New(codes.InvalidArgument, "environment: organization id must be specified")  // nolint:lll
-	statusOrganizationNameRequired        = gstatus.New(
-		codes.InvalidArgument,
-		"environment: organization name must be specified",
-	)
-	statusInvalidOrganizationName    = gstatus.New(codes.InvalidArgument, "environment: invalid organization name")
-	statusInvalidOrganizationUrlCode = gstatus.New(codes.InvalidArgument, "environment: invalid organization url code")
-	statusCannotUpdateSystemAdmin    = gstatus.New(
-		codes.InvalidArgument,
-		"environment: cannot update system admin organization",
-	)
-	statusEnvironmentNotFound       = gstatus.New(codes.NotFound, "environment: environment not found")
-	statusProjectNotFound           = gstatus.New(codes.NotFound, "environment: project not found")
-	statusOrganizationNotFound      = gstatus.New(codes.NotFound, "environment: organization not found")
-	statusEnvironmentAlreadyExists  = gstatus.New(codes.AlreadyExists, "environment: environment already exists")
-	statusProjectAlreadyExists      = gstatus.New(codes.AlreadyExists, "environment: project already exists")
-	statusOrganizationAlreadyExists = gstatus.New(codes.AlreadyExists, "environment: organization already exists")
-	statusProjectDisabled           = gstatus.New(codes.FailedPrecondition, "environment: project disabled")
-	statusUnauthenticated           = gstatus.New(codes.Unauthenticated, "environment: unauthenticated")
-	statusPermissionDenied          = gstatus.New(codes.PermissionDenied, "environment: permission denied")
-	statusNotFound                  = gstatus.New(codes.NotFound, "environment: not found")
-	statusDemoSiteDisabled          = gstatus.New(codes.FailedPrecondition, "environment: demo site is not enabled")
-	statusUserAlreadyInOrganization = gstatus.New(codes.FailedPrecondition, "environment: user already in organization")
+	statusEnvironmentNameRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(
+			pkgErr.EnvironmentPackageName,
+			"environment name must be specified",
+			"environment_name",
+		))
+	statusInvalidEnvironmentName = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"invalid environment name",
+			"environment_name",
+		))
+	statusInvalidEnvironmentUrlCode = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EnvironmentPackageName,
+			"invalid environment url code",
+			"environment_url_code",
+		))
+	statusProjectIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EnvironmentPackageName, "project id must be specified", "project_id"))
+	statusProjectNameRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EnvironmentPackageName, "project name must be specified", "project_name"))
+	statusInvalidProjectName = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EnvironmentPackageName, "invalid project name", "project_name"))
+	statusInvalidProjectUrlCode = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"invalid project url code",
+			"project_url_code",
+		))
+	statusInvalidProjectCreatorEmail = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"invalid project creator email",
+			"project_creator_email",
+		))
+	statusInvalidOrganizationCreatorEmail = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"invalid organization creator email",
+			"organization_creator_email",
+		))
+	statusInvalidOrderBy = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EnvironmentPackageName, "order_by is invalid", "order_by"))
+	statusOrganizationIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EnvironmentPackageName, "organization id must be specified", "organization_id"))
+	statusOrganizationNameRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(
+			pkgErr.EnvironmentPackageName,
+			"organization name must be specified",
+			"organization_name",
+		))
+	statusInvalidOrganizationName = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"invalid organization name",
+			"organization_name",
+		))
+	statusInvalidOrganizationUrlCode = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"invalid organization url code",
+			"organization_url_code",
+		))
+	statusCannotUpdateSystemAdmin = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(
+			pkgErr.EnvironmentPackageName,
+			"cannot update system admin organization",
+			"system_admin_organization",
+		))
+	statusEnvironmentNotFound = api.NewGRPCStatus(
+		pkgErr.NewErrorNotFound(pkgErr.EnvironmentPackageName, "environment not found", "environment"))
+	statusProjectNotFound = api.NewGRPCStatus(
+		pkgErr.NewErrorNotFound(pkgErr.EnvironmentPackageName, "project not found", "project"))
+	statusOrganizationNotFound = api.NewGRPCStatus(
+		pkgErr.NewErrorNotFound(pkgErr.EnvironmentPackageName, "organization not found", "organization"))
+	statusEnvironmentAlreadyExists = api.NewGRPCStatus(
+		pkgErr.NewErrorAlreadyExists(pkgErr.EnvironmentPackageName, "environment already exists"))
+	statusProjectAlreadyExists = api.NewGRPCStatus(
+		pkgErr.NewErrorAlreadyExists(pkgErr.EnvironmentPackageName, "project already exists"))
+	statusOrganizationAlreadyExists = api.NewGRPCStatus(
+		pkgErr.NewErrorAlreadyExists(pkgErr.EnvironmentPackageName, "organization already exists"))
+	statusProjectDisabled = api.NewGRPCStatus(
+		pkgErr.NewErrorFailedPrecondition(pkgErr.EnvironmentPackageName, "project disabled"))
+	statusUnauthenticated = api.NewGRPCStatus(
+		pkgErr.NewErrorUnauthenticated(pkgErr.EnvironmentPackageName, "unauthenticated"))
+	statusPermissionDenied = api.NewGRPCStatus(
+		pkgErr.NewErrorPermissionDenied(pkgErr.EnvironmentPackageName, "permission denied"))
+	statusNotFound = api.NewGRPCStatus(
+		pkgErr.NewErrorNotFound(pkgErr.EnvironmentPackageName, "not found", "account"))
+	statusDemoSiteDisabled = api.NewGRPCStatus(
+		pkgErr.NewErrorFailedPrecondition(pkgErr.EnvironmentPackageName, "demo site is not enabled"))
+	statusUserAlreadyInOrganization = api.NewGRPCStatus(
+		pkgErr.NewErrorFailedPrecondition(pkgErr.EnvironmentPackageName, "user already in organization"))
 )

--- a/pkg/environment/api/organization.go
+++ b/pkg/environment/api/organization.go
@@ -27,6 +27,7 @@ import (
 
 	accdomain "github.com/bucketeer-io/bucketeer/pkg/account/domain"
 	v2acc "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	domainevent "github.com/bucketeer-io/bucketeer/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/command"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
@@ -105,14 +106,7 @@ func (s *EnvironmentService) getOrganization(
 			}
 			return nil, dt.Err()
 		}
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return org, nil
 }
@@ -192,14 +186,7 @@ func (s *EnvironmentService) ListOrganizations(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.ListOrganizationsResponse{
 		Organizations: organizations,
@@ -286,26 +273,12 @@ func (s *EnvironmentService) CreateDemoOrganization(
 		nil,
 	)
 	if err != nil {
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	if err = s.publisher.Publish(ctx, event); err != nil {
 		s.logger.Error("failed to publish event",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.CreateDemoOrganizationResponse{
 		Organization: organization.Organization,
@@ -580,14 +553,7 @@ func (s *EnvironmentService) createOrganizationMySQL(
 		s.logger.Error(
 			"Failed to create a domain organization",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	var envRoles []*accountproto.AccountV2_EnvironmentRole
 	err = s.mysqlClient.RunInTransactionV2(ctx, func(contextWithTx context.Context, _ mysql.Transaction) error {
@@ -653,14 +619,7 @@ func (s *EnvironmentService) createOrganizationMySQL(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	// Create the admin account using the environment roles created in the last step
 	// Because the account storage has a different implementation,
@@ -775,14 +734,7 @@ func (s *EnvironmentService) createOrganization(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -966,14 +918,7 @@ func (s *EnvironmentService) updateOrganizationNoCommand(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 
 	// Update the organization role when the owner email changes
@@ -985,14 +930,7 @@ func (s *EnvironmentService) updateOrganizationNoCommand(
 				zap.String("prevOwnerEmail", prevOwnerEmail),
 				zap.String("newOwnerEmail", newOwnerEmail),
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 
@@ -1030,14 +968,7 @@ func (s *EnvironmentService) reportUpdateOrganizationError(
 		}
 		return dt.Err()
 	}
-	dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-		Locale:  localizer.GetLocale(),
-		Message: localizer.MustLocalize(locale.InternalServerError),
-	})
-	if err != nil {
-		return statusInternal.Err()
-	}
-	return dt.Err()
+	return api.NewGRPCStatus(err).Err()
 }
 
 func (s *EnvironmentService) getUpdateOrganizationCommands(
@@ -1181,14 +1112,7 @@ func (s *EnvironmentService) updateOrganization(
 				zap.String("prevOwnerEmail", prevOwnerEmail),
 				zap.String("newOwnerEmail", newOwnerEmail),
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return statusInternal.Err()
-			}
-			return dt.Err()
+			return api.NewGRPCStatus(err).Err()
 		}
 	}
 	return nil

--- a/pkg/environment/api/organization_test.go
+++ b/pkg/environment/api/organization_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"testing"
 
@@ -18,9 +17,11 @@ import (
 	accountdomain "github.com/bucketeer-io/bucketeer/pkg/account/domain"
 	v2as "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2"
 	accstoragemock "github.com/bucketeer-io/bucketeer/pkg/account/storage/v2/mock"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
 	v2es "github.com/bucketeer-io/bucketeer/pkg/environment/storage/v2"
 	storagemock "github.com/bucketeer-io/bucketeer/pkg/environment/storage/v2/mock"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	publishermock "github.com/bucketeer-io/bucketeer/pkg/pubsub/publisher/mock"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
@@ -75,10 +76,10 @@ func TestGetOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.orgStorage.(*storagemock.MockOrganizationStorage).EXPECT().GetOrganization(
 					gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("error"))
+				).Return(nil, pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			id:          "err-id-1",
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -147,11 +148,11 @@ func TestListOrganizationsMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.orgStorage.(*storagemock.MockOrganizationStorage).EXPECT().ListOrganizations(
 					gomock.Any(), gomock.Any(),
-				).Return(nil, 0, int64(0), errors.New("error"))
+				).Return(nil, 0, int64(0), pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			input:       &proto.ListOrganizationsRequest{},
 			expected:    nil,
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -280,12 +281,12 @@ func TestCreateOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.CreateOrganizationRequest{
 				Command: &proto.CreateOrganizationCommand{Name: "id-1", UrlCode: "id-1", OwnerEmail: "test@test.org"},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -431,13 +432,13 @@ func TestUpdateOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			req: &proto.UpdateOrganizationRequest{
 				Id:            "err-id-1",
 				RenameCommand: &proto.ChangeNameOrganizationCommand{Name: "id-1"},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -546,13 +547,13 @@ func TestUpdateOrganizationMySQLNoCommand(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			req: &proto.UpdateOrganizationRequest{
 				Id:   "err-id-1",
 				Name: wrapperspb.String("id-1"),
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -642,13 +643,13 @@ func TestEnableOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			req: &proto.EnableOrganizationRequest{
 				Id:      "id-1",
 				Command: &proto.EnableOrganizationCommand{},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -759,13 +760,13 @@ func TestDisableOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			req: &proto.DisableOrganizationRequest{
 				Id:      "id-1",
 				Command: &proto.DisableOrganizationCommand{},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -876,13 +877,13 @@ func TestArchiveOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal"))
 			},
 			req: &proto.ArchiveOrganizationRequest{
 				Id:      "id-1",
 				Command: &proto.ArchiveOrganizationCommand{},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success",
@@ -980,13 +981,13 @@ func TestUnarchiveOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.UnarchiveOrganizationRequest{
 				Id:      "id-1",
 				Command: &proto.UnarchiveOrganizationCommand{},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -1084,13 +1085,13 @@ func TestConvertTrialOrganizationMySQL(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req: &proto.ConvertTrialOrganizationRequest{
 				Id:      "id-1",
 				Command: &proto.ConvertTrialOrganizationCommand{},
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",
@@ -1210,10 +1211,10 @@ func TestEnvironmentService_CreateDemoOrganization(t *testing.T) {
 			setup: func(s *EnvironmentService) {
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
-				).Return(errors.New("error"))
+				).Return(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error"))
 			},
 			req:         &proto.CreateDemoOrganizationRequest{Name: "id-1", UrlCode: "id-1"},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EnvironmentPackageName, "error")).Err(),
 		},
 		{
 			desc: "success",

--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	domainevent "github.com/bucketeer-io/bucketeer/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/command"
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
@@ -105,14 +106,7 @@ func (s *EnvironmentService) getProject(
 			}
 			return nil, dt.Err()
 		}
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return project, nil
 }
@@ -194,14 +188,7 @@ func (s *EnvironmentService) ListProjects(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.ListProjectsResponse{
 		Projects:   projects,
@@ -420,14 +407,7 @@ func (s *EnvironmentService) reportCreateProjectRequestError(
 		}
 		return dt.Err()
 	}
-	dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-		Locale:  localizer.GetLocale(),
-		Message: localizer.MustLocalize(locale.InternalServerError),
-	})
-	if err != nil {
-		return statusInternal.Err()
-	}
-	return dt.Err()
+	return api.NewGRPCStatus(err).Err()
 }
 
 func (s *EnvironmentService) newCreateDomainEvent(
@@ -535,14 +515,7 @@ func (s *EnvironmentService) createProject(
 			"Failed to create project",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -723,14 +696,7 @@ func (s *EnvironmentService) getTrialProjectByEmail(
 			}
 			return nil, dt.Err()
 		}
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return project.Project, nil
 }
@@ -778,14 +744,7 @@ func (s *EnvironmentService) createTrialEnvironmentsAndAccounts(
 		},
 	}
 	if _, err := s.accountClient.CreateAccountV2(ctx, createAccountReq); err != nil {
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -1004,14 +963,7 @@ func (s *EnvironmentService) reportUpdateProjectRequestError(
 		}
 		return dt.Err()
 	}
-	dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-		Locale:  localizer.GetLocale(),
-		Message: localizer.MustLocalize(locale.InternalServerError),
-	})
-	if err != nil {
-		return statusInternal.Err()
-	}
-	return dt.Err()
+	return api.NewGRPCStatus(err).Err()
 }
 
 func (s *EnvironmentService) newUpdateDomainEvent(
@@ -1075,14 +1027,7 @@ func (s *EnvironmentService) updateProject(
 			"Failed to update project",
 			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return statusInternal.Err()
-		}
-		return dt.Err()
+		return api.NewGRPCStatus(err).Err()
 	}
 	return nil
 }
@@ -1332,14 +1277,7 @@ func (s *EnvironmentService) ListProjectsV2(
 				zap.Error(err),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &environmentproto.ListProjectsV2Response{
 		Projects:   projects,

--- a/pkg/environment/command/command.go
+++ b/pkg/environment/command/command.go
@@ -16,11 +16,12 @@ package command
 
 import (
 	"context"
-	"errors"
+
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 )
 
 var (
-	errUnknownCommand = errors.New("command: unknown command")
+	errUnknownCommand = pkgErr.NewErrorInvalidArgUnknown(pkgErr.EnvironmentPackageName, "unknown command", "command")
 )
 
 type Command interface{}

--- a/pkg/environment/domain/organization.go
+++ b/pkg/environment/domain/organization.go
@@ -15,12 +15,12 @@
 package domain
 
 import (
-	"errors"
 	"time"
 
 	"github.com/jinzhu/copier"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/uuid"
 	proto "github.com/bucketeer-io/bucketeer/proto/environment"
 )
@@ -30,8 +30,14 @@ type Organization struct {
 }
 
 var (
-	ErrCannotDisableSystemAdmin = errors.New("environment: cannot disable system admin")
-	ErrCannotArchiveSystemAdmin = errors.New("environment: cannot archive system admin")
+	ErrCannotDisableSystemAdmin = pkgErr.NewErrorInvalidArgNotMatchFormat(
+		pkgErr.EnvironmentPackageName,
+		"cannot disable system admin",
+		"system_admin_organization")
+	ErrCannotArchiveSystemAdmin = pkgErr.NewErrorInvalidArgNotMatchFormat(
+		pkgErr.EnvironmentPackageName,
+		"cannot archive system admin",
+		"system_admin_organization")
 )
 
 func NewOrganization(name, urlCode, ownerEmail, description string, trial, systemAdmin bool) (*Organization, error) {

--- a/pkg/environment/storage/v2/environment.go
+++ b/pkg/environment/storage/v2/environment.go
@@ -22,14 +22,22 @@ import (
 	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	proto "github.com/bucketeer-io/bucketeer/proto/environment"
 )
 
 var (
-	ErrEnvironmentAlreadyExists          = errors.New("environment: already exists")
-	ErrEnvironmentNotFound               = errors.New("environment: not found")
-	ErrEnvironmentUnexpectedAffectedRows = errors.New("environment: unexpected affected rows")
+	ErrEnvironmentAlreadyExists = pkgErr.NewErrorAlreadyExists(
+		pkgErr.EnvironmentPackageName,
+		"environment already exists")
+	ErrEnvironmentNotFound = pkgErr.NewErrorNotFound(
+		pkgErr.EnvironmentPackageName,
+		"environment not found",
+		"environment")
+	ErrEnvironmentUnexpectedAffectedRows = pkgErr.NewErrorUnexpectedAffectedRows(
+		pkgErr.EnvironmentPackageName,
+		"environment unexpected affected rows")
 
 	//go:embed sql/environment/insert_environment.sql
 	insertEnvironmentSQL string

--- a/pkg/environment/storage/v2/organization.go
+++ b/pkg/environment/storage/v2/organization.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	proto "github.com/bucketeer-io/bucketeer/proto/environment"
 )
@@ -42,9 +43,16 @@ var (
 )
 
 var (
-	ErrOrganizationAlreadyExists          = errors.New("organization: already exists")
-	ErrOrganizationNotFound               = errors.New("organization: not found")
-	ErrOrganizationUnexpectedAffectedRows = errors.New("organization: unexpected affected rows")
+	ErrOrganizationAlreadyExists = pkgErr.NewErrorAlreadyExists(
+		pkgErr.EnvironmentPackageName,
+		"organization already exists")
+	ErrOrganizationNotFound = pkgErr.NewErrorNotFound(
+		pkgErr.EnvironmentPackageName,
+		"organization not found",
+		"organization")
+	ErrOrganizationUnexpectedAffectedRows = pkgErr.NewErrorUnexpectedAffectedRows(
+		pkgErr.EnvironmentPackageName,
+		"organization unexpected affected rows")
 )
 
 type OrganizationStorage interface {

--- a/pkg/environment/storage/v2/project.go
+++ b/pkg/environment/storage/v2/project.go
@@ -18,18 +18,24 @@ package v2
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 
 	"github.com/bucketeer-io/bucketeer/pkg/environment/domain"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	proto "github.com/bucketeer-io/bucketeer/proto/environment"
 )
 
 var (
-	ErrProjectAlreadyExists          = errors.New("project: already exists")
-	ErrProjectNotFound               = errors.New("project: not found")
-	ErrProjectUnexpectedAffectedRows = errors.New("project: unexpected affected rows")
+	ErrProjectAlreadyExists = pkgErr.NewErrorAlreadyExists(
+		pkgErr.EnvironmentPackageName,
+		"project already exists")
+	ErrProjectNotFound = pkgErr.NewErrorNotFound(
+		pkgErr.EnvironmentPackageName,
+		"project not found", "project")
+	ErrProjectUnexpectedAffectedRows = pkgErr.NewErrorUnexpectedAffectedRows(
+		pkgErr.EnvironmentPackageName,
+		"project unexpected affected rows")
 
 	//go:embed sql/project/insert_project.sql
 	insertProjectSQL string

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -23,6 +23,7 @@ import (
 const (
 	AccountPackageName      = "account"
 	EventCounterPackageName = "eventcounter"
+	EnvironmentPackageName  = "environment"
 
 	invalidTypeUnknown        = "unknown"
 	invalidTypeEmpty          = "empty"
@@ -41,6 +42,7 @@ const (
 	ErrorTypePermissionDenied         ErrorType = "permission_denied"
 	ErrorTypeUnexpectedAffectedRows   ErrorType = "unexpected_affected_rows"
 	ErrorTypeInternal                 ErrorType = "internal"
+	ErrorTypeFailedPrecondition       ErrorType = "failed_precondition"
 	ErrorTypeInvalidArgUnknown        ErrorType = invalidPrefix + "_" + invalidTypeUnknown
 	ErrorTypeInvalidArgEmpty          ErrorType = invalidPrefix + "_" + invalidTypeEmpty
 	ErrorTypeInvalidArgNil            ErrorType = invalidPrefix + "_" + invalidTypeNil
@@ -136,6 +138,10 @@ func NewErrorUnexpectedAffectedRows(pkg string, message string) *BktError {
 
 func NewErrorInternal(pkg string, message string) *BktError {
 	return newBktError(pkg, ErrorTypeInternal, message)
+}
+
+func NewErrorFailedPrecondition(pkg string, message string) *BktError {
+	return newBktError(pkg, ErrorTypeFailedPrecondition, message)
 }
 
 func NewErrorInvalidArgUnknown(pkg string, message string, field string) *BktFieldError {

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	AccountPackageName = "account"
+	AccountPackageName      = "account"
+	EventCounterPackageName = "eventcounter"
 
 	invalidTypeUnknown        = "unknown"
 	invalidTypeEmpty          = "empty"

--- a/pkg/eventcounter/api/api.go
+++ b/pkg/eventcounter/api/api.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	accountclient "github.com/bucketeer-io/bucketeer/pkg/account/client"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
 	"github.com/bucketeer-io/bucketeer/pkg/cache"
 	cachev3 "github.com/bucketeer-io/bucketeer/pkg/cache/v3"
 	"github.com/bucketeer-io/bucketeer/pkg/errgroup"
@@ -254,14 +255,7 @@ func (s *eventCounterService) GetExperimentEvaluationCount(
 				zap.Int32("featureVersion", req.FeatureVersion),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	variationCounts := s.convertEvaluationCounts(evaluationCounts, req.VariationIds)
 	s.logger.Debug("GetExperimentEvaluationCount result", zap.Any("rows", variationCounts))
@@ -371,14 +365,7 @@ func (s *eventCounterService) GetEvaluationTimeseriesCount(
 				zap.String("featureId", req.FeatureId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	// This timestamp will be used as `Timestamps` field in ecproto.Timeseries.
 	timestamps, timestampUnit, err := s.getTimestamps(req.TimeRange)
@@ -891,14 +878,7 @@ func (s *eventCounterService) GetExperimentResult(
 				zap.String("experimentId", req.ExperimentId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &ecproto.GetExperimentResultResponse{
 		ExperimentResult: result.ExperimentResult,
@@ -949,14 +929,7 @@ func (s *eventCounterService) ListExperimentResults(
 			)...,
 		)
 		listExperimentCountsCounter.WithLabelValues(codeFail).Inc()
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	results := make(map[string]*ecproto.ExperimentResult, len(experiments))
 	for _, e := range experiments {
@@ -1049,14 +1022,7 @@ func (s *eventCounterService) GetExperimentGoalCount(
 				zap.Int32("featureVersion", req.FeatureVersion),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	variationCounts := s.convertGoalCounts(goalCounts, req.VariationIds)
 	s.logger.Debug("GetExperimentGoalCount result", zap.Any("rows", variationCounts))
@@ -1182,14 +1148,7 @@ func (s *eventCounterService) GetMAUCount(
 				zap.String("yearMonth", req.YearMonth),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &ecproto.GetMAUCountResponse{
 		UserCount:  userCount,
@@ -1227,14 +1186,7 @@ func (s *eventCounterService) SummarizeMAUCounts(
 				zap.String("yearMonth", req.YearMonth),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	summaries = append(summaries, groupBySourceID...)
 	// Get the mau counts grouped by environmentID.
@@ -1247,14 +1199,7 @@ func (s *eventCounterService) SummarizeMAUCounts(
 				zap.String("yearMonth", req.YearMonth),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	summaries = append(summaries, groupByEnvID...)
 	s.logger.Debug("SummarizeMAUCounts result", zap.Any("summaries", summaries))
@@ -1335,14 +1280,7 @@ func (s *eventCounterService) GetOpsEvaluationUserCount(
 				zap.String("variationId", req.VariationId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &ecproto.GetOpsEvaluationUserCountResponse{
 		OpsRuleId: req.OpsRuleId,
@@ -1457,14 +1395,7 @@ func (s *eventCounterService) GetOpsGoalUserCount(
 				zap.String("variationId", req.VariationId),
 			)...,
 		)
-		dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-			Locale:  localizer.GetLocale(),
-			Message: localizer.MustLocalize(locale.InternalServerError),
-		})
-		if err != nil {
-			return nil, statusInternal.Err()
-		}
-		return nil, dt.Err()
+		return nil, api.NewGRPCStatus(err).Err()
 	}
 	return &ecproto.GetOpsGoalUserCountResponse{
 		OpsRuleId: req.OpsRuleId,
@@ -1604,14 +1535,7 @@ func (s *eventCounterService) checkEnvironmentRole(
 					zap.String("environmentId", environmentId),
 				)...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil
@@ -1655,14 +1579,7 @@ func (s *eventCounterService) checkSystemAdminRole(
 				"Failed to check role",
 				log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
 			)
-			dt, err := statusInternal.WithDetails(&errdetails.LocalizedMessage{
-				Locale:  localizer.GetLocale(),
-				Message: localizer.MustLocalize(locale.InternalServerError),
-			})
-			if err != nil {
-				return nil, statusInternal.Err()
-			}
-			return nil, dt.Err()
+			return nil, api.NewGRPCStatus(err).Err()
 		}
 	}
 	return editor, nil

--- a/pkg/eventcounter/api/api_test.go
+++ b/pkg/eventcounter/api/api_test.go
@@ -30,6 +30,8 @@ import (
 	"google.golang.org/grpc/metadata"
 	gstatus "google.golang.org/grpc/status"
 
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/locale"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	"github.com/bucketeer-io/bucketeer/pkg/storage"
@@ -448,7 +450,7 @@ func TestListExperimentResultsMySQL(t *testing.T) {
 			setup: func(s *eventCounterService) {
 				s.experimentClient.(*experimentclientmock.MockClient).EXPECT().ListExperiments(
 					gomock.Any(), gomock.Any(),
-				).Return(nil, errors.New("test"))
+				).Return(nil, pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal"))
 			},
 			input: &ecproto.ListExperimentResultsRequest{
 				FeatureId:      "fid",
@@ -456,7 +458,7 @@ func TestListExperimentResultsMySQL(t *testing.T) {
 				EnvironmentId:  "ns0",
 			},
 			expected:    nil,
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal")).Err(),
 		},
 		{
 			desc:    "error: ErrPermissionDenied",
@@ -821,11 +823,11 @@ func TestGetMAUCount(t *testing.T) {
 			setup: func(s *eventCounterService) {
 				s.userCountStorage.(*v2ecsmock.MockUserCountStorage).EXPECT().GetMAUCount(
 					ctx, input.EnvironmentId, input.YearMonth,
-				).Return(int64(0), int64(0), errors.New("internal"))
+				).Return(int64(0), int64(0), pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal"))
 			},
 			input:       input,
 			expected:    nil,
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal")).Err(),
 		},
 		{
 			desc:        "error: ErrPermissionDenied",
@@ -912,11 +914,11 @@ func TestSummarizeMAUCounts(t *testing.T) {
 				).Return([]*ecproto.MAUSummary{}, nil)
 				s.userCountStorage.(*v2ecsmock.MockUserCountStorage).EXPECT().GetMAUCounts(
 					ctx, input.YearMonth,
-				).Return(nil, errors.New("internal"))
+				).Return(nil, pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal"))
 			},
 			input:       input,
 			expected:    nil,
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal")).Err(),
 		},
 		{
 			desc: "success get mau counts",
@@ -1261,14 +1263,14 @@ func TestGetEvaluationTimeseriesCount(t *testing.T) {
 							Id:         "fid",
 							Variations: []*featureproto.Variation{{Id: "vid0"}, {Id: "vid1"}},
 						},
-					}, errors.New("error"))
+					}, pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal"))
 			},
 			input: &ecproto.GetEvaluationTimeseriesCountRequest{
 				EnvironmentId: environmentId,
 				FeatureId:     fID,
 				TimeRange:     ecproto.GetEvaluationTimeseriesCountRequest_FOURTEEN_DAYS,
 			},
-			expectedErr: createError(statusInternal, localizer.MustLocalize(locale.InternalServerError)),
+			expectedErr: api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "internal")).Err(),
 		},
 		{
 			desc: "error: get event counts failed",

--- a/pkg/eventcounter/api/error.go
+++ b/pkg/eventcounter/api/error.go
@@ -15,25 +15,25 @@
 package api
 
 import (
-	"google.golang.org/grpc/codes"
-	gstatus "google.golang.org/grpc/status"
+	"github.com/bucketeer-io/bucketeer/pkg/api/api"
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 )
 
 var (
-	statusInternal               = gstatus.New(codes.Internal, "eventcounter: internal")
-	statusFeatureIDRequired      = gstatus.New(codes.InvalidArgument, "eventcounter: feature id is required")
-	statusFeatureVersionRequired = gstatus.New(codes.InvalidArgument, "eventcounter: feature version is required")
-	statusVariationIDRequired    = gstatus.New(codes.InvalidArgument, "eventcounter: variation id is required")
-	statusExperimentIDRequired   = gstatus.New(codes.InvalidArgument, "eventcounter: experiment id is required")
-	statusMAUYearMonthRequired   = gstatus.New(codes.InvalidArgument, "eventcounter: mau year month is required")
-	statusGoalIDRequired         = gstatus.New(codes.InvalidArgument, "eventcounter: goal id is required")
-	statusStartAtRequired        = gstatus.New(codes.InvalidArgument, "eventcounter: start at is required")
-	statusEndAtRequired          = gstatus.New(codes.InvalidArgument, "eventcounter: end at is required")
-	statusStartAtIsAfterEndAt    = gstatus.New(codes.InvalidArgument, "eventcounter: start at is after end at")
-	statusAutoOpsRuleIDRequired  = gstatus.New(codes.InvalidArgument, "eventcounter: auto ops rule id is required")
-	statusClauseIDRequired       = gstatus.New(codes.InvalidArgument, "eventcounter: clause id is required")
-	statusNotFound               = gstatus.New(codes.NotFound, "eventcounter: not found")
-	statusUnauthenticated        = gstatus.New(codes.Unauthenticated, "feature: unauthenticated")
-	statusPermissionDenied       = gstatus.New(codes.PermissionDenied, "feature: permission denied")
-	statusUnknownTimeRange       = gstatus.New(codes.Internal, "eventcounter: unknown time range")
+	statusInternal               = api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "eventcounter: internal"))
+	statusFeatureIDRequired      = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "feature id is required", "feature_id"))
+	statusFeatureVersionRequired = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "feature version is required", "feature_version"))
+	statusVariationIDRequired    = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "variation id is required", "variation_id"))
+	statusExperimentIDRequired   = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "experiment id is required", "experiment_id"))
+	statusMAUYearMonthRequired   = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "mau year month is required", "mau_year_month"))
+	statusGoalIDRequired         = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "goal id is required", "goal_id"))
+	statusStartAtRequired        = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "start at is required", "start_at"))
+	statusEndAtRequired          = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "end at is required", "end_at"))
+	statusStartAtIsAfterEndAt    = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EventCounterPackageName, "start at is after end at", "start_at"))
+	statusAutoOpsRuleIDRequired  = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "auto ops rule id is required", "auto_ops_rule_id"))
+	statusClauseIDRequired       = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "clause id is required", "clause_id"))
+	statusNotFound               = api.NewGRPCStatus(pkgErr.NewErrorNotFound(pkgErr.EventCounterPackageName, "not found", "eventcounter"))
+	statusUnauthenticated        = api.NewGRPCStatus(pkgErr.NewErrorUnauthenticated(pkgErr.EventCounterPackageName, "unauthenticated"))
+	statusPermissionDenied       = api.NewGRPCStatus(pkgErr.NewErrorPermissionDenied(pkgErr.EventCounterPackageName, "permission denied"))
+	statusUnknownTimeRange       = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EventCounterPackageName, "unknown time range", "time_range"))
 )

--- a/pkg/eventcounter/api/error.go
+++ b/pkg/eventcounter/api/error.go
@@ -20,20 +20,36 @@ import (
 )
 
 var (
-	statusInternal               = api.NewGRPCStatus(pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "eventcounter: internal"))
-	statusFeatureIDRequired      = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "feature id is required", "feature_id"))
-	statusFeatureVersionRequired = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "feature version is required", "feature_version"))
-	statusVariationIDRequired    = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "variation id is required", "variation_id"))
-	statusExperimentIDRequired   = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "experiment id is required", "experiment_id"))
-	statusMAUYearMonthRequired   = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "mau year month is required", "mau_year_month"))
-	statusGoalIDRequired         = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "goal id is required", "goal_id"))
-	statusStartAtRequired        = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "start at is required", "start_at"))
-	statusEndAtRequired          = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "end at is required", "end_at"))
-	statusStartAtIsAfterEndAt    = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EventCounterPackageName, "start at is after end at", "start_at"))
-	statusAutoOpsRuleIDRequired  = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "auto ops rule id is required", "auto_ops_rule_id"))
-	statusClauseIDRequired       = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "clause id is required", "clause_id"))
-	statusNotFound               = api.NewGRPCStatus(pkgErr.NewErrorNotFound(pkgErr.EventCounterPackageName, "not found", "eventcounter"))
-	statusUnauthenticated        = api.NewGRPCStatus(pkgErr.NewErrorUnauthenticated(pkgErr.EventCounterPackageName, "unauthenticated"))
-	statusPermissionDenied       = api.NewGRPCStatus(pkgErr.NewErrorPermissionDenied(pkgErr.EventCounterPackageName, "permission denied"))
-	statusUnknownTimeRange       = api.NewGRPCStatus(pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EventCounterPackageName, "unknown time range", "time_range"))
+	statusInternal = api.NewGRPCStatus(
+		pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "eventcounter: internal"))
+	statusFeatureIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "feature id is required", "feature_id"))
+	statusFeatureVersionRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "feature version is required", "feature_version"))
+	statusVariationIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "variation id is required", "variation_id"))
+	statusExperimentIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "experiment id is required", "experiment_id"))
+	statusMAUYearMonthRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "mau year month is required", "mau_year_month"))
+	statusGoalIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "goal id is required", "goal_id"))
+	statusStartAtRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "start at is required", "start_at"))
+	statusEndAtRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "end at is required", "end_at"))
+	statusStartAtIsAfterEndAt = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EventCounterPackageName, "start at is after end at", "start_at"))
+	statusAutoOpsRuleIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "auto ops rule id is required", "auto_ops_rule_id"))
+	statusClauseIDRequired = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgEmpty(pkgErr.EventCounterPackageName, "clause id is required", "clause_id"))
+	statusNotFound = api.NewGRPCStatus(
+		pkgErr.NewErrorNotFound(pkgErr.EventCounterPackageName, "not found", "eventcounter"))
+	statusUnauthenticated = api.NewGRPCStatus(
+		pkgErr.NewErrorUnauthenticated(pkgErr.EventCounterPackageName, "unauthenticated"))
+	statusPermissionDenied = api.NewGRPCStatus(
+		pkgErr.NewErrorPermissionDenied(pkgErr.EventCounterPackageName, "permission denied"))
+	statusUnknownTimeRange = api.NewGRPCStatus(
+		pkgErr.NewErrorInvalidArgNotMatchFormat(pkgErr.EventCounterPackageName, "unknown time range", "time_range"))
 )

--- a/pkg/eventcounter/storage/v2/event.go
+++ b/pkg/eventcounter/storage/v2/event.go
@@ -18,7 +18,6 @@ package v2
 import (
 	"context"
 	_ "embed"
-	"errors"
 	"fmt"
 	"time"
 
@@ -26,6 +25,7 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/api/iterator"
 
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/log"
 	bqquerier "github.com/bucketeer-io/bucketeer/pkg/storage/v2/bigquery/querier"
 )
@@ -45,8 +45,8 @@ var (
 	//go:embed sql/goal_count.sql
 	goalCountSQL string
 
-	ErrUnexpectedMultipleResults = errors.New("bigquery: unexpected multiple results")
-	ErrNoResultsFound            = errors.New("bigquery: no results found")
+	ErrUnexpectedMultipleResults = pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "bigquery: unexpected multiple results")
+	ErrNoResultsFound            = pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "bigquery: no results found")
 )
 
 type EventStorage interface {

--- a/pkg/eventcounter/storage/v2/event.go
+++ b/pkg/eventcounter/storage/v2/event.go
@@ -45,8 +45,12 @@ var (
 	//go:embed sql/goal_count.sql
 	goalCountSQL string
 
-	ErrUnexpectedMultipleResults = pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "bigquery: unexpected multiple results")
-	ErrNoResultsFound            = pkgErr.NewErrorInternal(pkgErr.EventCounterPackageName, "bigquery: no results found")
+	ErrUnexpectedMultipleResults = pkgErr.NewErrorInternal(
+		pkgErr.EventCounterPackageName,
+		"bigquery: unexpected multiple results")
+	ErrNoResultsFound = pkgErr.NewErrorInternal(
+		pkgErr.EventCounterPackageName,
+		"bigquery: no results found")
 )
 
 type EventStorage interface {

--- a/pkg/eventcounter/storage/v2/experiment_result.go
+++ b/pkg/eventcounter/storage/v2/experiment_result.go
@@ -26,7 +26,10 @@ import (
 	proto "github.com/bucketeer-io/bucketeer/proto/eventcounter"
 )
 
-var ErrExperimentResultNotFound = pkgErr.NewErrorNotFound(pkgErr.EventCounterPackageName, "experiment result not found", "experiment_result")
+var ErrExperimentResultNotFound = pkgErr.NewErrorNotFound(
+	pkgErr.EventCounterPackageName,
+	"experiment result not found",
+	"experiment_result")
 
 var (
 	//go:embed sql/select_experiment_result.sql

--- a/pkg/eventcounter/storage/v2/experiment_result.go
+++ b/pkg/eventcounter/storage/v2/experiment_result.go
@@ -20,12 +20,13 @@ import (
 	_ "embed"
 	"errors"
 
+	pkgErr "github.com/bucketeer-io/bucketeer/pkg/error"
 	"github.com/bucketeer-io/bucketeer/pkg/eventcounter/domain"
 	"github.com/bucketeer-io/bucketeer/pkg/storage/v2/mysql"
 	proto "github.com/bucketeer-io/bucketeer/proto/eventcounter"
 )
 
-var ErrExperimentResultNotFound = errors.New("experimentResult: experiment result not found")
+var ErrExperimentResultNotFound = pkgErr.NewErrorNotFound(pkgErr.EventCounterPackageName, "experiment result not found", "experiment_result")
 
 var (
 	//go:embed sql/select_experiment_result.sql


### PR DESCRIPTION
This pull request refactors error handling in the environment API and its tests to standardize the conversion of internal errors to gRPC status responses. It also adds support for the `FAILED_PRECONDITION` error type in gRPC status conversion. The changes improve maintainability and consistency of error reporting throughout the service.