### PR TITLE
feat(ui): add drag-and-drop reordering for segment rules

### DIFF
--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -21,6 +21,8 @@
     "src/**/*.{js,jsx,ts,tsx,css}": "prettier --write --ignore-unknown"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@hookform/resolvers": "^3.9.0",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/ui/dashboard/src/@icons/customized-icons/drop-zone-icon.svg
+++ b/ui/dashboard/src/@icons/customized-icons/drop-zone-icon.svg
@@ -1,0 +1,26 @@
+<svg
+  viewBox="0 0 24 24"
+  fill="none"
+  xmlns="http://www.w3.org/2000/svg"
+>
+  <rect
+    x="4"
+    y="6"
+    width="16"
+    height="12"
+    rx="2"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-dasharray="4 3"
+  />
+
+  <line
+    x1="7"
+    y1="12"
+    x2="17"
+    y2="12"
+    stroke="currentColor"
+    stroke-width="1.5"
+    stroke-linecap="round"
+  />
+</svg>

--- a/ui/dashboard/src/@icons/index.tsx
+++ b/ui/dashboard/src/@icons/index.tsx
@@ -19,6 +19,7 @@ import IconCopy from './customized-icons/copy.svg?react';
 import IconDisable from './customized-icons/disable.svg?react';
 import IconDocument from './customized-icons/document.svg?react';
 import IconDownload from './customized-icons/download.svg?react';
+import IconDropZone from './customized-icons/drop-zone-icon.svg?react';
 import IconEmail from './customized-icons/email.svg?react';
 import IconEnglishFlag from './customized-icons/english-flag.svg?react';
 import IconExpandSquar from './customized-icons/expand-squar.svg?react';
