### PR TITLE
fix(insights): exclude zero-request SDKs from source ID filter

### DIFF
--- a/ui/dashboard/src/pages/insights/page-loader.tsx
+++ b/ui/dashboard/src/pages/insights/page-loader.tsx
@@ -88,8 +88,8 @@ const PageLoader = () => {
       enabled: hasEnvironments
     });
 
-  // Discover which SDKs have data by fetching monthly summary for all source IDs.
-  // The DB only returns rows for SDKs that actually have records.
+  // Discover which SDKs have actual traffic by fetching monthly summary for
+  // all source IDs and filtering out zero-request entries.
   // Using ALL_SOURCE_IDS also lets React Query share the cache when the SDK
   // filter is set to "All", avoiding a duplicate request.
   const discoveryParams = useMemo(
@@ -107,7 +107,13 @@ const PageLoader = () => {
 
   const availableSourceIds = useMemo(() => {
     if (!allSourcesSummary) return null;
-    return new Set(allSourcesSummary.series.map(s => s.sourceId));
+    // Only include SDKs that have at least one month with requests > 0.
+    // The batch inserts rows for all SDKs even when there is no traffic.
+    return new Set(
+      allSourcesSummary.series
+        .filter(s => s.data.some(d => Number(d.requests) > 0))
+        .map(s => s.sourceId)
+    );
   }, [allSourcesSummary]);
 
   const timeRangeParams = useMemo(() => {


### PR DESCRIPTION
Follows up on #2530. The batch job upserts `monthly_summary` rows for every SDK even when there is no traffic (`mau=0, request_count=0`), so the previous row-existence check showed all SDKs regardless of actual usage.

- Filter `availableSourceIds` by checking `requests > 0` in at least one month instead of just checking series existence