### PR TITLE
test: fix delete goal e2e test

### DIFF
--- a/test/e2e/experiment/experiment_test.go
+++ b/test/e2e/experiment/experiment_test.go
@@ -499,7 +499,11 @@ func TestDeleteGoal(t *testing.T) {
 		Id:            goalID,
 		EnvironmentId: *environmentID,
 	})
-	assert.Equal(t, "rpc error: code = NotFound desc = experiment:not found, experiment", err.Error())
+	if err == nil {
+		t.Fatal("Expected error when getting deleted goal, got nil")
+	}
+	assert.Contains(t, err.Error(), "rpc error: code = NotFound")
+	assert.Contains(t, err.Error(), "goal not found")
 }
 
 func TestStatusUpdateFromWaitingToRunning(t *testing.T) {


### PR DESCRIPTION
After refactoring the error message format for the experiment service, the e2e test for deleting a goal broke.