### PR TITLE
chore: change to use mysql as data warehouse in dev container

### DIFF
--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -7,7 +7,7 @@ global:
   dataWarehouse:
     # Data warehouse type configuration
     # Supported types: bigquery, mysql
-    type: bigquery # Options: bigquery, mysql
+    type: mysql # Options: bigquery, mysql
     batchSize: 1000
     timezone: "UTC"
 


### PR DESCRIPTION
MySQL is faster and more stable when running e2e tests for local development.