### PR TITLE
fix: nil pointer exception in feature stale watcher

### DIFF
--- a/pkg/notification/sender/sender.go
+++ b/pkg/notification/sender/sender.go
@@ -116,8 +116,7 @@ func (s *sender) Send(ctx context.Context, notificationEvent *senderproto.Notifi
 		// When a flag changes it must be checked before sending notifications
 		send := true
 		if notificationEvent.Notification.DomainEventNotification != nil {
-			// If this is a feature domain event, we need to check the tags
-			// Check if the subscription tag is configured in the feature flag
+			// If this is a feature domain event, we need to check if the subscription tag is configured in the flag
 			// If not, we skip the notification
 			send = s.checkForFeatureDomainEvent(
 				subscription,


### PR DESCRIPTION
To resolve https://github.com/bucketeer-io/bucketeer/issues/2166

The nil pointer exception happened here
https://github.com/bucketeer-io/bucketeer/blob/8b138dee32853d771438076d113e8bc7e36c8a5f/pkg/notification/sender/sender.go#L120
The function call to send the notification that created in this function
https://github.com/bucketeer-io/bucketeer/blob/8b138dee32853d771438076d113e8bc7e36c8a5f/pkg/batch/jobs/notification/feature_stale_watcher.go#L103-L126
But in here, no DomainEventNotification created so is nil in the entity.