### PR TITLE
fix(ui): use variation name as label in evaluation chart for YAML/JSON type

### DIFF
--- a/ui/dashboard/src/pages/feature-flag-details/evaluation/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/evaluation/index.tsx
@@ -91,13 +91,19 @@ const EvaluationPage = ({ feature }: { feature: Feature }) => {
 
   const variationValues: Option[] = useMemo(
     () =>
-      countData?.map(item => ({
-        value: item.variationId,
-        label:
-          feature.variations.find(v => v.id === item.variationId)?.value ||
-          (item.variationId === 'default' ? 'default value' : ''),
-        variationType: feature.variationType
-      })) || [],
+      countData?.map(item => {
+        const variation = feature.variations.find(
+          v => v.id === item.variationId
+        );
+        return {
+          value: item.variationId,
+          label:
+            variation?.name ||
+            variation?.value ||
+            (item.variationId === 'default' ? 'default value' : ''),
+          variationType: feature.variationType
+        };
+      }) || [],
     [countData, feature]
   );
 


### PR DESCRIPTION
## Summary

- Evaluation chart legend was showing raw YAML/JSON blob content as the
  variation label, making it unreadable for those variation types
- Fix: resolve variation label using `variation.name || variation.value`,
  which prefers the human-readable name when set and falls back to value
  otherwise
- This aligns the chart legend with the evaluation table, which already
  uses the same `name || value` fallback pattern