### PR TITLE
feat: introduce gotestsum for improved test output formatting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GO_APP_DIRS := $(wildcard cmd/*)
 GO_APP_BUILD_TARGETS := $(addprefix build-,$(notdir $(GO_APP_DIRS)))
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
+GOTESTSUM_VERSION := v1.13.0
 
 ifeq ($(GOARCH), arm64)
 	PLATFORM = linux/arm64
@@ -156,7 +157,9 @@ build-go-embed: build-web-console $(GO_APP_BUILD_TARGETS) clean-web-console
 # Make sure bucketeer-httpstan is already running. If not, run "make start-httpstan".
 .PHONY: test-go
 test-go:
-	TZ=UTC CGO_ENABLED=0 go test -v ./pkg/... ./evaluation/go/...
+	TZ=UTC CGO_ENABLED=0 go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) \
+		--format pkgname \
+		-- -v ./pkg/... ./evaluation/go/...
 
 .PHONY: start-httpstan
 start-httpstan:


### PR DESCRIPTION
  ## Summary

 This PR introduces [gotestsum](https://github.com/gotestyourself/gotestsum) as the test runner for CI, replacing the standard `go test` command.
A bunch of oss use this tool(ref: https://github.com/gotestyourself/gotestsum?tab=readme-ov-file#who-uses-gotestsum)

  ### Changes

  - Added `GOTESTSUM_VERSION` variable to Makefile
  - Updated `test-go` target to use gotestsum with `--format pkgname`

  ### Benefits

  - **Improved readability**: Test output is formatted with one line per package, making it easier to scan results
  - **Better failure summaries**: Failed tests are clearly highlighted at the end of the run
  - **No installation required**: Uses `go run` to execute gotestsum directly
  - **No workflow changes needed**: Existing GitHub Actions workflow continues to work as-is

  ### Example Output

  Before:
```
  === RUN   TestSignDemoCreationToken
  === RUN   TestSignDemoCreationToken/success
  --- PASS: TestSignDemoCreationToken (0.00s)
      --- PASS: TestSignDemoCreationToken/success (0.00s)
      --- FAIL: ----
  ...
```

  After:
```
  ✓  pkg/token (812ms)
  ✓  pkg/locale (749ms)
  ✓  pkg/health (1.44s)
  
===FAIL: pkg/experimentcalculator/stan TestStanSample (0.00s)
```
