### PR TITLE
fix(ui): fix stale featureRef, uuid mismatch, and rollout weight unit in segment rule targeting

### DIFF
--- a/ui/dashboard/src/@queries/feature-details.ts
+++ b/ui/dashboard/src/@queries/feature-details.ts
@@ -55,3 +55,13 @@ export const invalidateFeature = (queryClient: QueryClient) => {
     queryKey: [FEATURE_QUERY_KEY]
   });
 };
+
+export const updateFeatureCache = (
+  queryClient: QueryClient,
+  params: FeatureFetcherParams,
+  updatedFeature: FeatureResponse['feature']
+) => {
+  queryClient.setQueryData<FeatureResponse>([FEATURE_QUERY_KEY, params], old =>
+    old ? { ...old, feature: updatedFeature } : old
+  );
+};

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
-import { FeatureResponse, featureUpdater } from '@api/features';
+import { featureUpdater } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateFeature } from '@queries/feature-details';
+import {
+  invalidateFeature,
+  updateFeatureCache
+} from '@queries/feature-details';
 import { invalidateFeatures, useQueryFeatures } from '@queries/features';
 import { useQueryRollouts } from '@queries/rollouts';
 import { useCreateScheduledFlagChange } from '@queries/scheduled-flag-changes';
@@ -20,7 +23,6 @@ import { useUnsavedLeavePage } from 'hooks/use-unsaved-leave-page';
 import { useTranslation } from 'i18n';
 import { isEqual, isNil } from 'lodash';
 import cloneDeep from 'lodash/cloneDeep';
-import { v4 as uuid } from 'uuid';
 import {
   Evaluation,
   Feature,
@@ -68,11 +70,11 @@ import {
 } from './types';
 import {
   checkDefaultRuleDiscardChanges,
+  computeRuleOrder,
   getDefaultRule,
   handleCheckIndividualDiscardChanges,
   handleCheckIndividualRules,
   handleCheckPrerequisiteDiscardChanges,
-  computeRuleOrder,
   handleCheckPrerequisites,
   handleCheckRuleDeleted,
   handleCheckSegmentRules,
@@ -271,12 +273,12 @@ const TargetingPage = ({
         ? index
         : segmentRulesWatch.length + 1;
       const newSegmentRule = getDefaultRule(feature);
-      segmentRulesInsert(segmentIndex!, { ...newSegmentRule, id: uuid() });
+      segmentRulesInsert(segmentIndex!, newSegmentRule);
       setFeatureRef(prev => ({
         ...prev,
         rules: [
           ...prev.rules.slice(0, segmentIndex),
-          { ...newSegmentRule, id: uuid() },
+          cloneDeep(newSegmentRule),
           ...prev.rules.slice(segmentIndex)
         ]
       }));
@@ -639,12 +641,17 @@ const TargetingPage = ({
                   action: t('updated')
                 })
               });
+              const updatedFeature = resp.feature;
+              updateFeatureCache(
+                queryClient,
+                { id: feature.id, environmentId: currentEnvironment.id },
+                updatedFeature
+              );
               invalidateFeature(queryClient);
               invalidateFeatures(queryClient);
               invalidateUserSegments(queryClient);
-              reset(
-                handleCreateDefaultValues((resp as FeatureResponse)?.feature)
-              );
+              reset(handleCreateDefaultValues(updatedFeature));
+              setFeatureRef(cloneDeep(updatedFeature));
               onCloseConfirmModal();
             }
           }

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
@@ -352,7 +352,7 @@ export const handleCheckSegmentRules = (
     const formattedRule = {
       ...currentRule,
       clauses: currentRule?.clauses,
-      strategy: handleGetStrategy(currentRule?.strategy)
+      strategy: handleGetStrategy(currentRule?.strategy, 1)
     } as FeatureRuleChange;
 
     const formattedItem = {


### PR DESCRIPTION
## Summary

Three bugs in the feature flag targeting page that caused the confirm modal to show incorrect changes for segment rules:

**Bug 1 — Stale `featureRef` after save**
After a successful save, `featureRef` (the local "before" snapshot used by the confirm modal diff) was never synced to the updated server state. On the next edit or reorder, rule ID lookups between `feature.rules` (fresh from server) and `featureRef.rules` (stale) always failed, causing the confirm modal to show false "add new rule" + "delete rule" instead of the actual changes. As a secondary effect, clicking the undo button on an existing saved rule would silently remove it from the form instead of resetting it to server state.

**Bug 2 — Duplicate `uuid()` calls for new segment rule**
When adding a new segment rule, `uuid()` was called separately for the form insert and for `featureRef`, giving each a different ID. Since `getDefaultRule` already generates a UUID internally, the extra `uuid()` overrides produced mismatched IDs between the form and `featureRef`, causing the same ID-lookup failure as Bug 1 for newly added rules.

**Bug 3 — Wrong `factor` when comparing rollout weights in `handleCheckSegmentRules`**
When checking for UPDATE changes, the server-side rule strategy (weights already in millipercent, e.g. `50000`) was passed to `handleGetStrategy` with the default `factor = 1000`, inflating weights to `50,000,000`. The form-side weights (percent, e.g. `50`) were also multiplied by `1000` to get `50,000`. Since these are always unequal, every rollout rule was emitting a spurious `UPDATE` on every save — even with no changes.

## Changes

- Reset `featureRef` to the API response feature after a successful save (same data used to reset the form)
- Remove redundant `uuid()` calls in `onAddRule` — use the object from `getDefaultRule` directly, and `cloneDeep` it into `featureRef` to share the same ID
- Pass `factor = 1` when formatting the server-side rule strategy for comparison in `handleCheckSegmentRules`, keeping both sides in millipercent
