### PR TITLE
fix(ui/insights): reset SDK filter when switching environments

### DIFF
--- a/ui/dashboard/src/pages/insights/page-content.tsx
+++ b/ui/dashboard/src/pages/insights/page-content.tsx
@@ -185,7 +185,7 @@ const PageContent = ({
 
   const handleEnvironmentChange = useCallback(
     (value: string) => {
-      onFiltersChange({ ...filters, environmentId: value });
+      onFiltersChange({ ...filters, environmentId: value, sourceId: ALL });
     },
     [filters, onFiltersChange]
   );

--- a/ui/dashboard/src/pages/insights/page-loader.tsx
+++ b/ui/dashboard/src/pages/insights/page-loader.tsx
@@ -56,7 +56,8 @@ const PageLoader = () => {
       setFilters({
         ...filters,
         projectId: projectId || ALL,
-        environmentId: normalizeEnvId(firstEnv?.id ?? '')
+        environmentId: normalizeEnvId(firstEnv?.id ?? ''),
+        sourceId: ALL
       });
     },
     [userEnvironments, filters, setFilters]


### PR DESCRIPTION
Issue with the SDK filter not resetting when switching environments

**Steps to reproduce:**

1. Open the Insights dashboard
2. Select an environment that has data for a specific SDK (e.g. go)
3. Select that SDK from the SDK filter dropdown
4. Switch to a different environment that has no data for that SDK

**Expected behavior:**

The SDK filter resets to "All", the URL updates accordingly, and API requests use sourceId=ALL.

**Actual behavior:**

The SDK dropdown visually shows only "All" (since the selected SDK has no data in the new environment and is filtered out of the options), but:

- The URL still contains the old sourceId (e.g. sourceId=go)
- The filter state still holds the stale sourceId
- API requests still use the old SDK as a parameter
