### PR TITLE
revert: "fix: set longer writeTimeout for longer batches"

### DIFF
--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -623,7 +623,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		rpc.WithService(healthChecker),
 		rpc.WithHandler("/health", healthChecker), // Liveness probe
 		rpc.WithHandler("/ready", healthChecker),  // Readiness probe
-		rpc.WithTimeouts(30*time.Second, 3600*time.Second, 60*time.Second),
 	)
 	go server.Run()
 


### PR DESCRIPTION
This reverts commit 59318b4841eeb00dbcfb1aba3fd10010c847cc3e, which was unintentionally pushed directly.

Let me open a new PR with the same content later.


