### PR TITLE
fix(ui): remove schedule option from flag switch confirmation modal

### DIFF
--- a/ui/dashboard/src/pages/feature-flag-details/elements/confirm-required-modal/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/elements/confirm-required-modal/index.tsx
@@ -380,7 +380,7 @@ const ConfirmationRequiredModal = ({
                 </>
               )}
               <div className="flex flex-col w-full px-5 pb-5">
-                  <Form.Field
+                <Form.Field
                   control={control}
                   name="comment"
                   render={({ field }) => (
@@ -415,9 +415,7 @@ const ConfirmationRequiredModal = ({
                           <Checkbox
                             ref={field.ref}
                             checked={field.value}
-                            onCheckedChange={checked =>
-                              field.onChange(checked)
-                            }
+                            onCheckedChange={checked => field.onChange(checked)}
                             title={t('form:reset-sampling')}
                           />
                         </Form.Control>

--- a/ui/dashboard/src/pages/feature-flags/page-loader.tsx
+++ b/ui/dashboard/src/pages/feature-flags/page-loader.tsx
@@ -45,7 +45,6 @@ const PageLoader = () => {
   const [selectedFlag, setSelectedFlag] = useState<Feature>();
   const [isArchiving, setIsArchiving] = useState(false);
 
-
   const [openConfirmModal, onOpenConfirmModal, onCloseConfirmModal] =
     useToggleOpen(false);
 


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2485

## Summary

- Removed the schedule option from the flag switch confirmation modal on the feature flags list page. The schedule flow via auto-ops API does not support saving the comment or resetting the sampling seed, so it is being removed until the new scheduling feature (which supports both) is ready.
- Fixed the comment field and reset the sampling checkbox to always be visible regardless of the selected option, instead of being hidden when the schedule radio button was selected.
