### PR TITLE
fix: api key last seen writer is not executing correctly after graceful shutdown

### DIFF
--- a/pkg/api/api/save_api_key_last_used_at.go
+++ b/pkg/api/api/save_api_key_last_used_at.go
@@ -56,7 +56,8 @@ func (s *grpcGatewayService) writeAPIKeyLastUsedAtCacheToDatabase(ctx context.Co
 	ticker := time.NewTicker(time.Minute)
 	defer ticker.Stop()
 
-	writeCtx := context.Background()
+	writeCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
Part of #1894