### PR TITLE
chore: remove project name from environment url code

### DIFF
--- a/pkg/environment/api/organization.go
+++ b/pkg/environment/api/organization.go
@@ -17,7 +17,6 @@ package api
 import (
 	"context"
 	"errors"
-	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
@@ -779,10 +778,9 @@ func (s *EnvironmentService) createDefaultEnvironments(
 		"Production",
 	}
 	for _, name := range envNames {
-		envURLCode := fmt.Sprintf("%s-%s", project.UrlCode, strings.ToLower(name))
 		env, err := domain.NewEnvironmentV2(
 			name,
-			envURLCode,
+			strings.ToLower(name),
 			"",
 			project.Id,
 			organizationID,


### PR DESCRIPTION
Fix: https://github.com/bucketeer-io/bucketeer/issues/2225

The console URL is too long when creating trial organizations because of the repeated project name.

/project_url_code/project_url_code_environment_url_code

---

This pull request makes a small but important change to how default environment URL codes are generated in the `EnvironmentService`. Instead of combining the project's URL code with the lowercased environment name, the code now uses just the lowercased environment name for the environment's URL code.

- **Environment URL code generation simplified:**
  - In `pkg/environment/api/organization.go`, the environment URL code is now set to just the lowercased environment name, rather than a combination of the project's URL code and the environment name.
  - The unnecessary import of `fmt` was removed since string formatting is no longer needed.