### PR TITLE
fix(insighst): use longer `writeTimeout` for batches

### DIFF
--- a/pkg/batch/cmd/server/server.go
+++ b/pkg/batch/cmd/server/server.go
@@ -597,7 +597,6 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 			cachev3.NewMAUCache(cachev3.NewRedisCache(persistentRedisClient)),
 			insightsstorage.NewMonthlySummaryStorage(mysqlClient),
 			promClient,
-			jobs.WithTimeout(30*time.Minute),
 			jobs.WithLogger(logger),
 		),
 		logger,
@@ -624,7 +623,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		rpc.WithService(healthChecker),
 		rpc.WithHandler("/health", healthChecker), // Liveness probe
 		rpc.WithHandler("/ready", healthChecker),  // Readiness probe
-		rpc.WithTimeouts(30*time.Second, 3600*time.Second, 60*time.Second),
+		rpc.WithTimeouts(30*time.Second, time.Hour, 60*time.Second),
 	)
 	go server.Run()
 


### PR DESCRIPTION
The batch server repeatedly retries the monthly-summary batch every 30 secs with `context canceled` errors.

The cause was the 30s `writeTimeout` of the batch server.

The long `writeTimeout` does not matter because each job has `jobs.WithTimeout()`.

`readTimeout` and `idleTimeout` are the same as the default values.

cf. writeTimeout: https://pkg.go.dev/net/http#Server

log: 

```json
{
  "severity": "INFO",
  "eventTime": 1774509987.5884523,
  "logger": "bucketeer-batch.server.monthly-summarizer",
  "caller": "monthlysummary/monthly_summarizer.go:75",
  "message": "MonthlySummarizer start running",
  "serviceContext": {
    "service": "bucketeer-batch.server",
    "version": "-"
  }
}
{
  "severity": "ERROR",
  "eventTime": 1774510007.2168393,
  "logger": "bucketeer-batch.server.monthly-summarizer",
  "caller": "monthlysummary/monthly_summarizer.go:127",
  "message": "Failed to upsert monthly_summary batch",
  "serviceContext": {
    "service": "bucketeer-batch.server",
    "version": "-"
  },
  "error": "context canceled",
  "stacktrace": "github.com/bucketeer-io/bucketeer/v2/pkg/batch/jobs/monthlysummary.(*monthlySummarizer).Run\n\t/home/runner/work/bucketeer/bucketeer/pkg/batch/jobs/monthlysummary/monthly_summarizer.go:127\ngithub.com/bucketeer-io/bucketeer/v2/pkg/batch/api.(*batchService).ExecuteBatchJob\n\t/home/runner/work/bucketeer/bucketeer/pkg/batch/api/api.go:125\ngithub.com/bucketeer-io/bucketeer/v2/proto/batch._BatchService_ExecuteBatchJob_Handler.func1\n\t/home/runner/work/bucketeer/bucketeer/proto/batch/service.pb.go:422\ngithub.com/bucketeer-io/bucketeer/v2/pkg/rpc.(*Server).setupRPC.AuthUnaryServerInterceptor.func2\n\t/home/runner/work/bucketeer/bucketeer/pkg/rpc/auth.go:110\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1242\ngithub.com/bucketeer-io/bucketeer/v2/pkg/rpc.(*Server).setupRPC.MetricsUnaryServerInterceptor.func1\n\t/home/runner/work/bucketeer/bucketeer/pkg/rpc/metrics.go:81\ngoogle.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1233\ngithub.com/bucketeer-io/bucketeer/v2/proto/batch._BatchService_ExecuteBatchJob_Handler\n\t/home/runner/work/bucketeer/bucketeer/proto/batch/service.pb.go:424\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1429\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1855\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1064"
}
{
  "severity": "INFO",
  "eventTime": 1774510017.6374087,
  "logger": "bucketeer-batch.server.monthly-summarizer",
  "caller": "monthlysummary/monthly_summarizer.go:75",
  "message": "MonthlySummarizer start running",
  "serviceContext": {
    "service": "bucketeer-batch.server",
    "version": "-"
  }
}
{
  "severity": "ERROR",
  "eventTime": 1774510037.1765072,
  "logger": "bucketeer-batch.server.monthly-summarizer",
  "caller": "monthlysummary/monthly_summarizer.go:127",
  "message": "Failed to upsert monthly_summary batch",
  "serviceContext": {
    "service": "bucketeer-batch.server",
    "version": "-"
  },
  "error": "context canceled",
  "stacktrace": "github.com/bucketeer-io/bucketeer/v2/pkg/batch/jobs/monthlysummary.(*monthlySummarizer).Run\n\t/home/runner/work/bucketeer/bucketeer/pkg/batch/jobs/monthlysummary/monthly_summarizer.go:127\ngithub.com/bucketeer-io/bucketeer/v2/pkg/batch/api.(*batchService).ExecuteBatchJob\n\t/home/runner/work/bucketeer/bucketeer/pkg/batch/api/api.go:125\ngithub.com/bucketeer-io/bucketeer/v2/proto/batch._BatchService_ExecuteBatchJob_Handler.func1\n\t/home/runner/work/bucketeer/bucketeer/proto/batch/service.pb.go:422\ngithub.com/bucketeer-io/bucketeer/v2/pkg/rpc.(*Server).setupRPC.AuthUnaryServerInterceptor.func2\n\t/home/runner/work/bucketeer/bucketeer/pkg/rpc/auth.go:110\ngoogle.golang.org/grpc.getChainUnaryHandler.func1\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1242\ngithub.com/bucketeer-io/bucketeer/v2/pkg/rpc.(*Server).setupRPC.MetricsUnaryServerInterceptor.func1\n\t/home/runner/work/bucketeer/bucketeer/pkg/rpc/metrics.go:81\ngoogle.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1233\ngithub.com/bucketeer-io/bucketeer/v2/proto/batch._BatchService_ExecuteBatchJob_Handler\n\t/home/runner/work/bucketeer/bucketeer/proto/batch/service.pb.go:424\ngoogle.golang.org/grpc.(*Server).processUnaryRPC\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1429\ngoogle.golang.org/grpc.(*Server).handleStream\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1855\ngoogle.golang.org/grpc.(*Server).serveStreams.func2.1\n\t/home/runner/work/bucketeer/bucketeer/vendor/google.golang.org/grpc/server.go:1064"
}
{
  "severity": "INFO",
  "eventTime": 1774510047.7240407,
  "logger": "bucketeer-batch.server.monthly-summarizer",
  "caller": "monthlysummary/monthly_summarizer.go:75",
  "message": "MonthlySummarizer start running",
  "serviceContext": {
    "service": "bucketeer-batch.server",
    "version": "-"
  }
}
{
  "severity": "ERROR",
  "eventTime": 1774510067.0168312,
  "logger": "bucketeer-batch.server.monthly-summarizer",
  "caller": "monthlysummary/monthly_summarizer.go:127",
  "message": "Failed to upsert monthly_summary batch",
  "serviceContext": {
    "service": "bucketeer-batch.server",
    "version": "-"
  },
  "error": "context canceled",
  "stacktrace": "...
```