### PR TITLE
chore(evaluation): update typescript evaluation version to 0.0.7

### DIFF
--- a/evaluation/typescript/CHANGELOG.md
+++ b/evaluation/typescript/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.7] (2026-01-20)
+
+### Fix
+
+- fix(evaluation): align equals/in semver fallback behavior with comparison operators [#2355](https://github.com/bucketeer-io/bucketeer/pull/2355)
+
 ## [0.0.6] (2025-11-19)
 
 ### Features

--- a/evaluation/typescript/package.json
+++ b/evaluation/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bucketeer/evaluation",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
I have released.
https://www.npmjs.com/package/@bucketeer/evaluation?activeTab=versions