### PR TITLE
feat(ui): infinite loading for the organization settings

### DIFF
--- a/ui/dashboard/src/elements/dropdown-list/index.tsx
+++ b/ui/dashboard/src/elements/dropdown-list/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, useCallback, useMemo, useRef } from 'react';
 import {
   FixedSizeList,
   ListChildComponentProps,
@@ -72,6 +72,9 @@ interface DropdownListProps extends RowWithDataProps {
   width?: string | number;
   itemSize?: number;
   maxOptions?: number;
+  isHasMore?: boolean;
+  isLoadingMore?: boolean;
+  onHasMoreOptions?: () => void;
 }
 
 const DropdownList = ({
@@ -87,14 +90,34 @@ const DropdownList = ({
   selectedFieldValue = 'value',
   className,
   additionalElement,
+  isHasMore,
+  isLoadingMore,
+  onHasMoreOptions,
   onSelectOption
 }: DropdownListProps) => {
+  const isLoadingMoreRef = useRef(isLoadingMore);
+  isLoadingMoreRef.current = isLoadingMore;
+
   const maxHeightList = useMemo(
     () =>
-      height || options.length > maxOptions
+      height ??
+      (isHasMore || options.length > maxOptions
         ? maxHeight
-        : options.length * itemSize,
-    [options, maxOptions, height, itemSize]
+        : options.length * itemSize),
+    [options, maxOptions, height, itemSize, isHasMore, maxHeight]
+  );
+
+  const handleScroll = useCallback(
+    ({ scrollOffset }: { scrollOffset: number }) => {
+      if (!isHasMore || isLoadingMoreRef.current) return;
+      const totalHeight = options.length * itemSize;
+      const isNearBottom =
+        scrollOffset + maxHeightList >= totalHeight - itemSize;
+      if (isNearBottom) {
+        onHasMoreOptions?.();
+      }
+    },
+    [isHasMore, options.length, itemSize, maxHeightList, onHasMoreOptions]
   );
 
   return (
@@ -119,6 +142,7 @@ const DropdownList = ({
       className={
         options?.length < maxOptions ? 'hidden-scroll' : 'small-scroll'
       }
+      onScroll={handleScroll}
     >
       {RowWithData}
     </List>

--- a/ui/dashboard/src/elements/dropdown-list/index.tsx
+++ b/ui/dashboard/src/elements/dropdown-list/index.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useCallback, useMemo, useRef } from 'react';
+import { ReactNode, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   FixedSizeList,
   ListChildComponentProps,
@@ -97,11 +97,20 @@ const DropdownList = ({
 }: DropdownListProps) => {
   const isLoadingMoreRef = useRef(isLoadingMore);
   isLoadingMoreRef.current = isLoadingMore;
+  const isFetchingRef = useRef(false);
+  const prevOptionsLengthRef = useRef(options.length);
+
+  useEffect(() => {
+    if (options.length !== prevOptionsLengthRef.current) {
+      prevOptionsLengthRef.current = options.length;
+      isFetchingRef.current = false;
+    }
+  }, [options.length]);
 
   const maxHeightList = useMemo(
     () =>
       height ??
-      (isHasMore || options.length > maxOptions
+      (isHasMore || options.length >= maxOptions
         ? maxHeight
         : options.length * itemSize),
     [options, maxOptions, height, itemSize, isHasMore, maxHeight]
@@ -109,11 +118,13 @@ const DropdownList = ({
 
   const handleScroll = useCallback(
     ({ scrollOffset }: { scrollOffset: number }) => {
-      if (!isHasMore || isLoadingMoreRef.current) return;
+      if (!isHasMore || isLoadingMoreRef.current || isFetchingRef.current)
+        return;
       const totalHeight = options.length * itemSize;
       const isNearBottom =
         scrollOffset + maxHeightList >= totalHeight - itemSize;
       if (isNearBottom) {
+        isFetchingRef.current = true;
         onHasMoreOptions?.();
       }
     },
@@ -140,7 +151,7 @@ const DropdownList = ({
         onSelectOption
       }}
       className={
-        options?.length < maxOptions ? 'hidden-scroll' : 'small-scroll'
+        options?.length <= maxOptions ? 'hidden-scroll' : 'small-scroll'
       }
       onScroll={handleScroll}
     >

--- a/ui/dashboard/src/elements/dropdown-with-search/index.tsx
+++ b/ui/dashboard/src/elements/dropdown-with-search/index.tsx
@@ -17,6 +17,7 @@ import {
   DropdownOption,
   DropdownValue
 } from 'components/dropdown';
+import Spinner from 'components/spinner';
 import DropdownList from 'elements/dropdown-list';
 
 export interface DropdownMenuWithSearchProps {
@@ -43,6 +44,9 @@ export interface DropdownMenuWithSearchProps {
   selectedFieldValue?: string;
   itemSize?: number;
   maxOptions?: number;
+  isHasMore?: boolean;
+  isLoadingMore?: boolean;
+  onHasMoreOptions?: () => void;
   notFoundOption?: (
     value: string,
     onChangeValue: (value: string) => void
@@ -88,6 +92,9 @@ const DropdownMenuWithSearch = ({
   itemSelected,
   itemSize = 44,
   maxOptions = 15,
+  isHasMore,
+  isLoadingMore,
+  onHasMoreOptions,
   notFoundOption,
   additionalElement,
   onSelectOption,
@@ -199,18 +206,28 @@ const DropdownMenuWithSearch = ({
           }
         />
         {dropdownOptions?.length > 0 ? (
-          <DropdownList
-            options={dropdownOptions}
-            itemSize={itemSize}
-            itemSelected={itemSelected}
-            maxOptions={maxOptions}
-            isMultiselect={isMultiselect}
-            selectedOptions={selectedOptions}
-            selectedFieldValue={selectedFieldValue}
-            additionalElement={additionalElement}
-            onSelectOption={onSelectOption}
-            className={itemClassName}
-          />
+          <>
+            <DropdownList
+              options={dropdownOptions}
+              itemSize={itemSize}
+              itemSelected={itemSelected}
+              maxOptions={maxOptions}
+              isMultiselect={isMultiselect}
+              selectedOptions={selectedOptions}
+              selectedFieldValue={selectedFieldValue}
+              additionalElement={additionalElement}
+              onSelectOption={onSelectOption}
+              className={itemClassName}
+              isHasMore={isHasMore}
+              isLoadingMore={isLoadingMore}
+              onHasMoreOptions={onHasMoreOptions}
+            />
+            {isLoadingMore && (
+              <div className="flex-center py-2">
+                <Spinner size="sm" />
+              </div>
+            )}
+          </>
         ) : notFoundOption ? (
           notFoundOption(searchValue, value => {
             setSearchValue(value);

--- a/ui/dashboard/src/elements/dropdown-with-search/index.tsx
+++ b/ui/dashboard/src/elements/dropdown-with-search/index.tsx
@@ -46,6 +46,7 @@ export interface DropdownMenuWithSearchProps {
   maxOptions?: number;
   isHasMore?: boolean;
   isLoadingMore?: boolean;
+  isSearching?: boolean;
   onHasMoreOptions?: () => void;
   notFoundOption?: (
     value: string,
@@ -94,6 +95,7 @@ const DropdownMenuWithSearch = ({
   maxOptions = 15,
   isHasMore,
   isLoadingMore,
+  isSearching,
   onHasMoreOptions,
   notFoundOption,
   additionalElement,
@@ -205,7 +207,11 @@ const DropdownMenuWithSearch = ({
             })
           }
         />
-        {dropdownOptions?.length > 0 ? (
+        {isSearching ? (
+          <div className="flex-center w-full h-[200px]">
+            <Spinner size="sm" />
+          </div>
+        ) : dropdownOptions?.length > 0 ? (
           <>
             <DropdownList
               options={dropdownOptions}

--- a/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
+++ b/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
@@ -1,0 +1,113 @@
+import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useQueryAccounts } from '@queries/accounts';
+import { LIST_PAGE_SIZE } from 'constants/app';
+import { debounce } from 'lodash';
+
+type UseAccountsLoaderParams = {
+  organizationId: string;
+  environmentId?: string;
+  environmentRole?: number;
+  pageSize?: number;
+};
+
+export const useAccountsLoader = ({
+  organizationId,
+  environmentId,
+  environmentRole,
+  pageSize = LIST_PAGE_SIZE
+}: UseAccountsLoaderParams) => {
+  const [cursor, setCursor] = useState(0);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [emails, setEmails] = useState<string[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+
+  const { data, isLoading, isFetching } = useQueryAccounts({
+    params: {
+      cursor: String(cursor),
+      pageSize,
+      searchKeyword: searchQuery,
+      organizationId,
+      environmentId,
+      environmentRole
+    }
+  });
+
+  const resetSearchState = useCallback(() => {
+    setEmails([]);
+    setHasMore(true);
+  }, []);
+
+  const debouncedSearch = useMemo(
+    () =>
+      debounce((value: string) => {
+        resetSearchState();
+        setCursor(0);
+        setSearchQuery(value);
+      }, 300),
+    [resetSearchState]
+  );
+
+  const onSearchChange = useCallback(
+    (value: string) => {
+      if (!value) {
+        debouncedSearch.cancel();
+        resetSearchState();
+        setCursor(0);
+        setSearchQuery('');
+      } else {
+        debouncedSearch(value);
+      }
+    },
+    [debouncedSearch, resetSearchState]
+  );
+
+  const loadMore = useCallback(() => {
+    setCursor(prev => prev + pageSize);
+  }, [pageSize]);
+
+  useEffect(() => {
+    if (!data?.accounts) return;
+
+    setEmails(prev => {
+      if (cursor === 0) {
+        return data.accounts.map(a => a.email);
+      }
+      const existingSet = new Set(prev);
+      const newEmails = data.accounts
+        .map(a => a.email)
+        .filter(e => !existingSet.has(e));
+      return newEmails.length ? [...prev, ...newEmails] : prev;
+    });
+  }, [data]);
+
+  useEffect(() => {
+    const total = Number(data?.totalCount ?? 0);
+    const nextCursor = cursor + pageSize;
+    setHasMore(nextCursor < total);
+  }, [data, cursor, pageSize]);
+
+  useEffect(() => {
+    return () => {
+      debouncedSearch.cancel();
+    };
+  }, [debouncedSearch]);
+
+  const emailOptions = useMemo(
+    () => emails.map(email => ({ label: email, value: email })),
+    [emails]
+  );
+
+  const isInitialLoading =
+    isLoading && !searchQuery && cursor === 0 && emails.length === 0;
+
+  return {
+    emails,
+    emailOptions,
+    isLoading,
+    hasMore,
+    isLoadingMore: isFetching && cursor > 0,
+    isInitialLoading,
+    loadMore,
+    onSearchChange
+  };
+};

--- a/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
+++ b/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
@@ -20,6 +20,7 @@ export const useAccountsLoader = ({
   const [searchQuery, setSearchQuery] = useState('');
   const [emails, setEmails] = useState<string[]>([]);
   const [hasMore, setHasMore] = useState(true);
+  const [isTyping, setIsTyping] = useState(false);
 
   const { data, isLoading, isFetching } = useQueryAccounts({
     params: {
@@ -35,6 +36,8 @@ export const useAccountsLoader = ({
   const debouncedSearch = useMemo(
     () =>
       debounce((value: string) => {
+        setEmails([]);
+        setHasMore(true);
         setCursor(0);
         setSearchQuery(value);
       }, 300),
@@ -45,9 +48,11 @@ export const useAccountsLoader = ({
     (value: string) => {
       if (!value) {
         debouncedSearch.cancel();
+        setIsTyping(false);
         setCursor(0);
         setSearchQuery('');
       } else {
+        setIsTyping(true);
         debouncedSearch(value);
       }
     },
@@ -61,6 +66,7 @@ export const useAccountsLoader = ({
   useEffect(() => {
     if (!data?.accounts) return;
 
+    setIsTyping(false);
     setEmails(prev => {
       if (cursor === 0) {
         return data.accounts.map(a => a.email);
@@ -71,12 +77,11 @@ export const useAccountsLoader = ({
         .filter(e => !existingSet.has(e));
       return newEmails.length ? [...prev, ...newEmails] : prev;
     });
-  }, [data]);
 
-  useEffect(() => {
-    const total = Number(data?.totalCount ?? 0);
-    const nextCursor = cursor + pageSize;
-    setHasMore(nextCursor < total);
+    if (data.totalCount != null) {
+      const total = Number(data.totalCount);
+      setHasMore(cursor + pageSize < total);
+    }
   }, [data, cursor, pageSize]);
 
   useEffect(() => {
@@ -93,6 +98,8 @@ export const useAccountsLoader = ({
   const isInitialLoading =
     isLoading && !searchQuery && cursor === 0 && emails.length === 0;
 
+  const isSearching = isTyping || (isFetching && cursor === 0 && !!searchQuery);
+
   return {
     emails,
     emailOptions,
@@ -100,6 +107,7 @@ export const useAccountsLoader = ({
     hasMore,
     isLoadingMore: isFetching && cursor > 0,
     isInitialLoading,
+    isSearching,
     loadMore,
     onSearchChange
   };

--- a/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
+++ b/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
@@ -32,33 +32,26 @@ export const useAccountsLoader = ({
     }
   });
 
-  const resetSearchState = useCallback(() => {
-    setEmails([]);
-    setHasMore(true);
-  }, []);
-
   const debouncedSearch = useMemo(
     () =>
       debounce((value: string) => {
-        resetSearchState();
         setCursor(0);
         setSearchQuery(value);
       }, 300),
-    [resetSearchState]
+    []
   );
 
   const onSearchChange = useCallback(
     (value: string) => {
       if (!value) {
         debouncedSearch.cancel();
-        resetSearchState();
         setCursor(0);
         setSearchQuery('');
       } else {
         debouncedSearch(value);
       }
     },
-    [debouncedSearch, resetSearchState]
+    [debouncedSearch]
   );
 
   const loadMore = useCallback(() => {

--- a/ui/dashboard/src/pages/settings/page-content.tsx
+++ b/ui/dashboard/src/pages/settings/page-content.tsx
@@ -4,26 +4,25 @@ import { IconLaunchOutlined } from 'react-icons-material-design';
 import { Link } from 'react-router';
 import { organizationUpdater } from '@api/organization';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useQueryAccounts } from '@queries/accounts';
 import { invalidateOrganizationDetails } from '@queries/organization-details';
 import { invalidateOrganizations } from '@queries/organizations';
 import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth, useAuthAccess } from 'auth';
-import { LIST_PAGE_SIZE } from 'constants/app';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
 import { useToast } from 'hooks';
+import { useAccountsLoader } from 'hooks/use-accounts-loading-more';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
 import { useUnsavedLeavePage } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import * as yup from 'yup';
 import { Organization } from '@types';
 import Button from 'components/button';
-import Dropdown from 'components/dropdown';
 import Form from 'components/form';
 import Icon from 'components/icon';
 import Input from 'components/input';
 import TextArea from 'components/textarea';
 import DisabledButtonTooltip from 'elements/disabled-button-tooltip';
+import DropdownMenuWithSearch from 'elements/dropdown-with-search';
 import PageLayout from 'elements/page-layout';
 
 const formSchema = ({ requiredMessage }: FormSchemaProps) =>
@@ -49,12 +48,15 @@ const PageContent = ({ organization }: { organization: Organization }) => {
   const queryClient = useQueryClient();
 
   const { t } = useTranslation(['common', 'form', 'message']);
-  const { data: accounts, isLoading: isLoadingAccounts } = useQueryAccounts({
-    params: {
-      cursor: String(0),
-      pageSize: LIST_PAGE_SIZE,
-      organizationId: currentEnvironment.organizationId
-    }
+  const {
+    emailOptions,
+    isInitialLoading: isLoadingAccounts,
+    isLoadingMore,
+    hasMore,
+    loadMore,
+    onSearchChange
+  } = useAccountsLoader({
+    organizationId: currentEnvironment.organizationId
   });
   const disabled = useMemo(
     () => !envEditable || !isOrganizationAdmin,
@@ -173,19 +175,19 @@ const PageContent = ({ organization }: { organization: Organization }) => {
                 <Form.Item>
                   <Form.Label required>{t('form:owner-email')}</Form.Label>
                   <Form.Control className="w-full">
-                    <Dropdown
-                      options={
-                        accounts?.accounts.map(item => ({
-                          value: item.email,
-                          label: item.email
-                        })) || []
-                      }
-                      value={field.value}
-                      onChange={field.onChange}
+                    <DropdownMenuWithSearch
+                      isExpand
+                      label={field.value}
                       placeholder={t('form:owner-email')}
-                      disabled={isLoadingAccounts || disabled}
-                      className="w-full"
-                      contentClassName="w-[400px]"
+                      options={emailOptions}
+                      itemSelected={field.value}
+                      isLoading={isLoadingAccounts}
+                      disabled={disabled}
+                      isHasMore={hasMore}
+                      isLoadingMore={isLoadingMore}
+                      onHasMoreOptions={loadMore}
+                      onSelectOption={value => field.onChange(value)}
+                      onSearchChange={onSearchChange}
                     />
                   </Form.Control>
                   <Form.Message />

--- a/ui/dashboard/src/pages/settings/page-content.tsx
+++ b/ui/dashboard/src/pages/settings/page-content.tsx
@@ -52,6 +52,7 @@ const PageContent = ({ organization }: { organization: Organization }) => {
     emailOptions,
     isInitialLoading: isLoadingAccounts,
     isLoadingMore,
+    isSearching,
     hasMore,
     loadMore,
     onSearchChange
@@ -185,6 +186,7 @@ const PageContent = ({ organization }: { organization: Organization }) => {
                       disabled={disabled}
                       isHasMore={hasMore}
                       isLoadingMore={isLoadingMore}
+                      isSearching={isSearching}
                       onHasMoreOptions={loadMore}
                       onSelectOption={value => field.onChange(value)}
                       onSearchChange={onSearchChange}


### PR DESCRIPTION
Fixed [#2539](https://github.com/bucketeer-io/bucketeer/issues/2539)

**Summary**

- Add infinite scroll support to the DropdownList and DropdownMenuWithSearch elements via new isHasMore, isLoadingMore, and onHasMoreOptions props, triggering loadMore when the user scrolls near the bottom of the list
- Introduce useAccountsLoader hook that manages paginated account fetching with cursor-based pagination, debounced search, and accumulated results across pages
- Replace the static Dropdown on the Organization Settings owner email field with the DropdownMenuWithSearch component wired to useAccountsLoader.