### PR TITLE
feat(insights): add 2 and update 1 Prometheus metrics

### DIFF
--- a/docs/rfcs/0045-insights-dashboard.md
+++ b/docs/rfcs/0045-insights-dashboard.md
@@ -153,13 +153,13 @@ CREATE TABLE `monthly_summary` (
 
 ### Prometheus Metrics
 
-Use 1 existing metric and add 3 new metrics.
+Use 2 existing metrics and add 2 new metrics.
 
 | Metric        | Name                                         | Status   | Note                                                                                                                                      |
 | ------------- | -------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | Request count | `bucketeer_gateway_api_request_total`        | Existing | Has all required labels                                                                                                                   |
 | Latency       | `bucketeer_gateway_api_handling_seconds`     | New      | Existing `bucketeer_grpc_server_handling_seconds` lacks `environment_id` and `source_id` labels                                           |
-| Evaluations   | `bucketeer_gateway_api_evaluations_v2_total` | New      | Existing `bucketeer_gateway_api_evaluations_total` lacks `source_id` label                                                                |
+| Evaluations   | `bucketeer_gateway_api_evaluations_total` | Existing | Add `source_id` label, remove `project_id`/`project_url_code` labels                                                                      |
 | Error count   | `bucketeer_gateway_api_error_total`          | New      | Existing `bucketeer_grpc_server_handled_total` lacks `environment_id` and `source_id` labels.<br>Error rate = error_total / request_total |
 
 ## Tasks

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -413,11 +413,7 @@ func (s *grpcGatewayService) GetEvaluations(
 			)...,
 		)
 		evaluationsCounter.WithLabelValues(
-			projectID, envAPIKey.ProjectUrlCode, environmentId,
-			envAPIKey.Environment.UrlCode, req.Tag, codeBadRequest).Inc()
-		evaluationsCounterV2.WithLabelValues(
-			environmentId,
-			envAPIKey.Environment.UrlCode, req.Tag, codeBadRequest, sourceID).Inc()
+			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeBadRequest, sourceID).Inc()
 		return nil, err
 	}
 
@@ -429,11 +425,8 @@ func (s *grpcGatewayService) GetEvaluations(
 		},
 	)
 	if err != nil {
-		evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError).Inc()
-		evaluationsCounterV2.WithLabelValues(
-			environmentId,
-			envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
+		evaluationsCounter.WithLabelValues(
+			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
 		apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetEvaluations).Inc()
 		return nil, err
 	}
