### PR TITLE
fix: add scheduled_feature_change to delete-e2e-data-mysql

### DIFF
--- a/hack/delete-e2e-data-mysql/Dockerfile
+++ b/hack/delete-e2e-data-mysql/Dockerfile
@@ -1,5 +1,12 @@
+FROM golang:1.25 AS builder
+
+WORKDIR /app
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o delete-e2e-data-mysql .
+
 FROM gcr.io/distroless/base
 
-COPY delete-e2e-data-mysql /usr/local/bin/
+COPY --from=builder /app/delete-e2e-data-mysql /usr/local/bin/
 
 ENTRYPOINT ["delete-e2e-data-mysql"]

--- a/hack/delete-e2e-data-mysql/Makefile
+++ b/hack/delete-e2e-data-mysql/Makefile
@@ -1,3 +1,6 @@
+TAG=v0.0.9
+IMAGE=ghcr.io/bucketeer-io/bucketeer-delete-e2e-data-mysql
+
 .PHONY: deps
 deps:
 	go mod tidy
@@ -12,14 +15,19 @@ build-darwin:
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o ./delete-e2e-data-mysql .
 
 .PHONY: docker-build
-docker-build: clean build
-	docker build . -t bucketeer-delete-e2e-data-mysql:$(TAG)
+docker-build:
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		-t $(IMAGE):$(TAG) \
+		.
 
 .PHONY: docker-push
 docker-push:
 	@echo $(PAT) | docker login ghcr.io -u $(GITHUB_USER_NAME) --password-stdin
-	docker tag bucketeer-delete-e2e-data-mysql:$(TAG) ghcr.io/bucketeer-io/bucketeer-delete-e2e-data-mysql:$(TAG)
-	docker push ghcr.io/bucketeer-io/bucketeer-delete-e2e-data-mysql:$(TAG)
+	docker buildx build \
+		--platform linux/amd64,linux/arm64 \
+		-t $(IMAGE):$(TAG) \
+		--push .
 
 .PHONY: clean
 clean:

--- a/hack/delete-e2e-data-mysql/command.go
+++ b/hack/delete-e2e-data-mysql/command.go
@@ -48,6 +48,7 @@ var (
 		{table: "ops_progressive_rollout", targetField: "feature_id"},
 		{table: "flag_trigger", targetField: "description"},
 		{table: "code_reference", targetField: "feature_id"},
+		{table: "scheduled_feature_change", targetField: "feature_id"},
 		{table: "feature", targetField: "id"},
 		{table: "api_key", targetField: "name"},
 	}


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2408

I have rebuilt and pushed the new version to [GHRC](https://github.com/orgs/bucketeer-io/packages/container/bucketeer-delete-e2e-data-mysql/690609538?tag=v0.0.9).

## Summary

- Add `scheduled_feature_change` table to the e2e data cleanup script to fix a foreign key constraint error when deleting from the `feature` table
- Update Dockerfile to multi-stage build so Go compilation happens inside the container
- Update Makefile to support multi-arch (`linux/amd64` + `linux/arm64`) Docker builds using `docker buildx`