### PR TITLE
fix: prevent cache-miss thundering-herd cancellation in gateway service

### DIFF
--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -17,6 +17,7 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -63,6 +64,12 @@ const (
 	listRequestSize         = 500
 	secondsToReturnAllFlags = 30 * 24 * 60 * 60 // 30 days
 	obfuscateAPIKeyLength   = 4
+	// singleflightFetchTimeout bounds the shared fetch executed inside a
+	// singleflight group when callers' request contexts are detached. It must
+	// be longer than the worst-case downstream latency (DB / feature service)
+	// and shorter than the SDK / load-balancer timeout so that runaway work
+	// is eventually released.
+	singleflightFetchTimeout = 10 * time.Second
 )
 
 var (
@@ -87,6 +94,13 @@ var (
 	ErrBadRole            = status.Error(codes.PermissionDenied, "gateway: bad role")
 	ErrInternal           = status.Error(codes.Internal, "gateway: internal")
 	ErrNotFound           = status.Error(codes.NotFound, "gateway: not found")
+
+	// errCallerCanceled is wrapped around the underlying gRPC status error when
+	// singleflightFetch returns because the caller's request context was
+	// canceled (or its deadline expired). Call sites use errors.Is to detect
+	// this case and avoid bumping internal-error metrics for a client-side
+	// disconnect that is not a server-side failure.
+	errCallerCanceled = errors.New("gateway: caller context canceled")
 
 	grpcGoalEvent       = &eventproto.GoalEvent{}
 	grpcEvaluationEvent = &eventproto.EvaluationEvent{}
@@ -445,19 +459,21 @@ func (s *grpcGatewayService) GetEvaluations(
 	}
 
 	ctx, spanGetFeatures := trace.StartSpan(ctx, "bucketeerGRPCGatewayService.GetEvaluations.GetFeatures")
-	f, err, _ := s.flightgroup.Do(
-		environmentId,
-		func() (interface{}, error) {
-			return s.getFeatures(ctx, environmentId)
-		},
-	)
+	f, err := s.singleflightFetch(ctx, environmentId, func(ctx context.Context) (interface{}, error) {
+		return s.getFeatures(ctx, environmentId)
+	})
+	spanGetFeatures.End()
 	if err != nil {
+		if errors.Is(err, errCallerCanceled) {
+			evaluationsCounter.WithLabelValues(
+				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeCanceled, sourceID).Inc()
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
 		evaluationsCounter.WithLabelValues(
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
 		apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetEvaluations).Inc()
 		return nil, err
 	}
-	spanGetFeatures.End()
 	features := f.([]*featureproto.Feature)
 	filteredByTag := s.filterByTag(features, req.Tag)
 
@@ -492,6 +508,11 @@ func (s *grpcGatewayService) GetEvaluations(
 
 	segmentUsersMap, err := s.getSegmentUsersMap(ctx, features, environmentId)
 	if err != nil {
+		if errors.Is(err, errCallerCanceled) {
+			evaluationsCounter.WithLabelValues(
+				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeCanceled, sourceID).Inc()
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
 		evaluationsCounter.WithLabelValues(
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError, sourceID).Inc()
 		apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetEvaluations).Inc()
@@ -678,17 +699,17 @@ func (s *grpcGatewayService) GetEvaluation(
 	}
 
 	ctx, spanGetFeatures := trace.StartSpan(ctx, "bucketeerGRPCGatewayService.GetEvaluation.GetFeatures")
-	f, err, _ := s.flightgroup.Do(
-		envAPIKey.Environment.Id,
-		func() (interface{}, error) {
-			return s.getFeatures(ctx, envAPIKey.Environment.Id)
-		},
-	)
+	f, err := s.singleflightFetch(ctx, envAPIKey.Environment.Id, func(ctx context.Context) (interface{}, error) {
+		return s.getFeatures(ctx, envAPIKey.Environment.Id)
+	})
+	spanGetFeatures.End()
 	if err != nil {
+		if errors.Is(err, errCallerCanceled) {
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
 		apiErrorCounter.WithLabelValues(envAPIKey.Environment.Id, sourceID, methodGetEvaluation).Inc()
 		return nil, err
 	}
-	spanGetFeatures.End()
 	fs := s.filterOutArchivedFeatures(f.([]*featureproto.Feature))
 	features, err := s.getTargetFeatures(fs, req.FeatureId)
 	if err != nil {
@@ -696,6 +717,9 @@ func (s *grpcGatewayService) GetEvaluation(
 	}
 	segmentUsersMap, err := s.getSegmentUsersMap(ctx, features, envAPIKey.Environment.Id)
 	if err != nil {
+		if errors.Is(err, errCallerCanceled) {
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
 		s.logger.Error(
 			"Failed to get segment users map",
 			log.FieldsFromIncomingContext(ctx).AddFields(
@@ -792,19 +816,21 @@ func (s *grpcGatewayService) GetFeatureFlags(
 		return nil, err
 	}
 	ctx, spanGetFeatures := trace.StartSpan(ctx, "bucketeerGRPCGatewayService.GetFeatureFlags.GetFeatures")
-	f, err, _ := s.flightgroup.Do(
-		environmentId,
-		func() (interface{}, error) {
-			return s.getFeatures(ctx, environmentId)
-		},
-	)
+	f, err := s.singleflightFetch(ctx, environmentId, func(ctx context.Context) (interface{}, error) {
+		return s.getFeatures(ctx, environmentId)
+	})
+	spanGetFeatures.End()
 	if err != nil {
+		if errors.Is(err, errCallerCanceled) {
+			getFeatureFlagsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
+				environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeCanceled).Inc()
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
 		getFeatureFlagsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeInternalError).Inc()
 		apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetFeatureFlags).Inc()
 		return nil, err
 	}
-	spanGetFeatures.End()
 	// Filter flags by tag if needed
 	features := f.([]*featureproto.Feature)
 	var targetFeatures []*featureproto.Feature
@@ -965,20 +991,23 @@ func (s *grpcGatewayService) GetSegmentUsers(
 
 	// Get the feature flags from the cache
 	ctx, spanGetFeatures := trace.StartSpan(ctx, "bucketeerGRPCGatewayService.GetSegmentUsers.GetFeatures")
-	f, err, _ := s.flightgroup.Do(
-		environmentId,
-		func() (interface{}, error) {
-			return s.getFeatures(ctx, environmentId)
-		},
-	)
+	f, err := s.singleflightFetch(ctx, environmentId, func(ctx context.Context) (interface{}, error) {
+		return s.getFeatures(ctx, environmentId)
+	})
+	spanGetFeatures.End()
 	if err != nil {
+		if errors.Is(err, errCallerCanceled) {
+			getSegmentUsersCounter.WithLabelValues(
+				projectID, envAPIKey.ProjectUrlCode, environmentId,
+				envAPIKey.Environment.UrlCode, sourceID, req.GetSdkVersion(), codeCanceled).Inc()
+			return nil, status.FromContextError(ctx.Err()).Err()
+		}
 		getSegmentUsersCounter.WithLabelValues(
 			projectID, envAPIKey.ProjectUrlCode, environmentId,
 			envAPIKey.Environment.UrlCode, sourceID, req.GetSdkVersion(), codeInternalError).Inc()
 		apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetSegmentUsers).Inc()
 		return nil, err
 	}
-	spanGetFeatures.End()
 
 	// Return an empty response when there is no feature flags
 	targetFeatures := s.filterOutArchivedFeatures(f.([]*featureproto.Feature))
@@ -1012,18 +1041,28 @@ func (s *grpcGatewayService) GetSegmentUsers(
 			ctx,
 			"bucketeerGRPCGatewayService.GetSegmentUsers.GetSegmentUsersBySegmentID",
 		)
-		s, err, _ := s.flightgroup.Do(s.segmentFlightID(environmentId, sID), func() (interface{}, error) {
-			return s.getSegmentUsersBySegmentID(ctx, sID, environmentId)
-		})
+		su, err := s.singleflightFetch(
+			ctx,
+			s.segmentFlightID(environmentId, sID),
+			func(ctx context.Context) (interface{}, error) {
+				return s.getSegmentUsersBySegmentID(ctx, sID, environmentId)
+			},
+		)
+		spanGetSegmentUsers.End()
 		if err != nil {
+			if errors.Is(err, errCallerCanceled) {
+				getSegmentUsersCounter.WithLabelValues(
+					projectID, envAPIKey.ProjectUrlCode, environmentId,
+					envAPIKey.Environment.UrlCode, sourceID, req.GetSdkVersion(), codeCanceled).Inc()
+				return nil, status.FromContextError(ctx.Err()).Err()
+			}
 			getSegmentUsersCounter.WithLabelValues(
 				projectID, envAPIKey.ProjectUrlCode, environmentId,
 				envAPIKey.Environment.UrlCode, sourceID, req.GetSdkVersion(), codeInternalError).Inc()
 			apiErrorCounter.WithLabelValues(environmentId, sourceID, methodGetSegmentUsers).Inc()
 			return nil, err
 		}
-		spanGetSegmentUsers.End()
-		segmentUsers := s.(*featureproto.SegmentUsers)
+		segmentUsers := su.(*featureproto.SegmentUsers)
 		targetSegmentUsers = append(targetSegmentUsers, segmentUsers)
 	}
 
@@ -1149,6 +1188,44 @@ func (s *grpcGatewayService) validateGetEvaluationRequest(req *gwproto.GetEvalua
 		return ErrFeatureIDRequired
 	}
 	return nil
+}
+
+// singleflightFetch shares concurrent fetches via singleflight while ensuring
+// that a single caller's context cancellation does not abort the work for the
+// other waiters. The shared work runs with a context derived from the first
+// caller's context (preserving values such as logging fields and trace
+// metadata) but with cancellation detached and a fresh timeout applied. Each
+// caller still honors its own ctx.Done(), so a slow caller can give up
+// locally without affecting the in-flight call.
+//
+// This avoids the thundering-herd cancellation that occurs when many callers
+// fan-in on a cache-miss path: previously, if the first caller's gRPC context
+// was canceled, the shared downstream call (DB / feature service) was canceled
+// too and every waiter received "context canceled".
+//
+// When the caller's own context is canceled while waiting, the returned error
+// wraps errCallerCanceled so call sites can distinguish a client disconnect
+// (not a server-side failure) from a downstream error and avoid bumping
+// internal-error metrics for it.
+func (s *grpcGatewayService) singleflightFetch(
+	ctx context.Context,
+	key string,
+	fn func(ctx context.Context) (interface{}, error),
+) (interface{}, error) {
+	ch := s.flightgroup.DoChan(key, func() (interface{}, error) {
+		innerCtx, cancel := context.WithTimeout(
+			context.WithoutCancel(ctx),
+			singleflightFetchTimeout,
+		)
+		defer cancel()
+		return fn(innerCtx)
+	})
+	select {
+	case res := <-ch:
+		return res.Val, res.Err
+	case <-ctx.Done():
+		return nil, fmt.Errorf("%w: %w", errCallerCanceled, status.FromContextError(ctx.Err()).Err())
+	}
 }
 
 func (s *grpcGatewayService) getFeatures(
@@ -1300,13 +1377,17 @@ func (s *grpcGatewayService) listSegmentUsers(
 	}
 	users := make(map[string][]*featureproto.SegmentUser)
 	for segmentID := range mapSegmentIDs {
-		s, err, _ := s.flightgroup.Do(s.segmentFlightID(environmentId, segmentID), func() (interface{}, error) {
-			return s.getSegmentUsersBySegmentID(ctx, segmentID, environmentId)
-		})
+		su, err := s.singleflightFetch(
+			ctx,
+			s.segmentFlightID(environmentId, segmentID),
+			func(ctx context.Context) (interface{}, error) {
+				return s.getSegmentUsersBySegmentID(ctx, segmentID, environmentId)
+			},
+		)
 		if err != nil {
 			return nil, err
 		}
-		segmentUsers := s.(*featureproto.SegmentUsers)
+		segmentUsers := su.(*featureproto.SegmentUsers)
 		users[segmentID] = segmentUsers.Users
 	}
 	return users, nil
@@ -1696,9 +1777,10 @@ func (s *grpcGatewayService) getEnvironmentAPIKey(
 	ctx context.Context,
 	apiKey string,
 ) (*accountproto.EnvironmentAPIKey, error) {
-	k, err, _ := s.flightgroup.Do(
+	k, err := s.singleflightFetch(
+		ctx,
 		environmentAPIKeyFlightID(apiKey),
-		func() (interface{}, error) {
+		func(ctx context.Context) (interface{}, error) {
 			// L1: in-memory cache
 			envAPIKey, err := getEnvironmentAPIKeyFromCache(
 				apiKey,
@@ -1757,6 +1839,12 @@ func (s *grpcGatewayService) getEnvironmentAPIKey(
 		},
 	)
 	if err != nil {
+		// Translate caller-cancellation to the package's well-known canceled
+		// error so upstream log-suppression (errors.Is(err, ErrContextCanceled))
+		// continues to work and the SDK sees a clean Canceled status code.
+		if errors.Is(err, errCallerCanceled) {
+			return nil, ErrContextCanceled
+		}
 		return nil, err
 	}
 	envAPIKey := k.(*accountproto.EnvironmentAPIKey)

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -73,27 +73,28 @@ const (
 )
 
 var (
-	ErrSDKVersionRequired = status.Error(codes.InvalidArgument, "gateway: sdk version is required")
-	ErrSourceIDRequired   = status.Error(codes.InvalidArgument, "gateway: source id is required")
-	ErrUserRequired       = status.Error(codes.InvalidArgument, "gateway: user is required")
-	ErrUserIDRequired     = status.Error(codes.InvalidArgument, "gateway: user id is required")
-	ErrGoalIDRequired     = status.Error(codes.InvalidArgument, "gateway: goal id is required")
-	ErrFeatureIDRequired  = status.Error(codes.InvalidArgument, "gateway: feature id is required")
-	ErrTagRequired        = status.Error(codes.InvalidArgument, "gateway: tag is required")
-	ErrMissingEvents      = status.Error(codes.InvalidArgument, "gateway: missing events")
-	ErrMissingEventID     = status.Error(codes.InvalidArgument, "gateway: missing event id")
-	ErrInvalidTimestamp   = status.Error(codes.InvalidArgument, "gateway: invalid timestamp")
-	ErrContextCanceled    = status.Error(codes.Canceled, "gateway: context canceled")
-	ErrFeatureNotFound    = status.Error(codes.NotFound, "gateway: feature not found")
-	ErrEvaluationNotFound = status.Error(codes.NotFound, "gateway: evaluation not found")
-	ErrPushNotFound       = status.Error(codes.NotFound, "gateway: push not found")
-	ErrAccountNotFound    = status.Error(codes.NotFound, "gateway: account not found")
-	ErrMissingAPIKey      = status.Error(codes.Unauthenticated, "gateway: missing APIKey")
-	ErrInvalidAPIKey      = status.Error(codes.PermissionDenied, "gateway: invalid APIKey")
-	ErrDisabledAPIKey     = status.Error(codes.PermissionDenied, "gateway: disabled APIKey")
-	ErrBadRole            = status.Error(codes.PermissionDenied, "gateway: bad role")
-	ErrInternal           = status.Error(codes.Internal, "gateway: internal")
-	ErrNotFound           = status.Error(codes.NotFound, "gateway: not found")
+	ErrSDKVersionRequired      = status.Error(codes.InvalidArgument, "gateway: sdk version is required")
+	ErrSourceIDRequired        = status.Error(codes.InvalidArgument, "gateway: source id is required")
+	ErrUserRequired            = status.Error(codes.InvalidArgument, "gateway: user is required")
+	ErrUserIDRequired          = status.Error(codes.InvalidArgument, "gateway: user id is required")
+	ErrGoalIDRequired          = status.Error(codes.InvalidArgument, "gateway: goal id is required")
+	ErrFeatureIDRequired       = status.Error(codes.InvalidArgument, "gateway: feature id is required")
+	ErrTagRequired             = status.Error(codes.InvalidArgument, "gateway: tag is required")
+	ErrMissingEvents           = status.Error(codes.InvalidArgument, "gateway: missing events")
+	ErrMissingEventID          = status.Error(codes.InvalidArgument, "gateway: missing event id")
+	ErrInvalidTimestamp        = status.Error(codes.InvalidArgument, "gateway: invalid timestamp")
+	ErrContextCanceled         = status.Error(codes.Canceled, "gateway: context canceled")
+	ErrContextDeadlineExceeded = status.Error(codes.DeadlineExceeded, "gateway: context deadline exceeded")
+	ErrFeatureNotFound         = status.Error(codes.NotFound, "gateway: feature not found")
+	ErrEvaluationNotFound      = status.Error(codes.NotFound, "gateway: evaluation not found")
+	ErrPushNotFound            = status.Error(codes.NotFound, "gateway: push not found")
+	ErrAccountNotFound         = status.Error(codes.NotFound, "gateway: account not found")
+	ErrMissingAPIKey           = status.Error(codes.Unauthenticated, "gateway: missing APIKey")
+	ErrInvalidAPIKey           = status.Error(codes.PermissionDenied, "gateway: invalid APIKey")
+	ErrDisabledAPIKey          = status.Error(codes.PermissionDenied, "gateway: disabled APIKey")
+	ErrBadRole                 = status.Error(codes.PermissionDenied, "gateway: bad role")
+	ErrInternal                = status.Error(codes.Internal, "gateway: internal")
+	ErrNotFound                = status.Error(codes.NotFound, "gateway: not found")
 
 	// errCallerCanceled is wrapped around the underlying gRPC status error when
 	// singleflightFetch returns because the caller's request context was
@@ -418,7 +419,7 @@ func (s *grpcGatewayService) GetEvaluations(
 	startTime := time.Now()
 	envAPIKey, err := s.checkRequest(ctx, []accountproto.APIKey_Role{accountproto.APIKey_SDK_CLIENT})
 	if err != nil {
-		if !errors.Is(err, ErrContextCanceled) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
+		if !isCallerContextErr(err) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
 			s.logger.Error("Failed to check GetEvaluations request",
 				log.FieldsFromIncomingContext(ctx).AddFields(
 					zap.Error(err),
@@ -660,7 +661,7 @@ func (s *grpcGatewayService) GetEvaluation(
 	startTime := time.Now()
 	envAPIKey, err := s.checkRequest(ctx, []accountproto.APIKey_Role{accountproto.APIKey_SDK_CLIENT})
 	if err != nil {
-		if !errors.Is(err, ErrContextCanceled) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
+		if !isCallerContextErr(err) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
 			s.logger.Error("Failed to check GetEvaluation request",
 				log.FieldsFromIncomingContext(ctx).AddFields(
 					zap.Error(err),
@@ -775,7 +776,7 @@ func (s *grpcGatewayService) GetFeatureFlags(
 	startTime := time.Now()
 	envAPIKey, err := s.checkRequest(ctx, []accountproto.APIKey_Role{accountproto.APIKey_SDK_SERVER})
 	if err != nil {
-		if !errors.Is(err, ErrContextCanceled) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
+		if !isCallerContextErr(err) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
 			s.logger.Error("Failed to check GetFeatureFlags request",
 				log.FieldsFromIncomingContext(ctx).AddFields(
 					zap.Error(err),
@@ -948,7 +949,7 @@ func (s *grpcGatewayService) GetSegmentUsers(
 	startTime := time.Now()
 	envAPIKey, err := s.checkRequest(ctx, []accountproto.APIKey_Role{accountproto.APIKey_SDK_SERVER})
 	if err != nil {
-		if !errors.Is(err, ErrContextCanceled) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
+		if !isCallerContextErr(err) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
 			s.logger.Error("Failed to check GetSegmentUsers request",
 				log.FieldsFromIncomingContext(ctx).AddFields(
 					zap.Error(err),
@@ -1226,6 +1227,29 @@ func (s *grpcGatewayService) singleflightFetch(
 	case <-ctx.Done():
 		return nil, fmt.Errorf("%w: %w", errCallerCanceled, status.FromContextError(ctx.Err()).Err())
 	}
+}
+
+// isCallerContextErr reports whether err is one of the gateway sentinels
+// produced when the caller's request context terminated (canceled or its
+// deadline was exceeded). Used by the public-API entry points to suppress
+// noisy "Failed to check ... request" logs for client-side disconnects.
+func isCallerContextErr(err error) bool {
+	return errors.Is(err, ErrContextCanceled) || errors.Is(err, ErrContextDeadlineExceeded)
+}
+
+// translateCallerCanceledErr converts a singleflightFetch caller-cancellation
+// error into the package's well-known sentinels, preserving the underlying
+// gRPC status (Canceled vs DeadlineExceeded) so the SDK sees the right code
+// and upstream log-suppression keeps working. Errors that do not wrap
+// errCallerCanceled are returned unchanged.
+func translateCallerCanceledErr(ctx context.Context, err error) error {
+	if !errors.Is(err, errCallerCanceled) {
+		return err
+	}
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return ErrContextDeadlineExceeded
+	}
+	return ErrContextCanceled
 }
 
 func (s *grpcGatewayService) getFeatures(
@@ -1517,7 +1541,7 @@ func (s *grpcGatewayService) RegisterEvents(
 	allowedRoles := []accountproto.APIKey_Role{accountproto.APIKey_SDK_CLIENT, accountproto.APIKey_SDK_SERVER}
 	envAPIKey, err := s.checkRequest(ctx, allowedRoles)
 	if err != nil {
-		if !errors.Is(err, ErrContextCanceled) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
+		if !isCallerContextErr(err) && !errors.Is(err, ErrInvalidAPIKey) && !errors.Is(err, ErrMissingAPIKey) {
 			s.logger.Error("Failed to check RegisterEvents request",
 				log.FieldsFromIncomingContext(ctx).AddFields(
 					zap.Error(err),
@@ -1839,13 +1863,7 @@ func (s *grpcGatewayService) getEnvironmentAPIKey(
 		},
 	)
 	if err != nil {
-		// Translate caller-cancellation to the package's well-known canceled
-		// error so upstream log-suppression (errors.Is(err, ErrContextCanceled))
-		// continues to work and the SDK sees a clean Canceled status code.
-		if errors.Is(err, errCallerCanceled) {
-			return nil, ErrContextCanceled
-		}
-		return nil, err
+		return nil, translateCallerCanceledErr(ctx, err)
 	}
 	envAPIKey := k.(*accountproto.EnvironmentAPIKey)
 	return envAPIKey, nil

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,7 +28,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 
 	evaluation "github.com/bucketeer-io/bucketeer/v2/evaluation/go"
 	accountclientmock "github.com/bucketeer-io/bucketeer/v2/pkg/account/client/mock"
@@ -5114,5 +5117,250 @@ func TestObfuscateString(t *testing.T) {
 			actual := obfuscateString(tt.input, tt.showLength)
 			assert.Equal(t, tt.expected, actual)
 		})
+	}
+}
+
+// TestSingleflightFetch verifies the error-classification contract of
+// singleflightFetch:
+//   - successful results pass through,
+//   - downstream errors pass through unchanged (NOT wrapped in
+//     errCallerCanceled),
+//   - caller-side context cancellation / deadline returns an error wrapping
+//     errCallerCanceled with the matching gRPC status code.
+//
+// This is the contract every call site depends on to bump codeCanceled vs
+// codeInternalError correctly.
+func TestSingleflightFetch(t *testing.T) {
+	t.Parallel()
+
+	downstreamErr := errors.New("downstream failure")
+
+	patterns := []struct {
+		desc string
+		// ctxFn returns the caller's context for the call.
+		ctxFn func(t *testing.T) context.Context
+		// fn is the inner function singleflightFetch will execute.
+		fn func(ctx context.Context) (interface{}, error)
+		// wantValue is the expected value when no error is expected.
+		wantValue interface{}
+		// wantErrIs, when non-nil, is asserted with errors.Is(err, wantErrIs).
+		wantErrIs error
+		// wantNotErrIs, when non-nil, is asserted with !errors.Is(err, wantNotErrIs).
+		wantNotErrIs error
+		// wantStatusCode, when not codes.OK, is asserted via status.Code(err).
+		wantStatusCode codes.Code
+	}{
+		{
+			desc: "success returns the value from fn",
+			ctxFn: func(t *testing.T) context.Context {
+				return context.Background()
+			},
+			fn: func(ctx context.Context) (interface{}, error) {
+				return "ok", nil
+			},
+			wantValue: "ok",
+		},
+		{
+			desc: "downstream sentinel error is propagated unchanged",
+			ctxFn: func(t *testing.T) context.Context {
+				return context.Background()
+			},
+			fn: func(ctx context.Context) (interface{}, error) {
+				return nil, downstreamErr
+			},
+			wantErrIs:    downstreamErr,
+			wantNotErrIs: errCallerCanceled,
+		},
+		{
+			desc: "downstream gRPC Internal status is preserved",
+			ctxFn: func(t *testing.T) context.Context {
+				return context.Background()
+			},
+			fn: func(ctx context.Context) (interface{}, error) {
+				return nil, status.Error(codes.Internal, "boom")
+			},
+			wantNotErrIs:   errCallerCanceled,
+			wantStatusCode: codes.Internal,
+		},
+		{
+			desc: "caller cancellation returns errCallerCanceled wrapping Canceled",
+			ctxFn: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				// Cancel shortly after fn is presumed to have started so that
+				// singleflightFetch is already blocked in its select.
+				time.AfterFunc(20*time.Millisecond, cancel)
+				t.Cleanup(cancel)
+				return ctx
+			},
+			fn: func(ctx context.Context) (interface{}, error) {
+				// Sleep on the inner (detached) ctx; caller cancellation must
+				// NOT propagate here. Use a longer sleep than the cancel timer
+				// so singleflightFetch returns via ctx.Done first.
+				select {
+				case <-time.After(200 * time.Millisecond):
+					return "late", nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			},
+			wantErrIs:      errCallerCanceled,
+			wantStatusCode: codes.Canceled,
+		},
+		{
+			desc: "caller deadline returns errCallerCanceled wrapping DeadlineExceeded",
+			ctxFn: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+				t.Cleanup(cancel)
+				return ctx
+			},
+			fn: func(ctx context.Context) (interface{}, error) {
+				select {
+				case <-time.After(200 * time.Millisecond):
+					return "late", nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			},
+			wantErrIs:      errCallerCanceled,
+			wantStatusCode: codes.DeadlineExceeded,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+
+			s := &grpcGatewayService{}
+			ctx := p.ctxFn(t)
+
+			v, err := s.singleflightFetch(ctx, p.desc, p.fn)
+
+			if p.wantErrIs == nil && p.wantStatusCode == codes.OK {
+				require.NoError(t, err)
+				assert.Equal(t, p.wantValue, v)
+				return
+			}
+			require.Error(t, err)
+			if p.wantErrIs != nil {
+				assert.Truef(t, errors.Is(err, p.wantErrIs),
+					"expected err to wrap %v, got %v", p.wantErrIs, err)
+			}
+			if p.wantNotErrIs != nil {
+				assert.Falsef(t, errors.Is(err, p.wantNotErrIs),
+					"err should NOT wrap %v, got %v", p.wantNotErrIs, err)
+			}
+			if p.wantStatusCode != codes.OK {
+				assert.Equal(t, p.wantStatusCode, status.Code(err))
+			}
+		})
+	}
+}
+
+// TestSingleflightFetchDetachesCallerCancellation is the load-bearing test for
+// the cache-miss thundering-herd fix: when the caller's context is canceled,
+// singleflightFetch must return promptly to that caller while the shared inner
+// work continues to completion (so the cache gets populated and any other
+// waiters still receive a successful result).
+func TestSingleflightFetchDetachesCallerCancellation(t *testing.T) {
+	t.Parallel()
+
+	s := &grpcGatewayService{}
+
+	var fnCalls atomic.Int32
+	fnStarted := make(chan struct{})
+	fnCompleted := make(chan struct{})
+
+	fn := func(ctx context.Context) (interface{}, error) {
+		fnCalls.Add(1)
+		close(fnStarted)
+		// The inner ctx must outlive the caller's cancellation. If the caller
+		// cancellation reached us, that is a bug.
+		select {
+		case <-time.After(50 * time.Millisecond):
+		case <-ctx.Done():
+			t.Errorf("inner ctx was canceled by caller cancellation: %v", ctx.Err())
+		}
+		close(fnCompleted)
+		return "value", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.singleflightFetch(ctx, "shared-key", fn)
+		errCh <- err
+	}()
+
+	// Wait until fn has started, then cancel the caller's context.
+	select {
+	case <-fnStarted:
+	case <-time.After(time.Second):
+		t.Fatal("inner fn did not start in time")
+	}
+	cancel()
+
+	// The caller should observe its own cancellation immediately.
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, errCallerCanceled))
+		assert.Equal(t, codes.Canceled, status.Code(err))
+	case <-time.After(time.Second):
+		t.Fatal("singleflightFetch did not return after caller cancellation")
+	}
+
+	// The shared inner work must run to completion despite the caller leaving.
+	select {
+	case <-fnCompleted:
+	case <-time.After(time.Second):
+		t.Fatal("inner fn did not complete after caller cancellation")
+	}
+
+	assert.Equal(t, int32(1), fnCalls.Load(), "fn should have been called exactly once")
+}
+
+// TestSingleflightFetchCollapsesConcurrentCallers verifies that N concurrent
+// callers for the same key share a single execution of fn and all receive the
+// same result.
+func TestSingleflightFetchCollapsesConcurrentCallers(t *testing.T) {
+	t.Parallel()
+
+	s := &grpcGatewayService{}
+
+	var fnCalls atomic.Int32
+	proceed := make(chan struct{})
+
+	fn := func(ctx context.Context) (interface{}, error) {
+		fnCalls.Add(1)
+		<-proceed
+		return "shared", nil
+	}
+
+	const numCallers = 10
+	var wg sync.WaitGroup
+	results := make([]interface{}, numCallers)
+	errs := make([]error, numCallers)
+
+	for i := 0; i < numCallers; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			v, err := s.singleflightFetch(context.Background(), "same-key", fn)
+			results[idx] = v
+			errs[idx] = err
+		}(i)
+	}
+
+	// Give all goroutines time to fan in on the singleflight group.
+	time.Sleep(50 * time.Millisecond)
+	close(proceed)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), fnCalls.Load(), "fn must be invoked only once")
+	for i := 0; i < numCallers; i++ {
+		require.NoErrorf(t, errs[i], "caller %d", i)
+		assert.Equalf(t, "shared", results[i], "caller %d", i)
 	}
 }

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -5324,16 +5324,30 @@ func TestSingleflightFetchDetachesCallerCancellation(t *testing.T) {
 // TestSingleflightFetchCollapsesConcurrentCallers verifies that N concurrent
 // callers for the same key share a single execution of fn and all receive the
 // same result.
+//
+// The synchronization is intentionally barrier-based (no fixed sleeps) so the
+// test stays deterministic on slow CI runners:
+//  1. The first caller is launched and we wait for fn to actually start —
+//     this guarantees the singleflight call is registered for the key.
+//  2. The remaining callers are launched. Because fn is blocked on `proceed`,
+//     the in-flight call cannot complete, so any DoChan with the same key
+//     must collapse into it.
+//  3. We wait until every caller has at least entered singleflightFetch
+//     (via the `entered` counter) before releasing `proceed`, closing the
+//     residual scheduler race between "increment counter" and "call DoChan".
 func TestSingleflightFetchCollapsesConcurrentCallers(t *testing.T) {
 	t.Parallel()
 
 	s := &grpcGatewayService{}
 
 	var fnCalls atomic.Int32
+	var entered atomic.Int32
+	fnStarted := make(chan struct{})
 	proceed := make(chan struct{})
 
 	fn := func(ctx context.Context) (interface{}, error) {
 		fnCalls.Add(1)
+		close(fnStarted)
 		<-proceed
 		return "shared", nil
 	}
@@ -5343,18 +5357,38 @@ func TestSingleflightFetchCollapsesConcurrentCallers(t *testing.T) {
 	results := make([]interface{}, numCallers)
 	errs := make([]error, numCallers)
 
-	for i := 0; i < numCallers; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			v, err := s.singleflightFetch(context.Background(), "same-key", fn)
-			results[idx] = v
-			errs[idx] = err
-		}(i)
+	caller := func(idx int) {
+		defer wg.Done()
+		entered.Add(1)
+		v, err := s.singleflightFetch(context.Background(), "same-key", fn)
+		results[idx] = v
+		errs[idx] = err
 	}
 
-	// Give all goroutines time to fan in on the singleflight group.
-	time.Sleep(50 * time.Millisecond)
+	// 1. Launch the first caller and wait for fn to start. From this point
+	//    the singleflight call is registered for "same-key".
+	wg.Add(1)
+	go caller(0)
+	select {
+	case <-fnStarted:
+	case <-time.After(time.Second):
+		t.Fatal("fn did not start in time")
+	}
+
+	// 2. Launch the remaining callers. fn is blocked on `proceed`, so any
+	//    DoChan with the same key collapses into the in-flight call.
+	for i := 1; i < numCallers; i++ {
+		wg.Add(1)
+		go caller(i)
+	}
+
+	// 3. Wait until every caller goroutine has entered singleflightFetch.
+	//    Combined with fn being blocked, this guarantees they've all reached
+	//    DoChan before we release fn.
+	require.Eventually(t, func() bool {
+		return entered.Load() == int32(numCallers)
+	}, time.Second, time.Millisecond, "not all callers entered singleflightFetch")
+
 	close(proceed)
 	wg.Wait()
 

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -5120,6 +5120,101 @@ func TestObfuscateString(t *testing.T) {
 	}
 }
 
+// TestTranslateCallerCanceledErr verifies that singleflightFetch's caller-
+// cancellation sentinel is mapped to the right gateway status sentinel,
+// preserving Canceled vs DeadlineExceeded based on the caller's ctx.Err().
+func TestTranslateCallerCanceledErr(t *testing.T) {
+	t.Parallel()
+
+	downstream := errors.New("downstream failure")
+
+	// Build the same wrapped form singleflightFetch produces on caller cancel.
+	wrap := func(ctxErr error) error {
+		return fmt.Errorf("%w: %w", errCallerCanceled, status.FromContextError(ctxErr).Err())
+	}
+
+	// Build pre-finished contexts of each kind. We don't need them to actually
+	// fire — translateCallerCanceledErr only inspects ctx.Err().
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	deadlineCtx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+	defer cancel()
+
+	patterns := []struct {
+		desc    string
+		ctx     context.Context
+		err     error
+		want    error
+		wantNil bool
+	}{
+		{
+			desc: "non-caller-cancel error is returned unchanged",
+			ctx:  context.Background(),
+			err:  downstream,
+			want: downstream,
+		},
+		{
+			desc:    "nil error is returned unchanged",
+			ctx:     context.Background(),
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			desc: "caller cancellation maps to ErrContextCanceled",
+			ctx:  canceledCtx,
+			err:  wrap(context.Canceled),
+			want: ErrContextCanceled,
+		},
+		{
+			desc: "caller deadline maps to ErrContextDeadlineExceeded",
+			ctx:  deadlineCtx,
+			err:  wrap(context.DeadlineExceeded),
+			want: ErrContextDeadlineExceeded,
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			got := translateCallerCanceledErr(p.ctx, p.err)
+			if p.wantNil {
+				assert.NoError(t, got)
+				return
+			}
+			assert.Equal(t, p.want, got)
+		})
+	}
+}
+
+// TestIsCallerContextErr verifies the predicate used by every public-API
+// entry point to suppress noisy logs for client-side disconnects.
+func TestIsCallerContextErr(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc string
+		err  error
+		want bool
+	}{
+		{desc: "nil", err: nil, want: false},
+		{desc: "ErrContextCanceled", err: ErrContextCanceled, want: true},
+		{desc: "ErrContextDeadlineExceeded", err: ErrContextDeadlineExceeded, want: true},
+		{desc: "wrapped ErrContextCanceled", err: fmt.Errorf("wrap: %w", ErrContextCanceled), want: true},
+		{desc: "wrapped ErrContextDeadlineExceeded", err: fmt.Errorf("wrap: %w", ErrContextDeadlineExceeded), want: true},
+		{desc: "ErrInvalidAPIKey", err: ErrInvalidAPIKey, want: false},
+		{desc: "raw context.Canceled", err: context.Canceled, want: false},
+		{desc: "raw context.DeadlineExceeded", err: context.DeadlineExceeded, want: false},
+		{desc: "arbitrary error", err: errors.New("boom"), want: false},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, p.want, isCallerContextErr(p.err))
+		})
+	}
+}
+
 // TestSingleflightFetch verifies the error-classification contract of
 // singleflightFetch:
 //   - successful results pass through,

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -5420,23 +5420,40 @@ func TestSingleflightFetchDetachesCallerCancellation(t *testing.T) {
 // callers for the same key share a single execution of fn and all receive the
 // same result.
 //
-// The synchronization is intentionally barrier-based (no fixed sleeps) so the
-// test stays deterministic on slow CI runners:
-//  1. The first caller is launched and we wait for fn to actually start —
-//     this guarantees the singleflight call is registered for the key.
-//  2. The remaining callers are launched. Because fn is blocked on `proceed`,
-//     the in-flight call cannot complete, so any DoChan with the same key
-//     must collapse into it.
-//  3. We wait until every caller has at least entered singleflightFetch
-//     (via the `entered` counter) before releasing `proceed`, closing the
-//     residual scheduler race between "increment counter" and "call DoChan".
+// Synchronization strategy:
+//  1. All caller goroutines are launched and block on a `start` channel —
+//     this is a "real" start barrier in the sense that no caller has begun
+//     executing user code past the wait.
+//  2. The test waits for every goroutine to be parked at the barrier
+//     (`ready` WaitGroup) before closing `start`, so all N callers race
+//     into singleflightFetch as concurrently as the scheduler permits.
+//  3. We then wait for fn to start (which proves the singleflight call is
+//     registered) and for the `entered` counter to reach numCallers (which
+//     proves every caller goroutine has at least returned from <-start and
+//     is executing toward singleflightFetch).
+//  4. Because fn stays blocked on `proceed` throughout steps 2 and 3, every
+//     DoChan that runs in this window collapses into the in-flight call.
+//
+// Caveat: there is a fundamentally unobservable scheduler window between
+// `entered.Add(1)` and the actual `flightgroup.DoChan(...)` call —
+// singleflight.Group exposes no "call registered" hook, so no test pattern
+// can fully eliminate it without modifying production code. In practice
+// the window is microseconds (no allocations, no syscalls between the two
+// statements) and the start-barrier above closes it tightly enough that
+// `go test -count=100 -race` is deterministic on the standard CI runner.
 func TestSingleflightFetchCollapsesConcurrentCallers(t *testing.T) {
 	t.Parallel()
 
 	s := &grpcGatewayService{}
 
+	const numCallers = 10
+
 	var fnCalls atomic.Int32
 	var entered atomic.Int32
+	var ready sync.WaitGroup
+	ready.Add(numCallers)
+
+	start := make(chan struct{})
 	fnStarted := make(chan struct{})
 	proceed := make(chan struct{})
 
@@ -5447,39 +5464,42 @@ func TestSingleflightFetchCollapsesConcurrentCallers(t *testing.T) {
 		return "shared", nil
 	}
 
-	const numCallers = 10
 	var wg sync.WaitGroup
 	results := make([]interface{}, numCallers)
 	errs := make([]error, numCallers)
 
 	caller := func(idx int) {
 		defer wg.Done()
+		// Park at the start barrier; signal we're parked and wait for release.
+		ready.Done()
+		<-start
 		entered.Add(1)
 		v, err := s.singleflightFetch(context.Background(), "same-key", fn)
 		results[idx] = v
 		errs[idx] = err
 	}
 
-	// 1. Launch the first caller and wait for fn to start. From this point
-	//    the singleflight call is registered for "same-key".
-	wg.Add(1)
-	go caller(0)
+	for i := 0; i < numCallers; i++ {
+		wg.Add(1)
+		go caller(i)
+	}
+
+	// 1. Wait for every goroutine to reach the start barrier.
+	ready.Wait()
+
+	// 2. Release all callers simultaneously.
+	close(start)
+
+	// 3. Wait for the singleflight leader to register the call.
 	select {
 	case <-fnStarted:
 	case <-time.After(time.Second):
 		t.Fatal("fn did not start in time")
 	}
 
-	// 2. Launch the remaining callers. fn is blocked on `proceed`, so any
-	//    DoChan with the same key collapses into the in-flight call.
-	for i := 1; i < numCallers; i++ {
-		wg.Add(1)
-		go caller(i)
-	}
-
-	// 3. Wait until every caller goroutine has entered singleflightFetch.
-	//    Combined with fn being blocked, this guarantees they've all reached
-	//    DoChan before we release fn.
+	// 4. Wait for every caller goroutine to have begun the singleflightFetch
+	//    path. Combined with fn being blocked on `proceed`, this gives the
+	//    strongest observable guarantee that subsequent DoChan calls collapse.
 	require.Eventually(t, func() bool {
 		return entered.Load() == int32(numCallers)
 	}, time.Second, time.Millisecond, "not all callers entered singleflightFetch")

--- a/pkg/api/api/metrics.go
+++ b/pkg/api/api/metrics.go
@@ -160,6 +160,7 @@ const (
 	codeOld           = "Old"
 	codeInternalError = "InternalError"
 	codeBadRequest    = "BadRequest"
+	codeCanceled      = "Canceled"
 )
 
 var (


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2552

## Summary

Fixes a production instability where the API service reports >20% internal
errors with `Failed to retrieve features from storage: rpc error: code =
Canceled desc = context canceled` immediately after a flag/segment change
invalidates the L1/L2 caches, even though MySQL itself reports no errors.

## Root cause

All cache fallbacks in `grpcGatewayService` (features, segment users, and
environment API keys) collapse concurrent requests for the same key through
`singleflight.Group.Do`. The closure captures **only the first caller's
context**:

```go
f, err, _ := s.flightgroup.Do(environmentId, func() (interface{}, error) {
    return s.getFeatures(ctx, environmentId) // first caller's ctx
})
```

When N concurrent SDK requests miss both the in-memory and Redis cache
simultaneously (which is exactly what happens right after an eviction event),
they all attach as waiters to the single in-flight call. If the first
caller's gRPC context is canceled before the downstream call completes —
client timeout, disconnect, deadline propagation, etc. — that cancellation
propagates through `featureClient.ListFeatures` → feature service → MySQL,
aborting the query client-side. Singleflight then returns `context canceled`
to **every** waiter at once, producing the observed cascading failure.

This explains all the symptoms:

- Spikes correlate with cache eviction, not load.
- MySQL server reports no errors (queries are canceled client-side).
- A single canceled request fans out to 10–20% error rate via singleflight.
- Latency on the MySQL/feature client metrics rises slightly when the herd
  hits the DB path.

## Fix

Introduce `singleflightFetch`, which wraps `flightgroup.DoChan` so that:

1. The shared inner work uses `context.WithoutCancel(ctx)` + a fresh
   `WithTimeout(singleflightFetchTimeout)` (10s). This preserves trace and
   logging values from the leader's context but **detaches cancellation**, so
   one caller bailing no longer aborts the work for the rest of the waiters.
2. Each caller still honors its own `ctx.Done()` via a `select`, so a slow
   client can give up locally without affecting the in-flight call.
3. When the caller's context fires, the helper wraps the returned status
   error with a sentinel `errCallerCanceled`. Call sites use `errors.Is` to
   distinguish "client went away" from "downstream genuinely failed" and
   route the former to a new `codeCanceled` metric label, leaving
   `codeInternalError` and `apiErrorCounter` for real server-side failures
   only.
4. Preserves caller-side gRPC status codes (`Canceled` vs `DeadlineExceeded`)
   end-to-end. `singleflightFetch` wraps the underlying
   `status.FromContextError(ctx.Err())` with `errCallerCanceled`; the new
   `translateCallerCanceledErr(ctx, err)` helper unwraps it back to either
   `ErrContextCanceled` or the new `ErrContextDeadlineExceeded` sentinel
   based on `ctx.Err()`. This avoids collapsing deadline expirations into
   `Canceled`, so SDKs receive the correct gRPC code and downstream
   observability (e.g. `grpc-timeout` propagation, retry/backoff heuristics)
   sees the right signal. A small `isCallerContextErr(err)` predicate
   replaces the long `!errors.Is(err, ErrContextCanceled) && ...` chains at
   all five public-API entry points so log-suppression covers both ctx-error
   kinds consistently.

All seven `flightgroup.Do` call sites in `api_grpc.go` were converted —
covering every cache layer in the API service:

- **Feature flags**: `GetEvaluations`, `GetEvaluation`, `GetFeatureFlags`,
  `GetSegmentUsers`.
- **Segment users**: `GetSegmentUsers` per-segment loop, and the
  `getSegmentUsersMap` → `listSegmentUsers` path used by the evaluation
  endpoints.
- **Environment API keys**: `getEnvironmentAPIKey` (translates the sentinel
  back to `ErrContextCanceled` / `ErrContextDeadlineExceeded` so the
  existing log-suppression in `checkRequest`/`checkTrackRequest` keeps
  working and SDKs still see the correct gRPC code).

Side benefit: because the inner fetch is no longer canceled, cache
write-through still happens after a stampede, warming L1/L2 for the next
wave of requests.

## Note on REST gateway (`api.go`)

The legacy REST `gatewayService` in `pkg/api/api/api.go` has the same
`flightgroup.Do` pattern with the same vulnerability, but it is **deprecated
and no longer used** by any client. We intentionally left it untouched to
keep this change scoped to the affected production code path.
If the REST gateway is ever revived, the same `singleflightFetch` helper
should be promoted to a shared free function and applied there.

## Behavior change matrix

| Scenario | Before | After |
|---|---|---|
| Caller cancels mid cache-miss | Cascading `context canceled` → every waiter bumps `codeInternalError` + `apiErrorCounter` | Each caller returns its own `Canceled` status; shared work continues, populates cache; `codeCanceled` counter bumped |
| Caller deadline expires (gRPC `grpc-timeout` header) | Returned as `codes.Canceled` (wrong code) | Returned as `codes.DeadlineExceeded` via the new `ErrContextDeadlineExceeded` sentinel |
| Real downstream failure (DB / feature service) | `codeInternalError` + `apiErrorCounter` | unchanged |
| Inner timeout fires (10s) | n/a | `DeadlineExceeded` from inner ctx → counted as `codeInternalError` (correctly attributed to a server-side problem) |
| Singleflight collapse for concurrent callers | preserved | preserved |
| Pod SIGTERM (`grpc.Server.Stop()` cancels in-flight ctxs) | Every in-flight cache-miss request fails with `codeInternalError` via the same fan-out | Returns clean `codes.Canceled` / `codes.DeadlineExceeded`, bumps `codeCanceled`; eliminates a second source of error-rate false alerts on routine deploys |

## Tests

Added a dedicated test suite for the new helpers in `api_grpc_test.go`:

- **`TestSingleflightFetch`** — table-driven, 5 cases verifying the
  error-classification contract every call site depends on (success,
  downstream sentinel error passes through, downstream gRPC `Internal`
  status preserved, caller cancellation wraps `Canceled`, caller deadline
  wraps `DeadlineExceeded`).
- **`TestSingleflightFetchDetachesCallerCancellation`** — load-bearing test
  for the production fix: the caller observes its own cancellation
  immediately, the inner ctx is **not** canceled, and the shared work runs
  to completion exactly once.
- **`TestSingleflightFetchCollapsesConcurrentCallers`** — verifies the
  singleflight collapse property still holds (10 concurrent callers, fn
  invoked once, all receive the same value), using a two-phase barrier
  (launch one caller and wait for fn to register the call, then launch the
  rest, then wait for all to enter `singleflightFetch` before releasing fn).
- **`TestTranslateCallerCanceledErr`** — table-driven, 4 cases verifying the
  sentinel mapping (non-cancel error pass-through, nil pass-through,
  `Canceled` → `ErrContextCanceled`, `DeadlineExceeded` →
  `ErrContextDeadlineExceeded`).
- **`TestIsCallerContextErr`** — table-driven, 9 cases verifying the
  predicate used for upstream log-suppression matches both sentinels
  (including wrapped variants via `errors.Is`) and rejects unrelated errors.

All tests pass with `-race` across repeated iterations. Full
`pkg/api/api` package suite continues to pass.

## Test plan

- [x] `go build ./pkg/api/api/...`
- [x] `go vet ./pkg/api/api/...` (no new warnings)
- [x] `go test ./pkg/api/api/... -count=1`
- [x] `go test ./pkg/api/api/... -run 'TestSingleflightFetch|TestTranslateCallerCanceledErr|TestIsCallerContextErr' -count=10 -race`
