### PR TITLE
ci: add --frozen-lockfile in 'yarn install'

### DIFF
--- a/.github/workflows/pr-evaluation-ts.yaml
+++ b/.github/workflows/pr-evaluation-ts.yaml
@@ -45,7 +45,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Init
-        run: make init
+        run: yarn install --frozen-lockfile
         
   lint:
     name: Lint

--- a/.github/workflows/pr-ui-dashboard.yaml
+++ b/.github/workflows/pr-ui-dashboard.yaml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn style:all
       - name: Build


### PR DESCRIPTION
Enforce `yarn.lock` integrity on CI by passing `--frozen-lockfile` to `yarn install`.

Advantages: 
- Detects PRs that edit `package.json` without updating `yarn.lock` (current CI silently auto-resolves and hides the mismatch)
- Makes CI builds reproducible — the same commit always installs the exact same dependency tree regardless of when CI runs
- Blocks unintended auto-upgrade to new versions (including potentially malicious ones) published while a PR is in review
- Reduces "passed yesterday, fails today" CI flakiness caused by `^` / `~` range drift

Local `make init` / `yarn install` behavior is unchanged; strictness applies only on CI.



cf. https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile