### PR TITLE
refactor(ui/dashboard): migrate unsaved-page blocker to react-router useBlocker

### DIFF
--- a/ui/dashboard/src/app/index.tsx
+++ b/ui/dashboard/src/app/index.tsx
@@ -1,12 +1,14 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import {
-  BrowserRouter,
+  createBrowserRouter,
+  Outlet,
   Route,
+  RouterProvider,
   Routes,
-  useParams,
+  useLocation,
   useNavigate,
-  useLocation
+  useParams
 } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -94,46 +96,12 @@ export const AppLoading = () => (
   </div>
 );
 
-function App() {
-  return (
-    <I18nextProvider i18n={i18n}>
-      <QueryClientProvider client={queryClient}>
-        <ConfirmProvider>
-          <BrowserRouter>
-            <AuthProvider>
-              <Routes>
-                <Route
-                  path={PAGE_PATH_AUTH_CALLBACK}
-                  element={<AuthCallbackPage />}
-                />
-                <Route
-                  path={PAGE_PATH_AUTH_DEMO_CALLBACK}
-                  element={<AuthDemoCallbackPage />}
-                />
-                <Route
-                  path={PAGE_PATH_AUTH_SIGNIN}
-                  element={<SignInEmailPage />}
-                />
-                <Route
-                  path={PAGE_PATH_DEMO_SITE}
-                  element={<AccessDemoPage />}
-                />
-                <Route
-                  path={`${PAGE_PATH_DEMO_SITE}/new`}
-                  element={<CreateDemoPage />}
-                />
-                <Route path={`${PAGE_PATH_ROOT}*`} element={<Root />} />
-              </Routes>
-            </AuthProvider>
-          </BrowserRouter>
-        </ConfirmProvider>
-        {/* {process.env.NODE_ENV === 'development' && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )} */}
-      </QueryClientProvider>
-    </I18nextProvider>
-  );
-}
+// All routes live inside AuthShell so every page can access AuthProvider context
+const AuthShell = () => (
+  <AuthProvider>
+    <Outlet />
+  </AuthProvider>
+);
 
 export const Root = memo(() => {
   const authToken = getTokenStorage();
@@ -143,7 +111,7 @@ export const Root = memo(() => {
 
   const handleChangePageKey = useCallback(() => {
     setPageKey(uuid());
-  }, [setPageKey]);
+  }, []);
 
   if (isInitialLoading) {
     return <AppLoading />;
@@ -291,11 +259,37 @@ export const EnvironmentRoot = memo(
         <Route path={`${PAGE_PATH_AUDIT_LOGS}/*`} element={<AuditLogsPage />} />
         <Route path={`${PAGE_PATH_DEBUGGER}/*`} element={<DebuggerPage />} />
         <Route path={`${PAGE_PATH_INSIGHTS}/*`} element={<InsightsPage />} />
-
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     );
   }
 );
+
+// Router is defined after all components to avoid "used before declaration" errors
+const router = createBrowserRouter([
+  {
+    element: <AuthShell />,
+    children: [
+      { path: PAGE_PATH_AUTH_CALLBACK, element: <AuthCallbackPage /> },
+      { path: PAGE_PATH_AUTH_DEMO_CALLBACK, element: <AuthDemoCallbackPage /> },
+      { path: PAGE_PATH_AUTH_SIGNIN, element: <SignInEmailPage /> },
+      { path: PAGE_PATH_DEMO_SITE, element: <AccessDemoPage /> },
+      { path: `${PAGE_PATH_DEMO_SITE}/new`, element: <CreateDemoPage /> },
+      { path: `${PAGE_PATH_ROOT}*`, element: <Root /> }
+    ]
+  }
+]);
+
+function App() {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={queryClient}>
+        <ConfirmProvider>
+          <RouterProvider router={router} />
+        </ConfirmProvider>
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+}
 
 export default App;

--- a/ui/dashboard/src/app/index.tsx
+++ b/ui/dashboard/src/app/index.tsx
@@ -1,12 +1,14 @@
 import { memo, useCallback, useEffect, useState } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import {
-  BrowserRouter,
+  createBrowserRouter,
+  Outlet,
   Route,
+  RouterProvider,
   Routes,
-  useParams,
+  useLocation,
   useNavigate,
-  useLocation
+  useParams
 } from 'react-router';
 import { QueryClientProvider } from '@tanstack/react-query';
 import {
@@ -97,46 +99,16 @@ export const AppLoading = () => (
   </div>
 );
 
-function App() {
-  return (
-    <I18nextProvider i18n={i18n}>
-      <QueryClientProvider client={queryClient}>
-        <ConfirmProvider>
-          <BrowserRouter>
-            <AuthProvider>
-              <Routes>
-                <Route
-                  path={PAGE_PATH_AUTH_CALLBACK}
-                  element={<AuthCallbackPage />}
-                />
-                <Route
-                  path={PAGE_PATH_AUTH_DEMO_CALLBACK}
-                  element={<AuthDemoCallbackPage />}
-                />
-                <Route
-                  path={PAGE_PATH_AUTH_SIGNIN}
-                  element={<SignInEmailPage />}
-                />
-                <Route
-                  path={PAGE_PATH_DEMO_SITE}
-                  element={<AccessDemoPage />}
-                />
-                <Route
-                  path={`${PAGE_PATH_DEMO_SITE}/new`}
-                  element={<CreateDemoPage />}
-                />
-                <Route path={`${PAGE_PATH_ROOT}*`} element={<Root />} />
-              </Routes>
-            </AuthProvider>
-          </BrowserRouter>
-        </ConfirmProvider>
-        {/* {process.env.NODE_ENV === 'development' && (
-          <ReactQueryDevtools initialIsOpen={false} />
-        )} */}
-      </QueryClientProvider>
-    </I18nextProvider>
-  );
-}
+// All routes live inside AuthShell so every page can access AuthProvider context.
+// ConfirmProvider is mounted here (inside the data router) rather than above
+// RouterProvider, because it calls useBlocker, which requires router context.
+const AuthShell = () => (
+  <AuthProvider>
+    <ConfirmProvider>
+      <Outlet />
+    </ConfirmProvider>
+  </AuthProvider>
+);
 
 export const Root = memo(() => {
   const authToken = getTokenStorage();
@@ -146,7 +118,7 @@ export const Root = memo(() => {
 
   const handleChangePageKey = useCallback(() => {
     setPageKey(uuid());
-  }, [setPageKey]);
+  }, []);
 
   if (isInitialLoading) {
     return <AppLoading />;
@@ -300,11 +272,35 @@ export const EnvironmentRoot = memo(
         <Route path={`${PAGE_PATH_AUDIT_LOGS}/*`} element={<AuditLogsPage />} />
         <Route path={`${PAGE_PATH_DEBUGGER}/*`} element={<DebuggerPage />} />
         <Route path={`${PAGE_PATH_INSIGHTS}/*`} element={<InsightsPage />} />
-
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
     );
   }
 );
+
+// Router is defined after all components to avoid "used before declaration" errors
+const router = createBrowserRouter([
+  {
+    element: <AuthShell />,
+    children: [
+      { path: PAGE_PATH_AUTH_CALLBACK, element: <AuthCallbackPage /> },
+      { path: PAGE_PATH_AUTH_DEMO_CALLBACK, element: <AuthDemoCallbackPage /> },
+      { path: PAGE_PATH_AUTH_SIGNIN, element: <SignInEmailPage /> },
+      { path: PAGE_PATH_DEMO_SITE, element: <AccessDemoPage /> },
+      { path: `${PAGE_PATH_DEMO_SITE}/new`, element: <CreateDemoPage /> },
+      { path: `${PAGE_PATH_ROOT}*`, element: <Root /> }
+    ]
+  }
+]);
+
+function App() {
+  return (
+    <I18nextProvider i18n={i18n}>
+      <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </I18nextProvider>
+  );
+}
 
 export default App;

--- a/ui/dashboard/src/components/navigation/my-projects.tsx
+++ b/ui/dashboard/src/components/navigation/my-projects.tsx
@@ -12,7 +12,7 @@ import {
 import { ENVIRONMENT_WITH_EMPTY_ID } from 'constants/app';
 import { PAGE_PATH_FEATURES } from 'constants/routing';
 import { useToast } from 'hooks';
-import { allowNavigation, useConfirm } from 'hooks/use-unsaved-leave-page';
+import { useConfirm } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import {
   clearCurrentEnvIdStorage,
@@ -38,7 +38,12 @@ const MyProjects = () => {
   const navigate = useNavigate();
   const { consoleAccount, logout } = useAuth();
   const { errorNotify } = useToast();
-  const { isShow: showConfirm, confirm, setIsShow } = useConfirm();
+  const {
+    isShow: showConfirm,
+    confirm,
+    setIsShow,
+    allowNavigation
+  } = useConfirm();
   const [isShowProjectsList, setIsShowProjectsList] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [projects, setProjects] = useState<Project[]>();

--- a/ui/dashboard/src/components/navigation/my-projects.tsx
+++ b/ui/dashboard/src/components/navigation/my-projects.tsx
@@ -12,7 +12,7 @@ import {
 import { ENVIRONMENT_WITH_EMPTY_ID } from 'constants/app';
 import { PAGE_PATH_FEATURES } from 'constants/routing';
 import { useToast } from 'hooks';
-import { allowNavigation, useConfirm } from 'hooks/use-unsaved-leave-page';
+import { useConfirm } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import {
   clearCurrentEnvIdStorage,
@@ -38,7 +38,12 @@ const MyProjects = () => {
   const navigate = useNavigate();
   const { consoleAccount, logout } = useAuth();
   const { errorNotify } = useToast();
-  const { isShow: showConfirm, confirm, setIsShow } = useConfirm();
+  const {
+    isShow: showConfirm,
+    confirm,
+    allowNavigation,
+    resetAllBlockers
+  } = useConfirm();
   const [isShowProjectsList, setIsShowProjectsList] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [projects, setProjects] = useState<Project[]>();
@@ -143,7 +148,7 @@ const MyProjects = () => {
           title: 'message:leave-page-unsaved-changes',
           message: 'message:leave-page-unsaved-changes-content',
           onConfirm: () => {
-            setIsShow(false);
+            resetAllBlockers();
             onHandleChange(environment);
           }
         });

--- a/ui/dashboard/src/components/navigation/switch-organization.tsx
+++ b/ui/dashboard/src/components/navigation/switch-organization.tsx
@@ -4,7 +4,7 @@ import { switchOrganization } from '@api/auth';
 import { useAuth } from 'auth';
 import { PAGE_PATH_ROOT } from 'constants/routing';
 import { useToast } from 'hooks';
-import { allowNavigation, useConfirm } from 'hooks/use-unsaved-leave-page';
+import { useConfirm } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import { clearCurrentEnvIdStorage } from 'storage/environment';
 import {
@@ -67,7 +67,13 @@ const SwitchOrganization = ({
   const { t } = useTranslation(['common', 'form']);
   const { myOrganizations, onMeFetcher } = useAuth();
   const { errorNotify } = useToast();
-  const { isShow: showConfirm, setIsShow, confirm, options } = useConfirm();
+  const {
+    isShow: showConfirm,
+    setIsShow,
+    confirm,
+    options,
+    allowNavigation
+  } = useConfirm();
   const organizationId = getOrgIdStorage();
   const [searchValue, setSearchValue] = useState('');
   const [currentOrganization, setCurrentOrganization] = useState(

--- a/ui/dashboard/src/components/navigation/switch-organization.tsx
+++ b/ui/dashboard/src/components/navigation/switch-organization.tsx
@@ -4,7 +4,7 @@ import { switchOrganization } from '@api/auth';
 import { useAuth } from 'auth';
 import { PAGE_PATH_ROOT } from 'constants/routing';
 import { useToast } from 'hooks';
-import { allowNavigation, useConfirm } from 'hooks/use-unsaved-leave-page';
+import { useConfirm } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import { clearCurrentEnvIdStorage } from 'storage/environment';
 import {
@@ -67,7 +67,13 @@ const SwitchOrganization = ({
   const { t } = useTranslation(['common', 'form']);
   const { myOrganizations, onMeFetcher } = useAuth();
   const { errorNotify } = useToast();
-  const { isShow: showConfirm, setIsShow, confirm, options } = useConfirm();
+  const {
+    isShow: showConfirm,
+    confirm,
+    options,
+    allowNavigation,
+    resetAllBlockers
+  } = useConfirm();
   const organizationId = getOrgIdStorage();
   const [searchValue, setSearchValue] = useState('');
   const [currentOrganization, setCurrentOrganization] = useState(
@@ -126,7 +132,7 @@ const SwitchOrganization = ({
           title: 'message:leave-page-unsaved-changes',
           message: 'message:leave-page-unsaved-changes-content',
           onConfirm: () => {
-            setIsShow(false);
+            resetAllBlockers();
             onChangeOrganization(organizationId);
             setCurrentOrganization(organizationId);
           },

--- a/ui/dashboard/src/hooks/use-unsaved-leave-page.tsx
+++ b/ui/dashboard/src/hooks/use-unsaved-leave-page.tsx
@@ -2,13 +2,16 @@ import {
   createContext,
   Dispatch,
   ReactNode,
+  RefObject,
   SetStateAction,
+  useCallback,
   useContext,
   useEffect,
+  useRef,
   useState
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { UNSAFE_NavigationContext as NavigationContext } from 'react-router';
+import { type BlockerFunction, useBlocker } from 'react-router';
 import Button from 'components/button';
 import { ButtonBar } from 'components/button-bar';
 import DialogModal from 'components/modal/dialog';
@@ -30,7 +33,11 @@ interface ConfirmContextType {
   options: ConfirmOptions | null;
   handleCancel: () => void;
   handleConfirm: () => void;
+  registerProceed: (fn: (() => void) | null) => void;
+  allowNavigation: (action: () => void) => void;
+  bypassRef: RefObject<boolean>;
 }
+
 interface Props {
   title?: string;
   titleStay?: string;
@@ -42,25 +49,6 @@ interface Props {
 }
 
 const ConfirmContext = createContext<ConfirmContextType | null>(null);
-
-let bypassNavigation = false;
-
-export function allowNavigation(action?: () => void) {
-  bypassNavigation = true;
-  if (action) {
-    try {
-      action();
-    } finally {
-      bypassNavigation = false;
-    }
-  } else {
-    // Fallback for existing call sites that do not pass a callback:
-    // ensure the bypass is short-lived and does not leak indefinitely.
-    setTimeout(() => {
-      bypassNavigation = false;
-    }, 0);
-  }
-}
 
 export function useUnsavedLeavePage({
   isShow,
@@ -75,93 +63,56 @@ export function useUnsavedLeavePage({
   titleStay?: string;
   callBackCancel?: () => void;
 }) {
-  const { confirm, setIsShow: setIsShowGlobal, isShow: global } = useConfirm();
-  const navigator = useContext(NavigationContext).navigator;
+  const {
+    confirm,
+    setIsShow: setIsShowGlobal,
+    registerProceed,
+    bypassRef
+  } = useConfirm();
+
+  const blocker = useBlocker(
+    useCallback<BlockerFunction>(
+      ({ currentLocation, nextLocation }) => {
+        if (bypassRef.current) {
+          bypassRef.current = false;
+          return false;
+        }
+        return isShow && currentLocation.pathname !== nextLocation.pathname;
+      },
+      [isShow]
+    )
+  );
 
   useEffect(() => {
     setIsShowGlobal(isShow);
   }, [isShow]);
 
+  // When blocker fires, show the confirmation dialog
   useEffect(() => {
-    if (!global) return;
+    if (blocker.state !== 'blocked') return;
 
-    const push = navigator.push;
-    const replace = navigator.replace;
-
-    navigator.push = (...args: Parameters<typeof push>) => {
-      if (bypassNavigation) {
-        bypassNavigation = false;
-        return push(...args);
+    confirm({
+      title,
+      message: content,
+      onConfirm: () => {
+        callBackCancel?.();
+        setIsShowGlobal(false);
+        blocker.proceed();
+      },
+      onCancel: () => {
+        blocker.reset();
       }
-      confirm({
-        title: title,
-        message: content,
-        onConfirm: () => {
-          if (callBackCancel) {
-            callBackCancel();
-          }
-          setIsShowGlobal(false);
-          return push(...args);
-        }
-      });
-    };
+    });
+  }, [blocker.state]);
 
-    navigator.replace = (...args: Parameters<typeof replace>) => {
-      if (bypassNavigation) {
-        bypassNavigation = false;
-        return replace(...args);
-      }
-      confirm({
-        title: title,
-        message: content,
-        onConfirm: () => {
-          if (callBackCancel) {
-            callBackCancel();
-          }
-          setIsShowGlobal(false);
-          return replace(...args);
-        }
-      });
-    };
-
-    return () => {
-      navigator.push = push;
-      navigator.replace = replace;
-    };
-  }, [global, title, content, navigator]);
-
+  // Register blocker.proceed only when the blocker is actually blocked
   useEffect(() => {
-    if (!global) return;
-    history.pushState(null, '', window.location.href);
+    registerProceed(
+      blocker.state === 'blocked' ? () => blocker.proceed() : null
+    );
+  }, [blocker.state]);
 
-    const handlePopState = () => {
-      if (bypassNavigation) {
-        bypassNavigation = false;
-        return;
-      }
-      confirm({
-        title: title,
-        message: content,
-        onConfirm: () => {
-          if (callBackCancel) {
-            callBackCancel();
-          }
-          setIsShowGlobal(false);
-          history.back();
-        },
-        onCancel: () => {
-          history.pushState(null, '', window.location.href);
-        }
-      });
-    };
-
-    window.addEventListener('popstate', handlePopState);
-
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, [global, title, content]);
-
+  // Browser tab close / reload guard
   useEffect(() => {
     if (!isShow) return;
     const handler = (e: BeforeUnloadEvent) => {
@@ -171,13 +122,39 @@ export function useUnsavedLeavePage({
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, [isShow]);
+
   return { isShow };
 }
 
 export function ConfirmProvider({ children }: { children: ReactNode }) {
   const [options, setOptions] = useState<ConfirmOptions | null>(null);
   const [isShow, setIsShow] = useState<boolean>(false);
+  const proceedRef = useRef<(() => void) | null>(null);
+  const bypassRef = useRef(false);
+
   const confirm = (opts: ConfirmOptions) => setOptions(opts);
+
+  const registerProceed = useCallback((fn: (() => void) | null) => {
+    proceedRef.current = fn;
+  }, []);
+
+  const allowNavigation = useCallback((action: () => void) => {
+    if (proceedRef.current) {
+      // Blocker is active — proceed through it, then run the action
+      proceedRef.current();
+      action();
+    } else {
+      // Blocker is idle — set a one-shot bypass so the next navigation isn't blocked.
+      bypassRef.current = true;
+      try {
+        action();
+      } finally {
+        queueMicrotask(() => {
+          bypassRef.current = false;
+        });
+      }
+    }
+  }, []);
 
   const handleConfirm = () => {
     options?.onConfirm();
@@ -198,7 +175,10 @@ export function ConfirmProvider({ children }: { children: ReactNode }) {
         isShow,
         setIsShow,
         handleCancel,
-        handleConfirm
+        handleConfirm,
+        registerProceed,
+        allowNavigation,
+        bypassRef
       }}
     >
       {children}

--- a/ui/dashboard/src/hooks/use-unsaved-leave-page.tsx
+++ b/ui/dashboard/src/hooks/use-unsaved-leave-page.tsx
@@ -1,14 +1,16 @@
 import {
   createContext,
-  Dispatch,
   ReactNode,
-  SetStateAction,
+  RefObject,
+  useCallback,
   useContext,
   useEffect,
+  useMemo,
+  useRef,
   useState
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { UNSAFE_NavigationContext as NavigationContext } from 'react-router';
+import { type BlockerFunction, useBlocker } from 'react-router';
 import { LEAVE_PAGE_CANCELLED_EVENT } from 'constants/walkthrough';
 import Button from 'components/button';
 import { ButtonBar } from 'components/button-bar';
@@ -23,15 +25,27 @@ interface ConfirmOptions {
   onCancel?: () => void;
 }
 
+interface RegisteredBlocker {
+  isShow: boolean;
+  title?: string;
+  content?: string;
+  titleLeave?: string;
+  titleStay?: string;
+  callBackCancel?: () => void;
+}
+
 interface ConfirmContextType {
   isShow: boolean;
-  setIsShow: Dispatch<SetStateAction<boolean>>;
-  setOptions: Dispatch<SetStateAction<ConfirmOptions | null>>;
   confirm: (options: ConfirmOptions) => void;
   options: ConfirmOptions | null;
   handleCancel: () => void;
   handleConfirm: () => void;
+  registerBlocker: (id: number, state: RegisteredBlocker | null) => void;
+  allowNavigation: (action: () => void) => void;
+  resetAllBlockers: () => void;
+  bypassRef: RefObject<boolean>;
 }
+
 interface Props {
   title?: string;
   titleStay?: string;
@@ -44,34 +58,19 @@ interface Props {
 
 const ConfirmContext = createContext<ConfirmContextType | null>(null);
 
-let bypassNavigation = false;
-
 // While the onboarding walkthrough (driver.js) runs, navigation attempts are
 // ignored instead of prompting, so its guided steps are never interrupted.
 const isWalkthroughActive = () =>
   document.body.classList.contains('driver-active');
 
-export function allowNavigation(action?: () => void) {
-  bypassNavigation = true;
-  if (action) {
-    try {
-      action();
-    } finally {
-      bypassNavigation = false;
-    }
-  } else {
-    // Fallback for existing call sites that do not pass a callback:
-    // ensure the bypass is short-lived and does not leak indefinitely.
-    setTimeout(() => {
-      bypassNavigation = false;
-    }, 0);
-  }
-}
+let nextInstanceId = 0;
 
 export function useUnsavedLeavePage({
   isShow,
   title = 'message:leave-page-unsaved-changes',
   content = 'message:leave-page-unsaved-changes-content',
+  titleLeave,
+  titleStay,
   callBackCancel
 }: {
   isShow: boolean;
@@ -81,100 +80,29 @@ export function useUnsavedLeavePage({
   titleStay?: string;
   callBackCancel?: () => void;
 }) {
-  const { confirm, setIsShow: setIsShowGlobal, isShow: global } = useConfirm();
-  const navigator = useContext(NavigationContext).navigator;
+  const { registerBlocker } = useConfirm();
 
+  const instanceId = useRef(++nextInstanceId).current;
+
+  // Register this instance's dirty state with the provider, which owns the
+  // single router blocker and aggregates every registered instance into one
+  // unsaved-state decision. Multiple instances can be mounted at once (e.g. a
+  // dirty parent page with a dirty nested modal), so each is tracked
+  // separately instead of each instance creating its own blocker.
   useEffect(() => {
-    setIsShowGlobal(isShow);
-  }, [isShow]);
+    registerBlocker(instanceId, {
+      isShow,
+      title,
+      content,
+      titleLeave,
+      titleStay,
+      callBackCancel
+    });
+  }, [isShow, title, content, titleLeave, titleStay, callBackCancel]);
 
-  useEffect(() => {
-    if (!global) return;
+  useEffect(() => () => registerBlocker(instanceId, null), []);
 
-    const push = navigator.push;
-    const replace = navigator.replace;
-
-    navigator.push = (...args: Parameters<typeof push>) => {
-      if (bypassNavigation) {
-        bypassNavigation = false;
-        return push(...args);
-      }
-      if (isWalkthroughActive()) return;
-      confirm({
-        title: title,
-        message: content,
-        onConfirm: () => {
-          if (callBackCancel) {
-            callBackCancel();
-          }
-          setIsShowGlobal(false);
-          return push(...args);
-        }
-      });
-    };
-
-    navigator.replace = (...args: Parameters<typeof replace>) => {
-      if (bypassNavigation) {
-        bypassNavigation = false;
-        return replace(...args);
-      }
-      if (isWalkthroughActive()) return;
-      confirm({
-        title: title,
-        message: content,
-        onConfirm: () => {
-          if (callBackCancel) {
-            callBackCancel();
-          }
-          setIsShowGlobal(false);
-          return replace(...args);
-        }
-      });
-    };
-
-    return () => {
-      navigator.push = push;
-      navigator.replace = replace;
-    };
-  }, [global, title, content, navigator]);
-
-  useEffect(() => {
-    if (!global) return;
-    history.pushState(null, '', window.location.href);
-
-    const handlePopState = () => {
-      if (bypassNavigation) {
-        bypassNavigation = false;
-        return;
-      }
-      if (isWalkthroughActive()) {
-        // Stay on the page without prompting.
-        history.pushState(null, '', window.location.href);
-        return;
-      }
-      confirm({
-        title: title,
-        message: content,
-        onConfirm: () => {
-          if (callBackCancel) {
-            callBackCancel();
-          }
-          setIsShowGlobal(false);
-          history.back();
-        },
-        onCancel: () => {
-          history.pushState(null, '', window.location.href);
-        }
-      });
-    };
-
-    window.addEventListener('popstate', handlePopState);
-
-    return () => {
-      window.removeEventListener('popstate', handlePopState);
-    };
-  }, [global, title, content]);
-
+  // Browser tab close / reload guard
   useEffect(() => {
     if (!isShow) return;
     const handler = (e: BeforeUnloadEvent) => {
@@ -184,37 +112,145 @@ export function useUnsavedLeavePage({
     window.addEventListener('beforeunload', handler);
     return () => window.removeEventListener('beforeunload', handler);
   }, [isShow]);
+
   return { isShow };
 }
 
 export function ConfirmProvider({ children }: { children: ReactNode }) {
-  const [options, setOptions] = useState<ConfirmOptions | null>(null);
-  const [isShow, setIsShow] = useState<boolean>(false);
-  const confirm = (opts: ConfirmOptions) => setOptions(opts);
+  const [queue, setQueue] = useState<ConfirmOptions[]>([]);
+  const [isShow, setIsShow] = useState(false);
+  const bypassRef = useRef(false);
+  const blockersRef = useRef<Map<number, RegisteredBlocker>>(new Map());
+
+  const options = queue[0] ?? null;
+
+  const confirm = useCallback((opts: ConfirmOptions) => {
+    setQueue(prev => [...prev, opts]);
+  }, []);
+
+  const isAnyDirty = useCallback(
+    () => [...blockersRef.current.values()].some(b => b.isShow),
+    []
+  );
+
+  const registerBlocker = useCallback(
+    (id: number, state: RegisteredBlocker | null) => {
+      if (state) {
+        blockersRef.current.set(id, state);
+      } else {
+        blockersRef.current.delete(id);
+      }
+      setIsShow(isAnyDirty());
+    },
+    [isAnyDirty]
+  );
+
+  // Leaving is a decision to discard every unsaved change, not just the one
+  // that triggered the prompt. Clearing the whole registry here (rather than
+  // relying on each instance to unmount and unregister itself) prevents a
+  // still-mounted dirty instance from re-blocking a chained navigation that
+  // fires before React has torn down the old route tree — e.g. switching
+  // organizations issues a root navigation, which then triggers a follow-up
+  // redirect to the env-specific URL from an effect in the newly mounted
+  // route; without this, that second navigation re-opens the confirm dialog.
+  const resetAllBlockers = useCallback(() => {
+    blockersRef.current.clear();
+    setIsShow(false);
+  }, []);
+
+  const blocker = useBlocker(
+    useCallback<BlockerFunction>(() => {
+      if (bypassRef.current) {
+        bypassRef.current = false;
+        return false;
+      }
+      return isAnyDirty();
+    }, [])
+  );
+
+  // When blocker fires, show the confirmation dialog — unless the onboarding
+  // walkthrough (driver.js) is running, in which case the navigation attempt
+  // is silently suppressed (reset without prompting) so guided steps are
+  // never interrupted.
+  useEffect(() => {
+    if (blocker.state !== 'blocked') return;
+
+    if (isWalkthroughActive()) {
+      blocker.reset();
+      return;
+    }
+
+    // Use the most recently registered dirty instance to source the dialog's
+    // copy, but proceeding must clear every dirty instance so none of them
+    // re-blocks the very navigation the user just confirmed.
+    const dirtyBlockers = [...blockersRef.current.values()].filter(
+      b => b.isShow
+    );
+    const active = dirtyBlockers[dirtyBlockers.length - 1];
+
+    confirm({
+      title: active?.title,
+      titleLeave: active?.titleLeave,
+      titleStay: active?.titleStay,
+      message: active?.content,
+      onConfirm: () => {
+        dirtyBlockers.forEach(b => b.callBackCancel?.());
+        resetAllBlockers();
+        blocker.proceed();
+      },
+      onCancel: () => {
+        blocker.reset();
+      }
+    });
+  }, [blocker.state]);
+
+  const allowNavigation = useCallback((action: () => void) => {
+    // One-shot bypass so the next blocked navigation isn't blocked.
+    bypassRef.current = true;
+    try {
+      action();
+    } finally {
+      queueMicrotask(() => {
+        bypassRef.current = false;
+      });
+    }
+  }, []);
 
   const handleConfirm = () => {
     options?.onConfirm();
-    setOptions(null);
+    setQueue(prev => prev.slice(1));
   };
 
   const handleCancel = () => {
     options?.onCancel?.();
-    setOptions(null);
+    setQueue(prev => prev.slice(1));
     document.dispatchEvent(new CustomEvent(LEAVE_PAGE_CANCELLED_EVENT));
   };
 
+  const value = useMemo<ConfirmContextType>(
+    () => ({
+      isShow,
+      confirm,
+      options,
+      handleCancel,
+      handleConfirm,
+      registerBlocker,
+      allowNavigation,
+      resetAllBlockers,
+      bypassRef
+    }),
+    [
+      isShow,
+      confirm,
+      options,
+      allowNavigation,
+      registerBlocker,
+      resetAllBlockers
+    ]
+  );
+
   return (
-    <ConfirmContext.Provider
-      value={{
-        confirm,
-        options,
-        setOptions,
-        isShow,
-        setIsShow,
-        handleCancel,
-        handleConfirm
-      }}
-    >
+    <ConfirmContext.Provider value={value}>
       {children}
       {options && (
         <PopupGlobal

--- a/ui/dashboard/src/pages/create-update-segment/segment-form/index.tsx
+++ b/ui/dashboard/src/pages/create-update-segment/segment-form/index.tsx
@@ -13,10 +13,7 @@ import { getCurrentEnvironment, useAuth } from 'auth';
 import { PAGE_PATH_USER_SEGMENTS } from 'constants/routing';
 import { useToast, useToggleOpen } from 'hooks';
 import useFormSchema from 'hooks/use-form-schema';
-import {
-  allowNavigation,
-  useUnsavedLeavePage
-} from 'hooks/use-unsaved-leave-page';
+import { useConfirm, useUnsavedLeavePage } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import { UserSegment } from '@types';
 import { covertFileToUint8ToBase64 } from 'utils/converts';
@@ -59,6 +56,7 @@ const SegmentForm = ({
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const navigate = useNavigate();
   const { notify, errorNotify } = useToast();
+  const { allowNavigation } = useConfirm();
 
   const isDisabledUserIds = useMemo(
     () =>


### PR DESCRIPTION
**Summary**

- Migrates the router from <BrowserRouter> to createBrowserRouter + RouterProvider
- Replaces the UNSAFE_NavigationContext / monkey-patched navigator hack with React Router's stable useBlocker API for intercepting in-app navigation when there are unsaved changes
- Extracts AuthProvider into an AuthShell wrapper using <Outlet /> to fit the new data router route config structure
- Removes the manual popstate listener + history.pushState trick — useBlocker natively handles back/forward navigation
