### PR TITLE
fix: system admin can't see other envs if it's a member

### DIFF
--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -153,7 +153,12 @@ func (s *AccountService) GetMe(
 			if orgAccount.OrganizationRole >= accountproto.AccountV2_Role_Organization_ADMIN {
 				envRoles = s.getAdminConsoleAccountEnvironmentRoles(environments, projects)
 			} else {
-				envRoles = s.getConsoleAccountEnvironmentRoles(orgAccount.EnvironmentRoles, environments, projects)
+				// System admin who joined as a non-admin member: show every environment in
+				// the org (system admins always have read access), but apply the explicit
+				// member role where one exists so write permissions are respected.
+				envRoles = s.getSystemAdminMemberEnvironmentRoles(
+					orgAccount.EnvironmentRoles, environments, projects,
+				)
 			}
 		case errors.Is(orgErr, v2as.ErrAccountNotFound):
 			s.logger.Warn(
@@ -323,6 +328,38 @@ func (s *AccountService) getConsoleAccountEnvironmentRoles(
 			Environment: env,
 			Role:        r.Role,
 			Project:     project,
+		})
+	}
+	return environmentRoles
+}
+
+func (s *AccountService) getSystemAdminMemberEnvironmentRoles(
+	roles []*accountproto.AccountV2_EnvironmentRole,
+	environments []*environmentproto.EnvironmentV2,
+	projects []*environmentproto.Project,
+) []*accountproto.ConsoleAccount_EnvironmentRole {
+	roleByEnv := make(map[string]accountproto.AccountV2_Role_Environment, len(roles))
+	for _, r := range roles {
+		roleByEnv[r.EnvironmentId] = r.Role
+	}
+	projectSet := s.makeProjectSet(projects)
+	environmentRoles := make([]*accountproto.ConsoleAccount_EnvironmentRole, 0, len(environments))
+	for _, e := range environments {
+		if e.Archived {
+			continue
+		}
+		p, ok := projectSet[e.ProjectId]
+		if !ok || p.Disabled {
+			continue
+		}
+		role, ok := roleByEnv[e.Id]
+		if !ok {
+			role = accountproto.AccountV2_Role_Environment_VIEWER
+		}
+		environmentRoles = append(environmentRoles, &accountproto.ConsoleAccount_EnvironmentRole{
+			Environment: e,
+			Project:     p,
+			Role:        role,
 		})
 	}
 	return environmentRoles

--- a/pkg/account/api/admin_account.go
+++ b/pkg/account/api/admin_account.go
@@ -338,6 +338,8 @@ func (s *AccountService) getSystemAdminMemberEnvironmentRoles(
 	environments []*environmentproto.EnvironmentV2,
 	projects []*environmentproto.Project,
 ) []*accountproto.ConsoleAccount_EnvironmentRole {
+	// If the system-admin user belongs to multiple non-system organizations,
+	// we must use the configured environment roles instead of configuring it to `VIEWER`.
 	roleByEnv := make(map[string]accountproto.AccountV2_Role_Environment, len(roles))
 	for _, r := range roles {
 		roleByEnv[r.EnvironmentId] = r.Role
@@ -354,6 +356,7 @@ func (s *AccountService) getSystemAdminMemberEnvironmentRoles(
 		}
 		role, ok := roleByEnv[e.Id]
 		if !ok {
+			// Only set to `VIEWER` if the system-admin user doesn't belong to the target organization.
 			role = accountproto.AccountV2_Role_Environment_VIEWER
 		}
 		environmentRoles = append(environmentRoles, &accountproto.ConsoleAccount_EnvironmentRole{

--- a/pkg/account/api/admin_account_test.go
+++ b/pkg/account/api/admin_account_test.go
@@ -682,6 +682,117 @@ func TestGetMeMySQL(t *testing.T) {
 				pkgErr.NewErrorInternal(pkgErr.AccountPackageName, "db is down"),
 			).Err(),
 		},
+		{
+			// Regression: a system admin joined as a non-admin member with editor access
+			// on ns0 only must still see ns1 (as viewer), since system admins always have
+			// read access to every environment in the org.
+			desc: "success: system admin non-admin member sees all envs with member role applied",
+			ctx:  createContextWithDefaultToken(t, true),
+			setup: func(s *AccountService) {
+				envClient := s.environmentClient.(*ecmock.MockClient)
+				accountStorage := s.accountStorage.(*accstoragemock.MockAccountStorage)
+				email := "bucketeer@example.com"
+				sysAdminOrgID := "sys-org"
+				projects := getProjects(t)
+				environments := getEnvironments(t)
+				sysAdminAccount := &domain.AccountV2{
+					AccountV2: &accountproto.AccountV2{
+						Email:            email,
+						Name:             "System Admin",
+						OrganizationId:   sysAdminOrgID,
+						OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+						LastSeen:         456,
+					},
+				}
+				sysAdminAccountForUpdate := &domain.AccountV2{
+					AccountV2: &accountproto.AccountV2{
+						Email:            email,
+						OrganizationId:   sysAdminOrgID,
+						OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+						LastSeen:         456,
+						UpdatedAt:        456,
+					},
+				}
+				memberOrgAccount := &domain.AccountV2{
+					AccountV2: &accountproto.AccountV2{
+						Email:            email,
+						OrganizationId:   org.Id,
+						OrganizationRole: accountproto.AccountV2_Role_Organization_MEMBER,
+						EnvironmentRoles: []*accountproto.AccountV2_EnvironmentRole{
+							{
+								EnvironmentId: "ns0",
+								Role:          accountproto.AccountV2_Role_Environment_EDITOR,
+							},
+						},
+					},
+				}
+				gomock.InOrder(
+					envClient.EXPECT().ListProjects(
+						gomock.Any(), gomock.Any(),
+					).Return(
+						&environmentproto.ListProjectsResponse{Projects: projects, Cursor: ""},
+						nil,
+					),
+					envClient.EXPECT().ListEnvironmentsV2(
+						gomock.Any(), gomock.Any(),
+					).Return(
+						&environmentproto.ListEnvironmentsV2Response{Environments: environments, Cursor: ""},
+						nil,
+					),
+					envClient.EXPECT().GetOrganization(
+						gomock.Any(), gomock.Any(),
+					).Return(
+						&environmentproto.GetOrganizationResponse{Organization: &org},
+						nil,
+					),
+					accountStorage.EXPECT().GetSystemAdminAccountV2(
+						gomock.Any(), email,
+					).Return(sysAdminAccount, nil),
+					accountStorage.EXPECT().GetAccountV2(
+						gomock.Any(), email, org.Id,
+					).Return(memberOrgAccount, nil),
+					accountStorage.EXPECT().UpdateAccountV2(
+						gomock.Any(), gomock.AssignableToTypeOf(&domain.AccountV2{}),
+					).Return(nil),
+					accountStorage.EXPECT().GetAccountV2(
+						gomock.Any(), email, sysAdminOrgID,
+					).Return(sysAdminAccountForUpdate, nil),
+					accountStorage.EXPECT().UpdateAccountV2(
+						gomock.Any(), gomock.AssignableToTypeOf(&domain.AccountV2{}),
+					).Return(nil),
+					accountStorage.EXPECT().GetAccountV2(
+						gomock.Any(), email, org.Id,
+					).Return(memberOrgAccount, nil),
+				)
+			},
+			input: &accountproto.GetMeRequest{OrganizationId: "org0"},
+			expected: &accountproto.GetMeResponse{
+				Account: &accountproto.ConsoleAccount{
+					Email:            "bucketeer@example.com",
+					Name:             "System Admin",
+					IsSystemAdmin:    true,
+					Organization:     &org,
+					OrganizationRole: accountproto.AccountV2_Role_Organization_MEMBER,
+					EnvironmentRoles: []*accountproto.ConsoleAccount_EnvironmentRole{
+						{
+							Environment: &environmentproto.EnvironmentV2{
+								Id: "ns0", Name: "ns0", ProjectId: "pj0",
+							},
+							Project: &environmentproto.Project{Id: "pj0"},
+							Role:    accountproto.AccountV2_Role_Environment_EDITOR,
+						},
+						{
+							Environment: &environmentproto.EnvironmentV2{
+								Id: "ns1", Name: "ns1", ProjectId: "pj0",
+							},
+							Project: &environmentproto.Project{Id: "pj0"},
+							Role:    accountproto.AccountV2_Role_Environment_VIEWER,
+						},
+					},
+				},
+			},
+			expectedErr: nil,
+		},
 	}
 
 	for _, p := range patterns {


### PR DESCRIPTION
To resolve https://github.com/bucketeer-io/bucketeer/issues/2600

Fixed by switch the logic for system admin in case it's a member, show every environment in the org (system admins always have read access), but apply the explicit member role where one exists so write permissions are respected.