### PR TITLE
feat: add domain event-driven redis cache eviction via subscriber service

### DIFF
--- a/docker-compose/config/subscriber-config/subscribers.json
+++ b/docker-compose/config/subscriber-config/subscribers.json
@@ -118,6 +118,23 @@
     "maxMps": 50,
     "workerNum": 1
   },
+  "cacheEviction": {
+    "pubSubType": "redis-stream",
+    "redisServerName": "redis",
+    "redisAddr": "redis:6379",
+    "redisPoolSize": 10,
+    "redisMinIdle": 1,
+    "project": "bucketeer",
+    "redisPartitionCount": 16,
+    "redisMode": "auto",
+    "topic": "domain",
+    "subscription": "cache-eviction",
+    "pullerNumGoroutines": 5,
+    "pullerMaxOutstandingMessages": 1000,
+    "pullerMaxOutstandingBytes": 1000000000,
+    "maxMps": 50,
+    "workerNum": 1
+  },
   "userEventPersister": {
     "pubSubType": "redis-stream",
     "redisServerName": "redis",

--- a/manifests/bucketeer/charts/subscriber/values.yaml
+++ b/manifests/bucketeer/charts/subscriber/values.yaml
@@ -153,6 +153,16 @@ subscribers:
     pullerMaxOutstandingBytes: 1000000000
     maxMps: 50
     workerNum: 1
+  cacheEviction:
+    pubSubType: google
+    project:
+    topic:
+    subscription:
+    pullerNumGoroutines: 5
+    pullerMaxOutstandingMessages: 1000
+    pullerMaxOutstandingBytes: 1000000000
+    maxMps: 50
+    workerNum: 1
   evaluationCountEventPersister:
     pubSubType: google
     project:

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -483,6 +483,20 @@ subscriber:
       pullerMaxOutstandingBytes: 1000000000
       maxMps: 50
       workerNum: 1
+    cacheEviction:
+      pubSubType: ${global.pubsub.type}
+      redisAddr: ${global.pubsub.redis.addr}
+      redisPoolSize: ${global.pubsub.redis.poolSize}
+      redisMinIdle: ${global.pubsub.redis.minIdle}
+      redisMode: ${global.pubsub.redis.mode}
+      project: ${global.pubsub.project}
+      topic: domain
+      subscription: cache-eviction-domain-sub
+      pullerNumGoroutines: 5
+      pullerMaxOutstandingMessages: 1000
+      pullerMaxOutstandingBytes: 1000000000
+      maxMps: 50
+      workerNum: 1
     evaluationCountEventPersister:
       pubSubType: ${global.pubsub.type}
       redisAddr: ${global.pubsub.redis.addr}

--- a/pkg/api/api/cache_invalidator.go
+++ b/pkg/api/api/cache_invalidator.go
@@ -16,6 +16,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 
 	"github.com/golang/protobuf/proto" // nolint:staticcheck
 	"go.uber.org/zap"
@@ -26,20 +27,23 @@ import (
 )
 
 type cacheInvalidator struct {
-	featuresCache     cachev3.FeaturesCache
-	segmentUsersCache cachev3.SegmentUsersCache
-	logger            *zap.Logger
+	featuresCache          cachev3.FeaturesCache
+	segmentUsersCache      cachev3.SegmentUsersCache
+	environmentAPIKeyCache cachev3.EnvironmentAPIKeyCache
+	logger                 *zap.Logger
 }
 
 func NewCacheInvalidator(
 	featuresCache cachev3.FeaturesCache,
 	segmentUsersCache cachev3.SegmentUsersCache,
+	environmentAPIKeyCache cachev3.EnvironmentAPIKeyCache,
 	logger *zap.Logger,
 ) *cacheInvalidator {
 	return &cacheInvalidator{
-		featuresCache:     featuresCache,
-		segmentUsersCache: segmentUsersCache,
-		logger:            logger.Named("cache-invalidator"),
+		featuresCache:          featuresCache,
+		segmentUsersCache:      segmentUsersCache,
+		environmentAPIKeyCache: environmentAPIKeyCache,
+		logger:                 logger.Named("cache-invalidator"),
 	}
 }
 
@@ -66,7 +70,15 @@ func (ci *cacheInvalidator) handleMessage(msg *puller.Message) {
 	}
 	switch event.EntityType {
 	case domaineventproto.Event_FEATURE:
-		ci.featuresCache.Evict(event.EnvironmentId)
+		if err := ci.featuresCache.Evict(event.EnvironmentId); err != nil {
+			ci.logger.Warn("Failed to evict features cache",
+				zap.Error(err),
+				zap.String("environmentId", event.EnvironmentId),
+				zap.String("entityId", event.EntityId),
+				zap.String("type", event.Type.String()),
+			)
+			return
+		}
 		cacheInvalidationCounter.WithLabelValues(
 			event.EntityType.String(), event.Type.String(), event.EnvironmentId,
 		).Inc()
@@ -76,7 +88,15 @@ func (ci *cacheInvalidator) handleMessage(msg *puller.Message) {
 			zap.String("type", event.Type.String()),
 		)
 	case domaineventproto.Event_SEGMENT:
-		ci.segmentUsersCache.Evict(event.EntityId, event.EnvironmentId)
+		if err := ci.segmentUsersCache.Evict(event.EntityId, event.EnvironmentId); err != nil {
+			ci.logger.Warn("Failed to evict segment users cache",
+				zap.Error(err),
+				zap.String("environmentId", event.EnvironmentId),
+				zap.String("segmentId", event.EntityId),
+				zap.String("type", event.Type.String()),
+			)
+			return
+		}
 		cacheInvalidationCounter.WithLabelValues(
 			event.EntityType.String(), event.Type.String(), event.EnvironmentId,
 		).Inc()
@@ -85,5 +105,68 @@ func (ci *cacheInvalidator) handleMessage(msg *puller.Message) {
 			zap.String("segmentId", event.EntityId),
 			zap.String("type", event.Type.String()),
 		)
+	case domaineventproto.Event_APIKEY:
+		secrets := apiKeySecretsForInvalidation(event)
+		if len(secrets) == 0 {
+			ci.logger.Warn(
+				"Skipping environment API key cache eviction; could not read api_key from entity data",
+				zap.String("environmentId", event.EnvironmentId),
+				zap.String("entityId", event.EntityId),
+				zap.String("type", event.Type.String()),
+			)
+			return
+		}
+		for _, s := range secrets {
+			if err := ci.environmentAPIKeyCache.Evict(s); err != nil {
+				ci.logger.Warn("Failed to evict environment API key cache",
+					zap.Error(err),
+					zap.String("environmentId", event.EnvironmentId),
+					zap.String("entityId", event.EntityId),
+					zap.String("type", event.Type.String()),
+				)
+				return
+			}
+		}
+		cacheInvalidationCounter.WithLabelValues(
+			event.EntityType.String(), event.Type.String(), event.EnvironmentId,
+		).Inc()
+		ci.logger.Debug("Evicted environment API key cache",
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("entityId", event.EntityId),
+			zap.String("type", event.Type.String()),
+		)
 	}
+}
+
+// apiKeySecretsForInvalidation returns distinct raw API key strings from domain event
+// entity snapshots (JSON of account.APIKey). Both previous and current are included so
+// a future rotation can evict the old and new secrets.
+func apiKeySecretsForInvalidation(e *domaineventproto.Event) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, raw := range []string{e.GetPreviousEntityData(), e.GetEntityData()} {
+		sec := apiKeySecretFromEntityJSON(raw)
+		if sec == "" {
+			continue
+		}
+		if _, ok := seen[sec]; ok {
+			continue
+		}
+		seen[sec] = struct{}{}
+		out = append(out, sec)
+	}
+	return out
+}
+
+func apiKeySecretFromEntityJSON(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var v struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return ""
+	}
+	return v.APIKey
 }

