### PR TITLE
docs: refine the RFC of the migrating i18n

### DIFF
--- a/docs/rfcs/move-i18n-logic-to-frontend.md
+++ b/docs/rfcs/move-i18n-logic-to-frontend.md
@@ -218,7 +218,7 @@ e.g. Error Response
 
 ### 2. The complete way
 
-Use the `messageKey`, other metadata, and message template files to show the complete message.
+Use the `messageKey`, other metadata, and message template files to show the complete message for each `details` element.
 As the current implementation, react-i18next is useful to embed nouns.
 We don't need to be aware of field names of the metadata except `messageKey` while developing the frontend.
 


### PR DESCRIPTION
I update some points of the RFC for https://github.com/bucketeer-io/bucketeer/issues/1253, following https://github.com/bucketeer-io/bucketeer/pull/1436.

### 1. Clarified the scope
- Clarified to focus only error messages and ignore domain events.

### 2. Improved the error response
- Lessened the message keys by using the general keys as before.
- Enabled to add fields more flexibly (key name and the number)

### 3. Added the frontend 

### 4. Clarified the development flow

- Currently, because only some parts of the backend use the new error struct, the frontend cannot show the error message correctly.

- We need to be aware of the compatibility and consistency between backend and frontend.