@@ -442,10 +435,8 @@ func (s *grpcGatewayService) GetEvaluations(
 	filteredByTag := s.filterByTag(features, req.Tag)
 
 	if len(features) == 0 {
-		evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode, environmentId,
-			envAPIKey.Environment.UrlCode, req.Tag, codeNoFeatures).Inc()
-		evaluationsCounterV2.WithLabelValues(environmentId,
-			envAPIKey.Environment.UrlCode, req.Tag, codeNoFeatures, sourceID).Inc()
+		evaluationsCounter.WithLabelValues(
+			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeNoFeatures, sourceID).Inc()
 		return &gwproto.GetEvaluationsResponse{
 			State:             featureproto.UserEvaluations_FULL,
 			Evaluations:       s.emptyUserEvaluations(),
@@ -454,9 +445,7 @@ func (s *grpcGatewayService) GetEvaluations(
 	}
 	ueid := evaluation.UserEvaluationsID(req.User.Id, req.User.Data, filteredByTag)
 	if req.UserEvaluationsId == ueid {
-		evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeNone).Inc()
-		evaluationsCounterV2.WithLabelValues(
+		evaluationsCounter.WithLabelValues(
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeNone, sourceID).Inc()
 		s.logger.Debug(
 			"Features length when UEID is the same",
@@ -476,9 +465,7 @@ func (s *grpcGatewayService) GetEvaluations(
 
 	segmentUsersMap, err := s.getSegmentUsersMap(ctx, features, environmentId)
 	if err != nil {
-		evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError).Inc()
-		evaluationsCounterV2.WithLabelValues(
+		evaluationsCounter.WithLabelValues(
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
 		apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetEvaluations).Inc()
 		s.logger.Error(
@@ -497,10 +484,8 @@ func (s *grpcGatewayService) GetEvaluations(
 	if req.UserEvaluationCondition == nil {
 		// Old evaluation requires tag to be set.
 		if req.Tag == "" {
-			evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode, environmentId,
-				envAPIKey.Environment.UrlCode, req.Tag, codeBadRequest).Inc()
-			evaluationsCounterV2.WithLabelValues(environmentId, envAPIKey.Environment.UrlCode,
-				req.Tag, codeBadRequest, sourceID).Inc()
+			evaluationsCounter.WithLabelValues(
+				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeBadRequest, sourceID).Inc()
 			return nil, ErrTagRequired
 		}
 		evaluations, err = evaluator.EvaluateFeatures(
@@ -510,9 +495,7 @@ func (s *grpcGatewayService) GetEvaluations(
 			req.Tag,
 		)
 		if err != nil {
-			evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError).Inc()
-			evaluationsCounterV2.WithLabelValues(
+			evaluationsCounter.WithLabelValues(
 				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
 			apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetEvaluations).Inc()
 
@@ -540,9 +523,7 @@ func (s *grpcGatewayService) GetEvaluations(
 			)
 			return nil, ErrInternal
 		}
-		evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeOld).Inc()
-		evaluationsCounterV2.WithLabelValues(
+		evaluationsCounter.WithLabelValues(
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeOld, sourceID).Inc()
 	} else {
 		evaluations, err = evaluator.EvaluateFeaturesByEvaluatedAt(
@@ -555,9 +536,7 @@ func (s *grpcGatewayService) GetEvaluations(
 			req.Tag,
 		)
 		if err != nil {
-			evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError).Inc()
-			evaluationsCounterV2.WithLabelValues(
+			evaluationsCounter.WithLabelValues(
 				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
 			apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetEvaluations).Inc()
 
@@ -589,14 +568,10 @@ func (s *grpcGatewayService) GetEvaluations(
 			return nil, ErrInternal
 		}
 		if evaluations.ForceUpdate {
-			evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeAll).Inc()
-			evaluationsCounterV2.WithLabelValues(
+			evaluationsCounter.WithLabelValues(
 				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeAll, sourceID).Inc()
 		} else {
-			evaluationsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
-				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeDiff).Inc()
-			evaluationsCounterV2.WithLabelValues(
+			evaluationsCounter.WithLabelValues(
 				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeDiff, sourceID).Inc()
 		}
 	}

--- a/pkg/api/api/metrics.go
+++ b/pkg/api/api/metrics.go
@@ -184,18 +184,6 @@ var (
 			Subsystem: "gateway",
 			Name:      "api_evaluations_total",
 			Help:      "Total number of evaluations",
-			// TODO: Remove project_id.
-		}, []string{
-			"project_id", "project_url_code",
-			"environment_id", "environment_url_code", "tag", "evaluation_type",
-		})
-	// evaluationsCounterV2 exists for filtering by source_id.
-	evaluationsCounterV2 = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: "bucketeer",
-			Subsystem: "gateway",
-			Name:      "api_evaluations_v2_total",
-			Help:      "Total number of evaluations with source_id label",
 		}, []string{"environment_id", "environment_url_code", "tag", "evaluation_type", "source_id"})
 	getFeatureFlagsCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -347,7 +335,6 @@ func registerMetrics(r metrics.Registerer) {
 			sdkErrorCounter,
 			evaluationEventErrorReasonCounter,
 			handledSecondsHistogram,
-			evaluationsCounterV2,
 			apiErrorCounter,
 		)
 	})


### PR DESCRIPTION
part of https://github.com/bucketeer-io/bucketeer/issues/2151
defined in the rfc#45 https://github.com/bucketeer-io/bucketeer/pull/2371/

Add two new metrics and start counting for the Insights Dashboard:
- handledSecondsHistogram: Latency tracking with `environment_id`, `source_id`, `method` labels
- evaluationsCounterV2: Evaluation counts with `environment_id`, `source_id` labels
- apiErrorCounter: Internal error counts with `environment_id`, `source_id`,  `method` labels

These metrics enable filtering by Environment/SDK/API in the dashboard.

The request count metrics already exist and have enough labels.