--- a/pkg/api/api/cache_invalidator.go
+++ b/pkg/api/api/cache_invalidator.go
@@ -108,14 +108,24 @@ func (ci *cacheInvalidator) handleMessage(msg *puller.Message) {
 	case domaineventproto.Event_APIKEY:
 		secrets, err := domaineventdomain.ExtractAPIKeySecrets(event)
 		if err != nil {
-			ci.logger.Error(
-				"Failed to extract api_key from entity data",
-				zap.Error(err),
-				zap.String("environmentId", event.EnvironmentId),
-				zap.String("entityId", event.EntityId),
-				zap.String("type", event.Type.String()),
-			)
-			return
+			if len(secrets) > 0 {
+				ci.logger.Warn(
+					"Partially failed to extract api_key from entity data; evicting available secrets",
+					zap.Error(err),
+					zap.String("environmentId", event.EnvironmentId),
+					zap.String("entityId", event.EntityId),
+					zap.String("type", event.Type.String()),
+				)
+			} else {
+				ci.logger.Error(
+					"Failed to extract api_key from entity data",
+					zap.Error(err),
+					zap.String("environmentId", event.EnvironmentId),
+					zap.String("entityId", event.EntityId),
+					zap.String("type", event.Type.String()),
+				)
+				return
+			}
 		}
 		if len(secrets) == 0 {
 			return

--- a/pkg/api/api/cache_invalidator.go
+++ b/pkg/api/api/cache_invalidator.go
@@ -16,12 +16,12 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/golang/protobuf/proto" // nolint:staticcheck
 	"go.uber.org/zap"
 
 	cachev3 "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3"
+	domaineventdomain "github.com/bucketeer-io/bucketeer/v2/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller"
 	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
@@ -106,14 +106,18 @@ func (ci *cacheInvalidator) handleMessage(msg *puller.Message) {
 			zap.String("type", event.Type.String()),
 		)
 	case domaineventproto.Event_APIKEY:
-		secrets := apiKeySecretsForInvalidation(event)
-		if len(secrets) == 0 {
-			ci.logger.Warn(
-				"Skipping environment API key cache eviction; could not read api_key from entity data",
+		secrets, err := domaineventdomain.ExtractAPIKeySecrets(event)
+		if err != nil {
+			ci.logger.Error(
+				"Failed to extract api_key from entity data",
+				zap.Error(err),
 				zap.String("environmentId", event.EnvironmentId),
 				zap.String("entityId", event.EntityId),
 				zap.String("type", event.Type.String()),
 			)
+			return
+		}
+		if len(secrets) == 0 {
 			return
 		}
 		for _, s := range secrets {
@@ -136,37 +140,4 @@ func (ci *cacheInvalidator) handleMessage(msg *puller.Message) {
 			zap.String("type", event.Type.String()),
 		)
 	}
-}
-
-// apiKeySecretsForInvalidation returns distinct raw API key strings from domain event
-// entity snapshots (JSON of account.APIKey). Both previous and current are included so
-// a future rotation can evict the old and new secrets.
-func apiKeySecretsForInvalidation(e *domaineventproto.Event) []string {
-	seen := make(map[string]struct{})
-	var out []string
-	for _, raw := range []string{e.GetPreviousEntityData(), e.GetEntityData()} {
-		sec := apiKeySecretFromEntityJSON(raw)
-		if sec == "" {
-			continue
-		}
-		if _, ok := seen[sec]; ok {
-			continue
-		}
-		seen[sec] = struct{}{}
-		out = append(out, sec)
-	}
-	return out
-}
-
-func apiKeySecretFromEntityJSON(raw string) string {
-	if raw == "" {
-		return ""
-	}
-	var v struct {
-		APIKey string `json:"api_key"`
-	}
-	if err := json.Unmarshal([]byte(raw), &v); err != nil {
-		return ""
-	}
-	return v.APIKey
 }

--- a/pkg/api/api/cache_invalidator_test.go
+++ b/pkg/api/api/cache_invalidator_test.go
@@ -25,6 +25,7 @@ import (
 
 	cachev3 "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller"
+	accountproto "github.com/bucketeer-io/bucketeer/v2/proto/account"
 	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
 )
@@ -35,9 +36,9 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 	patterns := []struct {
 		desc             string
 		event            *domaineventproto.Event
-		setupCache       func(featuresCache cachev3.FeaturesCache, segmentUsersCache cachev3.SegmentUsersCache)
-		verifyNotEvicted func(t *testing.T, featuresCache cachev3.FeaturesCache, segmentUsersCache cachev3.SegmentUsersCache)
-		verifyEvicted    func(t *testing.T, featuresCache cachev3.FeaturesCache, segmentUsersCache cachev3.SegmentUsersCache)
+		setupCache       func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache)
+		verifyNotEvicted func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache)
+		verifyEvicted    func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache)
 	}{
 		{
 			desc: "feature event evicts features cache",
@@ -47,12 +48,12 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 				EnvironmentId: "env-1",
 				Type:          domaineventproto.Event_FEATURE_UPDATED,
 			},
-			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				fc.Put(&featureproto.Features{
 					Features: []*featureproto.Feature{{Id: "feature-id-1"}},
 				}, "env-1")
 			},
-			verifyEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			verifyEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				_, err := fc.Get("env-1")
 				assert.Error(t, err, "features cache should be evicted for env-1")
 			},
@@ -65,15 +66,59 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 				EnvironmentId: "env-1",
 				Type:          domaineventproto.Event_SEGMENT_CREATED,
 			},
-			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				sc.Put(&featureproto.SegmentUsers{
 					SegmentId: "segment-id-1",
 					Users:     []*featureproto.SegmentUser{{UserId: "u1"}},
 				}, "env-1")
 			},
-			verifyEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			verifyEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				_, err := sc.Get("segment-id-1", "env-1")
 				assert.Error(t, err, "segment users cache should be evicted")
+			},
+		},
+		{
+			desc: "api key event evicts environment api key cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_APIKEY,
+				EntityId:      "apikey-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_APIKEY_CHANGED,
+				EntityData:    `{"api_key": "secret-123"}`,
+			},
+			setupCache: func(_ cachev3.FeaturesCache, _ cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache) {
+				akc.Put(&accountproto.EnvironmentAPIKey{
+					ApiKey: &accountproto.APIKey{ApiKey: "secret-123"},
+				})
+			},
+			verifyEvicted: func(t *testing.T, _ cachev3.FeaturesCache, _ cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache) {
+				_, err := akc.Get("secret-123")
+				assert.Error(t, err, "api key cache should be evicted for secret-123")
+			},
+		},
+		{
+			desc: "api key event evicts both old and new secrets on rotation",
+			event: &domaineventproto.Event{
+				EntityType:         domaineventproto.Event_APIKEY,
+				EntityId:           "apikey-id-1",
+				EnvironmentId:      "env-1",
+				Type:               domaineventproto.Event_APIKEY_CHANGED,
+				EntityData:         `{"api_key": "new-secret"}`,
+				PreviousEntityData: `{"api_key": "old-secret"}`,
+			},
+			setupCache: func(_ cachev3.FeaturesCache, _ cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache) {
+				akc.Put(&accountproto.EnvironmentAPIKey{
+					ApiKey: &accountproto.APIKey{ApiKey: "old-secret"},
+				})
+				akc.Put(&accountproto.EnvironmentAPIKey{
+					ApiKey: &accountproto.APIKey{ApiKey: "new-secret"},
+				})
+			},
+			verifyEvicted: func(t *testing.T, _ cachev3.FeaturesCache, _ cachev3.SegmentUsersCache, akc cachev3.EnvironmentAPIKeyCache) {
+				_, err := akc.Get("old-secret")
+				assert.Error(t, err, "old api key cache should be evicted")
+				_, err = akc.Get("new-secret")
+				assert.Error(t, err, "new api key cache should be evicted")
 			},
 		},
 		{
@@ -84,12 +129,12 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 				EnvironmentId: "env-1",
 				Type:          domaineventproto.Event_ACCOUNT_V2_CREATED,
 			},
-			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				fc.Put(&featureproto.Features{
 					Features: []*featureproto.Feature{{Id: "feature-id-1"}},
 				}, "env-1")
 			},
-			verifyNotEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			verifyNotEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				features, err := fc.Get("env-1")
 				assert.NoError(t, err, "features cache should NOT be evicted for unrelated entity type")
 				assert.Len(t, features.Features, 1)
@@ -103,7 +148,7 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 				EnvironmentId: "env-1",
 				Type:          domaineventproto.Event_FEATURE_VERSION_INCREMENTED,
 			},
-			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			setupCache: func(fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				fc.Put(&featureproto.Features{
 					Features: []*featureproto.Feature{{Id: "f1"}},
 				}, "env-1")
@@ -111,7 +156,7 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 					Features: []*featureproto.Feature{{Id: "f2"}},
 				}, "env-2")
 			},
-			verifyEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache) {
+			verifyEvicted: func(t *testing.T, fc cachev3.FeaturesCache, sc cachev3.SegmentUsersCache, _ cachev3.EnvironmentAPIKeyCache) {
 				_, err := fc.Get("env-1")
 				assert.Error(t, err, "env-1 should be evicted")
 				features, err := fc.Get("env-2")
@@ -131,7 +176,7 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 			invalidator := NewCacheInvalidator(featuresCache, segmentUsersCache, environmentAPIKeyCache, zap.NewNop())
 
 			if p.setupCache != nil {
-				p.setupCache(featuresCache, segmentUsersCache)
+				p.setupCache(featuresCache, segmentUsersCache, environmentAPIKeyCache)
 			}
 
 			data, err := proto.Marshal(p.event)
@@ -141,10 +186,10 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 			invalidator.handleMessage(msg)
 
 			if p.verifyEvicted != nil {
-				p.verifyEvicted(t, featuresCache, segmentUsersCache)
+				p.verifyEvicted(t, featuresCache, segmentUsersCache, environmentAPIKeyCache)
 			}
 			if p.verifyNotEvicted != nil {
-				p.verifyNotEvicted(t, featuresCache, segmentUsersCache)
+				p.verifyNotEvicted(t, featuresCache, segmentUsersCache, environmentAPIKeyCache)
 			}
 		})
 	}

