### PR TITLE
chore: remove old console workarounds from account service

### DIFF
--- a/pkg/account/api/account_test.go
+++ b/pkg/account/api/account_test.go
@@ -199,9 +199,6 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 				).Do(func(ctx context.Context, fn func(ctx context.Context, tx mysql.Transaction) error) {
 					_ = fn(ctx, nil)
 				}).Return(nil)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().CreateAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
@@ -241,9 +238,6 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 				).Do(func(ctx context.Context, fn func(ctx context.Context, tx mysql.Transaction) error) {
 					_ = fn(ctx, nil)
 				}).Return(nil)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().CreateAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
@@ -278,9 +272,6 @@ func TestCreateAccountV2MySQL(t *testing.T) {
 				).Do(func(ctx context.Context, fn func(ctx context.Context, tx mysql.Transaction) error) {
 					_ = fn(ctx, nil)
 				}).Return(nil)
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(nil, nil)
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().CreateAccountV2(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
@@ -480,33 +471,22 @@ func TestCreateAccountV2NoCommandMySQL(t *testing.T) {
 					},
 				}, nil)
 
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2(
-					gomock.Any(), gomock.Any(), gomock.Any(),
-				).Return(&domain.AccountV2{
-					AccountV2: &accountproto.AccountV2{
-						Email:            "bucketeer@example.com",
-						FirstName:        "Test",
-						LastName:         "User",
-						Language:         "en",
-						OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
-					},
-				}, nil)
-
-				s.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
-					gomock.Any(), gomock.Any(),
-				).Return(nil)
-
-				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().UpdateAccountV2(
-					gomock.Any(), gomock.Any(),
-				).Return(nil)
-
 				s.mysqlClient.(*mysqlmock.MockClient).EXPECT().RunInTransactionV2(
 					gomock.Any(), gomock.Any(),
 				).Do(func(ctx context.Context, fn func(ctx context.Context, tx mysql.Transaction) error) {
 					err := fn(ctx, nil)
 					require.NoError(t, err)
 				}).Return(nil)
