### PR TITLE
feat(insights): filter SDKs to only show SDKs with data

### DIFF
--- a/ui/dashboard/src/pages/insights/page-content.tsx
+++ b/ui/dashboard/src/pages/insights/page-content.tsx
@@ -81,6 +81,7 @@ interface PageContentProps {
   onFiltersChange: (filters: InsightsFilters) => void;
   onProjectChange: (projectId: string) => void;
   queriesEnabled: boolean;
+  availableSourceIds: Set<InsightSourceId> | null;
 }
 
 const PageContent = ({
@@ -92,11 +93,20 @@ const PageContent = ({
   filters,
   onFiltersChange,
   onProjectChange,
-  queriesEnabled
+  queriesEnabled,
+  availableSourceIds
 }: PageContentProps) => {
   const { t } = useTranslation(['common']);
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
-  const { sourceIdOptions, apiIdOptions } = useOptions();
+  const { sourceIdOptions: allSourceIdOptions, apiIdOptions } = useOptions();
+
+  // Show only SDKs that have data; fall back to full list while loading
+  const sourceIdOptions = useMemo(() => {
+    if (!availableSourceIds) return allSourceIdOptions;
+    return allSourceIdOptions.filter(
+      o => o.value === ALL || availableSourceIds.has(o.value as InsightSourceId)
+    );
+  }, [allSourceIdOptions, availableSourceIds]);
 
   const dateRangeLabel = useMemo(() => {
     if (!filters.customStartAt || !filters.customEndAt) return '';

--- a/ui/dashboard/src/pages/insights/page-loader.tsx
+++ b/ui/dashboard/src/pages/insights/page-loader.tsx
@@ -88,6 +88,28 @@ const PageLoader = () => {
       enabled: hasEnvironments
     });
 
+  // Discover which SDKs have data by fetching monthly summary for all source IDs.
+  // The DB only returns rows for SDKs that actually have records.
+  // Using ALL_SOURCE_IDS also lets React Query share the cache when the SDK
+  // filter is set to "All", avoiding a duplicate request.
+  const discoveryParams = useMemo(
+    () => ({
+      environmentIds,
+      sourceIds: ALL_SOURCE_IDS
+    }),
+    [environmentIds]
+  );
+
+  const { data: allSourcesSummary } = useQueryInsightsMonthlySummary({
+    params: discoveryParams,
+    enabled: hasEnvironments
+  });
+
+  const availableSourceIds = useMemo(() => {
+    if (!allSourcesSummary) return null;
+    return new Set(allSourcesSummary.series.map(s => s.sourceId));
+  }, [allSourcesSummary]);
+
   const timeRangeParams = useMemo(() => {
     const { startAt, endAt } = computeTimeRange(
       filters.timeRange,
@@ -134,6 +156,7 @@ const PageLoader = () => {
       onFiltersChange={setFilters}
       onProjectChange={handleProjectChange}
       queriesEnabled={hasEnvironments}
+      availableSourceIds={availableSourceIds}
     />
   );
 };


### PR DESCRIPTION
related to #2151 

Currently, in the Insights dashboard, all source IDs are available in the source ID filter.

This PR removes the SDKs that do not have monthly-summary or prometheus data to simplify the filter