### PR TITLE
feat: map synonym to improve correction

### DIFF
--- a/pkg/aichat/rag/github_search.go
+++ b/pkg/aichat/rag/github_search.go
@@ -146,6 +146,7 @@ func (g *GitHubSearcher) Search(ctx context.Context, query string, topK int) ([]
 	if len(tokens) == 0 {
 		return nil, nil
 	}
+	tokens = expandQueryTokens(tokens)
 
 	// Score all indexed docs
 	type scored struct {
@@ -346,6 +347,54 @@ func (g *GitHubSearcher) fetchRawDoc(ctx context.Context, docPath string) (index
 		lowerContent: strings.ToLower(content),
 		pathSegments: extractPathSegments(docPath),
 	}, nil
+}
+
+// querySynonyms maps a token to additional tokens that should also be searched.
+// Bucketeer's docs use canonical terminology (e.g. "experiment") that doesn't always
+// match how users phrase questions (e.g. "A/B test"). Expansion bridges that gap
+// without requiring a semantic search backend.
+//
+// Keep this list narrow: only terms that are genuinely interchangeable in the docs
+// domain. Avoid generic words like "test" — they would boost too many docs.
+var querySynonyms = map[string][]string{
+	// A/B testing -> experiments
+	"a/b":         {"experiment", "experiments"},
+	"ab":          {"experiment", "experiments"},
+	"split":       {"experiment", "experiments"},
+	"experiment":  {"a/b"},
+	"experiments": {"a/b"},
+	// Progressive / automated rollout -> auto-operation
+	"progressive": {"auto-operation", "rollout"},
+	"automated":   {"auto-operation"},
+	"autoops":     {"auto-operation"},
+	"automation":  {"auto-operation"},
+	// Variant terminology -> variations
+	"variant":  {"variations"},
+	"variants": {"variations"},
+	// Activity -> audit logs / history
+	"activity": {"audit-logs", "history"},
+	// Webhooks -> trigger (Bucketeer's flag-trigger feature)
+	"webhook":  {"trigger"},
+	"webhooks": {"trigger"},
+}
+
+// expandQueryTokens appends synonym tokens for any token in the input that has
+// entries in querySynonyms. Existing tokens are preserved; duplicates are skipped.
+func expandQueryTokens(tokens []string) []string {
+	seen := make(map[string]bool, len(tokens))
+	for _, t := range tokens {
+		seen[t] = true
+	}
+	expanded := tokens
+	for _, t := range tokens {
+		for _, syn := range querySynonyms[t] {
+			if !seen[syn] {
+				seen[syn] = true
+				expanded = append(expanded, syn)
+			}
+		}
+	}
+	return expanded
 }
 
 // tokenizeQuery splits a query into unique lowercase tokens,

--- a/pkg/aichat/rag/github_search.go
+++ b/pkg/aichat/rag/github_search.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -385,7 +386,8 @@ func expandQueryTokens(tokens []string) []string {
 	for _, t := range tokens {
 		seen[t] = true
 	}
-	expanded := tokens
+	// Clone so we never write into the caller's backing array via append.
+	expanded := slices.Clone(tokens)
 	for _, t := range tokens {
 		for _, syn := range querySynonyms[t] {
 			if !seen[syn] {

--- a/pkg/aichat/rag/github_search_test.go
+++ b/pkg/aichat/rag/github_search_test.go
@@ -368,11 +368,6 @@ func TestExpandQueryTokens(t *testing.T) {
 			expected: []string{"experiment", "a/b"},
 		},
 		{
-			desc:     "toggle expands to flag",
-			tokens:   []string{"toggle"},
-			expected: []string{"toggle", "flag", "flags"},
-		},
-		{
 			desc:     "progressive expands to auto-operation and rollout",
 			tokens:   []string{"progressive"},
 			expected: []string{"progressive", "auto-operation", "rollout"},

--- a/pkg/aichat/rag/github_search_test.go
+++ b/pkg/aichat/rag/github_search_test.go
@@ -344,6 +344,151 @@ func TestTokenizeQuery(t *testing.T) {
 	}
 }
 
+func TestExpandQueryTokens(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc     string
+		tokens   []string
+		expected []string
+	}{
+		{
+			desc:     "a/b expands to experiment terms",
+			tokens:   []string{"a/b", "test"},
+			expected: []string{"a/b", "test", "experiment", "experiments"},
+		},
+		{
+			desc:     "ab expands to experiment terms",
+			tokens:   []string{"ab"},
+			expected: []string{"ab", "experiment", "experiments"},
+		},
+		{
+			desc:     "experiment expands to a/b",
+			tokens:   []string{"experiment"},
+			expected: []string{"experiment", "a/b"},
+		},
+		{
+			desc:     "toggle expands to flag",
+			tokens:   []string{"toggle"},
+			expected: []string{"toggle", "flag", "flags"},
+		},
+		{
+			desc:     "progressive expands to auto-operation and rollout",
+			tokens:   []string{"progressive"},
+			expected: []string{"progressive", "auto-operation", "rollout"},
+		},
+		{
+			desc:     "automated expands to auto-operation",
+			tokens:   []string{"automated"},
+			expected: []string{"automated", "auto-operation"},
+		},
+		{
+			desc:     "variant expands to variations",
+			tokens:   []string{"variant"},
+			expected: []string{"variant", "variations"},
+		},
+		{
+			desc:     "activity expands to audit-logs and history",
+			tokens:   []string{"activity"},
+			expected: []string{"activity", "audit-logs", "history"},
+		},
+		{
+			desc:     "webhook expands to trigger",
+			tokens:   []string{"webhook"},
+			expected: []string{"webhook", "trigger"},
+		},
+		{
+			desc:     "no synonyms leaves tokens unchanged",
+			tokens:   []string{"sdk", "android"},
+			expected: []string{"sdk", "android"},
+		},
+		{
+			desc:     "does not duplicate existing tokens",
+			tokens:   []string{"a/b", "experiment"},
+			expected: []string{"a/b", "experiment", "experiments"},
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			result := expandQueryTokens(p.tokens)
+			assert.ElementsMatch(t, p.expected, result)
+		})
+	}
+}
+
+func TestGitHubSearcherSearchQuery(t *testing.T) {
+	t.Parallel()
+
+	// Fixture mirrors Bucketeer's actual docs paths. Each doc is filed under
+	// canonical terminology that doesn't always match how users phrase questions.
+	// The subtests verify expandQueryTokens bridges that gap end-to-end.
+	server := newTestServer(t, map[string]string{
+		"docs/experimentation/experiments.md":                                  "---\ntitle: Create an Experiment\n---\n\n# Create an Experiment\n\nDefine variations and goals.",
+		"docs/feature-flags/segments.mdx":                                      "---\ntitle: Segments\n---\n\n# Segments\n\nSegments allow grouping users.",
+		"docs/feature-flags/audit-logs.mdx":                                    "---\ntitle: Audit Logs\n---\n\n# Audit Logs\n\nTrack changes to your flags over time.",
+		"docs/feature-flags/creating-feature-flags/auto-operation/rollout.mdx": "---\ntitle: Progressive Rollout\n---\n\n# Auto-operation Rollout\n\nGradually increase traffic to a variation.",
+		"docs/feature-flags/creating-feature-flags/variations.mdx":             "---\ntitle: Variations\n---\n\n# Variations\n\nDefine the possible values returned by a flag.",
+		"docs/feature-flags/creating-feature-flags/trigger.mdx":                "---\ntitle: Triggers\n---\n\n# Triggers\n\nFire flag operations via webhook URLs.",
+	})
+	// t.Cleanup (not defer) so the server stays alive for parallel subtests
+	// that haven't started yet when this function returns.
+	t.Cleanup(server.Close)
+
+	searcher := NewGitHubSearcher(zap.NewNop(), "")
+	searcher.apiBaseURL = server.URL
+	searcher.rawBaseURL = server.URL
+
+	patterns := []struct {
+		desc         string
+		query        string
+		wantTopTitle string
+	}{
+		{
+			desc:         "A/B test query maps to experiments doc",
+			query:        "How do I set up an A/B test?",
+			wantTopTitle: "Create an Experiment",
+		},
+		{
+			desc:         "progressive rollout query maps to auto-operation doc",
+			query:        "How do I do a progressive rollout?",
+			wantTopTitle: "Progressive Rollout",
+		},
+		{
+			desc:         "variant query maps to variations doc",
+			query:        "How do I add a variant?",
+			wantTopTitle: "Variations",
+		},
+		{
+			desc:         "activity query maps to audit logs doc",
+			query:        "Where can I see flag activity?",
+			wantTopTitle: "Audit Logs",
+		},
+		{
+			desc:         "webhook query maps to trigger doc",
+			query:        "How do I set up a webhook?",
+			wantTopTitle: "Triggers",
+		},
+		{
+			desc:         "direct keyword query still works without expansion",
+			query:        "segments",
+			wantTopTitle: "Segments",
+		},
+	}
+
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			docs, err := searcher.Search(t.Context(), p.query, 3)
+			require.NoError(t, err)
+			require.NotEmpty(t, docs, "expected results for query %q", p.query)
+			assert.Equal(t, p.wantTopTitle, docs[0].Metadata.Title,
+				"for query %q", p.query)
+		})
+	}
+}
+
 func TestScoreDoc(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
An extension of #2150

RAG keyword search misses docs when users phrase questions with non-canonical terms (e.g. "A/B test" vs. the `experimentation/` folder, "webhook" vs. `trigger.mdx`). The LLM then refuses with "the provided reference documents do not contain information…".

Adds a small synonym map applied to query tokens before scoring.
**Before:**
<img width="377" height="502" alt="image" src="https://github.com/user-attachments/assets/f1a1a6bc-a798-47c3-b535-d89bfe8a9116" />

**After:**

https://github.com/user-attachments/assets/d0f54dfb-7e7b-40ae-9a31-e7ed1f161f7b
