### PR TITLE
fix(ui): prevent infinite 401 retry loop in axios interceptor

### DIFF
--- a/ui/dashboard/src/@api/axios-client.ts
+++ b/ui/dashboard/src/@api/axios-client.ts
@@ -29,18 +29,21 @@ axiosClient.interceptors.response.use(
     const authToken = getTokenStorage();
     const originalRequest = error.config;
     if (!authToken && error.response?.status === 401) {
-      return document.dispatchEvent(
+      document.dispatchEvent(
         new CustomEvent('unauthenticated', {
           bubbles: true
         })
       );
+      return Promise.reject(error);
     }
     if (
       authToken?.refreshToken &&
       error.response?.status === 401 &&
-      !isRefreshing
+      !isRefreshing &&
+      !originalRequest._retry
     ) {
       isRefreshing = true;
+      originalRequest._retry = true;
       return refreshTokenFetcher(authToken?.refreshToken)
         .then(response => {
           const newAccessToken = response.token.accessToken;
@@ -63,6 +66,13 @@ axiosClient.interceptors.response.use(
           );
           return Promise.reject(err);
         });
+    }
+    if (error.response?.status === 401 && originalRequest._retry) {
+      document.dispatchEvent(
+        new CustomEvent('unauthenticated', {
+          bubbles: true
+        })
+      );
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2455

## Summary

- Fix an infinite retry loop in the axios response interceptor that occurs when a
  request fails with 401 due to a non-token issue (e.g., invalid `environmentId`).
  Previously, the interceptor would refresh the token (which succeeds), retry the
  original request (which fails again with 401), and re-enter the refresh block
  indefinitely — generating ~5-10 error logs per second per open tab on the backend.
- Add a `_retry` flag to ensure each request is only refreshed and retried once.
  If the retried request still returns 401, dispatch `unauthenticated` to force
  logout instead of looping.
- Also fix the no-token 401 branch to properly reject the promise instead of
  returning the result of `dispatchEvent`.