### PR TITLE
fix: postgres can't resolve output column aliases in list features

### DIFF
--- a/pkg/feature/storage/v2/postgres/feature.go
+++ b/pkg/feature/storage/v2/postgres/feature.go
@@ -372,7 +372,9 @@ func listFeaturesOrders(
 	case proto.ListFeaturesRequest_ENABLED:
 		column = "feature.enabled"
 	case proto.ListFeaturesRequest_AUTO_OPS:
-		column = "(COALESCE(auto_ops_counts.progressive_rollout_count, 0) + COALESCE(auto_ops_counts.schedule_count, 0) + COALESCE(auto_ops_counts.kill_switch_count, 0))"
+		column = "(COALESCE(auto_ops_counts.progressive_rollout_count, 0) + " +
+			"COALESCE(auto_ops_counts.schedule_count, 0) + " +
+			"COALESCE(auto_ops_counts.kill_switch_count, 0))"
 	default:
 		return nil, v2fs.ErrInvalidListFeaturesOrderBy
 	}

--- a/pkg/feature/storage/v2/postgres/feature.go
+++ b/pkg/feature/storage/v2/postgres/feature.go
@@ -372,7 +372,7 @@ func listFeaturesOrders(
 	case proto.ListFeaturesRequest_ENABLED:
 		column = "feature.enabled"
 	case proto.ListFeaturesRequest_AUTO_OPS:
-		column = "(progressive_rollout_count + schedule_count + kill_switch_count)"
+		column = "(COALESCE(auto_ops_counts.progressive_rollout_count, 0) + COALESCE(auto_ops_counts.schedule_count, 0) + COALESCE(auto_ops_counts.kill_switch_count, 0))"
 	default:
 		return nil, v2fs.ErrInvalidListFeaturesOrderBy
 	}

--- a/pkg/feature/storage/v2/postgres/sql/feature/count_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/postgres/sql/feature/count_features_by_experiment.sql
@@ -1,5 +1,5 @@
 SELECT
-    COUNT(DISTINCT feature.id)
+    COUNT(1)
 FROM
     feature
 LEFT JOIN feature_last_used_info ON
@@ -12,7 +12,11 @@ LEFT JOIN feature_last_used_info ON
         AND (flui2.last_used_at > feature_last_used_info.last_used_at
         OR (flui2.last_used_at = feature_last_used_info.last_used_at AND flui2.version > feature_last_used_info.version))
     )
-LEFT JOIN experiment ON
-    feature.id = experiment.feature_id AND
-    feature.environment_id = experiment.environment_id AND
-    experiment.deleted = FALSE
+LEFT JOIN LATERAL (
+    SELECT e.id
+    FROM experiment e
+    WHERE e.feature_id = feature.id
+    AND e.environment_id = feature.environment_id
+    AND e.deleted = FALSE
+    LIMIT 1
+) experiment ON TRUE

--- a/pkg/feature/storage/v2/postgres/sql/feature/select_features.sql
+++ b/pkg/feature/storage/v2/postgres/sql/feature/select_features.sql
@@ -1,3 +1,14 @@
+WITH auto_ops_counts AS (
+    SELECT
+        aor.feature_id,
+        aor.environment_id,
+        COUNT(CASE WHEN aor.ops_type = 1 THEN 1 END) AS progressive_rollout_count,
+        COUNT(CASE WHEN aor.ops_type = 2 THEN 1 END) AS schedule_count,
+        COUNT(CASE WHEN aor.ops_type = 3 THEN 1 END) AS kill_switch_count
+    FROM auto_ops_rule aor
+    WHERE aor.deleted = FALSE
+    GROUP BY aor.feature_id, aor.environment_id
+)
 SELECT
     feature.id,
     feature.name,
@@ -20,33 +31,9 @@ SELECT
     feature.maintainer,
     feature.sampling_seed,
     feature.prerequisites,
-    (
-        SELECT COUNT(aor.id)
-        FROM auto_ops_rule aor
-        WHERE
-            aor.feature_id = feature.id AND
-            aor.environment_id = feature.environment_id AND
-            aor.ops_type = 1 AND
-            aor.deleted = FALSE
-    ) AS progressive_rollout_count,
-    (
-        SELECT COUNT(aor.id)
-        FROM auto_ops_rule aor
-        WHERE
-            aor.feature_id = feature.id AND
-            aor.environment_id = feature.environment_id AND
-            aor.ops_type = 2 AND
-            aor.deleted = FALSE
-    ) AS schedule_count,
-    (
-        SELECT COUNT(aor.id)
-        FROM auto_ops_rule aor
-        WHERE
-            aor.feature_id = feature.id AND
-            aor.environment_id = feature.environment_id AND
-            aor.ops_type = 3 AND
-            aor.deleted = FALSE
-    ) AS kill_switch_count,
+    COALESCE(auto_ops_counts.progressive_rollout_count, 0) AS progressive_rollout_count,
+    COALESCE(auto_ops_counts.schedule_count, 0) AS schedule_count,
+    COALESCE(auto_ops_counts.kill_switch_count, 0) AS kill_switch_count,
     COALESCE(feature_last_used_info.feature_id, '') AS feature_id,
     COALESCE(feature_last_used_info.version, 0) AS version,
     COALESCE(feature_last_used_info.last_used_at, 0) AS last_used_at,
@@ -55,6 +42,9 @@ SELECT
     COALESCE(feature_last_used_info.client_latest_version, '') AS client_latest_version
 FROM
     feature
