### PR TITLE
fix(ui/dashboard): fix auto-archive custom days value being reset on modal reopen

### DIFF
--- a/ui/dashboard/src/pages/project-details/environments/environment-modal/environment-create-update-modal/index.tsx
+++ b/ui/dashboard/src/pages/project-details/environments/environment-modal/environment-create-update-modal/index.tsx
@@ -89,8 +89,7 @@ const PRESET_DAYS = [7, 14, 30] as const;
 
 const isPresetDays = (days: number | undefined): boolean => {
   return (
-    days !== undefined &&
-    (PRESET_DAYS as readonly number[]).includes(days)
+    days !== undefined && (PRESET_DAYS as readonly number[]).includes(days)
   );
 };
 
@@ -117,7 +116,6 @@ const EnvironmentCreateUpdateModal = ({
   );
 
   const disabled = !envEditable || !isOrganizationAdmin;
-
 
   const [customDaysOverride, setCustomDaysOverride] = useState<boolean | null>(
     null


### PR DESCRIPTION
 ## Summary

  - Fix a bug where custom auto-archive days (e.g., 10) were reset to 7 when reopening the environment settings modal.
  - Unify `PRESET_DAYS` as the single source of truth for preset day options.

## Problem

1. Form initial value: `autoArchiveUnusedDays` checked if the saved value was in `PRESET_DAYS` ([7, 14, 30]) and fell back to `7` if not — discarding any custom value
2. Custom input visibility: `isCustomDays` was always initialized as `useState(false)`, so even when the server returned a custom value, the custom input field was never shown