### PR TITLE
fix(ui/dashboard): remove extra slash causing 404 errors in navigation paths

### DIFF
--- a/ui/dashboard/src/pages/goal-details/page-content.tsx
+++ b/ui/dashboard/src/pages/goal-details/page-content.tsx
@@ -50,7 +50,7 @@ const PageContent = ({ goal }: { goal: Goal }) => {
           action: t('deleted')
         })
       });
-      navigate(`/${currentEnvironment.urlCode}/${PAGE_PATH_GOALS}`);
+      navigate(`/${currentEnvironment.urlCode}${PAGE_PATH_GOALS}`);
     }
   });
 

--- a/ui/dashboard/src/pages/user-segments/user-segment-modal/flags-connected-modal/index.tsx
+++ b/ui/dashboard/src/pages/user-segments/user-segment-modal/flags-connected-modal/index.tsx
@@ -46,7 +46,7 @@ const FlagsConnectedModal = ({
             >
               <p>{index + 1}.</p>
               <Link
-                to={`/${currentEnvironment.urlCode}/${PAGE_PATH_FEATURES}/${item.id}/targeting`}
+                to={`/${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${item.id}/targeting`}
                 className="underline"
               >
                 {item.name}


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2272

Fixed 404 errors:

- User Segments → "Flags Connected" modal → clicking feature flag links
- Goal Details → after deleting a goal → redirect to goals list