### PR TITLE
fix: prevent login page flash during token refresh on app load

### DIFF
--- a/ui/dashboard/src/auth/auth-context.tsx
+++ b/ui/dashboard/src/auth/auth-context.tsx
@@ -150,6 +150,7 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       setMyOrganizations(organizationsList);
     } catch (error) {
       errorNotify(error);
+      setIsInitialLoading(false);
     }
   };
 
@@ -184,20 +185,13 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   }, []);
 
   useEffect(() => {
-    const handleTokenRefreshed = () => {
-      setIsInitialLoading(false);
-    };
-    window.addEventListener('tokenRefreshed', handleTokenRefreshed);
-    window.addEventListener('unauthenticated', () => {
+    const handleUnauthenticated = () => {
       logout();
       clearOrgIdStorage();
-    });
+    };
+    window.addEventListener('unauthenticated', handleUnauthenticated);
     return () => {
-      window.removeEventListener('tokenRefreshed', handleTokenRefreshed);
-      window.removeEventListener('unauthenticated', () => {
-        logout();
-        clearOrgIdStorage();
-      });
+      window.removeEventListener('unauthenticated', handleUnauthenticated);
     };
   }, []);
 


### PR DESCRIPTION
Related to https://github.com/bucketeer-io/bucketeer/issues/2277

Removed the `tokenRefreshed` event handler that prematurely set `isInitialLoading` to false before retried requests completed, causing a brief flash of the login page.

Now `isInitialLoading` only resets after the authentication flow fully completes in onMeFetcher, ensuring smooth UX when opening the console with an expired access token.

---

This pull request simplifies the authentication event handling logic in the `AuthProvider` component by removing unnecessary event listeners and ensuring proper loading state management when errors occur.

Authentication event handling:

* Removed the `tokenRefreshed` event listener and its associated state update, consolidating logic to only handle the `unauthenticated` event for logging out and clearing organization storage. (`ui/dashboard/src/auth/auth-context.tsx`, [ui/dashboard/src/auth/auth-context.tsxL187-R194](diffhunk://#diff-baa1ff4728d4ad5e216ad792287b35cb9d83da0a92d48fc4bcadeb0921a7684dL187-R194))

Error handling and loading state:

* Ensured that `setIsInitialLoading(false)` is called when an error occurs while fetching organizations, so the loading state is properly reset. (`ui/dashboard/src/auth/auth-context.tsx`, [ui/dashboard/src/auth/auth-context.tsxR153](diffhunk://#diff-baa1ff4728d4ad5e216ad792287b35cb9d83da0a92d48fc4bcadeb0921a7684dR153))