### PR TITLE
refactor: replace %v with %w in fmt.Errorf for proper error wrapping

### DIFF
--- a/evaluation/go/evaluation.go
+++ b/evaluation/go/evaluation.go
@@ -380,7 +380,7 @@ func (e *evaluator) convertVariationValue(
 func yamlToJSON(yamlStr string) (string, error) {
 	var data interface{}
 	if err := yaml.Unmarshal([]byte(yamlStr), &data); err != nil {
-		return "", fmt.Errorf("%w: %v", ErrYAMLToJSONConversion, err)
+		return "", fmt.Errorf("%w: %w", ErrYAMLToJSONConversion, err)
 	}
 
 	// Convert map[interface{}]interface{} to map[string]interface{} for JSON compatibility
@@ -388,7 +388,7 @@ func yamlToJSON(yamlStr string) (string, error) {
 
 	jsonBytes, err := json.Marshal(data)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrYAMLToJSONConversion, err)
+		return "", fmt.Errorf("%w: %w", ErrYAMLToJSONConversion, err)
 	}
 	return string(jsonBytes), nil
 }

--- a/hack/create-pubsub-topics/command.go
+++ b/hack/create-pubsub-topics/command.go
@@ -104,7 +104,7 @@ func (c *command) createTopic(ctx context.Context, client *pubsub.Client, topicN
 		defer existsCancel()
 		exists, existsErr := topic.Exists(existsCtx)
 		if existsErr != nil {
-			return fmt.Errorf("failed to check if topic exists: %w (create error: %v)", existsErr, err)
+			return fmt.Errorf("failed to check if topic exists: %w (create error: %w)", existsErr, err)
 		}
 		if exists {
 			logger.Info("Topic already exists", zap.String("topic", topicName))

--- a/hack/redis-data-copy/command.go
+++ b/hack/redis-data-copy/command.go
@@ -104,7 +104,7 @@ func (c *command) scanAndCopyBatch(src, dest v3.Client, logger *zap.Logger) erro
 				zap.Error(err),
 				zap.Uint64("cursor", cursor),
 			)
-			return fmt.Errorf("error scanning keys from source Redis: %v", err)
+			return fmt.Errorf("error scanning keys from source Redis: %w", err)
 		}
 
 		copiedKeys, err := c.copyBatch(src, dest, keys, logger)
@@ -145,18 +145,18 @@ func (c *command) copyBatch(src, dest v3.Client, keys []string, logger *zap.Logg
 				logger.Info("Key not found", zap.String("key", key))
 				continue
 			}
