### PR TITLE
ci: fix clang-format installation

### DIFF
--- a/.github/workflows/pr-go.yaml
+++ b/.github/workflows/pr-go.yaml
@@ -108,12 +108,19 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install protoc-gen-go-grpc
         run: go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-grpc-gateway@${{ env.PROTOC_GEN_GO_GRPC_VERSION }}
-      - name:  Check proto format
-        uses: jidicula/clang-format-action@6cd220de46c89139a0365edae93eee8eb30ca8fe # v4.16.0
-        with:
-          clang-format-version: '14'
-          check-path: 'proto'
-          exclude-regex: 'external' # googleapis proto files
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format-14
+      - name: Check proto format
+        run: |
+          cd proto
+          failed=0
+          for f in $(find . -name '*.proto' -not -path './external/*'); do
+            if ! clang-format-14 --dry-run --Werror --style=file --fallback-style=llvm "$f"; then
+              echo "Failed: $f"
+              failed=1
+            fi
+          done
+          exit $failed
       - name: Check proto lock
         run: make proto-lock-check
 


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2403

Fix the following [error](https://github.com/bucketeer-io/bucketeer/actions/runs/21983670448/job/63512376902):

```sh
Unable to find image 'ghcr.io/jidicula/clang-format:14' locally
14: Pulling from jidicula/clang-format
docker: failed to copy: httpReadSeeker: failed open: content at https://ghcr.io/v2/jidicula/clang-format/manifests/sha256:252d4b64b41bd4cdedf592d29ae0fa43ac1d0e491b3b332cc0ed5c6714c3a402 not found: not found
```

Reference issue: https://github.com/jidicula/clang-format-action/issues/267