### PR TITLE
fix(feature-flag-detail/targeting):  track rule reorder in discard/confirm modals and submit payload

### DIFF
--- a/ui/dashboard/src/@locales/en/form.json
+++ b/ui/dashboard/src/@locales/en/form.json
@@ -473,6 +473,8 @@
     "percent-variation": "<comp/> <p>{{percent}}%</p>"
   },
   "custom-rule-strategy-discard-desc": "Update variation allocation:",
+  "custom-rule-reorder-discard-desc": "The rules have been rearranged:",
+  "custom-rule-reorder-confirm-desc": "Rule order will be updated as follows:",
   "custom-rule-audience-not-include-desc": "Not allocated — <b>{{percent}}%</b> <variantElement/>",
   "custom-rule-audience-include-desc": "Allocated — <b>{{percent}}%</b> <variantElement/>",
   "custom-rule-strategy-add-new-discard-desc": "<b>IF {{clauseLabel}}</b>, Serve:",

--- a/ui/dashboard/src/@locales/ja/form.json
+++ b/ui/dashboard/src/@locales/ja/form.json
@@ -473,6 +473,8 @@
     "percent-variation": "<comp/> <p>{{percent}}%</p>"
   },
   "custom-rule-strategy-discard-desc": "バリエーションの配分を更新:",
+  "custom-rule-reorder-discard-desc": "ルールが並び替えられました:",
+  "custom-rule-reorder-confirm-desc": "ルールの順序は以下のように更新されます:",
   "custom-rule-strategy-add-new-discard-desc": "<b>IF {{clauseLabel}} の場合</b>、配信:",
   "custom-rule-audience-not-include-desc": "未割り当て <b>{{percent}}%</b> <variantElement/>",
   "custom-rule-audience-include-desc": "割り当て済み <b>{{percent}}%</b> <variantElement/>",

