### PR TITLE
fix: setting wrong role when creating an organization

### DIFF
--- a/pkg/environment/api/project.go
+++ b/pkg/environment/api/project.go
@@ -734,11 +734,10 @@ func (s *EnvironmentService) createTrialEnvironmentsAndAccounts(
 	createAccountReq := &accountproto.CreateAccountV2Request{
 		OrganizationId: project.OrganizationId,
 		Command: &accountproto.CreateAccountV2Command{
-			Email:          editor.Email,
-			Name:           strings.Split(editor.Email, "@")[0],
-			AvatarImageUrl: "",
-			// TODO Once we support new console design, we should set OWNER role.
-			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+			Email:            editor.Email,
+			Name:             strings.Split(editor.Email, "@")[0],
+			AvatarImageUrl:   "",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_OWNER,
 			EnvironmentRoles: envRoles,
 		},
 	}


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2251

Currently, when creating a new organization, the email in the request should be set as an owner, but it is being set as an admin instead due to the old console compatibility issues.
Since the new console has been released, we must update it.