### PR TITLE
ci: correct branch name extraction for nested branch names

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -57,7 +57,10 @@ jobs:
         run: echo "value=$(git describe --tags --always --abbrev=7)" >> $GITHUB_OUTPUT
       - name: Store git ref value to output
         id: ref
-        run: echo "value=${GITHUB_REF##*/}" >> $GITHUB_OUTPUT
+        run: |
+          REF=${GITHUB_REF#refs/heads/}
+          REF=${REF#refs/tags/}
+          echo "value=$REF" >> $GITHUB_OUTPUT
       - name: Store the first line of commit message
         id: commit_message
         env:


### PR DESCRIPTION
The previous implementation used ${GITHUB_REF##*/} which only extracts the part after the last slash. This caused issues with branch names containing slashes (e.g., feat/test-domain → test-domain).

- Changed to use ${GITHUB_REF#refs/heads/} and ${GITHUB_REF#refs/tags/} to properly extract the full branch/tag name.

Before: refs/heads/feat/archive-domain → test-domain (incorrect)
After:  refs/heads/feat/archive-domain → feat/test-domain (correct)

This change does not affect existing workflows for main branch or tags.