### PR TITLE
chore: set log_bin_trust_function_creators for local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,6 +414,7 @@ deploy-bucketeer: delete-bucketeer-from-minikube
 	make -C ./ pull-dev-images
 	TAG=localenv make -C ./ build-docker-images
 	TAG=localenv make -C ./ minikube-load-images
+	kubectl exec localenv-mysql-0 -- bash -c "mysql -u root -pYnVja2V0ZWVy -e 'SET GLOBAL log_bin_trust_function_creators = 1;'"
 	helm install bucketeer manifests/bucketeer/ --values manifests/bucketeer/values.dev.yaml
 
 #############################

--- a/docker-compose/compose.yml
+++ b/docker-compose/compose.yml
@@ -22,6 +22,7 @@ services:
     volumes:
       - mysql_data:/var/lib/mysql
       - ./init-db:/docker-entrypoint-initdb.d
+      - ./config/mysql-conf:/etc/mysql/conf.d
     command: --default-authentication-plugin=mysql_native_password --character-set-server=utf8mb4 --collation-server=utf8mb4_general_ci
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-u", "bucketeer", "-pbucketeer"]

--- a/docker-compose/config/mysql-conf/log_bin.cnf
+++ b/docker-compose/config/mysql-conf/log_bin.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+log_bin_trust_function_creators = 1

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -69,7 +69,7 @@ migration:
 
   # URL to access the DB to do the migration
   # E.g. mysql://user:password@host:port/db_name
-  dbUrl: mysql://bucketeer:bucketeer@localenv-mysql.default.svc:3306/bucketeer
+  dbUrl: mysql://root:YnVja2V0ZWVy@localenv-mysql.default.svc:3306/bucketeer
 
   # The migration baseline
   # First revision

--- a/manifests/localenv/values.yaml
+++ b/manifests/localenv/values.yaml
@@ -47,6 +47,7 @@ mysql:
     database: "bucketeer"
     username: "bucketeer"
     password: "bucketeer"
+    rootPassword: "YnVja2V0ZWVy"
   primary:
     service:
       type: NodePort


### PR DESCRIPTION
Migration scripts now require log_bin_trust_function_creators to create function in the reset API key migration

Apply this setting helps running locally without running the command manually