@@ -194,6 +195,7 @@ export {
   IconBucketWhite,
   IconArrowUpDown,
   IconDownload,
+  IconDropZone,
   // Special icons
   IconGoal,
   IconGoogle,

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
@@ -256,7 +256,8 @@ const TargetingPage = ({
     insert: segmentRulesInsert,
     remove: segmentRulesRemove,
     swap: segmentRulesSwap,
-    replace: segmentRulesReplace
+    replace: segmentRulesReplace,
+    move: segmentRulesMove
   } = useFieldArray({
     control,
     name: 'segmentRules',
@@ -393,6 +394,19 @@ const TargetingPage = ({
       setTrackedFeature(featureRuleSwap);
     },
     [trackedFeature]
+  );
+
+  const handleMoveSegmentRule = useCallback(
+    (fromIndex: number, toIndex: number) => {
+      segmentRulesMove(fromIndex, toIndex);
+      setTrackedFeature(prev => {
+        const newRules = [...prev.rules];
+        const [moved] = newRules.splice(fromIndex, 1);
+        newRules.splice(toIndex, 0, moved);
+        return { ...prev, rules: newRules };
+      });
+    },
+    [segmentRulesMove]
   );
 
   const buildSchedulePayload = useCallback(
@@ -892,6 +906,7 @@ const TargetingPage = ({
                     onAddRule={onAddRule}
                     segmentRulesRemove={handleSegmentRuleRemove}
                     segmentRulesSwap={handleSwapSegmentRule}
+                    segmentRulesMove={handleMoveSegmentRule}
                     handleDiscardChanges={handleDiscardChanges}
                     handleCheckEdit={checkEditRule}
                   />

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/index.tsx
@@ -1,28 +1,31 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { Trans } from 'react-i18next';
 import {
-  IconArrowDownwardFilled,
-  IconArrowUpwardFilled,
-  IconUndoOutlined
-} from 'react-icons-material-design';
-import { Fragment } from 'react/jsx-runtime';
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy
+} from '@dnd-kit/sortable';
 import { useQueryAttributeKeys } from '@queries/attribute-keys';
 import { useQueryUserSegments } from '@queries/user-segments';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { LIST_PAGE_SIZE } from 'constants/app';
-import { useTranslation } from 'i18n';
 import { Feature } from '@types';
-import { IconClose, IconInfo } from '@icons';
-import Icon from 'components/icon';
-import { Tooltip } from 'components/tooltip';
 import { TargetingDivider } from '..';
-import Card from '../../elements/card';
 import AddRule from '../add-rule';
 import { RuleSchema, TargetingSchema } from '../form-schema';
 import { DiscardChangesType, RuleCategory } from '../types';
-import RuleForm from './rule';
-import SegmentVariation from './variation';
+import SortableCard, { DragOverlayCard } from './sortable-card';
 
 interface RuleSchemaFields extends RuleSchema {
   segmentId: string;
@@ -37,6 +40,7 @@ interface Props {
   onAddRule: (rule: RuleCategory, index?: number) => void;
   segmentRulesRemove: (index: number) => void;
   segmentRulesSwap: (indexA: number, indexB: number) => void;
+  segmentRulesMove: (fromIndex: number, toIndex: number) => void;
   handleDiscardChanges: (type: DiscardChangesType, index?: number) => void;
   handleCheckEdit: (type: RuleCategory, index?: number) => boolean;
 }
@@ -50,15 +54,14 @@ const TargetSegmentRule = ({
   onAddRule,
   segmentRulesRemove,
   segmentRulesSwap,
+  segmentRulesMove,
   handleDiscardChanges,
   handleCheckEdit
 }: Props) => {
-  const { t } = useTranslation(['table', 'form']);
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
 
-  const methods = useFormContext<TargetingSchema>();
-  const { watch } = methods;
+  useFormContext<TargetingSchema>();
 
   const { data: segmentCollection } = useQueryUserSegments({
     params: {
@@ -74,12 +77,15 @@ const TargetSegmentRule = ({
     }
   });
 
-  const segmentRulesWatch = watch('segmentRules');
   const userSegments = segmentCollection?.segments || [];
   const sdkAttributeKeys = keysCollection?.userAttributeKeys || [];
-  const editSegmentRule = (index: number) => {
-    return handleCheckEdit(RuleCategory.CUSTOM, index);
-  };
+
+  const [activeDragId, setActiveDragId] = useState<string | null>(null);
+  const [activeDragHeight, setActiveDragHeight] = useState<number | null>(null);
+
+  const editSegmentRule = (index: number) =>
+    handleCheckEdit(RuleCategory.CUSTOM, index);
+
   const handleChangeIndexRule = useCallback(
     (type: 'increase' | 'decrease', currentIndex: number) => {
       segmentRulesSwap(
@@ -87,132 +93,118 @@ const TargetSegmentRule = ({
         type === 'increase' ? currentIndex + 1 : currentIndex - 1
       );
     },
-
-    [segmentRulesWatch, segmentRulesSwap]
+    [segmentRulesSwap]
   );
 
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 }
+    }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  );
+
+  const handleDragStart = useCallback((event: DragStartEvent) => {
+    setActiveDragId(event.active.id as string);
+    setActiveDragHeight(null);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      setActiveDragId(null);
+      setActiveDragHeight(null);
+      if (!over || active.id === over.id) return;
+      const fromIndex = segmentRules.findIndex(r => r.segmentId === active.id);
+      const toIndex = segmentRules.findIndex(r => r.segmentId === over.id);
+      if (fromIndex !== -1 && toIndex !== -1) {
+        segmentRulesMove(fromIndex, toIndex);
+      }
+    },
+    [segmentRules, segmentRulesMove]
+  );
+
+  const activeDragIndex = activeDragId
+    ? segmentRules.findIndex(r => r.segmentId === activeDragId)
+    : -1;
+  const activeDragSegment =
+    activeDragIndex !== -1 ? segmentRules[activeDragIndex] : null;
+
+  const sortableIds = segmentRules.map(r => r.segmentId);
+
+  if (segmentRules.length === 0) return null;
+
+  const sharedCardProps = {
+    feature,
+    features,
+    segmentRules,
+    userSegments,
+    sdkAttributeKeys,
+    editSegmentRule,
+    handleChangeIndexRule,
+    handleDiscardChanges,
+    segmentRulesRemove
+  };
+
   return (
-    segmentRules.length > 0 && (
-      <div className="flex flex-col w-full">
-        {segmentRules.map((segment, segmentIndex) => (
-          <div key={segment?.segmentId} className="flex flex-col w-full">
-            {segmentIndex !== 0 && (
-              <>
-                <TargetingDivider />
-                <AddRule
-                  isDisableAddIndividualRules={isDisableAddIndividualRules}
-                  isDisableAddPrerequisite={isDisableAddPrerequisite}
-                  onAddRule={onAddRule}
-                  indexInsertSegmentRule={segmentIndex}
-                  isInsertSegmentRule={true}
-                />
-                <TargetingDivider />
-              </>
-            )}
-            <Card>
-              <div className="w-full h-8 flex items-center justify-between">
-                <div className="flex items-center gap-x-2">
-                  <p className="typo-para-medium leading-5 text-gray-700">
-                    <Trans
-                      i18nKey={'table:feature-flags.rule-index'}
-                      values={{
-                        index: segmentIndex + 1
-                      }}
-                    />
-                  </p>
-                  <Tooltip
-                    align="start"
-                    alignOffset={-68}
-                    content={t('form:targeting.tooltip.custom-rules')}
-                    trigger={
-                      <div className="flex-center size-fit">
-                        <Icon icon={IconInfo} size={'xxs'} color="gray-500" />
-                      </div>
-                    }
-                    className="max-w-[400px]"
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={sortableIds}
+        strategy={verticalListSortingStrategy}
+      >
+        <div className="flex flex-col w-full">
+          {segmentRules.map((segment, segmentIndex) => (
+            <div key={segment.segmentId} className="flex flex-col w-full">
+              {segmentIndex !== 0 && (
+                <>
+                  <TargetingDivider />
+                  <AddRule
+                    isDisableAddIndividualRules={isDisableAddIndividualRules}
+                    isDisableAddPrerequisite={isDisableAddPrerequisite}
+                    onAddRule={onAddRule}
+                    indexInsertSegmentRule={segmentIndex}
+                    isInsertSegmentRule={true}
                   />
-                </div>
-                <div className="flex items-center gap-x-2">
-                  {editSegmentRule(segmentIndex) && (
-                    <div
-                      className="flex-center h-8 w-8 px-2 rounded-md cursor-pointer group border border-gray-300 hover:border-gray-800"
-                      onClick={() =>
-                        handleDiscardChanges(
-                          DiscardChangesType.CUSTOM,
-                          segmentIndex
-                        )
-                      }
-                    >
-                      <Icon
-                        icon={IconUndoOutlined}
-                        size={'sm'}
-                        className="flex-center text-gray-500 group-hover:text-gray-700"
-                      />
-                    </div>
-                  )}
-                  {segmentRules.length > 1 && (
-                    <div className="flex items-center gap-x-1">
-                      {segmentIndex !== segmentRules.length - 1 && (
-                        <div
-                          className="flex-center group cursor-pointer"
-                          onClick={() =>
-                            handleChangeIndexRule('increase', segmentIndex)
-                          }
-                        >
-                          <Icon
-                            icon={IconArrowDownwardFilled}
-                            size={'sm'}
-                            className="text-gray-500 group-hover:text-gray-700"
-                          />
-                        </div>
-                      )}
-                      {segmentIndex !== 0 && (
-                        <div
-                          className="flex-center group cursor-pointer"
-                          onClick={() =>
-                            handleChangeIndexRule('decrease', segmentIndex)
-                          }
-                        >
-                          <Icon
-                            icon={IconArrowUpwardFilled}
-                            size={'sm'}
-                            className="text-gray-500 group-hover:text-gray-700"
-                          />
-                        </div>
-                      )}
-                    </div>
-                  )}
-                  <div
-                    className="flex-center cursor-pointer group"
-                    onClick={() => segmentRulesRemove(segmentIndex)}
-                  >
-                    <Icon
-                      icon={IconClose}
-                      size={'sm'}
-                      className="flex-center text-gray-500 group-hover:text-gray-700"
-                    />
-                  </div>
-                </div>
-              </div>
-              <Fragment>
-                <RuleForm
-                  feature={feature}
-                  features={features}
-                  segmentIndex={segmentIndex}
-                  userSegments={userSegments}
-                  sdkAttributeKeys={sdkAttributeKeys}
-                />
-                <SegmentVariation
-                  feature={feature}
-                  segmentIndex={segmentIndex}
-                  segmentRules={segmentRules}
-                />
-              </Fragment>
-            </Card>
+                  <TargetingDivider />
+                </>
+              )}
+              <SortableCard
+                segment={segment}
+                segmentIndex={segmentIndex}
+                ghostHeight={activeDragHeight}
+                {...sharedCardProps}
+              />
+            </div>
+          ))}
+        </div>
+      </SortableContext>
+      <DragOverlay>
+        {activeDragSegment && activeDragIndex !== -1 && (
+          <div
+            className="opacity-95 shadow-lg"
+            ref={el => {
+              if (el && activeDragHeight === null)
+                setActiveDragHeight(el.getBoundingClientRect().height);
+            }}
+          >
+            <DragOverlayCard
+              segment={activeDragSegment}
+              segmentIndex={activeDragIndex}
+              feature={feature}
+              features={features}
+              userSegments={userSegments}
+              sdkAttributeKeys={sdkAttributeKeys}
+            />
           </div>
-        ))}
-      </div>
-    )
+        )}
+      </DragOverlay>
+    </DndContext>
   );
 };
 

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/sortable-card.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/sortable-card.tsx
@@ -1,0 +1,282 @@
+import { useForm, FormProvider } from 'react-hook-form';
+import { Trans } from 'react-i18next';
+import {
+  IconArrowDownwardFilled,
+  IconArrowUpwardFilled,
+  IconUndoOutlined
+} from 'react-icons-material-design';
+import { Fragment } from 'react/jsx-runtime';
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { useTranslation } from 'i18n';
+import { GripVertical } from 'lucide-react';
+import { Feature, UserSegment } from '@types';
+import { IconClose, IconDropZone, IconInfo } from '@icons';
+import Icon from 'components/icon';
+import { Tooltip } from 'components/tooltip';
+import Card from '../../elements/card';
+import { RuleSchema, TargetingSchema } from '../form-schema';
+import { DiscardChangesType } from '../types';
+import RuleForm from './rule';
+import SegmentVariation from './variation';
+
+export interface DragOverlayCardProps {
+  segment: RuleSchemaFields;
+  segmentIndex: number;
+  feature: Feature;
+  features: Feature[];
+  userSegments: UserSegment[];
+  sdkAttributeKeys: string[];
+}
+
+interface RuleSchemaFields extends RuleSchema {
+  segmentId: string;
+}
+
+export interface SortableCardProps {
+  segment: RuleSchemaFields;
+  segmentIndex: number;
+  segmentRules: RuleSchemaFields[];
+  feature: Feature;
+  features: Feature[];
+  userSegments: UserSegment[];
+  sdkAttributeKeys: string[];
+  ghostHeight?: number | null;
+  editSegmentRule: (index: number) => boolean;
+  handleChangeIndexRule: (type: 'increase' | 'decrease', index: number) => void;
+  handleDiscardChanges: (type: DiscardChangesType, index?: number) => void;
+  segmentRulesRemove: (index: number) => void;
+}
+
+export interface CardContentProps extends Omit<
+  SortableCardProps,
+  'isDisableAddIndividualRules' | 'isDisableAddPrerequisite' | 'onAddRule'
+> {
+  displayIndex?: number;
+  dragHandleProps?: {
+    attributes: ReturnType<typeof useSortable>['attributes'];
+    listeners: ReturnType<typeof useSortable>['listeners'];
+  };
+}
+
+export const CardContent = ({
+  segmentIndex,
+  displayIndex,
+  segmentRules,
+  feature,
+  features,
+  userSegments,
+  sdkAttributeKeys,
+  editSegmentRule,
+  handleChangeIndexRule,
+  handleDiscardChanges,
+  segmentRulesRemove,
+  dragHandleProps
+}: CardContentProps) => {
+  const { t } = useTranslation(['table', 'form']);
+
+  return (
+    <Card>
+      <div className="w-full h-8 flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          {segmentRules.length > 1 && (
+            <div
+              className="flex-center cursor-grab active:cursor-grabbing text-gray-400 hover:text-gray-600 touch-none"
+              {...dragHandleProps?.attributes}
+              {...dragHandleProps?.listeners}
+            >
+              <GripVertical size={16} />
+            </div>
+          )}
+          <p className="typo-para-medium leading-5 text-gray-700">
+            <Trans
+              i18nKey={'table:feature-flags.rule-index'}
+              values={{ index: (displayIndex ?? segmentIndex) + 1 }}
+            />
+          </p>
+          <Tooltip
+            align="start"
+            alignOffset={-68}
+            content={t('form:targeting.tooltip.custom-rules')}
+            trigger={
+              <div className="flex-center size-fit">
+                <Icon icon={IconInfo} size={'xxs'} color="gray-500" />
+              </div>
+            }
+            className="max-w-[400px]"
+          />
+        </div>
+        <div className="flex items-center gap-x-2">
+          {editSegmentRule(segmentIndex) && (
+            <div
+              className="flex-center h-8 w-8 px-2 rounded-md cursor-pointer group border border-gray-300 hover:border-gray-800"
+              onClick={() =>
+                handleDiscardChanges(DiscardChangesType.CUSTOM, segmentIndex)
+              }
+            >
+              <Icon
+                icon={IconUndoOutlined}
+                size={'sm'}
+                className="flex-center text-gray-500 group-hover:text-gray-700"
+              />
+            </div>
+          )}
+          {segmentRules.length > 1 && (
+            <div className="flex items-center gap-x-1">
+              {segmentIndex !== segmentRules.length - 1 && (
+                <div
+                  className="flex-center group cursor-pointer"
+                  onClick={() =>
+                    handleChangeIndexRule('increase', segmentIndex)
+                  }
+                >
+                  <Icon
+                    icon={IconArrowDownwardFilled}
+                    size={'sm'}
+                    className="text-gray-500 group-hover:text-gray-700"
+                  />
+                </div>
+              )}
+              {segmentIndex !== 0 && (
+                <div
+                  className="flex-center group cursor-pointer"
+                  onClick={() =>
+                    handleChangeIndexRule('decrease', segmentIndex)
+                  }
+                >
+                  <Icon
+                    icon={IconArrowUpwardFilled}
+                    size={'sm'}
+                    className="text-gray-500 group-hover:text-gray-700"
+                  />
+                </div>
+              )}
+            </div>
+          )}
+          <div
+            className="flex-center cursor-pointer group"
+            onClick={() => segmentRulesRemove(segmentIndex)}
+          >
+            <Icon
+              icon={IconClose}
+              size={'sm'}
+              className="flex-center text-gray-500 group-hover:text-gray-700"
+            />
+          </div>
+        </div>
+      </div>
+      <Fragment>
+        <RuleForm
+          feature={feature}
+          features={features}
+          segmentIndex={segmentIndex}
+          userSegments={userSegments}
+          sdkAttributeKeys={sdkAttributeKeys}
+        />
+        <SegmentVariation
+          feature={feature}
+          segmentIndex={segmentIndex}
+          segmentRules={segmentRules}
+        />
+      </Fragment>
+    </Card>
+  );
+};
+
+export const DragOverlayCard = ({
+  segment,
+  segmentIndex,
+  feature,
+  features,
+  userSegments,
+  sdkAttributeKeys
+}: DragOverlayCardProps) => {
+  // Mount RuleForm/SegmentVariation in an isolated FormProvider seeded with a
+  // frozen snapshot at index 0, so their useFieldArray / Form.Field hooks never
+  // touch the live parent form store.
+  const snapshotMethods = useForm<TargetingSchema>({
+    defaultValues: {
+      segmentRules: [segment]
+    } as unknown as TargetingSchema
+  });
+
+  const noop = () => false;
+
+  return (
+    <FormProvider {...snapshotMethods}>
+      <CardContent
+        segment={segment}
+        segmentIndex={0}
+        displayIndex={segmentIndex}
+        segmentRules={[segment]}
+        feature={feature}
+        features={features}
+        userSegments={userSegments}
+        sdkAttributeKeys={sdkAttributeKeys}
+        editSegmentRule={noop}
+        handleChangeIndexRule={() => {}}
+        handleDiscardChanges={() => {}}
+        segmentRulesRemove={() => {}}
+      />
+    </FormProvider>
+  );
+};
+
+const SortableCard = ({
+  segment,
+  segmentIndex,
+  segmentRules,
+  feature,
+  features,
+  userSegments,
+  sdkAttributeKeys,
+  ghostHeight,
+  editSegmentRule,
+  handleChangeIndexRule,
+  handleDiscardChanges,
+  segmentRulesRemove
+}: SortableCardProps) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging
+  } = useSortable({ id: segment.segmentId });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex flex-col w-full">
+      {isDragging ? (
+        <div
+          className="flex items-center justify-center gap-x-2 w-full rounded-lg border-2 border-dashed border-primary-500 bg-primary-50 text-primary-500"
+          style={{ height: ghostHeight ?? undefined }}
+        >
+          <Icon icon={IconDropZone} className="w-[120px] h-[120px]" />
+        </div>
+      ) : (
+        <CardContent
+          segment={segment}
+          segmentIndex={segmentIndex}
+          segmentRules={segmentRules}
+          feature={feature}
+          features={features}
+          userSegments={userSegments}
+          sdkAttributeKeys={sdkAttributeKeys}
+          editSegmentRule={editSegmentRule}
+          handleChangeIndexRule={handleChangeIndexRule}
+          handleDiscardChanges={handleDiscardChanges}
+          segmentRulesRemove={segmentRulesRemove}
+          dragHandleProps={{ attributes, listeners }}
+        />
+      )}
+    </div>
+  );
+};
+
+export default SortableCard;

--- a/ui/dashboard/yarn.lock
+++ b/ui/dashboard/yarn.lock
@@ -237,6 +237,37 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
 
+"@dnd-kit/accessibility@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz#3b4202bd6bb370a0730f6734867785919beac6af"
+  integrity sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.3.1.tgz#4c36406a62c7baac499726f899935f93f0e6d003"
+  integrity sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.1.1"
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-10.0.0.tgz#1f9382b90d835cd5c65d92824fa9dafb78c4c3e8"
+  integrity sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.2"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.2":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.2.tgz#5a32b6af356dc5f74d61b37d6f7129a4040ced7b"
+  integrity sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/babel-plugin@^11.13.5":
   version "11.13.5"
   resolved "https://registry.yarnpkg.com/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz#eab8d65dbded74e0ecfd28dc218e75607c4e7bc0"


### PR DESCRIPTION
## Summary

- Install `@dnd-kit/core` and `@dnd-kit/sortable` for drag-and-drop support
- Wrap the segment rule list in `DndContext` + `SortableContext`; each card
  uses `useSortable` and shows a grip handle (`GripVertical`) when there are
  multiple rules
- Add `DragOverlay` so the dragged card follows the cursor with a shadow;
  the original card fades to 30% opacity while dragging
- Keep up/down arrow buttons as an accessible fallback for keyboard users
- Add `segmentRulesMove` (from `useFieldArray`) alongside the existing `swap`,
  and `handleMoveSegmentRule` in the targeting page to sync both form state
  and `featureRef` on drag end