### PR TITLE
fix: segment e2e failed after switch to no command API

### DIFF
--- a/test/e2e/feature/segment_test.go
+++ b/test/e2e/feature/segment_test.go
@@ -222,8 +222,13 @@ func TestDeleteSegment(t *testing.T) {
 	)
 	assert.NotNil(t, res)
 	assert.NoError(t, err)
-	segment := getSegment(ctx, t, client, id)
-	assert.Equal(t, true, segment.Deleted)
+	// Verify that the segment is actually deleted
+	req := &featureproto.GetSegmentRequest{
+		Id:            id,
+		EnvironmentId: *environmentID,
+	}
+	_, err = client.GetSegment(ctx, req)
+	assert.NotNil(t, err)
 }
 
 func TestListSegmentsPageSize(t *testing.T) {


### PR DESCRIPTION
Root cause:
- In the old delete segment using command pattern, it's the soft delete.
- The API with no command use hard delete hence cause nil pointer in the assertion.

Part of #2073