+LEFT JOIN auto_ops_counts ON
+    feature.id = auto_ops_counts.feature_id AND
+    feature.environment_id = auto_ops_counts.environment_id
 LEFT JOIN feature_last_used_info ON
     feature.id = feature_last_used_info.feature_id AND
     feature.environment_id = feature_last_used_info.environment_id AND

--- a/pkg/feature/storage/v2/postgres/sql/feature/select_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/postgres/sql/feature/select_features_by_experiment.sql
@@ -1,3 +1,14 @@
+WITH auto_ops_counts AS (
+    SELECT
+        aor.feature_id,
+        aor.environment_id,
+        COUNT(CASE WHEN aor.ops_type = 1 THEN 1 END) AS progressive_rollout_count,
+        COUNT(CASE WHEN aor.ops_type = 2 THEN 1 END) AS schedule_count,
+        COUNT(CASE WHEN aor.ops_type = 3 THEN 1 END) AS kill_switch_count
+    FROM auto_ops_rule aor
+    WHERE aor.deleted = FALSE
+    GROUP BY aor.feature_id, aor.environment_id
+)
 SELECT DISTINCT
     feature.id,
     feature.name,
@@ -20,33 +31,9 @@ SELECT DISTINCT
     feature.maintainer,
     feature.sampling_seed,
     feature.prerequisites,
-    (
-        SELECT COUNT(aor.id)
-        FROM auto_ops_rule aor
-        WHERE
-            aor.feature_id = feature.id AND
-            aor.environment_id = feature.environment_id AND
-            aor.ops_type = 1 AND
-            aor.deleted = FALSE
-    ) AS progressive_rollout_count,
-    (
-        SELECT COUNT(aor.id)
-        FROM auto_ops_rule aor
-        WHERE
-            aor.feature_id = feature.id AND
-            aor.environment_id = feature.environment_id AND
-            aor.ops_type = 2 AND
-            aor.deleted = FALSE
-    ) AS schedule_count,
-    (
-        SELECT COUNT(aor.id)
-        FROM auto_ops_rule aor
-        WHERE
-            aor.feature_id = feature.id AND
-            aor.environment_id = feature.environment_id AND
-            aor.ops_type = 3 AND
-            aor.deleted = FALSE
-    ) AS kill_switch_count,
+    COALESCE(auto_ops_counts.progressive_rollout_count, 0) AS progressive_rollout_count,
+    COALESCE(auto_ops_counts.schedule_count, 0) AS schedule_count,
+    COALESCE(auto_ops_counts.kill_switch_count, 0) AS kill_switch_count,
     COALESCE(feature_last_used_info.feature_id, '') AS feature_id,
     COALESCE(feature_last_used_info.version, 0) AS version,
     COALESCE(feature_last_used_info.last_used_at, 0) AS last_used_at,
@@ -55,6 +42,9 @@ SELECT DISTINCT
     COALESCE(feature_last_used_info.client_latest_version, '') AS client_latest_version
 FROM
     feature
+LEFT JOIN auto_ops_counts ON
+    feature.id = auto_ops_counts.feature_id AND
+    feature.environment_id = auto_ops_counts.environment_id
 LEFT JOIN feature_last_used_info ON
     feature.id = feature_last_used_info.feature_id AND
     feature.environment_id = feature_last_used_info.environment_id AND

--- a/pkg/feature/storage/v2/postgres/sql/feature/select_features_by_experiment.sql
+++ b/pkg/feature/storage/v2/postgres/sql/feature/select_features_by_experiment.sql
@@ -9,7 +9,7 @@ WITH auto_ops_counts AS (
     WHERE aor.deleted = FALSE
     GROUP BY aor.feature_id, aor.environment_id
 )
-SELECT DISTINCT
+SELECT
     feature.id,
     feature.name,
     feature.description,
@@ -55,7 +55,11 @@ LEFT JOIN feature_last_used_info ON
         AND (flui2.last_used_at > feature_last_used_info.last_used_at
         OR (flui2.last_used_at = feature_last_used_info.last_used_at AND flui2.version > feature_last_used_info.version))
     )
-LEFT JOIN experiment ON
-    feature.id = experiment.feature_id AND
-    feature.environment_id = experiment.environment_id AND
-    experiment.deleted = FALSE
+LEFT JOIN LATERAL (
+    SELECT e.id
+    FROM experiment e
+    WHERE e.feature_id = feature.id
+    AND e.environment_id = feature.environment_id
+    AND e.deleted = FALSE
+    LIMIT 1
+) experiment ON TRUE


### PR DESCRIPTION
Part of #2306

### Summary
- Fix column "progressive_rollout_count" does not exist error in PostgreSQL feature list queries by refactoring correlated subqueries into a CTE
- Replace three per-row correlated subqueries on auto_ops_rule with a single WITH auto_ops_counts AS (...) CTE that pre-aggregates counts, then LEFT JOIN the results
- Update the AUTO_OPS ORDER BY to reference CTE columns directly instead of output aliases

### Why
PostgreSQL does not allow output column aliases to be used inside expressions in ORDER BY. A simple ORDER BY alias works, but ORDER BY (alias1 + alias2 + alias3) fails because PostgreSQL evaluates expressions in ORDER BY as input column references, not output aliases. This caused ListFeatures and ListFeaturesFilteredByExperiment to error when sorting by auto ops count.

### Performance note
The old approach used three correlated subqueries in the SELECT list — each one executed a separate COUNT scan on auto_ops_rule per row in the result set (i.e., 3 × N subquery executions for N features). The new CTE aggregates all counts in a single scan of auto_ops_rule grouped by (feature_id, environment_id), then joins the pre-computed results. This reduces the number of auto_ops_rule table accesses from O(3N) to O(1), which is especially significant when the feature list is large.