### PR TITLE
fix: improve Codespaces dev container setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,12 @@
   "features": {
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
-    }
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+        "version": "latest",
+        "moby": true,
+        "enableNonRootDocker": true
+    },
   },
   "mounts": [
     // Persistent Go modules cache

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,11 +16,6 @@
     "ghcr.io/devcontainers/features/sshd:1": {
       "version": "latest"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {
-        "version": "latest",
-        "moby": true,
-        "enableNonRootDocker": true
-    },
   },
   "mounts": [
     // Persistent Go modules cache

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -86,6 +86,6 @@
     "memory": "8gb",
     "storage": "32gb"
   },
-  "postCreateCommand": "bash .devcontainer/post-create-command.sh",
+  "postCreateCommand": "bash .devcontainer/setup-permissions.sh",
   "postAttachCommand": "bash .devcontainer/setup.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,11 @@
   "runArgs": [
     "--cgroupns=host"
   ],
+  "features": {
+    "ghcr.io/devcontainers/features/sshd:1": {
+      "version": "latest"
+    }
+  },
   "mounts": [
     // Persistent Go modules cache
     "source=bucketeer-go-mod-cache,target=/go/pkg/mod,type=volume",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -86,5 +86,6 @@
     "memory": "8gb",
     "storage": "32gb"
   },
+  "postCreateCommand": "bash .devcontainer/post-create-command.sh",
   "postAttachCommand": "bash .devcontainer/setup.sh"
 }

--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+USER_NAME="${USER_NAME:-codespace}"
+WORKSPACE_DIR="${WORKSPACE_DIR:-/workspaces/bucketeer}"
+
+echo "Running post-create setup..."
+
+run_privileged() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif sudo -n true >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "sudo is unavailable; skipping privileged command: $*"
+  fi
+}
+
+if id "$USER_NAME" >/dev/null 2>&1; then
+  run_privileged mkdir -p /go/pkg "/home/$USER_NAME"
+  run_privileged chown -R "$USER_NAME:$USER_NAME" /go/pkg "/home/$USER_NAME"
+else
+  echo "User '$USER_NAME' not found; skipping ownership setup"
+fi
+
+MYSQL_CONF_DIR="$WORKSPACE_DIR/docker-compose/config/mysql-conf"
+if [ -d "$MYSQL_CONF_DIR" ]; then
+  run_privileged chown -R "$USER_NAME:$USER_NAME" "$MYSQL_CONF_DIR"
+  find "$MYSQL_CONF_DIR" -type f -name "*.cnf" -exec chmod 0644 {} \;
+  find "$MYSQL_CONF_DIR" -type d -exec chmod 0755 {} \;
+else
+  echo "MySQL config directory not found: $MYSQL_CONF_DIR"
+fi
+
+echo "Post-create setup completed"

--- a/.devcontainer/setup-permissions.sh
+++ b/.devcontainer/setup-permissions.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-USER_NAME="${USER_NAME:-codespace}"
-WORKSPACE_DIR="${WORKSPACE_DIR:-/workspaces/bucketeer}"
-
-echo "Running post-create setup..."
+echo "Starting post-create setup..."
 
 # Keep Codespaces-mounted files usable by tools invoked from make docker-compose-up.
 # In particular, MySQL ignores world-writable config files and then misses local settings.
@@ -18,6 +15,7 @@ run_privileged() {
   fi
 }
 
+USER_NAME="${USER_NAME:-codespace}"
 if id "$USER_NAME" >/dev/null 2>&1; then
   run_privileged mkdir -p /go/pkg "/home/$USER_NAME"
   run_privileged chown -R "$USER_NAME:$USER_NAME" /go/pkg "/home/$USER_NAME"
@@ -25,7 +23,7 @@ else
   echo "User '$USER_NAME' not found; skipping ownership setup"
 fi
 
-MYSQL_CONF_DIR="$WORKSPACE_DIR/docker-compose/config/mysql-conf"
+MYSQL_CONF_DIR="${WORKSPACE_DIR:-/workspace/bucketeer}/docker-compose/config/mysql-conf"
 if [ -d "$MYSQL_CONF_DIR" ]; then
   run_privileged chown -R "$USER_NAME:$USER_NAME" "$MYSQL_CONF_DIR"
   # MySQL ignores world-writable config files, which can happen with Codespaces workspace mounts.

--- a/.devcontainer/setup-permissions.sh
+++ b/.devcontainer/setup-permissions.sh
@@ -6,6 +6,8 @@ WORKSPACE_DIR="${WORKSPACE_DIR:-/workspaces/bucketeer}"
 
 echo "Running post-create setup..."
 
+# Keep Codespaces-mounted files usable by tools invoked from make docker-compose-up.
+# In particular, MySQL ignores world-writable config files and then misses local settings.
 run_privileged() {
   if [ "$(id -u)" -eq 0 ]; then
     "$@"
@@ -26,6 +28,7 @@ fi
 MYSQL_CONF_DIR="$WORKSPACE_DIR/docker-compose/config/mysql-conf"
 if [ -d "$MYSQL_CONF_DIR" ]; then
   run_privileged chown -R "$USER_NAME:$USER_NAME" "$MYSQL_CONF_DIR"
+  # MySQL ignores world-writable config files, which can happen with Codespaces workspace mounts.
   find "$MYSQL_CONF_DIR" -type f -name "*.cnf" -exec chmod 0644 {} \;
   find "$MYSQL_CONF_DIR" -type d -exec chmod 0755 {} \;
 else


### PR DESCRIPTION
## Summary

Add Docker-in-Docker support to the Codespaces dev container to fix container-to-container communication issues when running `make docker-compose-up` and `make start-minikube`.

Also adds a post-create setup script to initialize Codespaces permissions for Go cache, the home directory, and MySQL config files.

## Changes
- Add the Docker-in-Docker dev container feature
- Add the SSHD dev container feature
- Add a post-create setup script for Codespaces permission initialization
- Update MySQL config file permissions during post-create setup

## Why

### Docker-in-Docker

Without Docker-in-Docker, Docker workloads started from the Codespaces dev container could not use the expected container networking behavior.

For `make docker-compose-up`, this caused container-to-container communication failures.

For `make start-minikube`, this caused Minikube addons to fail because required services were not reachable.

Docker-in-Docker makes the Docker daemon and its container networks run inside the Codespaces environment, which provides the expected networking behavior for these workflows.

### SSHD

SSHD is added so developers can connect to Codespaces with `gh cs ssh` and work directly inside the dev container, for example by using Neovim or other terminal-based tools installed in the environment.

### Permission initialization

Codespaces-mounted files can have permissions that are not suitable for some tools running inside containers.

MySQL ignores world-writable config files, so the post-create setup updates the MySQL config directory permissions to make sure local MySQL settings are loaded correctly.

The setup also initializes ownership for the Go package cache and the Codespaces user's home directory so development tools can write to them without permission errors.

## How to verify

- Rebuild the Codespaces dev container
- Run `make docker-compose-up`
- Run `make start-minikube`