### PR TITLE
fix(ui/dashboard): axios interceptor not waiting for token refresh on 401

### DIFF
--- a/ui/dashboard/src/@api/axios-client.ts
+++ b/ui/dashboard/src/@api/axios-client.ts
@@ -41,7 +41,7 @@ axiosClient.interceptors.response.use(
       !isRefreshing
     ) {
       isRefreshing = true;
-      refreshTokenFetcher(authToken?.refreshToken)
+      return refreshTokenFetcher(authToken?.refreshToken)
         .then(response => {
           const newAccessToken = response.token.accessToken;
           setTokenStorage(response.token);
@@ -51,6 +51,7 @@ axiosClient.interceptors.response.use(
               bubbles: true
             })
           );
+          isRefreshing = false;
           return axiosClient(originalRequest);
         })
         .catch(err => {


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2277

When opening the console after the access token expired (e.g., after 1 day),  users were immediately logged out with a 401 error, even though the refresh token was still valid (7-day TTL).

## Root Cause

The axios response interceptor was triggering token refresh on 401 errors, but not returning the refresh promise. This caused:

1. Token refresh started in the background
2. Original request rejected immediately
3. User saw 401 error and got logged out
4. Token refresh completed too late (after logout already happened)

Additionally, the `isRefreshing` flag was never reset after a successful refresh, 
preventing subsequent 401s from triggering refresh.

## Solution

**File:** `ui/dashboard/src/@api/axios-client.ts`

1. Added `return` keyword before `refreshTokenFetcher()` call (line 44)
   - Interceptor now waits for the token refresh to complete
   
2. Reset `isRefreshing = false` after successful refresh (line 54)
   - Allows subsequent 401 errors to trigger a refresh

## Expected Behavior

**Before:** Opening console after 1 day → 401 error → immediate logout

**After:** Opening console after 1 day → 401 detected → token refreshed → 
request retried with new token → dashboard loads successfully