--- a/ui/dashboard/src/pages/feature-flag-details/elements/confirm-required-modal/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/elements/confirm-required-modal/index.tsx
@@ -12,9 +12,12 @@ import {
 import { useTranslation } from 'i18n';
 import { isNil } from 'lodash';
 import { Feature, FeatureRuleStrategy } from '@types';
-import { IconInfo, IconToastWarning, IconWatch } from '@icons';
+import { IconArrowUpDown, IconInfo, IconToastWarning, IconWatch } from '@icons';
 import { TargetingSchema } from 'pages/feature-flag-details/targeting/form-schema';
-import { DiscardChangesStateData } from 'pages/feature-flag-details/targeting/types';
+import {
+  DiscardChangesStateData,
+  RuleOrders
+} from 'pages/feature-flag-details/targeting/types';
 import {
   checkDefaultRuleDiscardChanges,
   handleCheckIndividualDiscardChanges,
@@ -34,7 +37,8 @@ import DiscardChangeItems from '../discard-change-items';
 import {
   CustomRuleDiscardItem,
   IndividualDiscardItem,
-  PrerequisiteDiscardItem
+  PrerequisiteDiscardItem,
+  ReorderList
 } from '../discard-changes-modal';
 import {
   formSchema,
@@ -54,6 +58,7 @@ export type ConfirmationRequiredModalProps = {
     index: number,
     isAction: boolean
   ) => DiscardChangesStateData[];
+  onSegmentRuleReorder?: () => DiscardChangesStateData | null;
   onClose: () => void;
   onSubmit: (values: ConfirmRequiredValues) => Promise<void>;
 };
@@ -81,6 +86,7 @@ const ConfirmationRequiredModal = ({
   isShowRolloutWarning,
   onSegmentRuleDeleted,
   onSegmentRuleChannge,
+  onSegmentRuleReorder,
   onClose,
   onSubmit
 }: ConfirmationRequiredModalProps) => {
@@ -132,6 +138,10 @@ const ConfirmationRequiredModal = ({
     }
     return [];
   }, [onSegmentRuleDeleted]);
+
+  const segmentRuleReorderChange = useMemo(() => {
+    return onSegmentRuleReorder ? onSegmentRuleReorder() : null;
+  }, [onSegmentRuleReorder]);
 
   const segmentRulesChange = useMemo(() => {
     const change: {
@@ -206,6 +216,9 @@ const ConfirmationRequiredModal = ({
     // Count deleted rules
     deletes += segmentRuleDeletedChanges?.length ?? 0;
 
+    // Count reorder
+    if (segmentRuleReorderChange) updates++;
+
     // Count default rule changes
     defaultRulesChange?.forEach(item => {
       if (item.labelType === 'ADD') adds++;
@@ -219,7 +232,8 @@ const ConfirmationRequiredModal = ({
     defaultRulesChange,
     individualChange,
     prerequisiteChanges,
-    segmentRuleDeletedChanges
+    segmentRuleDeletedChanges,
+    segmentRuleReorderChange
   ]);
 
   const isShowChange = changeBreakdown.total;
@@ -268,7 +282,9 @@ const ConfirmationRequiredModal = ({
 
   const renderSegmentRuleChanges = (): ReactNode => {
     const showCustomRuleChange =
-      !!segmentRulesChange.length || !!segmentRuleDeletedChanges.length;
+      !!segmentRulesChange.length ||
+      !!segmentRuleDeletedChanges.length ||
+      !!segmentRuleReorderChange;
     if (!showCustomRuleChange) return null;
     return (
       <DiscardChangeItems title={t('common:custom-rule')}>
@@ -314,6 +330,17 @@ const ConfirmationRequiredModal = ({
                 </div>
               ))}
             </>
+          )}
+          {segmentRuleReorderChange?.ruleOrders && (
+            <div className="flex flex-col gap-2">
+              <div className="flex pb-1 gap-1 items-center typo-para-medium leading-[1px] my-2 text-gray-700">
+                <Icon icon={IconArrowUpDown} size="sm" color="gray-600" />
+                <Trans i18nKey="form:custom-rule-reorder-confirm-desc" />
+              </div>
+              <ReorderList
+                ruleOrders={segmentRuleReorderChange.ruleOrders as RuleOrders}
+              />
+            </div>
           )}
         </div>
       </DiscardChangeItems>

--- a/ui/dashboard/src/pages/feature-flag-details/elements/discard-changes-modal/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/elements/discard-changes-modal/index.tsx
@@ -8,6 +8,7 @@ import { IconArrowUpDown, IconPlus, IconSwitchUpdate } from '@icons';
 import {
   DiscardChangesStateData,
   DiscardChangesType,
+  RuleOrders,
   VariationPercent
 } from 'pages/feature-flag-details/targeting/types';
 import { FlagVariationPolygon } from 'pages/feature-flags/collection-layout/elements';
@@ -16,6 +17,7 @@ import Button from 'components/button';
 import { ButtonBar } from 'components/button-bar';
 import Icon from 'components/icon';
 import DialogModal from 'components/modal/dialog';
+import VariationLabel from 'elements/variation-label';
 
 interface Props {
   isOpen: boolean;
@@ -24,6 +26,7 @@ interface Props {
   ruleIndex?: number;
   actionSegmentRule?: 'new-rule' | 'edit-rule' | undefined;
   ruleDiscardChange?: DiscardChangesType;
+  reorderRule?: boolean;
   onClose: () => void;
   onSubmit: (type: DiscardChangesType, index?: number) => void;
 }
@@ -350,6 +353,62 @@ const StrategyList = ({ variations }: { variations?: VariationPercent[] }) =>
     </div>
   );
 
+export const ReorderList = ({ ruleOrders }: { ruleOrders: RuleOrders }) => {
+  const { t } = useTranslation(['common', 'form']);
+
+  const RuleLabel = (ruleLabel: string[], isNewRule: boolean) => (
+    <p>
+      {isNewRule && (
+        <span className="px-1 font-bold text-accent-red-400">
+          ({t('common:new')})
+        </span>
+      )}
+      {ruleLabel.reduce<React.ReactNode[]>((acc, label, i) => {
+        if (i > 0) {
+          acc.push(<b key={`and-${i}`}> {t('common:and').toLowerCase()} </b>);
+        }
+        acc.push(<span key={`label-${i}`}>{label}</span>);
+        return acc;
+      }, [])}
+      <strong className="pl-1">{t('common:server').toLowerCase()}</strong>
+      <span>:</span>
+    </p>
+  );
+
+  return (
+    <div className="pl-4">
+      <ol className="leading-7 space-y-2">
+        {ruleOrders.labels.map((ruleLabel: string[], index: number) => (
+          <li key={`label-${index}`}>
+            <div className="flex gap-1">
+              <span>{index + 1}.</span>
+              {RuleLabel(
+                ruleLabel,
+                (ruleOrders.isNewRules && ruleOrders?.isNewRules[index]) ||
+                  false
+              )}
+            </div>
+            {ruleOrders.variations[index].map((v, vIndex: number) => (
+              <div
+                className="flex items-center gap-1 ml-4"
+                key={`variation-${index}-${vIndex}`}
+              >
+                <VariationLabel
+                  label={v.variation}
+                  index={v.variationIndex || 0}
+                />
+                {!isNil(v.weight) && (
+                  <p className="text-gray-700"> - ({v.weight}%)</p>
+                )}
+              </div>
+            ))}
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
 export const CustomRuleDiscardItem = ({
   labelType,
   label,
@@ -408,6 +467,7 @@ const DiscardChangeModal = ({
   ruleIndex,
   actionSegmentRule,
   ruleDiscardChange,
+  reorderRule = false,
   onClose,
   onSubmit
 }: Props) => {
@@ -466,6 +526,7 @@ const DiscardChangeModal = ({
             const { PREREQUISITE, INDIVIDUAL, CUSTOM, DEFAULT } =
               DiscardChangesType;
             if (isNil(item)) return null;
+            if (item.changeType === 'reorder') return null;
             if (type === PREREQUISITE)
               return <PrerequisiteDiscardItem key={index} {...item} />;
             if (type === INDIVIDUAL)
@@ -481,6 +542,23 @@ const DiscardChangeModal = ({
             }
             return null;
           })}
+
+          {reorderRule &&
+            data.map(
+              (item, index) =>
+                item?.changeType === 'reorder' &&
+                item.ruleOrders && (
+                  <div key={`reorder-${index}`} className="flex flex-col gap-2">
+                    <div className="flex gap-1 items-center typo-para-medium text-gray-700">
+                      <Icon icon={IconArrowUpDown} size="sm" color="gray-600" />
+                      <span className="font-medium">
+                        <Trans i18nKey="form:custom-rule-reorder-discard-desc" />
+                      </span>
+                    </div>
+                    <ReorderList ruleOrders={item.ruleOrders} />
+                  </div>
+                )
+            )}
         </>
       </div>
 

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
@@ -72,6 +72,7 @@ import {
   checkDefaultRuleDiscardChanges,
   computeRuleOrder,
   getDefaultRule,
+  getFeatureRuleLabels,
   handleCheckIndividualDiscardChanges,
   handleCheckIndividualRules,
   handleCheckPrerequisiteDiscardChanges,
@@ -82,7 +83,10 @@ import {
   handleCreateDefaultValues,
   handleGetDefaultRuleStrategy,
   handleGetStrategy,
-  handleSwapRuleFeature
+  handleSwapRuleFeature,
+  hasRulePositionChanged,
+  normalizeSegmentRules,
+  reorderWithReset
 } from './utils';
 
 export const TargetingDivider = () => (
@@ -129,13 +133,16 @@ const TargetingPage = ({
   const [debuggerForm, setDebuggerForm] = useState<AddDebuggerFormType | null>(
     null
   );
-  const [featureRef, setFeatureRef] = useState<Feature>(cloneDeep(feature));
+  const [trackedFeature, setTrackedFeature] = useState<Feature>(
+    cloneDeep(feature)
+  );
   const [actionRuleSegment, setActionRuleSegment] = useState<
     'new-rule' | 'edit-rule' | undefined
   >(undefined);
   const [ruleDiscardChange, setRuleDiscardChange] = useState<
     DiscardChangesType | undefined
   >(undefined);
+  const [reorderRule, setReorderRule] = useState<boolean>(false);
   const [isShowRules, setIsShowRules] = useState<boolean>(feature.enabled);
   const [discardChangesState, setDiscardChangesState] =
     useState<DiscardChangesState>({
@@ -248,7 +255,8 @@ const TargetingPage = ({
     fields: segmentRules,
     insert: segmentRulesInsert,
     remove: segmentRulesRemove,
-    swap: segmentRulesSwap
+    swap: segmentRulesSwap,
+    replace: segmentRulesReplace
   } = useFieldArray({
     control,
     name: 'segmentRules',
@@ -274,7 +282,7 @@ const TargetingPage = ({
         : segmentRulesWatch.length + 1;
       const newSegmentRule = getDefaultRule(feature);
       segmentRulesInsert(segmentIndex!, newSegmentRule);
-      setFeatureRef(prev => ({
+      setTrackedFeature(prev => ({
         ...prev,
         rules: [
           ...prev.rules.slice(0, segmentIndex),
@@ -289,7 +297,7 @@ const TargetingPage = ({
 
   const handleCheckSegmentEditing = useCallback(
     (index: number) => {
-      const currentRule = featureRef.rules[index] as FeatureRule;
+      const currentRule = trackedFeature.rules[index] as FeatureRule;
 
       const matchedRuleIndex = feature.rules.findIndex(
         r => r.id === currentRule?.id
@@ -317,7 +325,7 @@ const TargetingPage = ({
         ) || !isEqual(segmentRuleChange.clauses, segmentRulesDefault.clauses)
       );
     },
-    [[feature.rules, featureRef.rules, segmentRulesWatch, feature]]
+    [feature.rules, trackedFeature.rules, segmentRulesWatch, feature]
   );
 
   const checkEditRule = useCallback(
@@ -325,7 +333,15 @@ const TargetingPage = ({
       switch (type) {
         case RuleCategory.CUSTOM:
           if (isNil(index)) return false;
-          return handleCheckSegmentEditing(index);
+          return (
+            handleCheckSegmentEditing(index) ||
+            (feature.rules.some(r => r.id === segmentRulesWatch[index]?.id) &&
+              hasRulePositionChanged(
+                segmentRulesWatch[index]?.id,
+                feature,
+                trackedFeature
+              ))
+          );
 
         case RuleCategory.PREREQUISITE:
           return checkFieldDirty(
@@ -360,7 +376,7 @@ const TargetingPage = ({
 
   const handleSegmentRuleRemove = (segmentIndex: number) => {
     segmentRulesRemove(segmentIndex);
-    setFeatureRef(prev => ({
+    setTrackedFeature(prev => ({
       ...prev,
       rules: prev.rules.filter((_, index) => index !== segmentIndex)
     }));
@@ -369,10 +385,14 @@ const TargetingPage = ({
   const handleSwapSegmentRule = useCallback(
     (indexA: number, indexB: number) => {
       segmentRulesSwap(indexA, indexB);
-      const featureRuleSwap = handleSwapRuleFeature(featureRef, indexA, indexB);
-      setFeatureRef(featureRuleSwap);
+      const featureRuleSwap = handleSwapRuleFeature(
+        trackedFeature,
+        indexA,
+        indexB
+      );
+      setTrackedFeature(featureRuleSwap);
     },
-    [featureRef]
+    [trackedFeature]
   );
 
   const buildSchedulePayload = useCallback(
@@ -441,7 +461,7 @@ const TargetingPage = ({
   );
   const handleSegmentRuleDeleted = () => {
     return handleCheckRuleDeleted(
-      featureRef.rules,
+      segmentRulesWatch as unknown as FeatureRule[],
       feature.rules,
       features,
       segmentCollection?.segments || [],
@@ -452,9 +472,40 @@ const TargetingPage = ({
     );
   };
 
+  const handleSegmentRuleReorder = (): DiscardChangesStateData | null => {
+    const hasPositionChange = segmentRulesWatch.some(
+      r =>
+        feature.rules.some(orig => orig.id === r.id) &&
+        hasRulePositionChanged(r.id, feature, trackedFeature)
+    );
+    if (!hasPositionChange) return null;
+    const formatCurrentRules = normalizeSegmentRules(
+      trackedFeature.rules,
+      segmentRulesWatch
+    );
+    const cloneTracked = { ...trackedFeature, rules: formatCurrentRules };
+    const labelRuleOrders = getFeatureRuleLabels(
+      feature,
+      cloneTracked as Feature,
+      features,
+      segmentCollection?.segments || [],
+      situationOptions,
+      operatorOptions,
+      t,
+      feature.variations
+    );
+    return {
+      label: '',
+      labelType: 'REORDER',
+      changeType: 'reorder',
+      variationIndex: 0,
+      ruleOrders: labelRuleOrders
+    };
+  };
+
   const handleSegmentRuleChangeDiscard = (index: number, isAction: boolean) => {
-    const preRules =
-      feature.rules.find(r => r.id === featureRef.rules[index].id) || null;
+    const ruleId = segmentRulesWatch[index]?.id;
+    const preRules = feature.rules.find(r => r.id === ruleId) || null;
     const { changes, action } = handleCheckSegmentRulesDiscardChanges(
       preRules || null,
       segmentCollection?.segments || [],
@@ -496,6 +547,43 @@ const TargetingPage = ({
       if (type === DiscardChangesType.CUSTOM && !isNil(index)) {
         if (segmentRules) {
           discardData = handleSegmentRuleChangeDiscard(index, true);
+
+          const ruleId = trackedFeature.rules[index]?.id;
+          const isExistingRule = feature.rules.some(r => r.id === ruleId);
+          const isChangePosition =
+            isExistingRule &&
+            hasRulePositionChanged(ruleId, feature, trackedFeature);
+          if (isChangePosition) {
+            setReorderRule(true);
+            const formatCurrentRules = normalizeSegmentRules(
+              trackedFeature.rules,
+              segmentRules
+            );
+            const cloneFeatureRef = {
+              ...trackedFeature,
+              rules: formatCurrentRules
+            };
+
+            const labelRuleOrders = getFeatureRuleLabels(
+              feature,
+              cloneFeatureRef as Feature,
+              features,
+              segmentCollection?.segments || [],
+              situationOptions,
+              operatorOptions,
+              t,
+              feature.variations
+            );
+
+            discardData = discardData ?? [];
+            discardData.push({
+              label: '',
+              labelType: 'REORDER',
+              changeType: 'reorder',
+              variationIndex: 0,
+              ruleOrders: labelRuleOrders
+            });
+          }
         }
       }
 
@@ -515,10 +603,11 @@ const TargetingPage = ({
         ruleIndex: index
       });
     },
-    [activeFeatures, feature, segmentRulesWatch, featureRef]
+    [activeFeatures, feature, segmentRulesWatch, trackedFeature]
   );
 
   const handleOnCloseDiscardModal = useCallback(() => {
+    setReorderRule(false);
     setDiscardChangesState({
       type: undefined,
       isOpen: false,
@@ -538,24 +627,67 @@ const TargetingPage = ({
 
       if (type === DiscardChangesType.CUSTOM && typeof index === 'number') {
         setActionRuleSegment(undefined);
-        const currentRule = featureRef.rules[index] as FeatureRule;
+        setReorderRule(false);
+        const currentRule = trackedFeature.rules[index] as FeatureRule;
 
         const matchedRuleIndex = feature.rules.findIndex(
           r => r.id === currentRule.id
         );
 
         if (matchedRuleIndex !== -1) {
-          const resetSegmentRules =
-            form.formState.defaultValues?.segmentRules?.[matchedRuleIndex!];
-          setValue(`segmentRules.${index}`, resetSegmentRules as FeatureRule, {
-            shouldDirty: true,
-            shouldValidate: true
-          });
+          const resetSegmentRules = form.formState.defaultValues?.segmentRules;
+          const resetSwap = resetSegmentRules?.find(
+            r => r?.id === currentRule.id
+          );
+
+          const isPositionChanged = hasRulePositionChanged(
+            currentRule.id,
+            feature,
+            trackedFeature
+          );
+
+          if (isPositionChanged && resetSwap) {
+            // Rule exists in original and position changed — restore position and content
+            const formatCurrentRules = normalizeSegmentRules(
+              trackedFeature.rules,
+              segmentRulesWatch
+            );
+
+            const { reordered, resetIndex } = reorderWithReset(
+              feature.rules,
+              formatCurrentRules as FeatureRule[],
+              currentRule.id,
+              resetSwap as FeatureRule
+            );
+
+            // Build new tracked rules (IDs only, no form content)
+            const reorderedTracked = reordered.map(r => ({
+              ...trackedFeature.rules.find(tr => tr.id === r.id)!,
+              ...r
+            }));
+            segmentRulesReplace(reordered);
+            setTrackedFeature(prev => ({ ...prev, rules: reorderedTracked }));
+            // Reset the moved rule's dirty state using its new position
+            resetField(`segmentRules.${resetIndex}`, {
+              defaultValue: resetSwap as FeatureRule,
+              keepDirty: false
+            });
+            setTimeout(() => form.trigger('segmentRules'), 0);
+          } else {
+            // Rule exists in original, content changed only — reset content
+            const resetSegmentRule =
+              form.formState.defaultValues?.segmentRules?.[matchedRuleIndex];
+            setValue(`segmentRules.${index}`, resetSegmentRule as FeatureRule, {
+              shouldDirty: false,
+              shouldValidate: true
+            });
+          }
         } else {
+          // New rule — remove it
           segmentRulesRemove(index);
-          setFeatureRef(() => ({
-            ...featureRef,
-            rules: featureRef.rules.filter((_, i) => i !== index)
+          setTrackedFeature(() => ({
+            ...trackedFeature,
+            rules: trackedFeature.rules.filter((_, i) => i !== index)
           }));
         }
       }
@@ -565,7 +697,7 @@ const TargetingPage = ({
       }
       handleOnCloseDiscardModal();
     },
-    [feature, featureRef, segmentRulesWatch]
+    [feature, trackedFeature, segmentRulesWatch]
   );
 
   const onSubmit = useCallback(
@@ -651,7 +783,7 @@ const TargetingPage = ({
               invalidateFeatures(queryClient);
               invalidateUserSegments(queryClient);
               reset(handleCreateDefaultValues(updatedFeature));
-              setFeatureRef(cloneDeep(updatedFeature));
+              setTrackedFeature(cloneDeep(updatedFeature));
               onCloseConfirmModal();
             }
           }
@@ -832,6 +964,7 @@ const TargetingPage = ({
           isShowScheduleSelect={SCHEDULED_FLAG_CHANGES_ENABLED}
           onSegmentRuleChannge={handleSegmentRuleChangeDiscard}
           onSegmentRuleDeleted={handleSegmentRuleDeleted}
+          onSegmentRuleReorder={handleSegmentRuleReorder}
           onClose={onCloseConfirmModal}
           onSubmit={additionalValues =>
             form.handleSubmit(values => onSubmit(values, additionalValues))()
@@ -872,6 +1005,7 @@ const TargetingPage = ({
           {...discardChangesState}
           actionSegmentRule={actionRuleSegment}
           ruleDiscardChange={ruleDiscardChange}
+          reorderRule={reorderRule}
           onClose={handleOnCloseDiscardModal}
           onSubmit={onDiscardChanges}
         />

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/types.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/types.ts
@@ -57,7 +57,8 @@ export interface DiscardChangesStateData {
     | 'default-audience'
     | 'audience'
     | 'new-rule'
-    | 'deleted-rule';
+    | 'deleted-rule'
+    | 'reorder';
   ruleOrders?: RuleOrders;
   variation?: FeatureVariation;
   ruleIndex?: number;

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
@@ -348,10 +348,9 @@ export const handleCheckSegmentRules = (
   segmentRules?.forEach(item => {
     const currentRule = featureRules?.find(rule => rule.id === item.id);
     if (!currentRule) ruleChanges.push(getRuleItem(item, 'CREATE'));
-
     const formattedRule = {
       ...currentRule,
-      clauses: currentRule?.clauses,
+      clauses: currentRule?.clauses?.map(item => omit(item, 'type')),
       strategy: handleGetStrategy(currentRule?.strategy, 1)
     } as FeatureRuleChange;
 
@@ -853,6 +852,80 @@ export const handleSwapRuleFeature = (
 
   return { ...feature, rules: newRules };
 };
+
+export const hasRulePositionChanged = (
+  ruleId: string,
+  originFeatures: Feature,
+  currentFeature: Feature
+) => {
+  const originIds = originFeatures.rules.map(r => r.id);
+  const currentIds = currentFeature.rules.map(r => r.id);
+
+  if (!originIds.includes(ruleId)) return false; // new rule itself
+
+  // Filter deleted rules from origin so deletions don't cause false positives.
+  // Keep new rules in currentIds so insertions before an existing rule are detected.
+  const survivingOriginIds = originIds.filter(id => currentIds.includes(id));
+
+  const originIndex = survivingOriginIds.indexOf(ruleId);
+  const currentIndex = currentIds.indexOf(ruleId);
+
+  return originIndex !== currentIndex;
+};
+
+export function normalizeSegmentRules(
+  featureRefRules: FeatureRule[],
+  segmentRules?: TargetingSchema['segmentRules'] | undefined
+) {
+  if (!segmentRules) return [];
+  return segmentRules.map(segRule => {
+    const originalRule = segRule.id
+      ? featureRefRules.find(rule => rule.id === segRule.id)
+      : undefined;
+    return {
+      ...segRule,
+      id: segRule.id ?? originalRule?.id,
+      clauses: segRule.clauses.map(clause => {
+        const originalClause =
+          clause.id && originalRule
+            ? originalRule.clauses.find(original => original.id === clause.id)
+            : undefined;
+        return {
+          ...clause,
+          id: clause.id ?? originalClause?.id
+        };
+      })
+    };
+  });
+}
+
+export function reorderWithReset(
+  originRules: FeatureRule[],
+  currentRules: FeatureRule[],
+  resetRuleId: string,
+  resetRule: FeatureRule
+): { reordered: FeatureRule[]; resetIndex: number } {
+  const withoutReset = currentRules.filter(r => r.id !== resetRuleId);
+  const currentIds = new Set(currentRules.map(r => r.id));
+
+  // Find the reset rule's target position among rules that survive in both
+  // origin and current (excluding deleted rules so they don't shift the index).
+  const survivingOriginIds = originRules
+    .map(r => r.id)
+    .filter(id => currentIds.has(id) || id === resetRuleId);
+
+  const resetIndex = survivingOriginIds.indexOf(resetRuleId);
+  if (resetIndex < 0) return { reordered: withoutReset, resetIndex };
+
+  // Map surviving-origin index back to an insertion point in withoutReset:
+  // count how many rules before resetRuleId in survivingOriginIds are present in withoutReset.
+  const precedingIds = survivingOriginIds.slice(0, resetIndex);
+  const insertAt = withoutReset.filter(r => precedingIds.includes(r.id)).length;
+
+  const reordered = [...withoutReset];
+  reordered.splice(insertAt, 0, resetRule);
+  return { reordered, resetIndex: insertAt };
+}
 
 const getAudienceChangeData = (
   strategy: FeatureRuleStrategy,


### PR DESCRIPTION
Fixed [#2172](https://github.com/bucketeer-io/bucketeer/issues/2172)

**Summary:**

- This PR introduces explicit tracking for rule reordering, displaying clear before/after sequences in both Discard Changes and Confirm Required modals.
- Adds ruleOrder to update and scheduled-change payloads to ensure the backend receives the correct rule sequence.