### PR TITLE
fix(ui): coerce boolean URL params to prevent silent filter inversion

### DIFF
--- a/ui/dashboard/src/pages/experiments/collection-loader/index.tsx
+++ b/ui/dashboard/src/pages/experiments/collection-loader/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect } from 'react';
+import { memo, useEffect, useMemo } from 'react';
 import { SortingState } from '@tanstack/react-table';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { sortingListFields } from 'constants/collection';
@@ -59,6 +59,7 @@ const CollectionLoader = memo(
 
     const experiments = collection?.experiments || [];
     const totalCount = Number(collection?.totalCount) || 0;
+
     useEffect(() => {
       if (!collection?.experiments?.length) return;
 
@@ -76,14 +77,22 @@ const CollectionLoader = memo(
       }
     }, [collection, refetch]);
 
+    const hasFilter = useMemo(() => {
+      const statuses = searchOptions?.statuses;
+      // `query-string` may return `statuses` as string or array of string based on the number of values in the URL
+      // depending on whether the query param appears once or multiple times.
+      const hasStatuses =
+        (typeof statuses === 'string' || Array.isArray(statuses)) &&
+        !!statuses.length;
+
+      return filters.isFilter || (hasStatuses && !filters.filterByTab);
+    }, [filters.isFilter, filters.filterByTab, searchOptions.statuses]);
+
     const emptyState = (
       <CollectionEmpty
         data={experiments}
         searchQuery={filters.searchQuery}
-        isFilter={
-          filters.isFilter ||
-          (!!searchOptions?.statuses?.length && !filters?.filterByTab)
-        }
+        isFilter={hasFilter}
         description={t('message:empty:experiment-match')}
         onClear={() => {
           setFilters(

--- a/ui/dashboard/src/pages/organization-details/projects/index.tsx
+++ b/ui/dashboard/src/pages/organization-details/projects/index.tsx
@@ -21,7 +21,6 @@ const OrganizationProjects = () => {
   const { t } = useTranslation(['form']);
   const { searchOptions, onChangSearchParams } = useSearchParams();
   const searchFilters: Partial<ProjectFilters> = searchOptions;
-
   const [openFilterModal, onOpenFilterModal, onCloseFilterModal] =
     useToggleOpen(false);
 

--- a/ui/dashboard/src/utils/search-params.ts
+++ b/ui/dashboard/src/utils/search-params.ts
@@ -2,14 +2,14 @@ import { useCallback, useMemo } from 'react';
 import { NavigateOptions, useLocation, useNavigate } from 'react-router';
 import queryString, { ParsedQuery } from 'query-string';
 
-export type SearchParams = ParsedQuery<string>;
+export type SearchParams = ParsedQuery<string | boolean>;
 
 export function useSearchParams() {
   const navigate = useNavigate();
   const location = useLocation();
 
   const searchOptions = useMemo<SearchParams>((): SearchParams => {
-    return queryString.parse(location.search);
+    return queryString.parse(location.search, { parseBooleans: true });
   }, [location.search, location.pathname]);
 
   const onChangSearchParams = useCallback(


### PR DESCRIPTION
**Summary**

- Query-string returns all URL params as strings, so a filter like ?hasExperiment=false was arriving as the string "false" — which is truthy in JS. This caused boolean filters set to "No" to silently behave as "Yes" on page reload or when sharing a URL.
- Added coerceBooleanFilters helper in utils/search-params.ts that converts known boolean keys from their string form to real booleans before they are spread into filter state.
- Applied the fix across all 9 pages that expose boolean filter fields via URL params: feature-flags, experiments, goals, user-segments, members, notifications, api-keys, projects, pushes.