### PR TITLE
fix: add subscription cleanup on shutdown and expiration policy for cache invalidator

### DIFF
--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -766,7 +766,7 @@ func (s *server) startCacheInvalidator(
 			zap.NamedError("hostnameErr", err),
 		)
 	}
-	subscription := fmt.Sprintf("gateway-cache-invalidator-%s", hostname)
+	subscription := fmt.Sprintf("api-cache-invalidator-%s", hostname)
 	domainPuller, err := pubsubClient.CreatePuller(subscription, *s.domainTopic,
 		puller.PullerOption{ExpirationPolicy: 24 * time.Hour},
 	)

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -511,13 +511,21 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	)
 
 	invalidatorCtx, invalidatorCancel := context.WithCancel(context.Background())
-	defer invalidatorCancel()
+	var invalidatorCleanup func()
+	defer func() {
+		invalidatorCancel()
+		if invalidatorCleanup != nil {
+			invalidatorCleanup()
+		}
+	}()
 	if *s.domainTopic != "" {
-		if err := s.startCacheInvalidator(
+		cleanup, err := s.startCacheInvalidator(
 			invalidatorCtx, pubsubClient, inMemoryCache, logger,
-		); err != nil {
+		)
+		if err != nil {
 			return err
 		}
+		invalidatorCleanup = cleanup
 	}
 
 	mysqlClient, err := s.createMySQLClient(ctx, registerer, logger)
@@ -722,18 +730,22 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 // startCacheInvalidator subscribes to domain events to evict L1 in-memory
 // cache entries when feature flags or segments are updated. Each pod uses a
 // unique consumer group (based on hostname) so every pod receives every event.
+// It returns a cleanup function that deletes the subscription on shutdown.
 func (s *server) startCacheInvalidator(
 	ctx context.Context,
 	pubsubClient factory.Client,
 	inMemoryCache *cachev3.InMemoryCache,
 	logger *zap.Logger,
-) error {
+) (func(), error) {
 	hostname, err := os.Hostname()
 	if err != nil || hostname == "" {
 		id, uuidErr := uuid.NewUUID()
 		if uuidErr != nil {
-			logger.Error("Failed to get hostname and generate UUID", zap.Error(err))
-			return fmt.Errorf("failed to generate unique subscription name: %w", uuidErr)
+			logger.Error("Failed to get hostname and generate UUID",
+				zap.NamedError("uuidErr", uuidErr),
+				zap.NamedError("hostnameErr", err),
+			)
+			return nil, fmt.Errorf("failed to generate unique subscription name: %w", uuidErr)
 		}
 		hostname = id.String()
 		logger.Warn("Failed to get hostname, using generated ID",
@@ -742,10 +754,12 @@ func (s *server) startCacheInvalidator(
 		)
 	}
 	subscription := fmt.Sprintf("gateway-cache-invalidator-%s", hostname)
-	domainPuller, err := pubsubClient.CreatePuller(subscription, *s.domainTopic)
+	domainPuller, err := pubsubClient.CreatePuller(subscription, *s.domainTopic,
+		puller.PullerOption{ExpirationPolicy: 24 * time.Hour},
+	)
 	if err != nil {
 		logger.Error("Failed to create domain event puller", zap.Error(err))
-		return err
+		return nil, err
 	}
 	rateLimitedPuller := puller.NewRateLimitedPuller(domainPuller, 1000)
 	invalidator := api.NewCacheInvalidator(
@@ -768,7 +782,19 @@ func (s *server) startCacheInvalidator(
 		zap.String("subscription", subscription),
 		zap.String("topic", *s.domainTopic),
 	)
-	return nil
+	cleanup := func() {
+		if err := pubsubClient.DeleteSubscription(subscription); err != nil {
+			logger.Warn("Failed to delete cache invalidator subscription. Will be deleted by expiration policy",
+				zap.String("subscription", subscription),
+				zap.Error(err),
+			)
+			return
+		}
+		logger.Info("Deleted cache invalidator subscription",
+			zap.String("subscription", subscription),
+		)
+	}
+	return cleanup, nil
 }
 
 func (s *server) createMySQLClient(

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -799,7 +799,7 @@ func (s *server) startCacheInvalidator(
 		if err := pubsubClient.DeleteSubscription(subscription, *s.domainTopic); err != nil {
 			logger.Warn(
 				"Failed to delete cache invalidator subscription; "+
-					"GCP may still remove inactive subscriptions (expiration policy)",
+					"manual cleanup or backend-specific TTL may be required",
 				zap.String("subscription", subscription),
 				zap.String("topic", *s.domainTopic),
 				zap.Error(err),

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -512,12 +512,17 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 
 	invalidatorCtx, invalidatorCancel := context.WithCancel(context.Background())
 	var invalidatorCleanup func()
-	defer func() {
-		invalidatorCancel()
-		if invalidatorCleanup != nil {
-			invalidatorCleanup()
-		}
-	}()
+	var stopInvalidatorOnce sync.Once
+	stopInvalidator := func() {
+		stopInvalidatorOnce.Do(func() {
+			invalidatorCancel()
+			if invalidatorCleanup != nil {
+				invalidatorCleanup()
+				invalidatorCleanup = nil
+			}
+		})
+	}
+	defer stopInvalidator()
 	if *s.domainTopic != "" {
 		cleanup, err := s.startCacheInvalidator(
 			invalidatorCtx, pubsubClient, inMemoryCache, logger,
@@ -661,6 +666,13 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		healthChecker.Stop()
 		restHealthChecker.Stop()
 
+		// Stop the domain puller and delete the per-pod Pub/Sub subscription (or
+		// Redis consumer groups) now, before the propagation sleep and long HTTP/gRPC
+		// drain. Otherwise the subscription keeps receiving topic messages while no
+		// consumer runs, and oldest_unacked_message_age ramps until ExpirationPolicy.
+		// L1 cache TTL covers brief lack of invalidations during drain.
+		stopInvalidator()
+
 		// Wait for K8s endpoint propagation
 		// This prevents "context deadline exceeded" errors during high traffic.
 		time.Sleep(propagationDelay)
@@ -730,7 +742,8 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 // startCacheInvalidator subscribes to domain events to evict L1 in-memory
 // cache entries when feature flags or segments are updated. Each pod uses a
 // unique consumer group (based on hostname) so every pod receives every event.
-// It returns a cleanup function that deletes the subscription on shutdown.
+// It returns a cleanup function that deletes the GCP subscription or Redis
+// consumer group on graceful shutdown.
 func (s *server) startCacheInvalidator(
 	ctx context.Context,
 	pubsubClient factory.Client,
@@ -783,9 +796,12 @@ func (s *server) startCacheInvalidator(
 		zap.String("topic", *s.domainTopic),
 	)
 	cleanup := func() {
-		if err := pubsubClient.DeleteSubscription(subscription); err != nil {
-			logger.Warn("Failed to delete cache invalidator subscription. Will be deleted by expiration policy",
+		if err := pubsubClient.DeleteSubscription(subscription, *s.domainTopic); err != nil {
+			logger.Warn(
+				"Failed to delete cache invalidator subscription; "+
+					"GCP may still remove inactive subscriptions (expiration policy)",
 				zap.String("subscription", subscription),
+				zap.String("topic", *s.domainTopic),
 				zap.Error(err),
 			)
 			return

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -762,8 +762,8 @@ func (s *server) startCacheInvalidator(
 		}
 		hostname = id.String()
 		logger.Warn("Failed to get hostname, using generated ID",
-			zap.Error(err),
 			zap.String("generatedId", hostname),
+			zap.NamedError("hostnameErr", err),
 		)
 	}
 	subscription := fmt.Sprintf("gateway-cache-invalidator-%s", hostname)

--- a/pkg/pubsub/factory/factory.go
+++ b/pkg/pubsub/factory/factory.go
@@ -58,8 +58,9 @@ type Client interface {
 	CreatePuller(subscription, topic string, opts ...puller.PullerOption) (puller.Puller, error)
 	// SubscriptionExists checks if a subscription exists.
 	SubscriptionExists(subscription string) (bool, error)
-	// DeleteSubscription deletes a subscription.
-	DeleteSubscription(subscription string) error
+	// DeleteSubscription deletes a subscription. Topic is the Redis Streams base name
+	// (same as CreatePuller); it is ignored for Google Pub/Sub.
+	DeleteSubscription(subscription, topic string) error
 	// Close closes the client.
 	Close() error
 }
@@ -245,7 +246,7 @@ func (a *GoogleClientAdapter) SubscriptionExists(subscription string) (bool, err
 }
 
 // DeleteSubscription deletes a subscription.
-func (a *GoogleClientAdapter) DeleteSubscription(subscription string) error {
+func (a *GoogleClientAdapter) DeleteSubscription(subscription, _ string) error {
 	return a.client.DeleteSubscription(subscription)
 }
 

--- a/pkg/pubsub/factory/factory.go
+++ b/pkg/pubsub/factory/factory.go
@@ -53,7 +53,9 @@ type Client interface {
 	// For Redis, this behaves the same as CreatePublisher.
 	CreatePublisherInProject(topic, project string) (publisher.Publisher, error)
 	// CreatePuller creates a puller for the given subscription and topic.
-	CreatePuller(subscription, topic string) (puller.Puller, error)
+	// PullerOption is optional. For GCP, ExpirationPolicy sets auto-deletion
+	// of inactive subscriptions. For Redis, options are ignored.
+	CreatePuller(subscription, topic string, opts ...puller.PullerOption) (puller.Puller, error)
 	// SubscriptionExists checks if a subscription exists.
 	SubscriptionExists(subscription string) (bool, error)
 	// DeleteSubscription deletes a subscription.
@@ -215,9 +217,20 @@ func (a *GoogleClientAdapter) CreatePublisherInProject(topic, project string) (p
 }
 
 // CreatePuller creates a puller for the given subscription and topic.
-func (a *GoogleClientAdapter) CreatePuller(subscription, topic string) (puller.Puller, error) {
-	// Google PubSub requires ReceiveOptions, but we don't expose them in our interface
-	// Use default options
+func (a *GoogleClientAdapter) CreatePuller(
+	subscription,
+	topic string,
+	opts ...puller.PullerOption,
+) (puller.Puller, error) {
+	var subOpts []pubsub.SubscriptionOption
+	for _, opt := range opts {
+		if opt.ExpirationPolicy > 0 {
+			subOpts = append(subOpts, pubsub.WithExpirationPolicy(opt.ExpirationPolicy))
+		}
+	}
+	if len(subOpts) > 0 {
+		return a.client.CreatePullerWithOptions(subscription, topic, subOpts)
+	}
 	return a.client.CreatePuller(subscription, topic)
 }
 

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -85,6 +85,18 @@ func WithLogger(l *zap.Logger) Option {
 	}
 }
 
+type subscriptionOptions struct {
+	expirationPolicy time.Duration
+}
+
+type SubscriptionOption func(*subscriptionOptions)
+
+func WithExpirationPolicy(d time.Duration) SubscriptionOption {
+	return func(opts *subscriptionOptions) {
+		opts.expirationPolicy = d
+	}
+}
+
 type receiveOptions = pubsub.ReceiveSettings
 
 type ReceiveOption func(*receiveOptions)
@@ -181,8 +193,28 @@ func (c *Client) createPublisher(topic *pubsub.Topic, opts ...PublishOption) (pu
 	return publisher.NewPublisher(topic, options...), nil
 }
 
+func (c *Client) CreatePullerWithOptions(
+	subscription, topic string,
+	subOpts []SubscriptionOption,
+	recvOpts ...ReceiveOption,
+) (puller.Puller, error) {
+	sopts := &subscriptionOptions{}
+	for _, opt := range subOpts {
+		opt(sopts)
+	}
+	return c.createPuller(subscription, topic, sopts, recvOpts...)
+}
+
 func (c *Client) CreatePuller(subscription, topic string, opts ...ReceiveOption) (puller.Puller, error) {
-	s, err := c.subscription(subscription, topic)
+	return c.createPuller(subscription, topic, nil, opts...)
+}
+
+func (c *Client) createPuller(
+	subscription, topic string,
+	subOpts *subscriptionOptions,
+	recvOpts ...ReceiveOption,
+) (puller.Puller, error) {
+	s, err := c.subscription(subscription, topic, subOpts)
 	if err != nil {
 		c.logger.Error("Failed to create puller",
 			zap.String("subscription", subscription),
@@ -191,7 +223,7 @@ func (c *Client) CreatePuller(subscription, topic string, opts ...ReceiveOption)
 		return nil, err
 	}
 	options := (receiveOptions)(pubsub.DefaultReceiveSettings)
-	for _, opt := range opts {
+	for _, opt := range recvOpts {
 		opt(&options)
 	}
 	s.ReceiveSettings = options
@@ -239,7 +271,7 @@ func (c *Client) createTopicForEmulator(ctx context.Context, id string) {
 }
 
 // TODO: add metrics
-func (c *Client) subscription(id, topicID string) (*pubsub.Subscription, error) {
+func (c *Client) subscription(id, topicID string, opts *subscriptionOptions) (*pubsub.Subscription, error) {
 	sub := c.Subscription(id)
 	topic := c.Topic(topicID)
 	var lastErr error
@@ -255,9 +287,13 @@ func (c *Client) subscription(id, topicID string) (*pubsub.Subscription, error) 
 		if ok {
 			return sub, nil
 		}
-		_, err = c.CreateSubscription(ctx, id, pubsub.SubscriptionConfig{
+		cfg := pubsub.SubscriptionConfig{
 			Topic: topic,
-		})
+		}
+		if opts != nil && opts.expirationPolicy > 0 {
+			cfg.ExpirationPolicy = opts.expirationPolicy
+		}
+		_, err = c.CreateSubscription(ctx, id, cfg)
 		if err == nil {
 			return sub, nil
 		}

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -285,6 +285,22 @@ func (c *Client) subscription(id, topicID string, opts *subscriptionOptions) (*p
 			continue
 		}
 		if ok {
+			if opts != nil && opts.expirationPolicy > 0 {
+				_, updErr := sub.Update(ctx, pubsub.SubscriptionConfigToUpdate{
+					ExpirationPolicy: opts.expirationPolicy,
+				})
+				if updErr != nil {
+					// No-op if nothing changed (e.g. policy already set).
+					if !strings.Contains(updErr.Error(), "nothing to update") {
+						c.logger.Warn(
+							"Failed to update expiration policy on existing subscription",
+							zap.String("subscription", id),
+							zap.Duration("expiration_policy", opts.expirationPolicy),
+							zap.Error(updErr),
+						)
+					}
+				}
+			}
 			return sub, nil
 		}
 		cfg := pubsub.SubscriptionConfig{

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -270,6 +270,33 @@ func (c *Client) createTopicForEmulator(ctx context.Context, id string) {
 	}
 }
 
+// tryUpdateSubscriptionExpiration applies opts.expirationPolicy when set (best-effort).
+func (c *Client) tryUpdateSubscriptionExpiration(
+	ctx context.Context,
+	id string,
+	sub *pubsub.Subscription,
+	opts *subscriptionOptions,
+) {
+	if opts == nil || opts.expirationPolicy <= 0 {
+		return
+	}
+	_, updErr := sub.Update(ctx, pubsub.SubscriptionConfigToUpdate{
+		ExpirationPolicy: opts.expirationPolicy,
+	})
+	if updErr == nil {
+		return
+	}
+	if strings.Contains(updErr.Error(), "nothing to update") {
+		return
+	}
+	c.logger.Warn(
+		"Failed to update expiration policy on existing subscription",
+		zap.String("subscription", id),
+		zap.Duration("expiration_policy", opts.expirationPolicy),
+		zap.Error(updErr),
+	)
+}
+
 // TODO: add metrics
 func (c *Client) subscription(id, topicID string, opts *subscriptionOptions) (*pubsub.Subscription, error) {
 	sub := c.Subscription(id)
@@ -285,22 +312,7 @@ func (c *Client) subscription(id, topicID string, opts *subscriptionOptions) (*p
 			continue
 		}
 		if ok {
-			if opts != nil && opts.expirationPolicy > 0 {
-				_, updErr := sub.Update(ctx, pubsub.SubscriptionConfigToUpdate{
-					ExpirationPolicy: opts.expirationPolicy,
-				})
-				if updErr != nil {
-					// No-op if nothing changed (e.g. policy already set).
-					if !strings.Contains(updErr.Error(), "nothing to update") {
-						c.logger.Warn(
-							"Failed to update expiration policy on existing subscription",
-							zap.String("subscription", id),
-							zap.Duration("expiration_policy", opts.expirationPolicy),
-							zap.Error(updErr),
-						)
-					}
-				}
-			}
+			c.tryUpdateSubscriptionExpiration(ctx, id, sub, opts)
 			return sub, nil
 		}
 		cfg := pubsub.SubscriptionConfig{
@@ -318,6 +330,7 @@ func (c *Client) subscription(id, topicID string, opts *subscriptionOptions) (*p
 				zap.String("subscription", id),
 				zap.String("topic", topicID),
 			)
+			c.tryUpdateSubscriptionExpiration(ctx, id, sub, opts)
 			return sub, nil
 		}
 		lastErr = err

--- a/pkg/pubsub/puller/puller.go
+++ b/pkg/pubsub/puller/puller.go
@@ -17,10 +17,18 @@ package puller
 
 import (
 	"context"
+	"time"
 
 	"cloud.google.com/go/pubsub"
 	"go.uber.org/zap"
 )
+
+// PullerOption configures optional behavior when creating a puller.
+// For GCP Pub/Sub, ExpirationPolicy sets auto-deletion of inactive subscriptions.
+// For Redis Streams, options are ignored.
+type PullerOption struct {
+	ExpirationPolicy time.Duration
+}
 
 type Message struct {
 	ID         string

--- a/pkg/pubsub/redis/stream_client.go
+++ b/pkg/pubsub/redis/stream_client.go
@@ -210,5 +210,7 @@ func isBenignXGroupDestroyErr(err error) bool {
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "nogroup") ||
 		strings.Contains(msg, "no such key") ||
-		strings.Contains(msg, "stream key not found")
+		strings.Contains(msg, "stream key not found") ||
+		strings.Contains(msg, "the xgroup subcommand requires the key to exist") ||
+		strings.Contains(msg, "requires the key to exist")
 }

--- a/pkg/pubsub/redis/stream_client.go
+++ b/pkg/pubsub/redis/stream_client.go
@@ -17,6 +17,8 @@ package redis
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
@@ -167,10 +169,34 @@ func (c *StreamClient) SubscriptionExists(subscription string) (bool, error) {
 	return true, nil
 }
 
-// DeleteSubscription deletes a subscription
-func (c *StreamClient) DeleteSubscription(subscription string) error {
-	// For Redis Streams, we would need to delete the consumer group
-	// This would require knowing the stream name, which we don't have
-	// Just return nil to indicate success since the operation is idempotent
+// DeleteSubscription removes the consumer group named subscription from every
+// partition stream for topic (same layout as StreamPuller). Missing streams or
+// groups are ignored so shutdown cleanup is best-effort and idempotent.
+func (c *StreamClient) DeleteSubscription(subscription, topic string) error {
+	if subscription == "" {
+		return ErrInvalidStreamSubscription
+	}
+	if topic == "" {
+		return ErrInvalidStreamTopic
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	for partition := 0; partition < c.partitionCount; partition++ {
+		streamKey := fmt.Sprintf("%s-%d{stream}", topic, partition)
+		exists, err := c.redisClient.Exists(streamKey)
+		if err != nil {
+			return fmt.Errorf("redis stream delete subscription: exists %q: %w", streamKey, err)
+		}
+		if exists == 0 {
+			continue
+		}
+		if err := c.redisClient.XGroupDestroy(ctx, streamKey, subscription); err != nil {
+			msg := strings.ToLower(err.Error())
+			if strings.Contains(msg, "nogroup") || strings.Contains(msg, "no such key") {
+				continue
+			}
+			return fmt.Errorf("redis stream delete subscription: xgroup destroy %q on %q: %w", subscription, streamKey, err)
+		}
+	}
 	return nil
 }

--- a/pkg/pubsub/redis/stream_client.go
+++ b/pkg/pubsub/redis/stream_client.go
@@ -117,8 +117,9 @@ func (c *StreamClient) CreatePublisher(topic string) (publisher.Publisher, error
 	return NewStreamPublisher(c.redisClient, topic, options...), nil
 }
 
-// CreatePuller creates a puller for the given subscription and topic
-func (c *StreamClient) CreatePuller(subscription, topic string) (puller.Puller, error) {
+// CreatePuller creates a puller for the given subscription and topic.
+// PullerOption is accepted for interface compatibility but ignored for Redis Streams.
+func (c *StreamClient) CreatePuller(subscription, topic string, _ ...puller.PullerOption) (puller.Puller, error) {
 	if subscription == "" {
 		return nil, ErrInvalidStreamSubscription
 	}

--- a/pkg/pubsub/redis/stream_client.go
+++ b/pkg/pubsub/redis/stream_client.go
@@ -171,7 +171,8 @@ func (c *StreamClient) SubscriptionExists(subscription string) (bool, error) {
 
 // DeleteSubscription removes the consumer group named subscription from every
 // partition stream for topic (same layout as StreamPuller). Missing streams or
-// groups are ignored so shutdown cleanup is best-effort and idempotent.
+// groups are ignored. Attempts all partitions and returns a joined error if any
+// non-benign destroy fails (best-effort shutdown cleanup).
 func (c *StreamClient) DeleteSubscription(subscription, topic string) error {
 	if subscription == "" {
 		return ErrInvalidStreamSubscription
@@ -181,22 +182,33 @@ func (c *StreamClient) DeleteSubscription(subscription, topic string) error {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
+	var errs []error
 	for partition := 0; partition < c.partitionCount; partition++ {
 		streamKey := fmt.Sprintf("%s-%d{stream}", topic, partition)
-		exists, err := c.redisClient.Exists(streamKey)
-		if err != nil {
-			return fmt.Errorf("redis stream delete subscription: exists %q: %w", streamKey, err)
-		}
-		if exists == 0 {
-			continue
-		}
 		if err := c.redisClient.XGroupDestroy(ctx, streamKey, subscription); err != nil {
-			msg := strings.ToLower(err.Error())
-			if strings.Contains(msg, "nogroup") || strings.Contains(msg, "no such key") {
+			if isBenignXGroupDestroyErr(err) {
 				continue
 			}
-			return fmt.Errorf("redis stream delete subscription: xgroup destroy %q on %q: %w", subscription, streamKey, err)
+			c.logger.Warn("Failed to destroy consumer group on stream partition",
+				zap.String("stream", streamKey),
+				zap.String("group", subscription),
+				zap.Error(err),
+			)
+			errs = append(errs, fmt.Errorf("partition %s: %w", streamKey, err))
 		}
 	}
+	if len(errs) > 0 {
+		return fmt.Errorf("redis stream delete subscription: %w", errors.Join(errs...))
+	}
 	return nil
+}
+
+func isBenignXGroupDestroyErr(err error) bool {
+	if err == nil {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "nogroup") ||
+		strings.Contains(msg, "no such key") ||
+		strings.Contains(msg, "stream key not found")
 }

--- a/pkg/pubsub/redis/stream_puller.go
+++ b/pkg/pubsub/redis/stream_puller.go
@@ -18,7 +18,6 @@ package redis
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -148,13 +147,6 @@ func (p *StreamPuller) Pull(ctx context.Context, handler func(context.Context, *
 	// Store the handler function for use in recoveryLoop
 	p.handler = handler
 	p.mutex.Unlock()
-
-	// Clean up stale consumer groups from terminated pods.
-	// If the subscription follows the per-pod convention "<prefix><hostname>",
-	// derive the prefix and destroy matching groups with that prefix, except for
-	// the current subscription. This cleanup does not inspect consumer counts
-	// because Redis Streams' consumer count reflects historical, not active, connections.
-	p.cleanupStaleConsumerGroups(ctx)
 
 	// Create consumer groups for all partitions
 	for partition := 0; partition < p.partitionCount; partition++ {
@@ -358,58 +350,6 @@ func (p *StreamPuller) consumerGroupExists(ctx context.Context, streamKey, group
 	}
 
 	return false, nil
-}
-
-// cleanupStaleConsumerGroups removes orphaned consumer groups left by terminated pods.
-// It derives a prefix from the subscription name by stripping the hostname suffix.
-// Any matching group other than the current subscription group is destroyed.
-// Note: Redis Streams' XINFO GROUPS "consumers" field counts historical consumers,
-// not currently connected ones, so consumer count checks are not reliable for
-// detecting stale groups.
-func (p *StreamPuller) cleanupStaleConsumerGroups(ctx context.Context) {
-	hostname, err := os.Hostname()
-	if err != nil || !strings.HasSuffix(p.subscription, hostname) {
-		return
-	}
-	prefix := strings.TrimSuffix(p.subscription, hostname)
-	if prefix == "" || prefix == p.subscription {
-		return
-	}
-	for partition := 0; partition < p.partitionCount; partition++ {
-		streamKey := p.getStreamKey(partition)
-		exists, err := p.redisClient.Exists(streamKey)
-		if err != nil || exists == 0 {
-			continue
-		}
-		groups, err := p.redisClient.XInfoGroups(ctx, streamKey)
-		if err != nil {
-			p.logger.Warn("Failed to list consumer groups for cleanup",
-				zap.String("stream", streamKey),
-				zap.Error(err),
-			)
-			continue
-		}
-		for _, group := range groups {
-			if !strings.HasPrefix(group.Name, prefix) {
-				continue
-			}
-			if group.Name == p.subscription {
-				continue
-			}
-			if err := p.redisClient.XGroupDestroy(ctx, streamKey, group.Name); err != nil {
-				p.logger.Warn("Failed to destroy stale consumer group",
-					zap.String("stream", streamKey),
-					zap.String("group", group.Name),
-					zap.Error(err),
-				)
-				continue
-			}
-			p.logger.Debug("Destroyed stale consumer group",
-				zap.String("stream", streamKey),
-				zap.String("group", group.Name),
-			)
-		}
-	}
 }
 
 // recoveryLoop periodically checks for stale messages and reclaims them

--- a/pkg/redis/v3/redis.go
+++ b/pkg/redis/v3/redis.go
@@ -1335,6 +1335,17 @@ func (c *client) XGroupDestroy(ctx context.Context, stream, group string) error 
 	).Observe(time.Since(startTime).Seconds())
 
 	if err != nil && err != goredis.Nil {
+		// Missing stream/group is expected during startup cleanup or when the
+		// topic partition never received messages; log at debug to avoid noisy
+		// error logs during normal rollouts.
+		if isBenignXGroupDestroyErr(err) {
+			c.logger.Debug("Consumer group or stream not found during destroy (expected)",
+				zap.String("stream", stream),
+				zap.String("group", group),
+				zap.Error(err),
+			)
+			return err
+		}
 		c.logger.Error("Failed to destroy consumer group",
 			zap.String("stream", stream),
 			zap.String("group", group),
@@ -1344,4 +1355,18 @@ func (c *client) XGroupDestroy(ctx context.Context, stream, group string) error 
 	}
 
 	return nil
+}
+
+// isBenignXGroupDestroyErr returns true for errors that indicate the stream or
+// consumer group simply does not exist, which is expected during cleanup.
+func isBenignXGroupDestroyErr(err error) bool {
+	if err == nil {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "nogroup") ||
+		strings.Contains(msg, "no such key") ||
+		strings.Contains(msg, "stream key not found") ||
+		strings.Contains(msg, "the xgroup subcommand requires the key to exist") ||
+		strings.Contains(msg, "requires the key to exist")
 }

--- a/pkg/subscriber/on_demand_subscriber.go
+++ b/pkg/subscriber/on_demand_subscriber.go
@@ -138,7 +138,10 @@ func (s *onDemandSubscriber) Run(ctx context.Context) {
 					continue
 				}
 				if exists {
-					err = s.factoryClient.DeleteSubscription(s.configuration.Subscription)
+					err = s.factoryClient.DeleteSubscription(
+						s.configuration.Subscription,
+						s.configuration.Topic,
+					)
 					if err != nil {
 						s.logger.Error("Failed to delete subscription",
 							zap.String("name", s.name),

--- a/pkg/subscriber/on_demand_subscriber.go
+++ b/pkg/subscriber/on_demand_subscriber.go
@@ -48,7 +48,7 @@ type onDemandSubscriber struct {
 	runningPullerCancel       func()
 	client                    *pubsub.Client
 	isRunning                 bool
-	pendingSubscriptionDelete bool
+	pendingSubscriptionDelete bool // true when we need a one-shot delete (running→stopped or off at startup)
 	group                     errgroup.Group
 	opts                      options
 	logger                    *zap.Logger
@@ -103,6 +103,10 @@ func (s *onDemandSubscriber) Run(ctx context.Context) {
 	ticker := time.NewTicker(time.Duration(s.configuration.CheckInterval) * time.Second)
 	defer ticker.Stop()
 	subscription := make(chan struct{})
+	// Assume a subscription/consumer-group may exist from a previous run when
+	// starting in the stopped state so we attempt a one-shot cleanup on the
+	// first tick.
+	s.pendingSubscriptionDelete = true
 	go s.subscribe(subscription)
 	for {
 		select {

--- a/pkg/subscriber/on_demand_subscriber.go
+++ b/pkg/subscriber/on_demand_subscriber.go
@@ -38,20 +38,21 @@ type OnDemandConfiguration struct {
 }
 
 type onDemandSubscriber struct {
-	name                string
-	configuration       OnDemandConfiguration
-	rateLimitedPuller   puller.RateLimitedPuller
-	processor           OnDemandProcessor
-	ctx                 context.Context
-	cancel              context.CancelFunc
-	runningPullerCtx    context.Context
-	runningPullerCancel func()
-	client              *pubsub.Client
-	isRunning           bool
-	group               errgroup.Group
-	opts                options
-	logger              *zap.Logger
-	factoryClient       factory.Client
+	name                      string
+	configuration             OnDemandConfiguration
+	rateLimitedPuller         puller.RateLimitedPuller
+	processor                 OnDemandProcessor
+	ctx                       context.Context
+	cancel                    context.CancelFunc
+	runningPullerCtx          context.Context
+	runningPullerCancel       func()
+	client                    *pubsub.Client
+	isRunning                 bool
+	pendingSubscriptionDelete bool
+	group                     errgroup.Group
+	opts                      options
+	logger                    *zap.Logger
+	factoryClient             factory.Client
 }
 
 func NewOnDemandSubscriber(
@@ -112,6 +113,7 @@ func (s *onDemandSubscriber) Run(ctx context.Context) {
 				continue
 			}
 			if start {
+				s.pendingSubscriptionDelete = false
 				if !s.IsRunning() {
 					err = s.createPuller()
 					if err != nil {
@@ -127,8 +129,13 @@ func (s *onDemandSubscriber) Run(ctx context.Context) {
 			} else {
 				if s.IsRunning() {
 					s.unsubscribe()
+					s.pendingSubscriptionDelete = true
 				}
-				// delete subscription if it exists
+				// One delete after stop; avoids Redis Streams calling XGROUP DESTROY on
+				// every tick (SubscriptionExists is always true for Redis).
+				if !s.pendingSubscriptionDelete {
+					continue
+				}
 				exists, err := s.factoryClient.SubscriptionExists(s.configuration.Subscription)
 				if err != nil {
 					s.logger.Error("Failed to check subscription existence",
@@ -137,19 +144,22 @@ func (s *onDemandSubscriber) Run(ctx context.Context) {
 					)
 					continue
 				}
-				if exists {
-					err = s.factoryClient.DeleteSubscription(
-						s.configuration.Subscription,
-						s.configuration.Topic,
-					)
-					if err != nil {
-						s.logger.Error("Failed to delete subscription",
-							zap.String("name", s.name),
-							zap.Error(err),
-						)
-						continue
-					}
+				if !exists {
+					s.pendingSubscriptionDelete = false
+					continue
 				}
+				err = s.factoryClient.DeleteSubscription(
+					s.configuration.Subscription,
+					s.configuration.Topic,
+				)
+				if err != nil {
+					s.logger.Error("Failed to delete subscription",
+						zap.String("name", s.name),
+						zap.Error(err),
+					)
+					continue
+				}
+				s.pendingSubscriptionDelete = false
 			}
 		case <-ctx.Done():
 			s.logger.Debug("Context is done")


### PR DESCRIPTION
## Summary

- Adds graceful subscription deletion on pod shutdown and a 24-hour GCP Pub/Sub `ExpirationPolicy` so orphaned subscriptions do not accumulate.
- **On SIGTERM:** stops the cache invalidator and **deletes the per-pod subscription (or Redis consumer groups) immediately** at the start of the graceful shutdown sequence—**before** the K8s propagation sleep—so `oldest_unacked_message_age` does not ramp for hours on rolled pods. A `sync.Once`-guarded `stopInvalidator()` plus a final `defer` avoids double delete.
- **Redis Streams:** implements real shutdown cleanup (`XGROUP DESTROY` for this pod’s consumer group on every partition) and **removes** startup logic that deleted other pods’ consumer groups (unsafe under multiple replicas).
- Extends the pub/sub factory `DeleteSubscription` API with a `topic` argument so Redis can target the correct stream partitions (ignored by GCP). Call sites updated (`api` server, **on-demand subscriber**).
- Fixes missing cache metrics for segment users in the REST gateway path.
- Keeps a dedicated invalidator context rooted in `context.Background()` with explicit `stopInvalidator()` / cancel + cleanup (invalidator still stopped early in shutdown; final `defer` is a safety net).

## Why

After deploying the cache invalidator with per-pod subscriptions, we saw many orphaned **GCP** Pub/Sub subscriptions from terminated pods (Spot preemptions, rolling updates). Each could accumulate unacked messages and fire alerts. Default GCP subscription TTL is long, so orphans stuck around. Even with **ExpirationPolicy**, dashboards showed **24h ramps** of `oldest_unacked_message_age` until the subscription expired—because delete previously ran only **after** the full shutdown sequence (including propagation sleep and HTTP/gRPC drain).

For **Redis Streams**, per-pod consumer groups are the right model (every pod must see every domain event). An earlier “startup cleanup” removed **all** other `gateway-cache-invalidator-*` groups on the stream, which could delete **live** peers’ groups. Shutdown also did not remove Redis groups because `DeleteSubscription` was a no-op.

## Changes

**Subscription / consumer-group lifecycle**

- `pkg/api/cmd/server.go`: `startCacheInvalidator` returns a cleanup that calls `DeleteSubscription(subscription, domainTopic)`. **`stopInvalidator()`** (`sync.Once`): cancels invalidator context, runs cleanup once, nils cleanup. Invoked **at the beginning** of the shutdown defer (after failing readiness, **before** `propagationDelay`), and again via **`defer stopInvalidator()`** for other exit paths. L1 TTL covers the drain window without domain invalidations.
- `pkg/pubsub/pubsub.go`: `SubscriptionOption` / `WithExpirationPolicy`, `CreatePullerWithOptions` for optional GCP subscription expiration.
- `pkg/pubsub/puller/puller.go`: `PullerOption` with `ExpirationPolicy` for cross-backend option passing.
- `pkg/pubsub/factory/factory.go`: `CreatePuller` accepts variadic `PullerOption`. `DeleteSubscription(subscription, topic string)` — `topic` is the Redis stream base name; **ignored** on GCP.
- `pkg/pubsub/redis/stream_client.go`: `DeleteSubscription` runs `XGROUP DESTROY` for the given group on each partition stream (same key layout as the puller). `PullerOption` on `CreatePuller` still ignored for compatibility.
- `pkg/pubsub/redis/stream_puller.go`: **Removed** cross-pod consumer group destruction on `Pull()`; only creates/uses **this** pod’s group.
- `pkg/redis/v3/redis.go`: `XGroupDestroy` on the Redis client (used for Redis shutdown cleanup).
- `pkg/subscriber/on_demand_subscriber.go`: pass `Topic` into `DeleteSubscription` after the factory API change.

**Review / bug fixes**

- `pkg/api/api/api.go`: REST `getSegmentUsers` — L1 fill after L3 where applicable; `restCacheCounter` for segment L1/L2.
- `pkg/api/api/cache_invalidator_test.go`: removed unused test field.
- `pkg/api/cmd/server.go`: hostname fallback uses `pkg/uuid`; logging/error handling per review.

## Cleanup strategy

| Scenario | GCP Pub/Sub | Redis Streams |
|----------|-------------|----------------|
| Rolling update / scale-down | **Early** delete at shutdown start + final `defer`; then propagation/drain | Same pattern: **early** `XGROUP DESTROY` + defer |
| Spot / tight shutdown window | Best-effort delete + **ExpirationPolicy (24h)** | Best-effort group destroy only (no built-in TTL) |
| OOMKill / crash | **ExpirationPolicy (24h)** | Group may remain until manual ops / future tooling |
| Multi-pod safety | N/A (unique subscription per pod) | **No** startup deletion of other pods’ groups |

## Test plan

- [x] Unit tests pass  
- [x] E2E gateway tests pass (37/37)  
- [x] Verified GCP subscription deletion on graceful shutdown (`kubectl` / logs)  
- [x] Verified cache invalidator starts and processes events on all pods  
- [x] Redis: verified shutdown path calls `DeleteSubscription` with topic and removes only the local consumer group (no cross-pod group deletes on startup)  
- [x] After deploy: confirm `oldest_unacked_message_age` for `gateway-cache-invalidator-*` **drops quickly** on rollout (no multi-hour ramp to 24h for cleanly terminated pods)
