### PR TITLE
fix(insights): include `UNKNOWN` sdk in monthly usages

### DIFF
--- a/pkg/batch/jobs/monthlysummary/monthly_summarizer.go
+++ b/pkg/batch/jobs/monthlysummary/monthly_summarizer.go
@@ -147,13 +147,9 @@ func (m *monthlySummarizer) listEnvironments(ctx context.Context) ([]*envproto.E
 }
 
 func listSourceIDs() []string {
-	ids := make([]string, 0, len(eventproto.SourceId_value)-1)
+	ids := make([]string, 0, len(eventproto.SourceId_value))
 	for _, v := range eventproto.SourceId_value {
-		id := eventproto.SourceId(v)
-		if id == eventproto.SourceId_UNKNOWN {
-			continue
-		}
-		ids = append(ids, id.String())
+		ids = append(ids, eventproto.SourceId(v).String())
 	}
 	return ids
 }

--- a/pkg/batch/jobs/monthlysummary/monthly_summarizer_test.go
+++ b/pkg/batch/jobs/monthlysummary/monthly_summarizer_test.go
@@ -157,6 +157,7 @@ func TestListSourceIDs(t *testing.T) {
 	t.Parallel()
 	ids := listSourceIDs()
 	expected := []string{
+		"UNKNOWN",
 		"ANDROID",
 		"IOS",
 		"WEB",

--- a/ui/dashboard/src/hooks/use-options.tsx
+++ b/ui/dashboard/src/hooks/use-options.tsx
@@ -535,7 +535,8 @@ const useOptions = () => {
       { label: 'OpenFeature Go', value: 'OPEN_FEATURE_GO' },
       { label: 'OpenFeature Node', value: 'OPEN_FEATURE_NODE' },
       { label: 'OpenFeature React', value: 'OPEN_FEATURE_REACT' },
-      { label: 'OpenFeature React Native', value: 'OPEN_FEATURE_REACT_NATIVE' }
+      { label: 'OpenFeature React Native', value: 'OPEN_FEATURE_REACT_NATIVE' },
+      { label: 'Unknown', value: 'UNKNOWN' }
     ],
     [language]
   );


### PR DESCRIPTION
When calculating the request counts for billing, the `UNKNOWN` SDK should also be included.
So the insights dashboard should show the req counts of `UNKNOWN` too.

After releasing this fix, the count for this month will be updated correctly; the previous months will not be updated.