+
+				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().CreateAccountV2(
+					gomock.Any(), gomock.Any(),
+				).Return(nil)
+
 				s.adminAuditLogStorage.(*alstoragemock.MockAdminAuditLogStorage).EXPECT().CreateAdminAuditLog(
+					gomock.Any(), gomock.Any(),
+				).Return(nil)
+
+				s.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
 			},

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -303,16 +303,6 @@ func (s *AccountService) getConsoleAccountEnvironmentRoles(
 		if !ok || project.Disabled {
 			continue
 		}
-		// TODO: Remove this checking after the web console 3.0 is ready
-		// If the account is enabled in any environment in this organization,
-		// we append the organization.
-		// Note: When we disable an account on the web console,
-		// we are updating the role to UNASSIGNED, not the `disabled` column.
-		// When the new console is ready, we will use the DisableAccount API instead,
-		// which will update the `disabled` column in the DB.
-		if r.Role == accountproto.AccountV2_Role_Environment_UNASSIGNED {
-			continue
-		}
 		environmentRoles = append(environmentRoles, &accountproto.ConsoleAccount_EnvironmentRole{
 			Environment: env,
 			Role:        r.Role,
@@ -413,22 +403,6 @@ func (s *AccountService) getMyOrganizations(
 		// Otherwise, we check if the account is enabled in any environment in this organization.
 		if accWithOrg.OrganizationRole >= accountproto.AccountV2_Role_Organization_ADMIN {
 			myOrgs = append(myOrgs, accWithOrg.Organization)
-			continue
-		}
-		// TODO: Remove this loop after the web console 3.0 is ready
-		// If the account is enabled in any environment in this organization,
-		// we append the organization.
-		// Note: When we disable an account on the web console,
-		// we are updating the role to UNASSIGNED, not the `disabled` column.
-		// When the new console is ready, we will use the DisableAccount API instead,
-		// which will update the `disabled` column in the DB.
-		var enabled bool
-		for _, role := range accWithOrg.EnvironmentRoles {
-			if role.Role != accountproto.AccountV2_Role_Environment_UNASSIGNED {
-				enabled = true
-			}
-		}
-		if !enabled {
 			continue
 		}
 		myOrgs = append(myOrgs, accWithOrg.Organization)

--- a/pkg/account/api/admin_account_test.go
+++ b/pkg/account/api/admin_account_test.go
@@ -959,7 +959,7 @@ func TestGetMyOrganizationsAdminRole(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "success: member with unassigned roles gets organization excluded",
+			desc: "success: member with unassigned roles gets organization included",
 			setup: func(s *AccountService) {
 				s.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountsWithOrganization(
 					gomock.Any(), "member@example.com",
@@ -985,8 +985,15 @@ func TestGetMyOrganizationsAdminRole(t *testing.T) {
 					},
 				}, nil)
 			},
-			email:       "member@example.com",
-			expected:    []*environmentproto.Organization{},
+			email: "member@example.com",
+			expected: []*environmentproto.Organization{
+				{
+					Id:       "org1",
+					Name:     "Organization 1",
+					Disabled: false,
+					Archived: false,
+				},
+			},
 			expectedErr: nil,
 		},
 		{


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2254

Removes deprecated workarounds and temporary implementations from the account service that were added to support the old console during the migration period.

## Changes
1. **Removed UNASSIGNED role filtering** - The old console used to set environment roles to `UNASSIGNED` to "disable" accounts in the UI instead of using the proper `DisableAccountV2` API. This filtering logic is no longer needed.
   - Cleaned up `getConsoleAccountEnvironmentRoles()` 
   - Cleaned up `getMyOrganizations()`

2. **Removed double-write implementation in CreateAccountV2** - Previously, `CreateAccountV2` silently updated existing accounts instead of returning an error. This was added to provide idempotent behavior during trial project creation but is no longer necessary.
   - `CreateAccountV2` now strictly creates accounts
   - Returns `AlreadyExistsError` if account already exists

## Impact
- Cleaner, more predictable API behavior
- Removes technical debt from console migration
- No breaking changes (new console already uses correct APIs)

---

This pull request removes legacy logic and temporary workarounds related to account creation and organization membership checks, aligning the codebase with the new behavior for account and organization role management. The changes simplify both the implementation and corresponding tests by removing checks for "UNASSIGNED" roles and the double-write logic, ensuring that organizations are now always included for accounts regardless of their environment role assignment.

**Account creation logic simplification:**

* Removed the temporary double-write logic and checks for existing accounts in `CreateAccountV2` and `createAccountV2NoCommand` methods, so accounts are now created without checking for or updating existing records. [[1]](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L88-L107) [[2]](diffhunk://#diff-367ff6f5c3b5f777a1dd666145d677135bb7da65135e4b87e1948c082d6993b4L191-L206)

**Test updates for new logic:**

* Updated `TestCreateAccountV2MySQL` and `TestCreateAccountV2NoCommandMySQL` to remove expectations for `GetAccountV2` and `UpdateAccountV2` calls, reflecting the simplified account creation workflow. [[1]](diffhunk://#diff-ffabb142db3484beff462245beac845e55983dcb81fd0251920ca531b1207461L202-L204) [[2]](diffhunk://#diff-ffabb142db3484beff462245beac845e55983dcb81fd0251920ca531b1207461L244-L246) [[3]](diffhunk://#diff-ffabb142db3484beff462245beac845e55983dcb81fd0251920ca531b1207461L281-L283) [[4]](diffhunk://#diff-ffabb142db3484beff462245beac845e55983dcb81fd0251920ca531b1207461L483-R491)

**Organization membership logic update:**

* Removed checks that excluded organizations for accounts with only "UNASSIGNED" environment roles in both `getConsoleAccountEnvironmentRoles` and `getMyOrganizations`, so organizations are now always included regardless of role assignment. [[1]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L306-L315) [[2]](diffhunk://#diff-1097fbb3548177580d8c5e170cc44b5cb9db843fc88c1e618802ad74122cfc95L418-L433)

**Test updates for organization membership:**

* Updated `TestGetMyOrganizationsAdminRole` to expect organizations to be included even when a member only has "UNASSIGNED" roles, matching the new logic. [[1]](diffhunk://#diff-e56903718b2dfe1cdba4377e98b8bd79e3f96e87891f34e1f4c83886509270ceL962-R962) [[2]](diffhunk://#diff-e56903718b2dfe1cdba4377e98b8bd79e3f96e87891f34e1f4c83886509270ceL989-R996)