### PR TITLE
fix(devcontainer): make httpstan docker targets idempotent

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -172,6 +172,35 @@ docker compose -f docker-compose/compose.yml restart api
 docker-compose -f docker-compose/compose.yml restart api
 ```
 
+# Running Unit Tests
+
+Before running unit tests, ensure that the httpstan container is running. The experiment package unit tests depend on httpstan for Bayesian analysis.
+
+### Start httpstan
+
+```shell
+make start-httpstan
+```
+
+This command is idempotent - it will:
+- Skip if the container is already running
+- Start the existing container if it was stopped
+- Create and start a new container if it doesn't exist
+
+### Run Unit Tests
+
+```shell
+make test-go
+```
+
+### Stop httpstan (Optional)
+
+When you're done running tests:
+
+```shell
+make stop-httpstan
+```
+
 # Running E2E Tests
 
 ## For Minikube Setup

--- a/Makefile
+++ b/Makefile
@@ -172,11 +172,19 @@ test-go:
 
 .PHONY: start-httpstan
 start-httpstan:
-	docker run --name bucketeer-httpstan -p 8080:8080 -d ghcr.io/bucketeer-io/bucketeer-httpstan:0.0.1
+	@if docker ps -q -f name=bucketeer-httpstan | grep -q .; then \
+		echo "httpstan container is already running"; \
+	elif docker ps -aq -f name=bucketeer-httpstan | grep -q .; then \
+		echo "Starting existing httpstan container..."; \
+		docker start bucketeer-httpstan; \
+	else \
+		echo "Creating and starting httpstan container..."; \
+		docker run --name bucketeer-httpstan -p 8080:8080 -d ghcr.io/bucketeer-io/bucketeer-httpstan:0.0.1; \
+	fi
 
 .PHONY: stop-httpstan
 stop-httpstan:
-	docker stop bucketeer-httpstan
+	@docker stop bucketeer-httpstan 2>/dev/null || echo "httpstan container is not running"
 
 #############################
 # Charts


### PR DESCRIPTION
### Summary

- Fix `start-httpstan` target to handle existing containers (running or stopped) gracefully
- Fix `stop-httpstan` target to not fail when the container is not running
- Updated docs explaining how to run unit tests in the dev-container