### PR TITLE
fix(insights): use recordingRule in batch

### DIFF
--- a/pkg/batch/jobs/monthlysummary/prometheus.go
+++ b/pkg/batch/jobs/monthlysummary/prometheus.go
@@ -23,7 +23,11 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-const metricRequestTotal = "bucketeer_gateway_api_request_total"
+const (
+	recordingRuleRequestTotal = "environment_id:source_id:method:bucketeer_gateway_api_request_total:rate5m"
+	// Step size must match the recording rule's rate window (5m).
+	recordingRuleStep = 5 * time.Minute
+)
 
 // queryRequestCounts retrieves request counts from Prometheus for all environment/sourceID combinations.
 // Returns map[environmentID]map[sourceID]count.
@@ -32,7 +36,7 @@ func (m *monthlySummarizer) queryRequestCounts(
 	targetDate time.Time,
 ) (map[string]map[string]int64, error) {
 	duration, evalTime := calculateTimeParams(targetDate)
-	query := requestCountIncreaseQuery(duration)
+	query := requestCountQuery(duration)
 
 	vector, err := m.promClient.QueryInstant(ctx, query, evalTime)
 	if err != nil {
@@ -53,14 +57,23 @@ func calculateTimeParams(targetDate time.Time) (duration time.Duration, evaluati
 	return
 }
 
-// requestCountIncreaseQuery builds an instant query for total request count over a duration.
-// Use with Instant Query at the end of the duration.
-func requestCountIncreaseQuery(duration time.Duration) string {
-	seconds := int(duration.Seconds())
+// requestCountQuery builds an instant query using the recording rule.
+// sum_over_time aggregates the rate5m values at 5m intervals,
+// then * 300 converts the sum of rates to total request count.
+// Subtract one step from the range because the subquery includes both ends.
+func requestCountQuery(duration time.Duration) string {
+	rangeDuration := duration - recordingRuleStep
+	if rangeDuration < time.Second {
+		rangeDuration = time.Second
+	}
+	seconds := int(rangeDuration.Seconds())
+	stepSeconds := int(recordingRuleStep / time.Second)
 	return fmt.Sprintf(
-		`sum by (environment_id,source_id) (increase(%s[%ds]))`,
-		metricRequestTotal,
+		`sum by (environment_id,source_id) (sum_over_time(%s[%ds:%dm])) * %d`,
+		recordingRuleRequestTotal,
 		seconds,
+		int(recordingRuleStep.Minutes()),
+		stepSeconds,
 	)
 }
 

--- a/pkg/batch/jobs/monthlysummary/prometheus_test.go
+++ b/pkg/batch/jobs/monthlysummary/prometheus_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_requestCountIncreaseQuery(t *testing.T) {
+func Test_requestCountQuery(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -34,34 +34,34 @@ func Test_requestCountIncreaseQuery(t *testing.T) {
 		{
 			desc:     "1 hour",
 			duration: time.Hour,
-			expected: `sum by (environment_id,source_id) (increase(bucketeer_gateway_api_request_total[3600s]))`,
+			expected: `sum by (environment_id,source_id) (sum_over_time(environment_id:source_id:method:bucketeer_gateway_api_request_total:rate5m[3300s:5m])) * 300`,
 		},
 		{
 			desc:     "31 days (January)",
 			duration: 31 * 24 * time.Hour,
-			expected: `sum by (environment_id,source_id) (increase(bucketeer_gateway_api_request_total[2678400s]))`,
+			expected: `sum by (environment_id,source_id) (sum_over_time(environment_id:source_id:method:bucketeer_gateway_api_request_total:rate5m[2678100s:5m])) * 300`,
 		},
 		{
 			desc:     "30 days (April)",
 			duration: 30 * 24 * time.Hour,
-			expected: `sum by (environment_id,source_id) (increase(bucketeer_gateway_api_request_total[2592000s]))`,
+			expected: `sum by (environment_id,source_id) (sum_over_time(environment_id:source_id:method:bucketeer_gateway_api_request_total:rate5m[2591700s:5m])) * 300`,
 		},
 		{
 			desc:     "29 days (February, leap year)",
 			duration: 29 * 24 * time.Hour,
-			expected: `sum by (environment_id,source_id) (increase(bucketeer_gateway_api_request_total[2505600s]))`,
+			expected: `sum by (environment_id,source_id) (sum_over_time(environment_id:source_id:method:bucketeer_gateway_api_request_total:rate5m[2505300s:5m])) * 300`,
 		},
 		{
 			desc:     "28 days (February)",
 			duration: 28 * 24 * time.Hour,
-			expected: `sum by (environment_id,source_id) (increase(bucketeer_gateway_api_request_total[2419200s]))`,
+			expected: `sum by (environment_id,source_id) (sum_over_time(environment_id:source_id:method:bucketeer_gateway_api_request_total:rate5m[2418900s:5m])) * 300`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
-			q := requestCountIncreaseQuery(tt.duration)
+			q := requestCountQuery(tt.duration)
 			assert.Equal(t, tt.expected, q)
 		})
 	}


### PR DESCRIPTION
part of #2151 

I fixed to use the Prometheus recording rule in the daily batch.
Currently, I'm mistakenly using raw metrics, which causes a timeout due to a long query.