-			return copiedKeys, fmt.Errorf("error dumping key %s: %v", key, err)
+			return copiedKeys, fmt.Errorf("error dumping key %s: %w", key, err)
 		}
 
 		exists, err := dest.Exists(key)
 		if err != nil {
-			return copiedKeys, fmt.Errorf("error checking key existence %s: %v", key, err)
+			return copiedKeys, fmt.Errorf("error checking key existence %s: %w", key, err)
 		}
 
 		if exists == 1 {
 			if *c.overrideDestKey {
 				if err := dest.Del(key); err != nil {
-					return copiedKeys, fmt.Errorf("error deleting existing key %s: %v", key, err)
+					return copiedKeys, fmt.Errorf("error deleting existing key %s: %w", key, err)
 				}
 			} else {
 				logger.Info("Skipping existing key", zap.String("key", key))
@@ -167,7 +167,7 @@ func (c *command) copyBatch(src, dest v3.Client, keys []string, logger *zap.Logg
 		err = dest.Restore(key, 0, dumpedValue)
 
 		if err != nil {
-			return copiedKeys, fmt.Errorf("error restoring key %s: %v", key, err)
+			return copiedKeys, fmt.Errorf("error restoring key %s: %w", key, err)
 		}
 		copiedKeys++
 	}

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -552,13 +552,13 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		gateway.WithKeyPath(*s.keyPath),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create API gateway: %v", err)
+		return fmt.Errorf("failed to create API gateway: %w", err)
 	}
 
 	serverCtx, serverCtxCancel := context.WithCancel(context.Background())
 	defer serverCtxCancel()
 	if err := apiGateway.Start(serverCtx, gatewayHandler); err != nil {
-		return fmt.Errorf("failed to start API gateway: %v", err)
+		return fmt.Errorf("failed to start API gateway: %w", err)
 	}
 
 	restHealthChecker := health.NewRestChecker(

--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -643,13 +643,13 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		gateway.WithKeyPath(*s.keyPath),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create batch gateway: %v", err)
+		return fmt.Errorf("failed to create batch gateway: %w", err)
 	}
 
 	batchCtx, batchCancel := context.WithCancel(context.Background())
 	defer batchCancel()
 	if err := batchGateway.Start(batchCtx, batchHandler); err != nil {
-		return fmt.Errorf("failed to start batch gateway: %v", err)
+		return fmt.Errorf("failed to start batch gateway: %w", err)
 	}
 
 	defer func() {

--- a/pkg/rpc/client/log.go
+++ b/pkg/rpc/client/log.go
@@ -72,7 +72,7 @@ func makeUnmarshallable(msg interface{}) *unmarshallable {
 func (m *unmarshallable) MarshalJSON() ([]byte, error) {
 	b := &bytes.Buffer{}
 	if err := marshaler.Marshal(b, m); err != nil {
-		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
+		return nil, fmt.Errorf("jsonpb serializer failed: %w", err)
 	}
 	return b.Bytes(), nil
 }

--- a/pkg/rpc/gateway/gateway.go
+++ b/pkg/rpc/gateway/gateway.go
@@ -248,7 +248,7 @@ func NewGateway(restAddr string, opts ...Option) (*Gateway, error) {
 	if options.logger == nil {
 		logger, err := log.NewLogger()
 		if err != nil {
-			return nil, fmt.Errorf("failed to create logger: %v", err)
+			return nil, fmt.Errorf("failed to create logger: %w", err)
 		}
 		options.logger = logger
 	}
@@ -342,7 +342,7 @@ func (g *Gateway) Start(ctx context.Context,
 	if g.opts.certPath != "" {
 		creds, err := credentials.NewClientTLSFromFile(g.opts.certPath, "")
 		if err != nil {
-			return fmt.Errorf("failed to create grpc-gateway TLS credentials: %v", err)
+			return fmt.Errorf("failed to create grpc-gateway TLS credentials: %w", err)
 		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(creds))
 	} else {
@@ -369,7 +369,7 @@ func (g *Gateway) Start(ctx context.Context,
 	// connections will be closed automatically by the generated gateway code.
 	for _, registerFunc := range registerFuncs {
 		if err := registerFunc(ctx, mux, dialOpts); err != nil {
-			return fmt.Errorf("failed to register grpc-gateway handler: %v", err)
+			return fmt.Errorf("failed to register grpc-gateway handler: %w", err)
 		}
 	}
 
@@ -400,7 +400,7 @@ func (g *Gateway) Start(ctx context.Context,
 	// Check if there was an immediate error
 	select {
 	case err := <-errChan:
-		return fmt.Errorf("failed to start grpc-gateway: %v", err)
+		return fmt.Errorf("failed to start grpc-gateway: %w", err)
 	default:
 		// No immediate error, server is starting
 		g.logger.Debug("grpc-gateway started",

--- a/pkg/rpc/log.go
+++ b/pkg/rpc/log.go
@@ -99,7 +99,7 @@ zap json encoder calls json.Marshal when doing zap.Reflected()
 func (m *marshallable) MarshalJSON() ([]byte, error) {
 	b := &bytes.Buffer{}
 	if err := marshaler.Marshal(b, m.Message); err != nil {
-		return nil, fmt.Errorf("jsonpb serializer failed: %v", err)
+		return nil, fmt.Errorf("jsonpb serializer failed: %w", err)
 	}
 	return b.Bytes(), nil
 }

--- a/pkg/token/verifier.go
+++ b/pkg/token/verifier.go
@@ -59,15 +59,15 @@ func NewVerifier(keyPath, issuer, audience string) (Verifier, error) {
 func (v *verifier) VerifyAccessToken(rawAccessToken string) (*AccessToken, error) {
 	jws, err := jose.ParseSigned(rawAccessToken, []jose.SignatureAlgorithm{v.algorithm})
 	if err != nil {
-		return nil, fmt.Errorf("malformed jwt: %v", err)
+		return nil, fmt.Errorf("malformed jwt: %w", err)
 	}
 	payload, err := jws.Verify(v.pubKey)
 	if err != nil {
-		return nil, fmt.Errorf("invalid jwt: %v", err)
+		return nil, fmt.Errorf("invalid jwt: %w", err)
 	}
 	t := &AccessToken{}
 	if err := json.Unmarshal(payload, t); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal claims: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal claims: %w", err)
 	}
 	if t.Issuer != v.issuer {
 		return nil, fmt.Errorf("id token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)
@@ -87,15 +87,15 @@ func (v *verifier) VerifyAccessToken(rawAccessToken string) (*AccessToken, error
 func (v *verifier) VerifyRefreshToken(rawRefreshToken string) (*RefreshToken, error) {
 	jws, err := jose.ParseSigned(rawRefreshToken, []jose.SignatureAlgorithm{v.algorithm})
 	if err != nil {
-		return nil, fmt.Errorf("malformed jwt: %v", err)
+		return nil, fmt.Errorf("malformed jwt: %w", err)
 	}
 	payload, err := jws.Verify(v.pubKey)
 	if err != nil {
-		return nil, fmt.Errorf("invalid jwt: %v", err)
+		return nil, fmt.Errorf("invalid jwt: %w", err)
 	}
 	t := &RefreshToken{}
 	if err := json.Unmarshal(payload, t); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal claims: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal claims: %w", err)
 	}
 	if t.Expiry.Before(time.Now()) {
 		return nil, fmt.Errorf("token is expired (Token Expiry: %v)", t.Expiry)
@@ -109,15 +109,15 @@ func (v *verifier) VerifyRefreshToken(rawRefreshToken string) (*RefreshToken, er
 func (v *verifier) VerifyDemoCreationToken(rawDemoToken string) (*DemoCreationToken, error) {
 	jws, err := jose.ParseSigned(rawDemoToken, []jose.SignatureAlgorithm{v.algorithm})
 	if err != nil {
-		return nil, fmt.Errorf("malformed jwt: %v", err)
+		return nil, fmt.Errorf("malformed jwt: %w", err)
 	}
 	payload, err := jws.Verify(v.pubKey)
 	if err != nil {
-		return nil, fmt.Errorf("invalid jwt: %v", err)
+		return nil, fmt.Errorf("invalid jwt: %w", err)
 	}
 	t := &DemoCreationToken{}
 	if err := json.Unmarshal(payload, t); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal claims: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal claims: %w", err)
 	}
 	if t.Issuer != v.issuer {
 		return nil, fmt.Errorf("demo token issued by a different provider, expected %q got %q", v.issuer, t.Issuer)

--- a/pkg/web/cmd/server/server.go
+++ b/pkg/web/cmd/server/server.go
@@ -878,11 +878,11 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		gatewayapi.WithKeyPath(*s.keyPath),
 	)
 	if err != nil {
-		return fmt.Errorf("failed to create web gRPC gateway: %v", err)
+		return fmt.Errorf("failed to create web gRPC gateway: %w", err)
 	}
 
 	if err := webGrpcGateway.Start(ctx, s.createGatewayHandlers()...); err != nil {
-		return fmt.Errorf("failed to start web gRPC gateway: %v", err)
+		return fmt.Errorf("failed to start web gRPC gateway: %w", err)
 	}
 
 	defer func() {


### PR DESCRIPTION
For issue: #2475 

This commit updates fmt.Errorf calls to use the %w verb instead of %v when the argument is an error type. This ensures the error chain is preserved, allowing callers to inspect underlying errors using errors.Is() and errors.As().

Note:
- Only modified fmt.Errorf calls where the argument is definitively an error.
- Ignored non-error values (e.g., %v for structs/integers).
- Ignored testing.Fatalf and grpc/status.Errorf as they do not support %w.