### PR TITLE
fix: write last used at firing error request to database

### DIFF
--- a/pkg/account/domain/api_key.go
+++ b/pkg/account/domain/api_key.go
@@ -123,14 +123,3 @@ func (a *APIKey) Update(
 	updated.UpdatedAt = time.Now().Unix()
 	return updated, nil
 }
-
-func (a *APIKey) SetUsedAt(lastUsedAt int64) error {
-	if lastUsedAt <= 0 {
-		return ErrInvalidLastUsedAt
-	}
-	if a.LastUsedAt >= lastUsedAt {
-		return ErrLastUsedAtNotUpdated
-	}
-	a.LastUsedAt = lastUsedAt
-	return nil
-}

--- a/pkg/account/storage/v2/api_key.go
+++ b/pkg/account/storage/v2/api_key.go
@@ -40,6 +40,8 @@ var (
 	insertAPIKeyV2SQLQuery string
 	//go:embed sql/api_key_v2/update_api_key_v2.sql
 	updateAPIKeyV2SQLQuery string
+	//go:embed sql/api_key_v2/update_api_key_v2_last_used_at.sql
+	updateAPIKeyLastUsedAtV2SQLQuery string
 	//go:embed sql/api_key_v2/select_api_key_v2.sql
 	selectAPIKeyV2SQLQuery string
 	//go:embed sql/api_key_v2/select_api_key_v2_count.sql
@@ -88,7 +90,6 @@ func (s *accountStorage) UpdateAPIKey(ctx context.Context, k *domain.APIKey, env
 		k.Maintainer,
 		k.Description,
 		k.UpdatedAt,
-		k.LastUsedAt,
 		k.Id,
 		environmentID,
 	)
@@ -103,6 +104,29 @@ func (s *accountStorage) UpdateAPIKey(ctx context.Context, k *domain.APIKey, env
 		return ErrAPIKeyUnexpectedAffectedRows
 	}
 	return nil
+}
+
+func (s *accountStorage) UpdateAPIKeyLastUsedAt(
+	ctx context.Context,
+	id, environmentID string,
+	lastUsedAt int64,
+) (bool, error) {
+	result, err := s.qe.ExecContext(
+		ctx,
+		updateAPIKeyLastUsedAtV2SQLQuery,
+		lastUsedAt,
+		id,
+		environmentID,
+		lastUsedAt,
+	)
+	if err != nil {
+		return false, err
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return rowsAffected == 1, nil
 }
 
 func (s *accountStorage) GetAPIKey(ctx context.Context, id, environmentID string) (*domain.APIKey, error) {

--- a/pkg/account/storage/v2/api_key_test.go
+++ b/pkg/account/storage/v2/api_key_test.go
@@ -126,7 +126,6 @@ func TestUpdateAPIKey(t *testing.T) {
 	createdAt := int64(2)
 	updatedAt := int64(3)
 	maintainer := "demo@bucketeer.io"
-	lastUsedAt := int64(16000000000)
 
 	patterns := []struct {
 		desc          string
@@ -171,11 +170,11 @@ func TestUpdateAPIKey(t *testing.T) {
 				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
 					gomock.Any(),
 					gomock.Any(),
-					name, int32(role), disabled, maintainer, description, updatedAt, lastUsedAt, id, environmentId,
+					name, int32(role), disabled, maintainer, description, updatedAt, id, environmentId,
 				).Return(result, nil)
 			},
 			input: &domain.APIKey{
-				APIKey: &proto.APIKey{Id: id, Name: name, Role: role, Disabled: disabled, Maintainer: maintainer, Description: description, LastUsedAt: lastUsedAt, CreatedAt: createdAt, UpdatedAt: updatedAt},
+				APIKey: &proto.APIKey{Id: id, Name: name, Role: role, Disabled: disabled, Maintainer: maintainer, Description: description, CreatedAt: createdAt, UpdatedAt: updatedAt},
 			},
 			environmentId: environmentId,
 			expectedErr:   nil,

--- a/pkg/account/storage/v2/mock/storage.go
+++ b/pkg/account/storage/v2/mock/storage.go
@@ -268,6 +268,21 @@ func (mr *MockAccountStorageMockRecorder) UpdateAPIKey(ctx, k, environmentID any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAPIKey", reflect.TypeOf((*MockAccountStorage)(nil).UpdateAPIKey), ctx, k, environmentID)
 }
 
+// UpdateAPIKeyLastUsedAt mocks base method.
+func (m *MockAccountStorage) UpdateAPIKeyLastUsedAt(ctx context.Context, id, environmentID string, lastUsedAt int64) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAPIKeyLastUsedAt", ctx, id, environmentID, lastUsedAt)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAPIKeyLastUsedAt indicates an expected call of UpdateAPIKeyLastUsedAt.
+func (mr *MockAccountStorageMockRecorder) UpdateAPIKeyLastUsedAt(ctx, id, environmentID, lastUsedAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAPIKeyLastUsedAt", reflect.TypeOf((*MockAccountStorage)(nil).UpdateAPIKeyLastUsedAt), ctx, id, environmentID, lastUsedAt)
+}
+
 // UpdateAccountV2 mocks base method.
 func (m *MockAccountStorage) UpdateAccountV2(ctx context.Context, a *domain.AccountV2) error {
 	m.ctrl.T.Helper()

--- a/pkg/account/storage/v2/sql/api_key_v2/update_api_key_v2.sql
+++ b/pkg/account/storage/v2/sql/api_key_v2/update_api_key_v2.sql
@@ -4,8 +4,7 @@ UPDATE api_key SET
     disabled = ?,
     maintainer = ?,
     description = ?,
-    updated_at = ?,
-    last_used_at = ?
+    updated_at = ?
 WHERE
     id = ? AND
     environment_id = ?

--- a/pkg/account/storage/v2/sql/api_key_v2/update_api_key_v2_last_used_at.sql
+++ b/pkg/account/storage/v2/sql/api_key_v2/update_api_key_v2_last_used_at.sql
@@ -1,0 +1,5 @@
+UPDATE api_key
+SET last_used_at = ?
+WHERE id = ?
+  AND environment_id = ?
+  AND last_used_at < ?

--- a/pkg/account/storage/v2/storage.go
+++ b/pkg/account/storage/v2/storage.go
@@ -38,6 +38,7 @@ type AccountStorage interface {
 	GetSystemAdminAccountV2(ctx context.Context, email string) (*domain.AccountV2, error)
 	CreateAPIKey(ctx context.Context, k *domain.APIKey, environmentID string) error
 	UpdateAPIKey(ctx context.Context, k *domain.APIKey, environmentID string) error
+	UpdateAPIKeyLastUsedAt(ctx context.Context, id, environmentID string, lastUsedAt int64) (bool, error)
 	GetAPIKey(ctx context.Context, id, environmentID string) (*domain.APIKey, error)
 	GetAPIKeyByAPIKey(ctx context.Context, apiKey string, environmentID string) (*domain.APIKey, error)
 	GetEnvironmentAPIKey(ctx context.Context, apiKey string) (*domain.EnvironmentAPIKey, error)


### PR DESCRIPTION
If many pods saving the same data, `"error": "account:last used at not updated" ` error will be fired rapidly