### PR TITLE
feat(ui/dashboard): implement infinite loader for filter maintainer

### DIFF
--- a/ui/dashboard/src/@queries/accounts.ts
+++ b/ui/dashboard/src/@queries/accounts.ts
@@ -1,5 +1,10 @@
 import { accountsFetcher, AccountsFetcherParams } from '@api/account';
-import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  QueryClient,
+  useInfiniteQuery,
+  useQuery,
+  useQueryClient
+} from '@tanstack/react-query';
 import type { AccountCollection, QueryOptionsRespond } from '@types';
 
 type QueryOptions = QueryOptionsRespond<AccountCollection> & {
@@ -51,3 +56,25 @@ export const invalidateAccounts = (queryClient: QueryClient) => {
     queryKey: [ACCOUNTS_QUERY_KEY]
   });
 };
+
+type InfiniteQueryOptions = {
+  params?: Omit<AccountsFetcherParams, 'cursor'>;
+  enabled?: boolean;
+};
+
+export const useInfiniteQueryAccounts = ({
+  params,
+  enabled = true
+}: InfiniteQueryOptions = {}) =>
+  useInfiniteQuery({
+    queryKey: [ACCOUNTS_QUERY_KEY, 'infinite', params],
+    queryFn: ({ pageParam = '0' }) =>
+      accountsFetcher({ ...params, cursor: pageParam as string }),
+    initialPageParam: '0',
+    getNextPageParam: (lastPage: AccountCollection) => {
+      const nextCursor = Number(lastPage.cursor);
+      const total = Number(lastPage.totalCount);
+      return nextCursor < total ? String(nextCursor) : undefined;
+    },
+    enabled
+  });

--- a/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
+++ b/ui/dashboard/src/hooks/use-accounts-loading-more.tsx
@@ -1,55 +1,111 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
-import { useQueryAccounts } from '@queries/accounts';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { accountsFetcher } from '@api/account';
+import {
+  ACCOUNTS_QUERY_KEY,
+  useInfiniteQueryAccounts
+} from '@queries/accounts';
+import { useQueries } from '@tanstack/react-query';
 import { LIST_PAGE_SIZE } from 'constants/app';
 import { debounce } from 'lodash';
