### PR TITLE
fix: align migration imagePullSecrets with other services

### DIFF
--- a/manifests/bucketeer-migration/templates/atlas-migration.yaml
+++ b/manifests/bucketeer-migration/templates/atlas-migration.yaml
@@ -10,7 +10,7 @@ spec:
   {{- end }}
   template:
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- with .Values.image.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/manifests/bucketeer-migration/values.yaml
+++ b/manifests/bucketeer-migration/values.yaml
@@ -6,8 +6,7 @@ image:
   repository: ghcr.io/bucketeer-io/bucketeer-migration
   pullPolicy: IfNotPresent
   tag: v0.4.5 # x-release-please-version
-
-imagePullSecrets: []
+  imagePullSecrets: []
 
 backoffLimit: 0
 ttlSecondsAfterFinished:

--- a/manifests/bucketeer/templates/atlas-migration.yaml
+++ b/manifests/bucketeer/templates/atlas-migration.yaml
@@ -14,7 +14,7 @@ spec:
   {{- end }}
   template:
     spec:
-      {{- with .Values.migration.imagePullSecrets }}
+      {{- with .Values.migration.imagePullSecrets | default .Values.global.image.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: Never

--- a/manifests/bucketeer/values.yaml
+++ b/manifests/bucketeer/values.yaml
@@ -1,22 +1,19 @@
 global:
   image:
     tag: v2.1.1 # x-release-please-version
-    imagePullSecrets:
-  
+    imagePullSecrets: # Used by all services including migration
   # Global data warehouse configuration
   dataWarehouse:
     # Data warehouse type configuration
     # Supported types: bigquery, mysql
-    type: bigquery  # Options: bigquery, mysql
+    type: bigquery # Options: bigquery, mysql
     batchSize: 1000
     timezone: "UTC"
-    
     # BigQuery configuration (used when type: bigquery)
     bigquery:
       project: ""
       dataset: ""
       location: ""
-    
     # MySQL configuration (used when type: mysql)
     mysql:
       useMainConnection: true
@@ -25,7 +22,6 @@ global:
       user: ""
       password: ""
       database: ""
-  
   pubsub:
     # Type of pubsub to use: redis-stream or google
     type: ""
@@ -50,8 +46,7 @@ migration:
   image:
     repository: ghcr.io/bucketeer-io/bucketeer-migration
     tag: v2.1.1 # x-release-please-version
-
-  imagePullSecrets: []
+  # imagePullSecrets: []  # Optional: Override global.image.imagePullSecrets for migration only
 
   backoffLimit: 0
   ttlSecondsAfterFinished:


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2202

Use `global.image.imagePullSecrets` for the migration Job, consistent with api, 
web, batch, and subscriber services. Adds optional override capability via 
migration.imagePullSecrets for special cases.

Fixes 403 errors when pulling migration images from private registries.