### PR TITLE
fix(ui): update now option is scheduling instead of updating immediately

### DIFF
--- a/ui/dashboard/src/pages/feature-flags/page-loader.tsx
+++ b/ui/dashboard/src/pages/feature-flags/page-loader.tsx
@@ -168,8 +168,8 @@ const PageLoader = () => {
                   values={{
                     name: selectedFlag.name,
                     state: selectedFlag.enabled
-                      ? t('disabled')
-                      : t('enabled')
+                      ? t('form:disabled')
+                      : t('form:enabled')
                   }}
                 />
               )


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2480

Fix the "Update now" radio button in the flag list confirmation modal, calling the auto ops scheduling API instead of the flag update API to toggle the flag immediately

The flag list page (`page-loader.tsx`) was using `ConfirmationRequiredModal` from the shared component at `pages/feature-flag-details/elements/confirm-required-modal`, which sends `scheduleType: 'UPDATE_NOW'` when the "Update now" radio button is selected.

However, `handleToggleFeatureState` was checking `['ENABLE', 'DISABLE'].includes(scheduleType)` — a condition left over from the old local modal that used `'ENABLE'`/`'DISABLE'` as values. Since `'UPDATE_NOW'` didn't match, every submission fell through to the `else` branch and called `autoOpsCreator` (scheduling API) instead of `featureUpdater` (direct update API).

**Fix:** Inverted the logic to check for `SCHEDULE_TYPE_SCHEDULE` explicitly, so only the "Schedule" option triggers `autoOpsCreator`. Everything else (including `'UPDATE_NOW'`) correctly calls `featureUpdater`.