+import { Account } from '@types';
 
 type UseAccountsLoaderParams = {
   organizationId: string;
   environmentId?: string;
   environmentRole?: number;
   pageSize?: number;
+  enabled?: boolean;
+  preloadEmails?: string[];
 };
 
 export const useAccountsLoader = ({
   organizationId,
   environmentId,
   environmentRole,
-  pageSize = LIST_PAGE_SIZE
+  pageSize = LIST_PAGE_SIZE,
+  enabled = true,
+  preloadEmails = []
 }: UseAccountsLoaderParams) => {
-  const [cursor, setCursor] = useState(0);
   const [searchQuery, setSearchQuery] = useState('');
-  const [emails, setEmails] = useState<string[]>([]);
-  const [hasMore, setHasMore] = useState(true);
   const [isTyping, setIsTyping] = useState(false);
 
-  const { data, isLoading, isFetching } = useQueryAccounts({
-    params: {
-      cursor: String(cursor),
-      pageSize,
-      searchKeyword: searchQuery,
-      organizationId,
-      environmentId,
-      environmentRole
-    }
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } =
+    useInfiniteQueryAccounts({
+      params: {
+        pageSize,
+        searchKeyword: searchQuery,
+        organizationId,
+        environmentId,
+        environmentRole
+      },
+      enabled
+    });
+
+  const accumulatedAccounts = useMemo<Account[]>(
+    () => data?.pages.flatMap(page => page.accounts) ?? [],
+    [data]
+  );
+
+  const uniquePreloadEmails = useMemo(
+    () => Array.from(new Set(preloadEmails.filter(Boolean))),
+    [preloadEmails.join(',')]
+  );
+
+  const preloadResults = useQueries({
+    queries: uniquePreloadEmails.map(email => ({
+      queryKey: [
+        ACCOUNTS_QUERY_KEY,
+        {
+          searchKeyword: email,
+          organizationId,
+          environmentId,
+          environmentRole,
+          cursor: '0',
+          pageSize: 1
+        }
+      ],
+      queryFn: () =>
+        accountsFetcher({
+          cursor: '0',
+          pageSize: 1,
+          searchKeyword: email,
+          organizationId,
+          environmentId,
+          environmentRole
+        })
+    }))
   });
+
+  const preloadedAccounts = useMemo(
+    () => preloadResults.flatMap(r => r.data?.accounts ?? []),
+    [preloadResults.map(r => r.dataUpdatedAt).join(',')]
+  );
+
+  const allAccounts = useMemo(() => {
+    if (!preloadedAccounts.length) return accumulatedAccounts;
+    const emailsInList = new Set(accumulatedAccounts.map(a => a.email));
+    const missing = preloadedAccounts.filter(a => !emailsInList.has(a.email));
+    return missing.length
+      ? [...accumulatedAccounts, ...missing]
+      : accumulatedAccounts;
+  }, [accumulatedAccounts, preloadedAccounts]);
 
   const debouncedSearch = useMemo(
     () =>
       debounce((value: string) => {
-        setEmails([]);
-        setHasMore(true);
-        setCursor(0);
         setSearchQuery(value);
+        setIsTyping(false);
       }, 300),
     []
   );
+
+  useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
 
   const onSearchChange = useCallback(
     (value: string) => {
       if (!value) {
         debouncedSearch.cancel();
         setIsTyping(false);
-        setCursor(0);
         setSearchQuery('');
       } else {
         setIsTyping(true);
@@ -60,55 +116,44 @@ export const useAccountsLoader = ({
   );
 
   const loadMore = useCallback(() => {
-    setCursor(prev => prev + pageSize);
-  }, [pageSize]);
+    if (hasNextPage && !isFetchingNextPage) fetchNextPage();
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  useEffect(() => {
-    if (!data?.accounts) return;
-
-    setIsTyping(false);
-    setEmails(prev => {
-      if (cursor === 0) {
-        return data.accounts.map(a => a.email);
-      }
-      const existingSet = new Set(prev);
-      const newEmails = data.accounts
-        .map(a => a.email)
-        .filter(e => !existingSet.has(e));
-      return newEmails.length ? [...prev, ...newEmails] : prev;
-    });
-
-    if (data.totalCount != null) {
-      const total = Number(data.totalCount);
-      setHasMore(cursor + pageSize < total);
-    }
-  }, [data, cursor, pageSize]);
-
-  useEffect(() => {
-    return () => {
-      debouncedSearch.cancel();
-    };
-  }, [debouncedSearch]);
+  const getAccountLabel = useCallback(
+    (email: string) => {
+      const account = allAccounts.find(a => a.email === email);
+      if (account?.firstName || account?.lastName)
+        return `${account.firstName} ${account.lastName}`.trim();
+      return account?.email ?? email;
+    },
+    [allAccounts]
+  );
 
   const emailOptions = useMemo(
-    () => emails.map(email => ({ label: email, value: email })),
-    [emails]
+    () =>
+      accumulatedAccounts.map(account => ({
+        label: account.email,
+        value: account.email
+      })),
+    [accumulatedAccounts]
   );
 
   const isInitialLoading =
-    isLoading && !searchQuery && cursor === 0 && emails.length === 0;
+    enabled && isLoading && accumulatedAccounts.length === 0;
 
-  const isSearching = isTyping || (isFetching && cursor === 0 && !!searchQuery);
+  const isSearching =
+    isTyping || (enabled && isLoading && accumulatedAccounts.length === 0);
 
   return {
-    emails,
+    accounts: allAccounts,
     emailOptions,
     isLoading,
-    hasMore,
-    isLoadingMore: isFetching && cursor > 0,
+    hasMore: !!hasNextPage,
+    isLoadingMore: isFetchingNextPage,
     isInitialLoading,
     isSearching,
     loadMore,
-    onSearchChange
+    onSearchChange,
+    getAccountLabel
   };
 };

--- a/ui/dashboard/src/pages/feature-flag-details/settings/general-info-form/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/settings/general-info-form/index.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { IconLaunchOutlined } from 'react-icons-material-design';
 import { featureUpdater } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useQueryAccounts } from '@queries/accounts';
 import { invalidateFeature } from '@queries/feature-details';
 import { invalidateFeatures } from '@queries/features';
 import { invalidateHistories } from '@queries/histories';
@@ -14,6 +13,7 @@ import { getCurrentEnvironment, useAuth } from 'auth';
 import { SCHEDULED_FLAG_CHANGES_ENABLED } from 'configs';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
 import { useToast, useToggleOpen } from 'hooks';
+import { useAccountsLoader } from 'hooks/use-accounts-loading-more';
 import useFormSchema from 'hooks/use-form-schema';
 import { useUnsavedLeavePage } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
@@ -63,16 +63,6 @@ const GeneralInfoForm = ({
     }
   });
 
-  const { data: accountCollection, isLoading: isLoadingAccounts } =
-    useQueryAccounts({
-      params: {
-        cursor: String(0),
-        environmentId: currentEnvironment.id,
-        organizationId: currentEnvironment.organizationId,
-        environmentRole: 2
-      }
-    });
-
   const form = useForm<GeneralInfoFormType>({
     resolver: yupResolver(useFormSchema(generalInfoFormSchema)),
     defaultValues: {
@@ -96,19 +86,24 @@ const GeneralInfoForm = ({
   } = form;
   const maintainer = watch('maintainer');
   const tags = tagCollection?.tags || [];
-  const accounts = accountCollection?.accounts || [];
 
-  const accountOptions = accounts.map(item => ({
-    label: item.email,
-    value: item.email
-  }));
+  const {
+    emailOptions: accountOptions,
+    isInitialLoading: isLoadingAccounts,
+    hasMore,
+    isLoadingMore,
+    isSearching,
+    loadMore,
+    onSearchChange: onAccountSearchChange,
+    getAccountLabel
+  } = useAccountsLoader({
+    organizationId: currentEnvironment.organizationId,
+    environmentId: currentEnvironment.id,
+    environmentRole: 2,
+    preloadEmails: maintainer ? [maintainer] : []
+  });
 
-  const maintainerLabel = useMemo(() => {
-    const currentAccount = accounts.find(item => item.email === maintainer);
-    if (currentAccount?.firstName && currentAccount?.lastName)
-      return `${currentAccount.firstName} ${currentAccount.lastName}`;
-    return currentAccount?.email || maintainer;
-  }, [accounts, maintainer]);
+  const maintainerLabel = getAccountLabel(maintainer);
 
   const handleCheckTags = useCallback(
     (tagValues: string[]) => {
@@ -288,6 +283,11 @@ const GeneralInfoForm = ({
                     options={accountOptions}
                     itemSelected={field.value}
                     selectedOptions={[field.value]}
+                    isHasMore={hasMore}
+                    isLoadingMore={isLoadingMore}
+                    isSearching={isSearching}
+                    onHasMoreOptions={loadMore}
+                    onSearchChange={onAccountSearchChange}
                     onSelectOption={field.onChange}
                   />
                 </Form.Control>

--- a/ui/dashboard/src/pages/feature-flags/flags-modal/filter-flag-modal/index.tsx
+++ b/ui/dashboard/src/pages/feature-flags/flags-modal/filter-flag-modal/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useQueryAccounts } from '@queries/accounts';
 import { useQueryTags } from '@queries/tags';
 import { getCurrentEnvironment, useAuth } from 'auth';
+import { useAccountsLoader } from 'hooks/use-accounts-loading-more';
 import useOptions, { FilterOption, FilterTypes } from 'hooks/use-options';
 import { useTranslation } from 'i18n';
 import { isEmpty } from 'utils/data-type';
@@ -14,6 +14,7 @@ import Divider from 'components/divider';
 import Dropdown, { DropdownOption, DropdownValue } from 'components/dropdown';
 import Icon from 'components/icon';
 import DialogModal from 'components/modal/dialog';
+import DropdownMenuWithSearch from 'elements/dropdown-with-search';
 
 export type FilterProps = {
   isOpen: boolean;
@@ -39,27 +40,42 @@ const FilterFlagModal = ({
     flagFilterOptions[0]
   ]);
 
-  const { data: collection, isLoading } = useQueryAccounts({
-    params: {
-      cursor: String(0),
-      environmentId: currentEnvironment?.id,
-      organizationId: currentEnvironment?.organizationId
-    },
-    enabled: !!selectedFilters?.find(
+  const hasMaintainerFilter = !!selectedFilters.find(
+    item => item.value === FilterTypes.MAINTAINER
+  );
+
+  const selectedMaintainer = useMemo(() => {
+    const filter = selectedFilters.find(
       item => item.value === FilterTypes.MAINTAINER
-    )
+    );
+    return typeof filter?.filterValue === 'string' ? filter.filterValue : '';
+  }, [selectedFilters]);
+
+  const {
+    emailOptions,
+    isInitialLoading: isLoadingAccounts,
+    isLoadingMore,
+    isSearching,
+    hasMore,
+    loadMore,
+    onSearchChange: onAccountSearchChange,
+    getAccountLabel
+  } = useAccountsLoader({
+    organizationId: currentEnvironment.organizationId,
+    environmentId: currentEnvironment.id,
+    enabled: hasMaintainerFilter,
+    preloadEmails: selectedMaintainer ? [selectedMaintainer] : []
   });
 
   const { data: tagCollection, isLoading: isLoadingTags } = useQueryTags({
     params: {
       cursor: String(0),
-      environmentId: currentEnvironment?.id,
+      environmentId: currentEnvironment.id,
       entityType: 'FEATURE_FLAG'
     },
     enabled: !!selectedFilters?.find(item => item.value === FilterTypes.TAGS)
   });
 
-  const accounts = useMemo(() => collection?.accounts || [], [collection]);
   const tags = useMemo(() => tagCollection?.tags || [], [tagCollection]);
 
   const remainingFilterOptions = useMemo(
@@ -86,31 +102,16 @@ const FilterFlagModal = ({
   const getValueOptions = useCallback(
     (filterOption: FilterOption) => {
       if (!filterOption.value) return [];
-      const isMaintainerFilter = filterOption.value === FilterTypes.MAINTAINER;
       const isTagFilter = filterOption.value === FilterTypes.TAGS;
       const isStatusFilter = filterOption.value === FilterTypes.STATUS;
 
-      const isHaveSearchingDropdown =
-        isMaintainerFilter || isTagFilter || isStatusFilter;
-      if (isHaveSearchingDropdown) {
-        const options = isMaintainerFilter
-          ? accounts.map(item => ({
-              label: item.email,
-              value: item.email
-            }))
-          : isTagFilter
-            ? tags.map(item => ({
-                label: item.name,
-                value: item.name
-              }))
-            : flagStatusOptions;
-
-        return options;
+      if (isTagFilter) {
+        return tags.map(item => ({ label: item.name, value: item.name }));
       }
-
+      if (isStatusFilter) return flagStatusOptions;
       return booleanOptions;
     },
-    [accounts, tags]
+    [tags, flagStatusOptions, booleanOptions]
   );
 
   const handleSetFilterOnInit = useCallback(() => {
@@ -169,7 +170,7 @@ const FilterFlagModal = ({
         const isStatusFilter = filterType === FilterTypes.STATUS;
 
         return isMaintainerFilter
-          ? filterValue || ''
+          ? getAccountLabel(filterValue as string)
           : isTagFilter
             ? (Array.isArray(filterValue) &&
                 tags.length &&
@@ -183,7 +184,7 @@ const FilterFlagModal = ({
       }
       return '';
     },
-    [tags]
+    [tags, flagStatusOptions, booleanOptions, getAccountLabel]
   );
 
   const handleChangeFilterValue = useCallback(
@@ -194,27 +195,27 @@ const FilterFlagModal = ({
       if (isTagOption) {
         const values = filterValue as string[];
         if (Array.isArray(value) && isEmpty(value)) {
-          selectedFilters[filterIndex] = {
-            ...selectedFilters[filterIndex],
-            filterValue: value
-          };
-          return setSelectedFilters([...selectedFilters]);
+          return setSelectedFilters(prev => {
+            const next = [...prev];
+            next[filterIndex] = { ...next[filterIndex], filterValue: value };
+            return next;
+          });
         }
         const isExisted = values.find(item => item === value);
         const newValue: string[] = isExisted
           ? values.filter(item => item !== value)
           : [...values, value as string];
-        selectedFilters[filterIndex] = {
-          ...selectedFilters[filterIndex],
-          filterValue: newValue
-        };
-        return setSelectedFilters([...selectedFilters]);
+        return setSelectedFilters(prev => {
+          const next = [...prev];
+          next[filterIndex] = { ...next[filterIndex], filterValue: newValue };
+          return next;
+        });
       }
-      selectedFilters[filterIndex] = {
-        ...selectedFilters[filterIndex],
-        filterValue: value
-      };
-      setSelectedFilters([...selectedFilters]);
+      setSelectedFilters(prev => {
+        const next = [...prev];
+        next[filterIndex] = { ...next[filterIndex], filterValue: value };
+        return next;
+      });
     },
     [selectedFilters]
   );
@@ -223,12 +224,11 @@ const FilterFlagModal = ({
     const selectedOption = flagFilterOptions.find(item => item.value === value);
     if (selectedOption) {
       const filterValue = selectedOption.value === FilterTypes.TAGS ? [] : '';
-
-      selectedFilters[filterIndex] = {
-        ...selectedOption,
-        filterValue
-      };
-      setSelectedFilters([...selectedFilters]);
+      setSelectedFilters(prev => {
+        const next = [...prev];
+        next[filterIndex] = { ...selectedOption, filterValue };
+        return next;
+      });
     }
   };
 
@@ -262,7 +262,7 @@ const FilterFlagModal = ({
       ...defaultFilters,
       ...newFilters
     });
-  }, [selectedFilters]);
+  }, [selectedFilters, onSubmit]);
 
   useEffect(() => {
     handleSetFilterOnInit();
@@ -310,32 +310,66 @@ const FilterFlagModal = ({
                 contentClassName="w-[270px]"
               />
               <p className="typo-para-medium text-gray-600">is</p>
-              <Dropdown
-                disabled={
-                  (isTagFilter && isLoadingTags) ||
-                  (isMaintainerFilter && isLoading) ||
-                  !filterType
-                }
-                loading={
-                  (isTagFilter && isLoadingTags) ||
-                  (isMaintainerFilter && isLoading)
-                }
-                isListItem={isHaveSearchingDropdown}
-                multiselect={isTagFilter}
-                placeholder={t(`select-value`)}
-                value={filterOption?.filterValue as DropdownValue}
-                labelCustom={handleGetLabelFilterValue(filterOption)}
-                isSearchable={isHaveSearchingDropdown}
-                options={valueOptions as DropdownOption[]}
-                onChange={value =>
-                  handleChangeFilterValue(value as DropdownValue, filterIndex)
-                }
-                className="w-full truncate"
-                contentClassName={cn('w-[235px]', {
-                  'pt-0 w-[300px]': isHaveSearchingDropdown,
-                  'hidden-scroll': valueOptions?.length > 15
-                })}
-              />
+              {isHaveSearchingDropdown ? (
+                <DropdownMenuWithSearch
+                  disabled={
+                    (isTagFilter && isLoadingTags) ||
+                    (isMaintainerFilter && isLoadingAccounts) ||
+                    !filterType
+                  }
+                  isLoading={
+                    (isTagFilter && isLoadingTags) ||
+                    (isMaintainerFilter && isLoadingAccounts)
+                  }
+                  isMultiselect={isTagFilter}
+                  placeholder={t(`select-value`)}
+                  itemSelected={
+                    isMaintainerFilter
+                      ? (filterOption?.filterValue as string)
+                      : undefined
+                  }
+                  selectedOptions={
+                    isTagFilter
+                      ? (filterOption?.filterValue as string[])
+                      : undefined
+                  }
+                  label={handleGetLabelFilterValue(filterOption) as string}
+                  options={
+                    isMaintainerFilter
+                      ? emailOptions
+                      : (valueOptions as DropdownOption[])
+                  }
+                  isHasMore={
+                    isMaintainerFilter && hasMaintainerFilter && hasMore
+                  }
+                  isLoadingMore={isMaintainerFilter && isLoadingMore}
+                  onHasMoreOptions={isMaintainerFilter ? loadMore : undefined}
+                  isSearching={isMaintainerFilter && isSearching}
+                  onSearchChange={
+                    isMaintainerFilter ? onAccountSearchChange : undefined
+                  }
+                  onSelectOption={value =>
+                    handleChangeFilterValue(value as DropdownValue, filterIndex)
+                  }
+                  triggerClassName="w-full truncate"
+                  contentClassName={cn('w-[300px]', {
+                    'hidden-scroll': valueOptions?.length > 15
+                  })}
+                />
+              ) : (
+                <Dropdown
+                  disabled={!filterType}
+                  placeholder={t(`select-value`)}
+                  value={filterOption?.filterValue as DropdownValue}
+                  labelCustom={handleGetLabelFilterValue(filterOption)}
+                  options={valueOptions as DropdownOption[]}
+                  onChange={value =>
+                    handleChangeFilterValue(value as DropdownValue, filterIndex)
+                  }
+                  className="w-full truncate"
+                  contentClassName="w-[235px]"
+                />
+              )}
 
               <Button
                 variant={'grey'}


### PR DESCRIPTION
## Summary

- Refactored `useAccountsLoader` hook to accumulate full `Account` objects instead of email strings, enabling richer label resolution (first + last name).
- Added `preloadEmails` support so that already-selected maintainer values always resolve their display label even before the user scrolls to them in the list.
- Added `enabled` flag to lazily fetch accounts only when the maintainer filter is active.
- Replaced the static `useQueryAccounts` call in `GeneralInfoForm` with `useAccountsLoader`, enabling infinite scroll on the maintainer selector.
- Replaced the static `useQueryAccounts` call in `FilterFlagModal` with `useAccountsLoader` and swapped the maintainer `Dropdown` for `DropdownMenuWithSearch`, enabling infinite scroll and live search for the maintainer filter option.
