### PR TITLE
chore: use updated_at for server sdk feature hash to match client sdk

### DIFF
--- a/evaluation/go/user_evaluations.go
+++ b/evaluation/go/user_evaluations.go
@@ -48,7 +48,10 @@ func UserEvaluationsID(userID string, userMetadata map[string]string, features [
 	sort.SliceStable(features, func(i, j int) bool {
 		return features[i].Id < features[j].Id
 	})
-	// TODO: consider about a better hash algorithm?
+	// FNV-1a 64-bit is sufficient for change detection:
+	// - Fast enough for SDK polling frequency
+	// - 64-bit provides negligible collision risk for feature flag counts
+	// - No cryptographic requirements
 	h := fnv.New64a()
 	h.Write([]byte(userID)) // nolint:errcheck
 	keys := sortMapKeys(userMetadata)
@@ -74,9 +77,13 @@ func GenerateFeaturesID(features []*ftproto.Feature) string {
 	sort.SliceStable(features, func(i, j int) bool {
 		return features[i].Id < features[j].Id
 	})
+	// FNV-1a 64-bit is sufficient for change detection:
+	// - Fast enough for SDK polling frequency
+	// - 64-bit provides negligible collision risk for feature flag counts
+	// - No cryptographic requirements
 	h := fnv.New64a()
 	for _, feature := range features {
-		fmt.Fprintf(h, "%s:%d", feature.Id, feature.Version)
+		fmt.Fprintf(h, "%s:%d", feature.Id, feature.UpdatedAt)
 	}
 	return strconv.FormatUint(h.Sum64(), 10)
 }

--- a/evaluation/go/user_evaluations_test.go
+++ b/evaluation/go/user_evaluations_test.go
@@ -95,7 +95,72 @@ func TestSortMapKeys(t *testing.T) {
 	}
 }
 
+func TestUserEvaluationsID(t *testing.T) {
+	patterns := []struct {
+		desc         string
+		userID       string
+		userMetadata map[string]string
+		features     []*ftproto.Feature
+		expected     string
+	}{
+		{
+			desc:         "empty user ID, empty metadata, empty features",
+			userID:       "",
+			userMetadata: nil,
+			features:     nil,
+			expected:     "14695981039346656037",
+		},
+		{
+			desc:         "user ID only",
+			userID:       "user-1",
+			userMetadata: nil,
+			features:     nil,
+			expected:     "17891572797655370708",
+		},
+		{
+			desc:         "user ID with metadata",
+			userID:       "user-1",
+			userMetadata: map[string]string{"age": "25", "country": "jp"},
+			features:     nil,
+			expected:     "15857499200645826216",
+		},
+		{
+			desc:         "user ID with metadata and single feature",
+			userID:       "user-1",
+			userMetadata: map[string]string{"age": "25", "country": "jp"},
+			features: []*ftproto.Feature{
+				{
+					Id:        "feature-1",
+					UpdatedAt: 1000,
+				},
+			},
+			expected: "10450974209164395423",
+		},
+		{
+			desc:         "user ID with metadata and multiple features",
+			userID:       "user-1",
+			userMetadata: map[string]string{"age": "25", "country": "jp"},
+			features: []*ftproto.Feature{
+				{
+					Id:        "feature-1",
+					UpdatedAt: 1000,
+				},
+				{
+					Id:        "feature-2",
+					UpdatedAt: 2000,
+				},
+			},
+			expected: "7257619227440290900",
+		},
+	}
+	for _, p := range patterns {
+		actual := UserEvaluationsID(p.userID, p.userMetadata, p.features)
+		assert.Equal(t, p.expected, actual, p.desc)
+	}
+}
+
 func TestGenerateFeaturesID(t *testing.T) {
+	// Note: GenerateFeaturesID uses UpdatedAt (not Version) to generate the hash
 	patterns := []struct {
 		desc     string
 		input    []*ftproto.Feature
@@ -110,8 +175,8 @@ func TestGenerateFeaturesID(t *testing.T) {
 			desc: "success: single",
 			input: []*ftproto.Feature{
 				{
-					Id:      "id-1",
-					Version: 1,
+					Id:        "id-1",
+					UpdatedAt: 1,
 				},
 			},
 			expected: "5476413260388599211",
@@ -120,12 +185,12 @@ func TestGenerateFeaturesID(t *testing.T) {
 			desc: "success: multiple",
 			input: []*ftproto.Feature{
 				{
-					Id:      "id-1",
-					Version: 1,
+					Id:        "id-1",
+					UpdatedAt: 1,
 				},
 				{
-					Id:      "id-2",
-					Version: 2,
+					Id:        "id-2",
+					UpdatedAt: 2,
 				},
 			},
 			expected: "17283374094628184689",

--- a/evaluation/typescript/src/userEvaluation.ts
+++ b/evaluation/typescript/src/userEvaluation.ts
@@ -27,6 +27,11 @@ function sortMapKeys(data: Record<string, string>): string[] {
   return keys;
 }
 
+// GenerateFeaturesID generates a hash ID for the server SDK to detect feature flag changes.
+// It uses FNV-1a 64-bit hash algorithm which is:
+// - Fast enough for SDK polling frequency
+// - 64-bit provides negligible collision risk for feature flag counts
+// - No cryptographic requirements for change detection
 function GenerateFeaturesID(features: Feature[]): string {
   // Sort features based on the 'id'
   features.sort((a, b) => (a.getId() < b.getId() ? -1 : 1));
@@ -34,9 +39,9 @@ function GenerateFeaturesID(features: Feature[]): string {
   // Initialize FNV-1a 64-bit hash string
   let hashInput = '';
 
-  // Concatenate each feature's 'id' and 'version' into the hash input
+  // Concatenate each feature's 'id' and 'updatedAt' into the hash input
   features.forEach((feature) => {
-    hashInput += `${feature.getId()}:${feature.getVersion()}`;
+    hashInput += `${feature.getId()}:${feature.getUpdatedAt()}`;
   });
 
   // Generate the FNV-1a 64-bit hash and return it as a decimal string
@@ -44,6 +49,11 @@ function GenerateFeaturesID(features: Feature[]): string {
   return hash.dec();
 }
 
+// UserEvaluationsID generates a hash ID for the client SDK to detect evaluation changes.
+// It uses FNV-1a 64-bit hash algorithm which is:
+// - Fast enough for SDK polling frequency
+// - 64-bit provides negligible collision risk for feature flag counts
+// - No cryptographic requirements for change detection
 function UserEvaluationsID(
   userID: string,
   userMetadata: Record<string, string>, // equivalent to map[string]string in Go

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -63,8 +63,14 @@ import (
 const (
 	listRequestSize         = 500
 	secondsToReturnAllFlags = 30 * 24 * 60 * 60 // 30 days
-	secondsForAdjustment    = 10                // 10 seconds
-	obfuscateAPIKeyLength   = 4
+	// secondsForAdjustment is a safety buffer subtracted from the SDK's requestedAt timestamp
+	// when filtering for updated items. This handles:
+	// - Minor clock skew between SDK and server
+	// - Race conditions where items are updated during the request window
+	// - Near-simultaneous updates that might otherwise be missed
+	// The value should be small enough to avoid excessive duplicate data in responses.
+	secondsForAdjustment  = 10
+	obfuscateAPIKeyLength = 4
 )
 
 var (
@@ -820,7 +826,9 @@ func (s *grpcGatewayService) GetFeatureFlags(
 			ForceUpdate:            true,
 		}, nil
 	}
-	// Check and return only the updated feature flags
+	// Check and return only the updated feature flags.
+	// We subtract a small buffer (secondsForAdjustment) from the SDK's requestedAt
+	// to account for clock skew and ensure recently updated flags aren't missed.
 	adjustedRequestedAt := req.RequestedAt - secondsForAdjustment
 	updatedFeatures := make([]*featureproto.Feature, 0, len(targetFeatures))
 	archivedIDs := make([]string, 0)
@@ -987,7 +995,9 @@ func (s *grpcGatewayService) GetSegmentUsers(
 		}
 	}
 
-	// Filter the updated segments
+	// Filter the updated segments.
+	// We subtract a small buffer (secondsForAdjustment) from the SDK's requestedAt
+	// to account for clock skew and ensure recently updated segments aren't missed.
 	updatedSegments := make([]*featureproto.SegmentUsers, 0, len(targetSegmentUsers))
 	adjustedRequestedAt := req.RequestedAt - secondsForAdjustment
 	for _, su := range targetSegmentUsers {

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -1436,6 +1436,9 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 			Archived:  true,
 		},
 	}
+	// Calculate expected feature flags IDs dynamically using UpdatedAt
+	multiFeaturesID := evaluation.GenerateFeaturesID(multiFeatures[:3])
+	singleFeatureID := evaluation.GenerateFeaturesID(singleFeature)
 	patterns := []struct {
 		desc        string
 		setup       func(*grpcGatewayService)
@@ -1597,7 +1600,7 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId: "12580091098247002273",
+				FeatureFlagsId: multiFeaturesID,
 				Features: []*featureproto.Feature{
 					multiFeatures[0],
 					multiFeatures[1],
@@ -1628,12 +1631,12 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 			},
 			input: &gwproto.GetFeatureFlagsRequest{
 				Tag:            "",
-				FeatureFlagsId: "12580091098247002273",
+				FeatureFlagsId: multiFeaturesID,
 				SourceId:       eventproto.SourceId_GO_SERVER,
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId:         "12580091098247002273",
+				FeatureFlagsId:         multiFeaturesID,
 				Features:               []*featureproto.Feature{},
 				ArchivedFeatureFlagIds: make([]string, 0),
 				RequestedAt:            timeNow.Unix(),
@@ -1666,7 +1669,7 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId: "12580091098247002273",
+				FeatureFlagsId: multiFeaturesID,
 				Features: []*featureproto.Feature{
 					multiFeatures[0],
 					multiFeatures[1],
@@ -1702,7 +1705,7 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId:         "13164487566000689278",
+				FeatureFlagsId:         singleFeatureID,
 				Features:               singleFeature,
 				RequestedAt:            timeNow.Unix(),
 				ArchivedFeatureFlagIds: make([]string, 0),
@@ -1729,12 +1732,12 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 			},
 			input: &gwproto.GetFeatureFlagsRequest{
 				Tag:            tag,
-				FeatureFlagsId: "13164487566000689278",
+				FeatureFlagsId: singleFeatureID,
 				SourceId:       eventproto.SourceId_GO_SERVER,
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId:         "13164487566000689278",
+				FeatureFlagsId:         singleFeatureID,
 				Features:               []*featureproto.Feature{},
 				ArchivedFeatureFlagIds: make([]string, 0),
 				RequestedAt:            timeNow.Unix(),
@@ -1766,7 +1769,7 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId:         "13164487566000689278",
+				FeatureFlagsId:         singleFeatureID,
 				Features:               singleFeature,
 				ArchivedFeatureFlagIds: make([]string, 0),
 				RequestedAt:            timeNow.Unix(),
@@ -1799,7 +1802,7 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 				SdkVersion:     "v0.0.1",
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
-				FeatureFlagsId:         "13164487566000689278",
+				FeatureFlagsId:         singleFeatureID,
 				Features:               make([]*featureproto.Feature, 0),
 				ArchivedFeatureFlagIds: []string{multiFeatures[4].Id},
 				RequestedAt:            timeNow.Unix(),


### PR DESCRIPTION
This is not a bug. I'm unifying the hash algorithm used for evaluation detection to maintain consistency across SDKs.