### PR TITLE
fix: tighten pdb selectors to exclude job-owned pods

### DIFF
--- a/manifests/bucketeer/charts/api/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/api/templates/pdb.yaml
@@ -9,4 +9,5 @@ spec:
   selector:
     matchLabels:
       app: {{ template "api.name" . }}
+      release: {{ template "api.fullname" . }}
 {{ end }}

--- a/manifests/bucketeer/charts/batch/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/batch/templates/pdb.yaml
@@ -9,4 +9,5 @@ spec:
   selector:
     matchLabels:
       app: {{ template "batch-server.name" . }}
+      release: {{ template "batch-server.fullname" . }}
 {{- end }}

--- a/manifests/bucketeer/charts/subscriber/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/subscriber/templates/pdb.yaml
@@ -9,4 +9,5 @@ spec:
   selector:
     matchLabels:
       app: {{ template "subscriber.name" . }}
+      release: {{ template "subscriber.fullname" . }}
 {{ end }}

--- a/manifests/bucketeer/charts/web/templates/pdb.yaml
+++ b/manifests/bucketeer/charts/web/templates/pdb.yaml
@@ -9,4 +9,5 @@ spec:
   selector:
     matchLabels:
       app: {{ template "web.name" . }}
+      release: {{ template "web.fullname" . }}
 {{ end }}


### PR DESCRIPTION
Solve #2609 

The PDB selector on all four service charts (api, web, batch, subscriber) used only `app=<name>`, which on the batch chart also matched CronJob/Job-owned pods. The PDB controller fails to compute the expected pod count for Job-owned pods ("jobs.batch does not implement the scale subresource"), causing the PDB to report disruptionsAllowed=0 and block all evictions — stalling node drains during cluster upgrades. 

Add the `release` label to each selector so it matches only the Deployment-owned pods, mirroring each Deployment's own selector.

Refs: https://github.com/kubernetes/kubernetes/issues/129625