### PR TITLE
fix: use resilient token source for google pub/sub to survive spot preemption

### DIFF
--- a/pkg/pubsub/factory/factory.go
+++ b/pkg/pubsub/factory/factory.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"go.uber.org/zap"
+	"golang.org/x/oauth2/google"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/metrics"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub"
@@ -144,7 +145,16 @@ func NewClient(ctx context.Context, opts ...Option) (Client, error) {
 		if options.projectID == "" {
 			return nil, fmt.Errorf("project ID is required for Google PubSub")
 		}
+		baseTS, err := google.DefaultTokenSource(ctx,
+			"https://www.googleapis.com/auth/pubsub",
+			"https://www.googleapis.com/auth/cloud-platform",
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to obtain default token source: %w", err)
+		}
+		rts := &resilientTokenSource{base: baseTS}
 		var googleOpts []pubsub.Option
+		googleOpts = append(googleOpts, pubsub.WithTokenSource(rts))
 		if options.metrics != nil {
 			googleOpts = append(googleOpts, pubsub.WithMetrics(options.metrics))
 		}

--- a/pkg/pubsub/factory/factory.go
+++ b/pkg/pubsub/factory/factory.go
@@ -18,6 +18,7 @@ package factory
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"go.uber.org/zap"
 	"golang.org/x/oauth2/google"
@@ -145,16 +146,19 @@ func NewClient(ctx context.Context, opts ...Option) (Client, error) {
 		if options.projectID == "" {
 			return nil, fmt.Errorf("project ID is required for Google PubSub")
 		}
-		baseTS, err := google.DefaultTokenSource(ctx,
-			"https://www.googleapis.com/auth/pubsub",
-			"https://www.googleapis.com/auth/cloud-platform",
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to obtain default token source: %w", err)
-		}
-		rts := &resilientTokenSource{base: baseTS}
 		var googleOpts []pubsub.Option
-		googleOpts = append(googleOpts, pubsub.WithTokenSource(rts))
+		if os.Getenv("PUBSUB_EMULATOR_HOST") == "" {
+			baseTS, err := google.DefaultTokenSource(ctx,
+				"https://www.googleapis.com/auth/pubsub",
+				"https://www.googleapis.com/auth/cloud-platform",
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to obtain default token source: %w", err)
+			}
+			googleOpts = append(googleOpts, pubsub.WithTokenSource(
+				&resilientTokenSource{base: baseTS},
+			))
+		}
 		if options.metrics != nil {
 			googleOpts = append(googleOpts, pubsub.WithMetrics(options.metrics))
 		}

--- a/pkg/pubsub/factory/token_source.go
+++ b/pkg/pubsub/factory/token_source.go
@@ -1,0 +1,49 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factory
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// resilientTokenSource wraps an oauth2.TokenSource and returns the last
+// successfully fetched token when the underlying source cannot refresh
+// (e.g. GCE metadata server unreachable during spot VM preemption).
+// This gives in-flight RPCs a chance to succeed with the still-valid cached
+// token instead of failing immediately with an authentication error.
+type resilientTokenSource struct {
+	base     oauth2.TokenSource
+	mu       sync.Mutex
+	lastGood *oauth2.Token
+}
+
+func (s *resilientTokenSource) Token() (*oauth2.Token, error) {
+	tok, err := s.base.Token()
+	if err == nil {
+		s.mu.Lock()
+		s.lastGood = tok
+		s.mu.Unlock()
+		return tok, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lastGood != nil && time.Now().Before(s.lastGood.Expiry) {
+		return s.lastGood, nil
+	}
+	return nil, err
+}

--- a/pkg/pubsub/factory/token_source.go
+++ b/pkg/pubsub/factory/token_source.go
@@ -15,11 +15,14 @@
 package factory
 
 import (
+	"errors"
 	"sync"
 	"time"
 
 	"golang.org/x/oauth2"
 )
+
+var errTokenNil = errors.New("resilientTokenSource: base returned nil token")
 
 // resilientTokenSource wraps an oauth2.TokenSource and returns the last
 // successfully fetched token when the underlying source cannot refresh
@@ -46,5 +49,8 @@ func (s *resilientTokenSource) Token() (*oauth2.Token, error) {
 		(s.lastGood.Expiry.IsZero() || time.Now().Before(s.lastGood.Expiry)) {
 		return s.lastGood, nil
 	}
-	return nil, err
+	if err != nil {
+		return nil, err
+	}
+	return nil, errTokenNil
 }

--- a/pkg/pubsub/factory/token_source.go
+++ b/pkg/pubsub/factory/token_source.go
@@ -34,7 +34,7 @@ type resilientTokenSource struct {
 
 func (s *resilientTokenSource) Token() (*oauth2.Token, error) {
 	tok, err := s.base.Token()
-	if err == nil {
+	if err == nil && tok != nil {
 		s.mu.Lock()
 		s.lastGood = tok
 		s.mu.Unlock()
@@ -42,7 +42,8 @@ func (s *resilientTokenSource) Token() (*oauth2.Token, error) {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.lastGood != nil && time.Now().Before(s.lastGood.Expiry) {
+	if s.lastGood != nil &&
+		(s.lastGood.Expiry.IsZero() || time.Now().Before(s.lastGood.Expiry)) {
 		return s.lastGood, nil
 	}
 	return nil, err

--- a/pkg/pubsub/factory/token_source_test.go
+++ b/pkg/pubsub/factory/token_source_test.go
@@ -98,6 +98,11 @@ func TestResilientTokenSource(t *testing.T) {
 			wantTok: "cached",
 		},
 		{
+			desc: "nil token from base with no cache returns error",
+			// base returns (nil, nil), no prior cache
+			wantErr: true,
+		},
+		{
 			desc: "zero expiry treated as never expires",
 			setup: func(base *stubTokenSource, rts *resilientTokenSource) {
 				base.tok = &oauth2.Token{AccessToken: "forever"}

--- a/pkg/pubsub/factory/token_source_test.go
+++ b/pkg/pubsub/factory/token_source_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package factory
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type stubTokenSource struct {
+	tok *oauth2.Token
+	err error
+}
+
+func (s *stubTokenSource) Token() (*oauth2.Token, error) {
+	return s.tok, s.err
+}
+
+func TestResilientTokenSource_DelegatesOnSuccess(t *testing.T) {
+	want := &oauth2.Token{
+		AccessToken: "good",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	rts := &resilientTokenSource{base: &stubTokenSource{tok: want}}
+
+	got, err := rts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, want.AccessToken, got.AccessToken)
+}
+
+func TestResilientTokenSource_FallsBackToCachedToken(t *testing.T) {
+	good := &oauth2.Token{
+		AccessToken: "cached",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	base := &stubTokenSource{tok: good}
+	rts := &resilientTokenSource{base: base}
+
+	// First call succeeds and caches.
+	_, err := rts.Token()
+	require.NoError(t, err)
+
+	// Base starts failing (metadata server gone).
+	base.tok = nil
+	base.err = errors.New("connection refused")
+
+	got, err := rts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "cached", got.AccessToken)
+}
+
+func TestResilientTokenSource_FailsWhenCachedTokenExpired(t *testing.T) {
+	expired := &oauth2.Token{
+		AccessToken: "old",
+		Expiry:      time.Now().Add(-time.Minute),
+	}
+	base := &stubTokenSource{tok: expired}
+	rts := &resilientTokenSource{base: base}
+
+	// Cache an already-expired token.
+	_, _ = rts.Token()
+
+	// Base starts failing.
+	base.tok = nil
+	base.err = errors.New("connection refused")
+
+	_, err := rts.Token()
+	assert.Error(t, err)
+}
+
+func TestResilientTokenSource_UpdatesCacheOnNewToken(t *testing.T) {
+	tok1 := &oauth2.Token{
+		AccessToken: "v1",
+		Expiry:      time.Now().Add(time.Hour),
+	}
+	tok2 := &oauth2.Token{
+		AccessToken: "v2",
+		Expiry:      time.Now().Add(2 * time.Hour),
+	}
+
+	base := &stubTokenSource{tok: tok1}
+	rts := &resilientTokenSource{base: base}
+
+	got1, _ := rts.Token()
+	assert.Equal(t, "v1", got1.AccessToken)
+
+	base.tok = tok2
+	got2, _ := rts.Token()
+	assert.Equal(t, "v2", got2.AccessToken)
+
+	// Fail base — should return v2, not v1.
+	base.tok = nil
+	base.err = errors.New("fail")
+	got3, err := rts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "v2", got3.AccessToken)
+}
+
+func TestResilientTokenSource_NoCacheFallsThrough(t *testing.T) {
+	base := &stubTokenSource{err: errors.New("no credentials")}
+	rts := &resilientTokenSource{base: base}
+
+	_, err := rts.Token()
+	assert.Error(t, err)
+}

--- a/pkg/pubsub/factory/token_source_test.go
+++ b/pkg/pubsub/factory/token_source_test.go
@@ -33,90 +33,100 @@ func (s *stubTokenSource) Token() (*oauth2.Token, error) {
 	return s.tok, s.err
 }
 
-func TestResilientTokenSource_DelegatesOnSuccess(t *testing.T) {
-	want := &oauth2.Token{
-		AccessToken: "good",
-		Expiry:      time.Now().Add(time.Hour),
-	}
-	rts := &resilientTokenSource{base: &stubTokenSource{tok: want}}
+func TestResilientTokenSource(t *testing.T) {
+	t.Parallel()
+	errRefused := errors.New("connection refused")
 
-	got, err := rts.Token()
-	require.NoError(t, err)
-	assert.Equal(t, want.AccessToken, got.AccessToken)
-}
-
-func TestResilientTokenSource_FallsBackToCachedToken(t *testing.T) {
-	good := &oauth2.Token{
-		AccessToken: "cached",
-		Expiry:      time.Now().Add(time.Hour),
-	}
-	base := &stubTokenSource{tok: good}
-	rts := &resilientTokenSource{base: base}
-
-	// First call succeeds and caches.
-	_, err := rts.Token()
-	require.NoError(t, err)
-
-	// Base starts failing (metadata server gone).
-	base.tok = nil
-	base.err = errors.New("connection refused")
-
-	got, err := rts.Token()
-	require.NoError(t, err)
-	assert.Equal(t, "cached", got.AccessToken)
-}
-
-func TestResilientTokenSource_FailsWhenCachedTokenExpired(t *testing.T) {
-	expired := &oauth2.Token{
-		AccessToken: "old",
-		Expiry:      time.Now().Add(-time.Minute),
-	}
-	base := &stubTokenSource{tok: expired}
-	rts := &resilientTokenSource{base: base}
-
-	// Cache an already-expired token.
-	_, _ = rts.Token()
-
-	// Base starts failing.
-	base.tok = nil
-	base.err = errors.New("connection refused")
-
-	_, err := rts.Token()
-	assert.Error(t, err)
-}
-
-func TestResilientTokenSource_UpdatesCacheOnNewToken(t *testing.T) {
-	tok1 := &oauth2.Token{
-		AccessToken: "v1",
-		Expiry:      time.Now().Add(time.Hour),
-	}
-	tok2 := &oauth2.Token{
-		AccessToken: "v2",
-		Expiry:      time.Now().Add(2 * time.Hour),
+	validToken := func(access string, expiry time.Duration) *oauth2.Token {
+		return &oauth2.Token{AccessToken: access, Expiry: time.Now().Add(expiry)}
 	}
 
-	base := &stubTokenSource{tok: tok1}
-	rts := &resilientTokenSource{base: base}
+	tests := []struct {
+		desc    string
+		setup   func(base *stubTokenSource, rts *resilientTokenSource)
+		baseTok *oauth2.Token
+		baseErr error
+		wantTok string
+		wantErr bool
+	}{
+		{
+			desc:    "delegates to base on success",
+			baseTok: validToken("good", time.Hour),
+			wantTok: "good",
+		},
+		{
+			desc: "falls back to cached token when base fails",
+			setup: func(base *stubTokenSource, rts *resilientTokenSource) {
+				base.tok = validToken("cached", time.Hour)
+				_, _ = rts.Token()
+			},
+			baseErr: errRefused,
+			wantTok: "cached",
+		},
+		{
+			desc: "fails when cached token is expired",
+			setup: func(base *stubTokenSource, rts *resilientTokenSource) {
+				base.tok = validToken("old", -time.Minute)
+				_, _ = rts.Token()
+			},
+			baseErr: errRefused,
+			wantErr: true,
+		},
+		{
+			desc: "updates cache and returns latest on fallback",
+			setup: func(base *stubTokenSource, rts *resilientTokenSource) {
+				base.tok = validToken("v1", time.Hour)
+				_, _ = rts.Token()
+				base.tok = validToken("v2", 2*time.Hour)
+				_, _ = rts.Token()
+			},
+			baseErr: errRefused,
+			wantTok: "v2",
+		},
+		{
+			desc:    "no cache falls through with error",
+			baseErr: errors.New("no credentials"),
+			wantErr: true,
+		},
+		{
+			desc: "nil token from base does not overwrite cache",
+			setup: func(base *stubTokenSource, rts *resilientTokenSource) {
+				base.tok = validToken("cached", time.Hour)
+				_, _ = rts.Token()
+			},
+			// base returns (nil, nil)
+			wantTok: "cached",
+		},
+		{
+			desc: "zero expiry treated as never expires",
+			setup: func(base *stubTokenSource, rts *resilientTokenSource) {
+				base.tok = &oauth2.Token{AccessToken: "forever"}
+				_, _ = rts.Token()
+			},
+			baseErr: errRefused,
+			wantTok: "forever",
+		},
+	}
 
-	got1, _ := rts.Token()
-	assert.Equal(t, "v1", got1.AccessToken)
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			t.Parallel()
+			base := &stubTokenSource{}
+			rts := &resilientTokenSource{base: base}
 
-	base.tok = tok2
-	got2, _ := rts.Token()
-	assert.Equal(t, "v2", got2.AccessToken)
+			if tt.setup != nil {
+				tt.setup(base, rts)
+			}
+			base.tok = tt.baseTok
+			base.err = tt.baseErr
 
-	// Fail base — should return v2, not v1.
-	base.tok = nil
-	base.err = errors.New("fail")
-	got3, err := rts.Token()
-	require.NoError(t, err)
-	assert.Equal(t, "v2", got3.AccessToken)
-}
-
-func TestResilientTokenSource_NoCacheFallsThrough(t *testing.T) {
-	base := &stubTokenSource{err: errors.New("no credentials")}
-	rts := &resilientTokenSource{base: base}
-
-	_, err := rts.Token()
-	assert.Error(t, err)
+			got, err := rts.Token()
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantTok, got.AccessToken)
+		})
+	}
 }

--- a/pkg/pubsub/pubsub.go
+++ b/pkg/pubsub/pubsub.go
@@ -23,6 +23,8 @@ import (
 
 	"cloud.google.com/go/pubsub"
 	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/backoff"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/metrics"
@@ -45,10 +47,11 @@ type Client struct {
 }
 
 type options struct {
-	backoff backoff.Backoff
-	retries int
-	metrics metrics.Registerer
-	logger  *zap.Logger
+	backoff     backoff.Backoff
+	retries     int
+	metrics     metrics.Registerer
+	logger      *zap.Logger
+	tokenSource oauth2.TokenSource
 }
 
 func defaultOptions() *options {
@@ -82,6 +85,12 @@ func WithMetrics(registerer metrics.Registerer) Option {
 func WithLogger(l *zap.Logger) Option {
 	return func(opts *options) {
 		opts.logger = l
+	}
+}
+
+func WithTokenSource(ts oauth2.TokenSource) Option {
+	return func(opts *options) {
+		opts.tokenSource = ts
 	}
 }
 
@@ -142,13 +151,17 @@ func WithPublishTimeout(timeout time.Duration) PublishOption {
 }
 
 func NewClient(ctx context.Context, project string, opts ...Option) (*Client, error) {
-	c, err := pubsub.NewClient(ctx, project)
-	if err != nil {
-		return nil, err
-	}
 	options := defaultOptions()
 	for _, opt := range opts {
 		opt(options)
+	}
+	var clientOpts []option.ClientOption
+	if options.tokenSource != nil {
+		clientOpts = append(clientOpts, option.WithTokenSource(options.tokenSource))
+	}
+	c, err := pubsub.NewClient(ctx, project, clientOpts...)
+	if err != nil {
+		return nil, err
 	}
 	return &Client{
 		Client: c,


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2544

## Summary

The e2e tests have passed in the dev environment and the devcontainer.

- Fix `Unauthenticated` errors when deleting the cache invalidator Pub/Sub subscription during shutdown on spot VM preemption
- Wrap the default GCE `TokenSource` in a `resilientTokenSource` that falls back to the last valid cached token when the metadata server is unreachable
- Add `WithTokenSource` option to the `pubsub` package so the factory can inject a custom token source into the Google Cloud client

## Background

When a GKE spot node is preempted, the GCE metadata server (`169.254.169.254`) becomes unreachable before the pod finishes its graceful shutdown. The Google `oauth2.ReuseTokenSource` tries to proactively refresh the token when it's within ~10 seconds of expiry — if the metadata server is down at that moment, it returns an error even though the cached token is still technically valid. This causes the `DeleteSubscription` RPC to fail with:

```
rpc error: code = Unauthenticated desc = transport: per-RPC creds failed due to error:
credentials: cannot fetch token: dial tcp 169.254.169.254:80: connect: connection refused
```

The `resilientTokenSource` catches this case: when the underlying source fails to refresh, but the previously cached token hasn't actually expired, it returns the cached token instead of the error. During normal operation, the wrapper is transparent — it only activates when refresh fails, and a valid token exists.