--- a/pkg/api/api/cache_invalidator_test.go
+++ b/pkg/api/api/cache_invalidator_test.go
@@ -126,8 +126,9 @@ func TestCacheInvalidatorHandleMessage(t *testing.T) {
 			inMemoryCache := cachev3.NewInMemoryCache()
 			featuresCache := cachev3.NewFeaturesCache(inMemoryCache, 10*time.Minute)
 			segmentUsersCache := cachev3.NewSegmentUsersCache(inMemoryCache, 10*time.Minute)
+			environmentAPIKeyCache := cachev3.NewEnvironmentAPIKeyCache(inMemoryCache, 10*time.Minute)
 
-			invalidator := NewCacheInvalidator(featuresCache, segmentUsersCache, zap.NewNop())
+			invalidator := NewCacheInvalidator(featuresCache, segmentUsersCache, environmentAPIKeyCache, zap.NewNop())
 
 			if p.setupCache != nil {
 				p.setupCache(featuresCache, segmentUsersCache)

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -740,10 +740,12 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 }
 
 // startCacheInvalidator subscribes to domain events to evict L1 in-memory
-// cache entries when feature flags or segments are updated. Each pod uses a
-// unique consumer group (based on hostname) so every pod receives every event.
-// It returns a cleanup function that deletes the GCP subscription or Redis
-// consumer group on graceful shutdown.
+// cache entries when feature flags, segments, or API keys are updated. Each
+// pod uses a unique consumer group (based on hostname) so every pod receives
+// every event. (L2 Redis for features/segments/API keys is not invalidated here,
+// same as for feature and segment caches.)
+// It returns a cleanup function that deletes the pub/sub subscription or
+// pub/sub consumer group on graceful shutdown.
 func (s *server) startCacheInvalidator(
 	ctx context.Context,
 	pubsubClient factory.Client,
@@ -778,6 +780,7 @@ func (s *server) startCacheInvalidator(
 	invalidator := api.NewCacheInvalidator(
 		cachev3.NewFeaturesCache(inMemoryCache, 0),
 		cachev3.NewSegmentUsersCache(inMemoryCache, 0),
+		cachev3.NewEnvironmentAPIKeyCache(inMemoryCache, 0),
 		logger,
 	)
 	go func() {

--- a/pkg/cache/v3/autoops.go
+++ b/pkg/cache/v3/autoops.go
@@ -33,6 +33,7 @@ const (
 type AutoOpsRulesCache interface {
 	Get(environmentId string) (*aoproto.AutoOpsRules, error)
 	Put(autoOps *aoproto.AutoOpsRules, environmentId string) error
+	Evict(environmentId string) error
 }
 
 type autoOpsRulesCache struct {
@@ -68,6 +69,10 @@ func (c *autoOpsRulesCache) Put(autoOps *aoproto.AutoOpsRules, environmentId str
 	}
 	key := c.key(environmentId)
 	return c.cache.Put(key, buffer, autoOpsRuleCacheTTL)
+}
+
+func (c *autoOpsRulesCache) Evict(environmentId string) error {
+	return evictKey(c.cache, c.key(environmentId))
 }
 
 func (c *autoOpsRulesCache) key(environmentId string) string {

--- a/pkg/cache/v3/environment_api_key.go
+++ b/pkg/cache/v3/environment_api_key.go
@@ -31,6 +31,7 @@ const (
 type EnvironmentAPIKeyCache interface {
 	Get(string) (*accountproto.EnvironmentAPIKey, error)
 	Put(*accountproto.EnvironmentAPIKey) error
+	Evict(apiKey string) error
 }
 
 type environmentAPIKeyCache struct {
@@ -66,6 +67,10 @@ func (c *environmentAPIKeyCache) Put(environmentAPIKey *accountproto.Environment
 	}
 	key := c.key(environmentAPIKey.ApiKey.ApiKey)
 	return c.cache.Put(key, buffer, c.ttl)
+}
+
+func (c *environmentAPIKeyCache) Evict(apiKey string) error {
+	return evictKey(c.cache, c.key(apiKey))
 }
 
 func (c *environmentAPIKeyCache) key(apiKey string) string {

--- a/pkg/cache/v3/eviction.go
+++ b/pkg/cache/v3/eviction.go
@@ -14,6 +14,8 @@
 
 package v3
 
+import "fmt"
+
 type keyDeleter interface {
 	Delete(key string) error
 }
@@ -26,6 +28,6 @@ func evictKey(c interface{}, key string) error {
 	case keyDeleter:
 		return backing.Delete(key)
 	default:
-		return nil
+		return fmt.Errorf("cache: unsupported cache backend type %T for eviction", c)
 	}
 }

--- a/pkg/cache/v3/eviction.go
+++ b/pkg/cache/v3/eviction.go
@@ -1,0 +1,31 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v3
+
+type keyDeleter interface {
+	Delete(key string) error
+}
+
+func evictKey(c interface{}, key string) error {
+	switch backing := c.(type) {
+	case *InMemoryCache:
+		backing.Delete(key)
+		return nil
+	case keyDeleter:
+		return backing.Delete(key)
+	default:
+		return nil
+	}
+}

--- a/pkg/cache/v3/experiments.go
+++ b/pkg/cache/v3/experiments.go
@@ -33,6 +33,7 @@ const (
 type ExperimentsCache interface {
 	Get(environmentId string) (*exproto.Experiments, error)
 	Put(experiments *exproto.Experiments, environmentId string) error
+	Evict(environmentId string) error
 }
 
 type experimentsCache struct {
@@ -68,6 +69,10 @@ func (c *experimentsCache) Put(experiments *exproto.Experiments, environmentId s
 	}
 	key := c.key(environmentId)
 	return c.cache.Put(key, buffer, experimentCacheTTL)
+}
+
+func (c *experimentsCache) Evict(environmentId string) error {
+	return evictKey(c.cache, c.key(environmentId))
 }
 
 func (c *experimentsCache) key(environmentId string) string {

--- a/pkg/cache/v3/features.go
+++ b/pkg/cache/v3/features.go
@@ -32,7 +32,7 @@ const (
 type FeaturesCache interface {
 	Get(environmentId string) (*featureproto.Features, error)
 	Put(features *featureproto.Features, environmentId string) error
-	Evict(environmentId string)
+	Evict(environmentId string) error
 }
 
 type featuresCache struct {
@@ -71,10 +71,8 @@ func (c *featuresCache) Put(features *featureproto.Features, environmentId strin
 	return c.cache.Put(key, buffer, c.ttl)
 }
 
-func (c *featuresCache) Evict(environmentId string) {
-	if inMemory, ok := c.cache.(*InMemoryCache); ok {
-		inMemory.Delete(c.key(environmentId))
-	}
+func (c *featuresCache) Evict(environmentId string) error {
+	return evictKey(c.cache, c.key(environmentId))
 }
 
 func (c *featuresCache) key(environmentId string) string {

--- a/pkg/cache/v3/mock/autoops.go
+++ b/pkg/cache/v3/mock/autoops.go
@@ -40,6 +40,20 @@ func (m *MockAutoOpsRulesCache) EXPECT() *MockAutoOpsRulesCacheMockRecorder {
 	return m.recorder
 }
 
+// Evict mocks base method.
+func (m *MockAutoOpsRulesCache) Evict(environmentId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Evict", environmentId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Evict indicates an expected call of Evict.
+func (mr *MockAutoOpsRulesCacheMockRecorder) Evict(environmentId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Evict", reflect.TypeOf((*MockAutoOpsRulesCache)(nil).Evict), environmentId)
+}
+
 // Get mocks base method.
 func (m *MockAutoOpsRulesCache) Get(environmentId string) (*autoops.AutoOpsRules, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cache/v3/mock/environment_api_key.go
+++ b/pkg/cache/v3/mock/environment_api_key.go
@@ -40,6 +40,20 @@ func (m *MockEnvironmentAPIKeyCache) EXPECT() *MockEnvironmentAPIKeyCacheMockRec
 	return m.recorder
 }
 
+// Evict mocks base method.
+func (m *MockEnvironmentAPIKeyCache) Evict(apiKey string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Evict", apiKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Evict indicates an expected call of Evict.
+func (mr *MockEnvironmentAPIKeyCacheMockRecorder) Evict(apiKey any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Evict", reflect.TypeOf((*MockEnvironmentAPIKeyCache)(nil).Evict), apiKey)
+}
+
 // Get mocks base method.
 func (m *MockEnvironmentAPIKeyCache) Get(arg0 string) (*account.EnvironmentAPIKey, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cache/v3/mock/experiments.go
+++ b/pkg/cache/v3/mock/experiments.go
@@ -40,6 +40,20 @@ func (m *MockExperimentsCache) EXPECT() *MockExperimentsCacheMockRecorder {
 	return m.recorder
 }
 
+// Evict mocks base method.
+func (m *MockExperimentsCache) Evict(environmentId string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Evict", environmentId)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Evict indicates an expected call of Evict.
+func (mr *MockExperimentsCacheMockRecorder) Evict(environmentId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Evict", reflect.TypeOf((*MockExperimentsCache)(nil).Evict), environmentId)
+}
+
 // Get mocks base method.
 func (m *MockExperimentsCache) Get(environmentId string) (*experiment.Experiments, error) {
 	m.ctrl.T.Helper()

--- a/pkg/cache/v3/mock/features.go
+++ b/pkg/cache/v3/mock/features.go
@@ -41,9 +41,11 @@ func (m *MockFeaturesCache) EXPECT() *MockFeaturesCacheMockRecorder {
 }
 
 // Evict mocks base method.
-func (m *MockFeaturesCache) Evict(environmentId string) {
+func (m *MockFeaturesCache) Evict(environmentId string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Evict", environmentId)
+	ret := m.ctrl.Call(m, "Evict", environmentId)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Evict indicates an expected call of Evict.

--- a/pkg/cache/v3/mock/segment_users.go
+++ b/pkg/cache/v3/mock/segment_users.go
@@ -41,9 +41,11 @@ func (m *MockSegmentUsersCache) EXPECT() *MockSegmentUsersCacheMockRecorder {
 }
 
 // Evict mocks base method.
-func (m *MockSegmentUsersCache) Evict(segmentID, environmentId string) {
+func (m *MockSegmentUsersCache) Evict(segmentID, environmentId string) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Evict", segmentID, environmentId)
+	ret := m.ctrl.Call(m, "Evict", segmentID, environmentId)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Evict indicates an expected call of Evict.

--- a/pkg/cache/v3/segment_users.go
+++ b/pkg/cache/v3/segment_users.go
@@ -36,7 +36,7 @@ type SegmentUsersCache interface {
 	Get(segmentID, environmentId string) (*featureproto.SegmentUsers, error)
 	GetAll(environmentId string) ([]*featureproto.SegmentUsers, error)
 	Put(segmentUsers *featureproto.SegmentUsers, environmentId string) error
-	Evict(segmentID, environmentId string)
+	Evict(segmentID, environmentId string) error
 }
 
 type segmentUsersCache struct {
@@ -127,10 +127,8 @@ func (c *segmentUsersCache) scan(multiCache cache.MultiGetCache, environmentId s
 	return keys, nil
 }
 
-func (c *segmentUsersCache) Evict(segmentID, environmentId string) {
-	if inMemory, ok := c.cache.(*InMemoryCache); ok {
-		inMemory.Delete(c.key(segmentID, environmentId))
-	}
+func (c *segmentUsersCache) Evict(segmentID, environmentId string) error {
+	return evictKey(c.cache, c.key(segmentID, environmentId))
 }
 
 func (c *segmentUsersCache) key(segmentID, environmentId string) string {

--- a/pkg/domainevent/domain/api_key.go
+++ b/pkg/domainevent/domain/api_key.go
@@ -48,8 +48,11 @@ func ExtractAPIKeySecrets(e *deproto.Event) ([]string, error) {
 		seen[sec] = struct{}{}
 		out = append(out, sec)
 	}
-	if len(out) == 0 && lastErr != nil {
-		return nil, fmt.Errorf("failed to extract api_key from entity data: %w", lastErr)
+	if lastErr != nil {
+		if len(out) == 0 {
+			return nil, fmt.Errorf("failed to extract api_key from entity data: %w", lastErr)
+		}
+		return out, fmt.Errorf("partially failed to extract api_key from entity data: %w", lastErr)
 	}
 	return out, nil
 }

--- a/pkg/domainevent/domain/api_key.go
+++ b/pkg/domainevent/domain/api_key.go
@@ -18,15 +18,15 @@ import (
 	"encoding/json"
 	"fmt"
 
-	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+	deproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
 
 // ExtractAPIKeySecrets returns distinct API key secret strings from a domain
 // event's entity data snapshots. Both previous and current snapshots are
 // checked so that key rotations evict both the old and new secrets.
-// Returns an error if the JSON is malformed or the api_key field is missing
-// from all non-empty snapshots.
-func ExtractAPIKeySecrets(e *domaineventproto.Event) ([]string, error) {
+// Returns an error if all non-empty snapshots fail to parse as JSON. Snapshots
+// without an api_key field are ignored and do not cause an error.
+func ExtractAPIKeySecrets(e *deproto.Event) ([]string, error) {
 	seen := make(map[string]struct{})
 	var out []string
 	var lastErr error

--- a/pkg/domainevent/domain/api_key.go
+++ b/pkg/domainevent/domain/api_key.go
@@ -1,0 +1,65 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"encoding/json"
+	"fmt"
+
+	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+// ExtractAPIKeySecrets returns distinct API key secret strings from a domain
+// event's entity data snapshots. Both previous and current snapshots are
+// checked so that key rotations evict both the old and new secrets.
+// Returns an error if the JSON is malformed or the api_key field is missing
+// from all non-empty snapshots.
+func ExtractAPIKeySecrets(e *domaineventproto.Event) ([]string, error) {
+	seen := make(map[string]struct{})
+	var out []string
+	var lastErr error
+	for _, raw := range []string{e.GetPreviousEntityData(), e.GetEntityData()} {
+		if raw == "" {
+			continue
+		}
+		sec, err := parseAPIKeySecret(raw)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if sec == "" {
+			continue
+		}
+		if _, ok := seen[sec]; ok {
+			continue
+		}
+		seen[sec] = struct{}{}
+		out = append(out, sec)
+	}
+	if len(out) == 0 && lastErr != nil {
+		return nil, fmt.Errorf("failed to extract api_key from entity data: %w", lastErr)
+	}
+	return out, nil
+}
+
+func parseAPIKeySecret(raw string) (string, error) {
+	var v struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return "", fmt.Errorf("invalid JSON in entity data: %w", err)
+	}
+	return v.APIKey, nil
+}

--- a/pkg/domainevent/domain/api_key_test.go
+++ b/pkg/domainevent/domain/api_key_test.go
@@ -81,12 +81,13 @@ func TestExtractAPIKeySecrets(t *testing.T) {
 			expected: nil,
 		},
 		{
-			desc: "one valid and one invalid snapshot returns the valid secret",
+			desc: "one valid and one invalid snapshot returns secret with error",
 			event: &deproto.Event{
 				EntityData:         `{"api_key": "good-secret"}`,
 				PreviousEntityData: `not json`,
 			},
-			expected: []string{"good-secret"},
+			expected:    []string{"good-secret"},
+			expectError: true,
 		},
 	}
 
@@ -95,9 +96,9 @@ func TestExtractAPIKeySecrets(t *testing.T) {
 			result, err := ExtractAPIKeySecrets(p.event)
 			if p.expectError {
 				assert.Error(t, err)
-				return
+			} else {
+				assert.NoError(t, err)
 			}
-			assert.NoError(t, err)
 			assert.Equal(t, p.expected, result)
 		})
 	}

--- a/pkg/domainevent/domain/api_key_test.go
+++ b/pkg/domainevent/domain/api_key_test.go
@@ -1,0 +1,104 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+func TestExtractAPIKeySecrets(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc        string
+		event       *domaineventproto.Event
+		expected    []string
+		expectError bool
+	}{
+		{
+			desc: "entity data only",
+			event: &domaineventproto.Event{
+				EntityData: `{"api_key": "secret-1"}`,
+			},
+			expected: []string{"secret-1"},
+		},
+		{
+			desc: "previous entity data only",
+			event: &domaineventproto.Event{
+				PreviousEntityData: `{"api_key": "old-secret"}`,
+			},
+			expected: []string{"old-secret"},
+		},
+		{
+			desc: "both with different secrets",
+			event: &domaineventproto.Event{
+				EntityData:         `{"api_key": "new-secret"}`,
+				PreviousEntityData: `{"api_key": "old-secret"}`,
+			},
+			expected: []string{"old-secret", "new-secret"},
+		},
+		{
+			desc: "both with same secret deduplicates",
+			event: &domaineventproto.Event{
+				EntityData:         `{"api_key": "same-secret"}`,
+				PreviousEntityData: `{"api_key": "same-secret"}`,
+			},
+			expected: []string{"same-secret"},
+		},
+		{
+			desc:     "empty entity data returns nil without error",
+			event:    &domaineventproto.Event{},
+			expected: nil,
+		},
+		{
+			desc: "invalid JSON returns error",
+			event: &domaineventproto.Event{
+				EntityData: `not json`,
+			},
+			expectError: true,
+		},
+		{
+			desc: "valid JSON but missing api_key field returns empty",
+			event: &domaineventproto.Event{
+				EntityData: `{"name": "test"}`,
+			},
+			expected: nil,
+		},
+		{
+			desc: "one valid and one invalid snapshot returns the valid secret",
+			event: &domaineventproto.Event{
+				EntityData:         `{"api_key": "good-secret"}`,
+				PreviousEntityData: `not json`,
+			},
+			expected: []string{"good-secret"},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			result, err := ExtractAPIKeySecrets(p.event)
+			if p.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, p.expected, result)
+		})
+	}
+}

--- a/pkg/domainevent/domain/api_key_test.go
+++ b/pkg/domainevent/domain/api_key_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+	deproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
 
 func TestExtractAPIKeySecrets(t *testing.T) {
@@ -27,27 +27,27 @@ func TestExtractAPIKeySecrets(t *testing.T) {
 
 	patterns := []struct {
 		desc        string
-		event       *domaineventproto.Event
+		event       *deproto.Event
 		expected    []string
 		expectError bool
 	}{
 		{
 			desc: "entity data only",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				EntityData: `{"api_key": "secret-1"}`,
 			},
 			expected: []string{"secret-1"},
 		},
 		{
 			desc: "previous entity data only",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				PreviousEntityData: `{"api_key": "old-secret"}`,
 			},
 			expected: []string{"old-secret"},
 		},
 		{
 			desc: "both with different secrets",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				EntityData:         `{"api_key": "new-secret"}`,
 				PreviousEntityData: `{"api_key": "old-secret"}`,
 			},
@@ -55,7 +55,7 @@ func TestExtractAPIKeySecrets(t *testing.T) {
 		},
 		{
 			desc: "both with same secret deduplicates",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				EntityData:         `{"api_key": "same-secret"}`,
 				PreviousEntityData: `{"api_key": "same-secret"}`,
 			},
@@ -63,26 +63,26 @@ func TestExtractAPIKeySecrets(t *testing.T) {
 		},
 		{
 			desc:     "empty entity data returns nil without error",
-			event:    &domaineventproto.Event{},
+			event:    &deproto.Event{},
 			expected: nil,
 		},
 		{
 			desc: "invalid JSON returns error",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				EntityData: `not json`,
 			},
 			expectError: true,
 		},
 		{
 			desc: "valid JSON but missing api_key field returns empty",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				EntityData: `{"name": "test"}`,
 			},
 			expected: nil,
 		},
 		{
 			desc: "one valid and one invalid snapshot returns the valid secret",
-			event: &domaineventproto.Event{
+			event: &deproto.Event{
 				EntityData:         `{"api_key": "good-secret"}`,
 				PreviousEntityData: `not json`,
 			},

--- a/pkg/subscriber/cmd/server/server.go
+++ b/pkg/subscriber/cmd/server/server.go
@@ -540,6 +540,19 @@ func (s *server) registerPubSubProcessorMap(
 			processor.NewDomainEventInformer(environmentClient, sender, logger),
 		)
 
+		nonPersistentRedisCache := cachev3.NewRedisCache(nonPersistentRedisClient)
+		processors.RegisterProcessor(
+			processor.CacheEvictionName,
+			processor.NewCacheEviction(
+				cachev3.NewFeaturesCache(nonPersistentRedisCache, 0),
+				cachev3.NewSegmentUsersCache(nonPersistentRedisCache, 0),
+				cachev3.NewEnvironmentAPIKeyCache(nonPersistentRedisCache, 0),
+				cachev3.NewExperimentsCache(nonPersistentRedisCache),
+				cachev3.NewAutoOpsRulesCache(nonPersistentRedisCache),
+				logger,
+			),
+		)
+
 		segmentPersister, err := processor.NewSegmentUserPersister(
 			processorsConfigMap[processor.SegmentUserPersisterName],
 			batchClient,

--- a/pkg/subscriber/processor/cache_eviction.go
+++ b/pkg/subscriber/processor/cache_eviction.go
@@ -1,0 +1,251 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/bucketeer-io/bucketeer/v2/pkg/cache"
+
+	cachev3 "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3"
+	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller"
+	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller/codes"
+	"github.com/bucketeer-io/bucketeer/v2/pkg/subscriber"
+	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+const subscriberCacheEviction = "CacheEviction"
+
+var errCacheEvictionBadMessage = errors.New("cache eviction bad message")
+
+type cacheEviction struct {
+	featuresCache          cachev3.FeaturesCache
+	segmentUsersCache      cachev3.SegmentUsersCache
+	environmentAPIKeyCache cachev3.EnvironmentAPIKeyCache
+	experimentsCache       cachev3.ExperimentsCache
+	autoOpsRulesCache      cachev3.AutoOpsRulesCache
+	logger                 *zap.Logger
+}
+
+func NewCacheEviction(
+	featuresCache cachev3.FeaturesCache,
+	segmentUsersCache cachev3.SegmentUsersCache,
+	environmentAPIKeyCache cachev3.EnvironmentAPIKeyCache,
+	experimentsCache cachev3.ExperimentsCache,
+	autoOpsRulesCache cachev3.AutoOpsRulesCache,
+	logger *zap.Logger,
+) subscriber.PubSubProcessor {
+	return &cacheEviction{
+		featuresCache:          featuresCache,
+		segmentUsersCache:      segmentUsersCache,
+		environmentAPIKeyCache: environmentAPIKeyCache,
+		experimentsCache:       experimentsCache,
+		autoOpsRulesCache:      autoOpsRulesCache,
+		logger:                 logger,
+	}
+}
+
+func (c *cacheEviction) Process(ctx context.Context, msgChan <-chan *puller.Message) error {
+	for {
+		select {
+		case msg, ok := <-msgChan:
+			if !ok {
+				c.logger.Error("cacheEviction: message channel closed")
+				return nil
+			}
+			subscriberReceivedCounter.WithLabelValues(subscriberCacheEviction).Inc()
+			c.handleMessage(msg)
+		case <-ctx.Done():
+			c.logger.Debug("cacheEviction: context done, stopped processing messages")
+			return nil
+		}
+	}
+}
+
+func (c *cacheEviction) handleMessage(msg *puller.Message) {
+	event := &domaineventproto.Event{}
+	if err := proto.Unmarshal(msg.Data, event); err != nil {
+		c.logger.Error("Failed to unmarshal domain event",
+			zap.Error(err),
+			zap.String("msgID", msg.ID),
+		)
+		subscriberHandledCounter.WithLabelValues(subscriberCacheEviction, codes.BadMessage.String()).Inc()
+		msg.Ack()
+		return
+	}
+	if err := c.evict(event); err != nil {
+		if errors.Is(err, errCacheEvictionBadMessage) {
+			subscriberHandledCounter.WithLabelValues(subscriberCacheEviction, codes.BadMessage.String()).Inc()
+			msg.Ack()
+			return
+		}
+		if isRepeatable(err) {
+			c.logger.Warn("Failed to evict cache with repeatable error",
+				zap.Error(err),
+				zap.String("environmentId", event.EnvironmentId),
+				zap.String("entityId", event.EntityId),
+				zap.String("entityType", event.EntityType.String()),
+				zap.String("type", event.Type.String()),
+			)
+			subscriberHandledCounter.WithLabelValues(subscriberCacheEviction, codes.RepeatableError.String()).Inc()
+			msg.Nack()
+			return
+		}
+		c.logger.Error("Failed to evict cache with non-repeatable error",
+			zap.Error(err),
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("entityId", event.EntityId),
+			zap.String("entityType", event.EntityType.String()),
+			zap.String("type", event.Type.String()),
+		)
+		subscriberHandledCounter.WithLabelValues(subscriberCacheEviction, codes.NonRepeatableError.String()).Inc()
+		msg.Ack()
+		return
+	}
+	subscriberHandledCounter.WithLabelValues(subscriberCacheEviction, codes.OK.String()).Inc()
+	msg.Ack()
+}
+
+func (c *cacheEviction) evict(event *domaineventproto.Event) error {
+	switch event.EntityType {
+	case domaineventproto.Event_FEATURE:
+		if err := c.featuresCache.Evict(event.EnvironmentId); err != nil {
+			return err
+		}
+		c.logger.Debug("Evicted features redis cache",
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("entityId", event.EntityId),
+			zap.String("type", event.Type.String()),
+		)
+	case domaineventproto.Event_SEGMENT:
+		if err := c.segmentUsersCache.Evict(event.EntityId, event.EnvironmentId); err != nil {
+			return err
+		}
+		c.logger.Debug("Evicted segment users redis cache",
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("segmentId", event.EntityId),
+			zap.String("type", event.Type.String()),
+		)
+	case domaineventproto.Event_APIKEY:
+		secrets := apiKeySecretsFromEvent(event)
+		if len(secrets) == 0 {
+			c.logger.Error(
+				"Skipping API key cache eviction; could not extract api_key from entity data",
+				zap.String("environmentId", event.EnvironmentId),
+				zap.String("entityId", event.EntityId),
+				zap.String("type", event.Type.String()),
+			)
+			return errCacheEvictionBadMessage
+		}
+		for _, s := range secrets {
+			if err := c.environmentAPIKeyCache.Evict(s); err != nil {
+				return err
+			}
+		}
+		c.logger.Debug("Evicted environment API key redis cache",
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("entityId", event.EntityId),
+			zap.String("type", event.Type.String()),
+		)
+	case domaineventproto.Event_EXPERIMENT:
+		if err := c.experimentsCache.Evict(event.EnvironmentId); err != nil {
+			return err
+		}
+		c.logger.Debug("Evicted experiments redis cache",
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("entityId", event.EntityId),
+			zap.String("type", event.Type.String()),
+		)
+	case domaineventproto.Event_AUTOOPS_RULE:
+		if err := c.autoOpsRulesCache.Evict(event.EnvironmentId); err != nil {
+			return err
+		}
+		c.logger.Debug("Evicted auto ops rules redis cache",
+			zap.String("environmentId", event.EnvironmentId),
+			zap.String("entityId", event.EntityId),
+			zap.String("type", event.Type.String()),
+		)
+	default:
+		return nil
+	}
+	return nil
+}
+
+func isRepeatable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, cache.ErrNotFound) || errors.Is(err, cache.ErrInvalidType) {
+		return false
+	}
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout()
+	}
+	msg := strings.ToLower(err.Error())
+	if strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "eof") {
+		return true
+	}
+	return false
+}
+
+// apiKeySecretsFromEvent extracts distinct API key secrets from the domain
+// event's entity data snapshots (JSON of account.APIKey).
+func apiKeySecretsFromEvent(e *domaineventproto.Event) []string {
+	seen := make(map[string]struct{})
+	var out []string
+	for _, raw := range []string{e.GetPreviousEntityData(), e.GetEntityData()} {
+		sec := apiKeySecretFromJSON(raw)
+		if sec == "" {
+			continue
+		}
+		if _, ok := seen[sec]; ok {
+			continue
+		}
+		seen[sec] = struct{}{}
+		out = append(out, sec)
+	}
+	return out
+}
+
+func apiKeySecretFromJSON(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	var v struct {
+		APIKey string `json:"api_key"`
+	}
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return ""
+	}
+	return v.APIKey
+}

--- a/pkg/subscriber/processor/cache_eviction.go
+++ b/pkg/subscriber/processor/cache_eviction.go
@@ -33,8 +33,6 @@ import (
 	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
 
-const subscriberCacheEviction = "CacheEviction"
-
 var errCacheEvictionBadMessage = errors.New("cache eviction bad message")
 
 type cacheEviction struct {

--- a/pkg/subscriber/processor/cache_eviction.go
+++ b/pkg/subscriber/processor/cache_eviction.go
@@ -202,8 +202,8 @@ func isRepeatable(err error) bool {
 		return false
 	}
 	var ne net.Error
-	if errors.As(err, &ne) {
-		return ne.Timeout()
+	if errors.As(err, &ne) && ne.Timeout() {
+		return true
 	}
 	msg := strings.ToLower(err.Error())
 	if strings.Contains(msg, "timeout") ||

--- a/pkg/subscriber/processor/cache_eviction.go
+++ b/pkg/subscriber/processor/cache_eviction.go
@@ -145,14 +145,24 @@ func (c *cacheEviction) evict(event *domaineventproto.Event) error {
 	case domaineventproto.Event_APIKEY:
 		secrets, err := domaineventdomain.ExtractAPIKeySecrets(event)
 		if err != nil {
-			c.logger.Error(
-				"Failed to extract api_key from entity data",
-				zap.Error(err),
-				zap.String("environmentId", event.EnvironmentId),
-				zap.String("entityId", event.EntityId),
-				zap.String("type", event.Type.String()),
-			)
-			return errCacheEvictionBadMessage
+			if len(secrets) > 0 {
+				c.logger.Warn(
+					"Partially failed to extract api_key from entity data; evicting available secrets",
+					zap.Error(err),
+					zap.String("environmentId", event.EnvironmentId),
+					zap.String("entityId", event.EntityId),
+					zap.String("type", event.Type.String()),
+				)
+			} else {
+				c.logger.Error(
+					"Failed to extract api_key from entity data",
+					zap.Error(err),
+					zap.String("environmentId", event.EnvironmentId),
+					zap.String("entityId", event.EntityId),
+					zap.String("type", event.Type.String()),
+				)
+				return errCacheEvictionBadMessage
+			}
 		}
 		if len(secrets) == 0 {
 			return nil

--- a/pkg/subscriber/processor/cache_eviction.go
+++ b/pkg/subscriber/processor/cache_eviction.go
@@ -16,7 +16,6 @@ package processor
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"net"
 	"strings"
@@ -25,8 +24,8 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/cache"
-
 	cachev3 "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3"
+	domaineventdomain "github.com/bucketeer-io/bucketeer/v2/pkg/domainevent/domain"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller/codes"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/subscriber"
@@ -144,15 +143,19 @@ func (c *cacheEviction) evict(event *domaineventproto.Event) error {
 			zap.String("type", event.Type.String()),
 		)
 	case domaineventproto.Event_APIKEY:
-		secrets := apiKeySecretsFromEvent(event)
-		if len(secrets) == 0 {
+		secrets, err := domaineventdomain.ExtractAPIKeySecrets(event)
+		if err != nil {
 			c.logger.Error(
-				"Skipping API key cache eviction; could not extract api_key from entity data",
+				"Failed to extract api_key from entity data",
+				zap.Error(err),
 				zap.String("environmentId", event.EnvironmentId),
 				zap.String("entityId", event.EntityId),
 				zap.String("type", event.Type.String()),
 			)
 			return errCacheEvictionBadMessage
+		}
+		if len(secrets) == 0 {
+			return nil
 		}
 		for _, s := range secrets {
 			if err := c.environmentAPIKeyCache.Evict(s); err != nil {
@@ -214,36 +217,4 @@ func isRepeatable(err error) bool {
 		return true
 	}
 	return false
-}
-
-// apiKeySecretsFromEvent extracts distinct API key secrets from the domain
-// event's entity data snapshots (JSON of account.APIKey).
-func apiKeySecretsFromEvent(e *domaineventproto.Event) []string {
-	seen := make(map[string]struct{})
-	var out []string
-	for _, raw := range []string{e.GetPreviousEntityData(), e.GetEntityData()} {
-		sec := apiKeySecretFromJSON(raw)
-		if sec == "" {
-			continue
-		}
-		if _, ok := seen[sec]; ok {
-			continue
-		}
-		seen[sec] = struct{}{}
-		out = append(out, sec)
-	}
-	return out
-}
-
-func apiKeySecretFromJSON(raw string) string {
-	if raw == "" {
-		return ""
-	}
-	var v struct {
-		APIKey string `json:"api_key"`
-	}
-	if err := json.Unmarshal([]byte(raw), &v); err != nil {
-		return ""
-	}
-	return v.APIKey
 }

--- a/pkg/subscriber/processor/cache_eviction_test.go
+++ b/pkg/subscriber/processor/cache_eviction_test.go
@@ -16,6 +16,9 @@ package processor
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -23,10 +26,23 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/bucketeer-io/bucketeer/v2/pkg/cache"
 	cachev3mock "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3/mock"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller"
 	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
+
+type testNetError struct {
+	timeout   bool
+	temporary bool
+	msg       string
+}
+
+func (e *testNetError) Error() string   { return e.msg }
+func (e *testNetError) Timeout() bool   { return e.timeout }
+func (e *testNetError) Temporary() bool { return e.temporary }
+
+var _ net.Error = (*testNetError)(nil)
 
 func TestCacheEvictionHandleMessage(t *testing.T) {
 	t.Parallel()
@@ -255,6 +271,98 @@ func TestAPIKeySecretsFromEvent(t *testing.T) {
 		t.Run(p.desc, func(t *testing.T) {
 			result := apiKeySecretsFromEvent(p.event)
 			assert.Equal(t, p.expected, result)
+		})
+	}
+}
+
+func TestIsRepeatable(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc     string
+		err      error
+		expected bool
+	}{
+		{
+			desc:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			desc:     "context.Canceled is not repeatable",
+			err:      context.Canceled,
+			expected: false,
+		},
+		{
+			desc:     "context.DeadlineExceeded is repeatable",
+			err:      context.DeadlineExceeded,
+			expected: true,
+		},
+		{
+			desc:     "cache.ErrNotFound is not repeatable",
+			err:      cache.ErrNotFound,
+			expected: false,
+		},
+		{
+			desc:     "cache.ErrInvalidType is not repeatable",
+			err:      cache.ErrInvalidType,
+			expected: false,
+		},
+		{
+			desc:     "net.Error with timeout is repeatable",
+			err:      &testNetError{timeout: true, msg: "i/o timeout"},
+			expected: true,
+		},
+		{
+			desc:     "net.Error without timeout is not repeatable",
+			err:      &testNetError{timeout: false, msg: "some net error"},
+			expected: false,
+		},
+		{
+			desc:     "error containing timeout string is repeatable",
+			err:      errors.New("redis: command Timeout exceeded"),
+			expected: true,
+		},
+		{
+			desc:     "error containing connection reset is repeatable",
+			err:      errors.New("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			desc:     "error containing broken pipe is repeatable",
+			err:      errors.New("write: broken pipe"),
+			expected: true,
+		},
+		{
+			desc:     "error containing connection refused is repeatable",
+			err:      errors.New("dial tcp: connection refused"),
+			expected: true,
+		},
+		{
+			desc:     "error containing eof is repeatable",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			desc:     "wrapped context.DeadlineExceeded is repeatable",
+			err:      fmt.Errorf("operation failed: %w", context.DeadlineExceeded),
+			expected: true,
+		},
+		{
+			desc:     "wrapped cache.ErrNotFound is not repeatable",
+			err:      fmt.Errorf("lookup failed: %w", cache.ErrNotFound),
+			expected: false,
+		},
+		{
+			desc:     "generic error is not repeatable",
+			err:      errors.New("something unexpected"),
+			expected: false,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			assert.Equal(t, p.expected, isRepeatable(p.err))
 		})
 	}
 }

--- a/pkg/subscriber/processor/cache_eviction_test.go
+++ b/pkg/subscriber/processor/cache_eviction_test.go
@@ -314,9 +314,19 @@ func TestIsRepeatable(t *testing.T) {
 			expected: true,
 		},
 		{
-			desc:     "net.Error without timeout is not repeatable",
+			desc:     "net.Error without timeout falls through to string check",
 			err:      &testNetError{timeout: false, msg: "some net error"},
 			expected: false,
+		},
+		{
+			desc:     "net.Error without timeout but with connection reset message is repeatable",
+			err:      &testNetError{timeout: false, msg: "read: connection reset by peer"},
+			expected: true,
+		},
+		{
+			desc:     "net.Error without timeout but with broken pipe message is repeatable",
+			err:      &testNetError{timeout: false, msg: "write: broken pipe"},
+			expected: true,
 		},
 		{
 			desc:     "error containing timeout string is repeatable",

--- a/pkg/subscriber/processor/cache_eviction_test.go
+++ b/pkg/subscriber/processor/cache_eviction_test.go
@@ -215,66 +215,6 @@ func TestCacheEvictionHandleMessageNackOnRepeatableError(t *testing.T) {
 	assert.True(t, nacked)
 }
 
-func TestAPIKeySecretsFromEvent(t *testing.T) {
-	t.Parallel()
-
-	patterns := []struct {
-		desc     string
-		event    *domaineventproto.Event
-		expected []string
-	}{
-		{
-			desc: "entity data only",
-			event: &domaineventproto.Event{
-				EntityData: `{"api_key": "secret-1"}`,
-			},
-			expected: []string{"secret-1"},
-		},
-		{
-			desc: "previous entity data only",
-			event: &domaineventproto.Event{
-				PreviousEntityData: `{"api_key": "old-secret"}`,
-			},
-			expected: []string{"old-secret"},
-		},
-		{
-			desc: "both with different secrets",
-			event: &domaineventproto.Event{
-				EntityData:         `{"api_key": "new-secret"}`,
-				PreviousEntityData: `{"api_key": "old-secret"}`,
-			},
-			expected: []string{"old-secret", "new-secret"},
-		},
-		{
-			desc: "both with same secret deduplicates",
-			event: &domaineventproto.Event{
-				EntityData:         `{"api_key": "same-secret"}`,
-				PreviousEntityData: `{"api_key": "same-secret"}`,
-			},
-			expected: []string{"same-secret"},
-		},
-		{
-			desc:     "empty entity data",
-			event:    &domaineventproto.Event{},
-			expected: nil,
-		},
-		{
-			desc: "invalid JSON",
-			event: &domaineventproto.Event{
-				EntityData: `not json`,
-			},
-			expected: nil,
-		},
-	}
-
-	for _, p := range patterns {
-		t.Run(p.desc, func(t *testing.T) {
-			result := apiKeySecretsFromEvent(p.event)
-			assert.Equal(t, p.expected, result)
-		})
-	}
-}
-
 func TestIsRepeatable(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/subscriber/processor/cache_eviction_test.go
+++ b/pkg/subscriber/processor/cache_eviction_test.go
@@ -1,0 +1,260 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	cachev3mock "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3/mock"
+	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/puller"
+	domaineventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+func TestCacheEvictionHandleMessage(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc  string
+		event *domaineventproto.Event
+		setup func(
+			fc *cachev3mock.MockFeaturesCache,
+			sc *cachev3mock.MockSegmentUsersCache,
+			ak *cachev3mock.MockEnvironmentAPIKeyCache,
+			ec *cachev3mock.MockExperimentsCache,
+			ao *cachev3mock.MockAutoOpsRulesCache,
+		)
+	}{
+		{
+			desc: "feature event evicts features cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_FEATURE,
+				EntityId:      "feature-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_FEATURE_UPDATED,
+			},
+			setup: func(fc *cachev3mock.MockFeaturesCache, _ *cachev3mock.MockSegmentUsersCache, _ *cachev3mock.MockEnvironmentAPIKeyCache, _ *cachev3mock.MockExperimentsCache, _ *cachev3mock.MockAutoOpsRulesCache) {
+				fc.EXPECT().Evict("env-1").Return(nil)
+			},
+		},
+		{
+			desc: "segment event evicts segment users cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_SEGMENT,
+				EntityId:      "segment-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_SEGMENT_CREATED,
+			},
+			setup: func(_ *cachev3mock.MockFeaturesCache, sc *cachev3mock.MockSegmentUsersCache, _ *cachev3mock.MockEnvironmentAPIKeyCache, _ *cachev3mock.MockExperimentsCache, _ *cachev3mock.MockAutoOpsRulesCache) {
+				sc.EXPECT().Evict("segment-id-1", "env-1").Return(nil)
+			},
+		},
+		{
+			desc: "api key event evicts environment api key cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_APIKEY,
+				EntityId:      "apikey-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_APIKEY_CHANGED,
+				EntityData:    `{"api_key": "secret-123"}`,
+			},
+			setup: func(_ *cachev3mock.MockFeaturesCache, _ *cachev3mock.MockSegmentUsersCache, ak *cachev3mock.MockEnvironmentAPIKeyCache, _ *cachev3mock.MockExperimentsCache, _ *cachev3mock.MockAutoOpsRulesCache) {
+				ak.EXPECT().Evict("secret-123").Return(nil)
+			},
+		},
+		{
+			desc: "api key event evicts both previous and current secrets",
+			event: &domaineventproto.Event{
+				EntityType:         domaineventproto.Event_APIKEY,
+				EntityId:           "apikey-id-1",
+				EnvironmentId:      "env-1",
+				Type:               domaineventproto.Event_APIKEY_CHANGED,
+				EntityData:         `{"api_key": "new-secret"}`,
+				PreviousEntityData: `{"api_key": "old-secret"}`,
+			},
+			setup: func(_ *cachev3mock.MockFeaturesCache, _ *cachev3mock.MockSegmentUsersCache, ak *cachev3mock.MockEnvironmentAPIKeyCache, _ *cachev3mock.MockExperimentsCache, _ *cachev3mock.MockAutoOpsRulesCache) {
+				ak.EXPECT().Evict("old-secret").Return(nil)
+				ak.EXPECT().Evict("new-secret").Return(nil)
+			},
+		},
+		{
+			desc: "experiment event evicts experiments cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_EXPERIMENT,
+				EntityId:      "experiment-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_EXPERIMENT_CREATED,
+			},
+			setup: func(_ *cachev3mock.MockFeaturesCache, _ *cachev3mock.MockSegmentUsersCache, _ *cachev3mock.MockEnvironmentAPIKeyCache, ec *cachev3mock.MockExperimentsCache, _ *cachev3mock.MockAutoOpsRulesCache) {
+				ec.EXPECT().Evict("env-1").Return(nil)
+			},
+		},
+		{
+			desc: "auto ops rule event evicts auto ops rules cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_AUTOOPS_RULE,
+				EntityId:      "autoops-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_AUTOOPS_RULE_CREATED,
+			},
+			setup: func(_ *cachev3mock.MockFeaturesCache, _ *cachev3mock.MockSegmentUsersCache, _ *cachev3mock.MockEnvironmentAPIKeyCache, _ *cachev3mock.MockExperimentsCache, ao *cachev3mock.MockAutoOpsRulesCache) {
+				ao.EXPECT().Evict("env-1").Return(nil)
+			},
+		},
+		{
+			desc: "unrelated entity type does not evict any cache",
+			event: &domaineventproto.Event{
+				EntityType:    domaineventproto.Event_ACCOUNT,
+				EntityId:      "account-id-1",
+				EnvironmentId: "env-1",
+				Type:          domaineventproto.Event_ACCOUNT_V2_CREATED,
+			},
+			setup: func(_ *cachev3mock.MockFeaturesCache, _ *cachev3mock.MockSegmentUsersCache, _ *cachev3mock.MockEnvironmentAPIKeyCache, _ *cachev3mock.MockExperimentsCache, _ *cachev3mock.MockAutoOpsRulesCache) {
+			},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			fc := cachev3mock.NewMockFeaturesCache(ctrl)
+			sc := cachev3mock.NewMockSegmentUsersCache(ctrl)
+			ak := cachev3mock.NewMockEnvironmentAPIKeyCache(ctrl)
+			ec := cachev3mock.NewMockExperimentsCache(ctrl)
+			ao := cachev3mock.NewMockAutoOpsRulesCache(ctrl)
+
+			p.setup(fc, sc, ak, ec, ao)
+
+			processor := NewCacheEviction(fc, sc, ak, ec, ao, zap.NewNop())
+			ce := processor.(*cacheEviction)
+
+			data, err := proto.Marshal(p.event)
+			assert.NoError(t, err)
+
+			msg := &puller.Message{
+				Data: data,
+				Ack:  func() {},
+				Nack: func() {},
+			}
+			ce.handleMessage(msg)
+		})
+	}
+}
+
+func TestCacheEvictionHandleMessageNackOnRepeatableError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	fc := cachev3mock.NewMockFeaturesCache(ctrl)
+	sc := cachev3mock.NewMockSegmentUsersCache(ctrl)
+	ak := cachev3mock.NewMockEnvironmentAPIKeyCache(ctrl)
+	ec := cachev3mock.NewMockExperimentsCache(ctrl)
+	ao := cachev3mock.NewMockAutoOpsRulesCache(ctrl)
+
+	fc.EXPECT().Evict("env-1").Return(context.DeadlineExceeded)
+
+	processor := NewCacheEviction(fc, sc, ak, ec, ao, zap.NewNop())
+	ce := processor.(*cacheEviction)
+
+	data, err := proto.Marshal(&domaineventproto.Event{
+		EntityType:    domaineventproto.Event_FEATURE,
+		EntityId:      "feature-id-1",
+		EnvironmentId: "env-1",
+		Type:          domaineventproto.Event_FEATURE_UPDATED,
+	})
+	assert.NoError(t, err)
+
+	acked := false
+	nacked := false
+	msg := &puller.Message{
+		Data: data,
+		Ack: func() {
+			acked = true
+		},
+		Nack: func() {
+			nacked = true
+		},
+	}
+
+	ce.handleMessage(msg)
+
+	assert.False(t, acked)
+	assert.True(t, nacked)
+}
+
+func TestAPIKeySecretsFromEvent(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc     string
+		event    *domaineventproto.Event
+		expected []string
+	}{
+		{
+			desc: "entity data only",
+			event: &domaineventproto.Event{
+				EntityData: `{"api_key": "secret-1"}`,
+			},
+			expected: []string{"secret-1"},
+		},
+		{
+			desc: "previous entity data only",
+			event: &domaineventproto.Event{
+				PreviousEntityData: `{"api_key": "old-secret"}`,
+			},
+			expected: []string{"old-secret"},
+		},
+		{
+			desc: "both with different secrets",
+			event: &domaineventproto.Event{
+				EntityData:         `{"api_key": "new-secret"}`,
+				PreviousEntityData: `{"api_key": "old-secret"}`,
+			},
+			expected: []string{"old-secret", "new-secret"},
+		},
+		{
+			desc: "both with same secret deduplicates",
+			event: &domaineventproto.Event{
+				EntityData:         `{"api_key": "same-secret"}`,
+				PreviousEntityData: `{"api_key": "same-secret"}`,
+			},
+			expected: []string{"same-secret"},
+		},
+		{
+			desc:     "empty entity data",
+			event:    &domaineventproto.Event{},
+			expected: nil,
+		},
+		{
+			desc: "invalid JSON",
+			event: &domaineventproto.Event{
+				EntityData: `not json`,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			result := apiKeySecretsFromEvent(p.event)
+			assert.Equal(t, p.expected, result)
+		})
+	}
+}

--- a/pkg/subscriber/processor/metrics.go
+++ b/pkg/subscriber/processor/metrics.go
@@ -34,6 +34,7 @@ const (
 	subscriberSegmentUser           = "SegmentUser"
 	subscriberUserEvent             = "UserEvent"
 	subscriberDemoOrganizationEvent = "DemoOrganizationEvent"
+	subscriberCacheEviction         = "CacheEviction"
 )
 
 const (

--- a/pkg/subscriber/processor/processors.go
+++ b/pkg/subscriber/processor/processors.go
@@ -35,6 +35,7 @@ const (
 	SegmentUserPersisterName             = "segmentUserPersister"
 	UserEventPersisterName               = "userEventPersister"
 	DemoOrganizationCreationNotifierName = "demoOrganizationCreationNotifier"
+	CacheEvictionName                    = "cacheEviction"
 )
 
 var (


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2548

## Summary

- Add a `cacheEviction` subscriber processor that listens to domain events and evicts Redis (L2) cache entries for features, segments, API keys, experiments, and auto ops rules.
- Extend the gateway's L1 in-memory cache invalidator to also handle API key (`Event_APIKEY`) domain events.
- Update all cache `Evict` methods to return errors and add a shared `evictKey` helper that supports both in-memory and Redis-backed stores.
- Add `isRepeatable` error classification so transient Redis failures (timeout, connection reset) trigger message redelivery (Nack), while permanent errors are acknowledged and logged.

## Background

The gateway service invalidates its per-pod in-memory (L1) cache for feature flags and segments when it receives domain events. However, the shared Redis (L2) cache, used by multiple services, is only refreshed by a cron job running every minute. This means changes like disabling an API key or updating an experiment could serve stale data for up to 60 seconds.

This PR adds event-driven Redis eviction as a fast path, reducing staleness from ~60s to sub-second in the normal case. The cron job continues to run as a reconciliation fallback for cases where pub/sub delivery fails or the subscriber is temporarily down.

## Architecture

```
Config change (e.g. API key disabled)
  -> DB commit -> publish domain event

  -> Subscriber service (shared consumer group, processes once):
      -> Deletes Redis (L2) cache entry

  -> Gateway pods (per-pod consumer group, each pod receives):
      -> Evicts in-memory (L1) cache entry

  -> Cron job (every minute):
      -> Full reconciliation from DB to Redis (safety net)
```

## Changes

**Subscriber processor (`pkg/subscriber/processor/`)**
- New `cache_eviction.go` processor handling 5 entity types: `FEATURE`, `SEGMENT`, `APIKEY`, `EXPERIMENT`, `AUTOOPS_RULE`
- Error handling with repeatable (Nack for retry) vs non-repeatable (Ack + log) classification
- Registered in `cmd/server/server.go` using the `nonPersistentRedisClient`

**Cache layer (`pkg/cache/v3/`)**
- `Evict` now returns `error` on all cache interfaces (`FeaturesCache`, `SegmentUsersCache`, `EnvironmentAPIKeyCache`, `ExperimentsCache`, `AutoOpsRulesCache`)
- New `eviction.go` with shared `evictKey` helper supporting `*InMemoryCache` and `keyDeleter` (Redis)
- Added `Evict` to `ExperimentsCache` and `AutoOpsRulesCache` (previously had no eviction support)

**Gateway L1 invalidator (`pkg/api/api/cache_invalidator.go`)**
- Added `Event_APIKEY` handling to evict API key entries from per-pod in-memory cache
- Added error checking on all `Evict` calls with warning logs on failure

**Configuration**
- Added `cacheEviction` subscriber entry in `values.yaml` and `values.dev.yaml`, subscribed to the `domain` topic with a dedicated subscription

## Test plan

- [x] Unit tests for the `cacheEviction` processor covering all 5 entity types and unrelated entity types
- [x] Unit test verifying Nack on repeatable errors (e.g. `context.DeadlineExceeded`)
- [x] Unit tests for API key secret extraction from entity data JSON
- [x] Existing `cache_invalidator_test.go` updated and passing
- [x] All mocks regenerated for updated cache interfaces
- [x] Full project builds successfully
- [x] All existing tests pass