### PR TITLE
fix: add grace window to feature flag diff filter to prevent partial-diff trap

### DIFF
--- a/evaluation/go/evaluation.go
+++ b/evaluation/go/evaluation.go
@@ -74,8 +74,13 @@ type EvaluatorOption func(*evaluator)
 // WithSecondsForAdjustment overrides the grace period (in seconds) used by
 // EvaluateFeaturesByEvaluatedAt when computing the diff filter. A larger
 // value re-includes more recently updated flags and protects against the
-// partial-diff trap, at the cost of slightly larger responses.
+// partial-diff trap, at the cost of slightly larger responses. Negative
+// values are clamped to 0 because they would narrow the filter and
+// re-introduce the trap this option is meant to prevent.
 func WithSecondsForAdjustment(seconds int64) EvaluatorOption {
+	if seconds < 0 {
+		seconds = 0
+	}
 	return func(e *evaluator) {
 		e.secondsForAdjustment = seconds
 	}

--- a/evaluation/go/evaluation.go
+++ b/evaluation/go/evaluation.go
@@ -31,7 +31,13 @@ import (
 
 const (
 	secondsToReEvaluateAll = 30 * 24 * 60 * 60 // 30 days
-	secondsForAdjustment   = 10                // 10 seconds
+	// defaultSecondsForAdjustment is the grace period (in seconds) applied
+	// to the diff filter (`feature.UpdatedAt > evaluatedAt - grace`). It
+	// re-includes recently updated flags that may have been missed by a
+	// previous diff response due to L2 propagation lag combined with
+	// concurrent updates (the "RequestedAt trap" / partial-diff trap).
+	// Callers can override via WithSecondsForAdjustment.
+	defaultSecondsForAdjustment = 10 // 10 seconds
 )
 
 var (
@@ -53,12 +59,37 @@ type evaluator struct {
 	// variationCache caches YAML to JSON conversions using variation ID as the key.
 	// Since variation IDs are UUIDs, they are globally unique and safe to use as cache keys.
 	variationCache *sync.Map
+	// secondsForAdjustment widens the diff filter in
+	// EvaluateFeaturesByEvaluatedAt to recover from missed updates caused
+	// by L2 propagation race conditions. Defaults to
+	// defaultSecondsForAdjustment (10s). The server overrides this with a
+	// larger value (typically minutes) to defend against the partial-diff
+	// trap on the gateway path.
+	secondsForAdjustment int64
 }
 
-func NewEvaluator() *evaluator {
-	return &evaluator{
-		variationCache: &sync.Map{},
+// EvaluatorOption configures an evaluator instance.
+type EvaluatorOption func(*evaluator)
+
+// WithSecondsForAdjustment overrides the grace period (in seconds) used by
+// EvaluateFeaturesByEvaluatedAt when computing the diff filter. A larger
+// value re-includes more recently updated flags and protects against the
+// partial-diff trap, at the cost of slightly larger responses.
+func WithSecondsForAdjustment(seconds int64) EvaluatorOption {
+	return func(e *evaluator) {
+		e.secondsForAdjustment = seconds
 	}
+}
+
+func NewEvaluator(opts ...EvaluatorOption) *evaluator {
+	e := &evaluator{
+		variationCache:       &sync.Map{},
+		secondsForAdjustment: defaultSecondsForAdjustment,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e
 }
 
 // This function will be removed once all the SDK clients are updated.
@@ -87,7 +118,7 @@ func (e *evaluator) EvaluateFeaturesByEvaluatedAt(
 	if evaluatedAt < now.Unix()-secondsToReEvaluateAll {
 		return e.evaluate(fs, user, mapSegmentUsers, true, targetTag)
 	}
-	adjustedEvalAt := evaluatedAt - secondsForAdjustment
+	adjustedEvalAt := evaluatedAt - e.secondsForAdjustment
 	updatedFeatures := make([]*ftproto.Feature, 0, len(fs))
 	for _, feature := range fs {
 		if feature.UpdatedAt > adjustedEvalAt {

--- a/manifests/bucketeer/charts/api/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/api/templates/deployment.yaml
@@ -173,6 +173,10 @@ spec:
             - name: BUCKETEER_API_SEGMENT_USERS_MEMORY_CACHE_TTL
               value: "{{ .Values.env.segmentUsersMemoryCacheTTL }}"
             {{- end }}
+            {{- if .Values.env.featureFlagDiffGracePeriod }}
+            - name: BUCKETEER_API_FEATURE_FLAG_DIFF_GRACE_PERIOD
+              value: "{{ .Values.env.featureFlagDiffGracePeriod }}"
+            {{- end }}
             {{- if .Values.env.cacheInvalidationTopic }}
             - name: BUCKETEER_API_CACHE_INVALIDATION_TOPIC
               value: "{{ .Values.env.cacheInvalidationTopic }}"

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -44,13 +44,14 @@ env:
     mode: auto
   oldestEventTimestamp:
   furthestEventTimestamp:
-  # Grace window applied to the GetFeatureFlags / GetEvaluations diff
-  # filter (UpdatedAt >= RequestedAt - grace). Re-includes recently
-  # updated flags that the previous diff response may have missed due to
-  # L2 cache propagation lag under rapid back-to-back updates (partial-
-  # diff trap). Leave unset to use the server default (10m). Increase if
-  # SDK pods continue to observe stale flags; decrease to reduce diff
-  # response size.
+  # Grace window applied to the diff filters for:
+  #   - GetFeatureFlags: UpdatedAt >= RequestedAt - grace
+  #   - GetEvaluations: UpdatedAt > evaluatedAt - grace
+  # Re-includes recently updated flags that the previous diff response may
+  # have missed due to L2 cache propagation lag under rapid back-to-back
+  # updates (partial-diff trap). Leave unset to use the server default
+  # (10m). Increase if SDK pods continue to observe stale flags; decrease
+  # to reduce diff response size.
   featureFlagDiffGracePeriod:
   # Bounded worker pool for processing metrics events. Leave unset to use
   # the Go defaults (4 workers, 4096-batch buffered queue). Increase

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -44,6 +44,14 @@ env:
     mode: auto
   oldestEventTimestamp:
   furthestEventTimestamp:
+  # Grace window applied to the GetFeatureFlags / GetEvaluations diff
+  # filter (UpdatedAt >= RequestedAt - grace). Re-includes recently
+  # updated flags that the previous diff response may have missed due to
+  # L2 cache propagation lag under rapid back-to-back updates (partial-
+  # diff trap). Leave unset to use the server default (10m). Increase if
+  # SDK pods continue to observe stale flags; decrease to reduce diff
+  # response size.
+  featureFlagDiffGracePeriod:
   # Bounded worker pool for processing metrics events. Leave unset to use
   # the Go defaults (4 workers, 4096-batch buffered queue). Increase
   # metricsWorkers if bucketeer_gateway_api_metrics_overflow_total is

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -115,6 +115,7 @@ type options struct {
 	pubsubTimeout                     time.Duration
 	oldestEventTimestamp              time.Duration
 	furthestEventTimestamp            time.Duration
+	featureFlagDiffGracePeriod        time.Duration
 	metricsWorkers                    int
 	metricsQueueSize                  int
 	inMemoryCache                     *cachev3.InMemoryCache
@@ -132,9 +133,16 @@ var defaultOptions = options{
 	oldestEventTimestamp: 744 * time.Hour,
 	// 1 hour - handles legitimate clock skew while preventing malicious timestamps
 	furthestEventTimestamp: 1 * time.Hour,
-	logger:                 zap.NewNop(),
-	metricsWorkers:         4,
-	metricsQueueSize:       4096,
+	// 10 minutes - widens the GetFeatureFlags / GetEvaluations diff filter
+	// (UpdatedAt >= RequestedAt - grace) so changes missed by a previous
+	// diff response due to L2 propagation lag are re-included on the next
+	// poll. Prevents the partial-diff trap where the SDK silently keeps
+	// stale flag values when an unrelated flag update advances its
+	// RequestedAt cursor past a still-stale flag's UpdatedAt.
+	featureFlagDiffGracePeriod: 10 * time.Minute,
+	logger:                     zap.NewNop(),
+	metricsWorkers:             4,
+	metricsQueueSize:           4096,
 }
 
 type Option func(*options)
@@ -172,6 +180,17 @@ func WithFeaturesMemoryCacheTTL(ttl time.Duration) Option {
 func WithSegmentUsersMemoryCacheTTL(ttl time.Duration) Option {
 	return func(opts *options) {
 		opts.segmentUsersMemoryCacheTTL = ttl
+	}
+}
+
+// WithFeatureFlagDiffGracePeriod widens the diff filter for the
+// GetFeatureFlags / GetEvaluations APIs by the given duration, so flags
+// updated within (RequestedAt - grace, RequestedAt] are re-included on the
+// next poll. Defends against the partial-diff trap caused by L2 cache
+// propagation lag under rapid back-to-back flag changes.
+func WithFeatureFlagDiffGracePeriod(d time.Duration) Option {
+	return func(opts *options) {
+		opts.featureFlagDiffGracePeriod = d
 	}
 }
 
@@ -547,7 +566,14 @@ func (s *grpcGatewayService) GetEvaluations(
 		)
 		return nil, err
 	}
-	evaluator := evaluation.NewEvaluator()
+	// Use the same grace window as GetFeatureFlags so the
+	// EvaluateFeaturesByEvaluatedAt diff filter does not miss flags whose
+	// updates reached L2 only after a previous response advanced the
+	// SDK's evaluatedAt cursor past them (partial-diff trap on the client
+	// SDK path).
+	evaluator := evaluation.NewEvaluator(
+		evaluation.WithSecondsForAdjustment(int64(s.opts.featureFlagDiffGracePeriod / time.Second)),
+	)
 	var evaluations *featureproto.UserEvaluations
 	// FIXME Remove s.getEvaluations once all SDKs use UserEvaluationCondition.
 	// New SDKs always use UserEvaluationCondition.
@@ -924,6 +950,14 @@ func (s *grpcGatewayService) GetFeatureFlags(
 	}
 	// Diff path: only reached when req.RequestedAt is within [now-30days, now],
 	// so req.RequestedAt can be used directly without clamping.
+	//
+	// Grace window: widen the filter by featureFlagDiffGracePeriod so flags
+	// whose update reached L2 after the SDK's previous poll (but were
+	// missed because an unrelated flag's update bumped the SDK's
+	// RequestedAt past them) are re-emitted on the next poll. This is the
+	// primary defense against the partial-diff trap. The empty-diff
+	// fallback below catches any remaining edge case.
+	gracePeriodSeconds := int64(s.opts.featureFlagDiffGracePeriod / time.Second)
 	updatedFeatures := make([]*featureproto.Feature, 0, len(targetFeatures))
 	archivedIDs := make([]string, 0)
 	for _, feature := range targetFeatures {
@@ -931,18 +965,17 @@ func (s *grpcGatewayService) GetFeatureFlags(
 			archivedIDs = append(archivedIDs, feature.Id)
 			continue
 		}
-		if feature.UpdatedAt >= req.RequestedAt {
+		if feature.UpdatedAt >= req.RequestedAt-gracePeriodSeconds {
 			updatedFeatures = append(updatedFeatures, feature)
 		}
 	}
-	// Force-recover fallback: ffID mismatched but the diff filter excluded
-	// every flag AND there are no archives. Happens when req.RequestedAt has
-	// advanced past a changed flag's UpdatedAt (e.g. L2 propagation race
-	// under rapid updates). Returning an empty diff here would let the SDK
-	// adopt our new ffID without applying the change and get stuck on stale
-	// data until pod restart. Return the full set with ForceUpdate=true so
-	// the SDK reconciles. Tracked under a distinct metric label for
-	// observability.
+	// Force-recover fallback: ffID mismatched but the diff filter still
+	// excluded every flag AND there are no archives. Should be rare with
+	// the grace window above but kept as a defense-in-depth: returning an
+	// empty diff would let the SDK adopt our new ffID without applying any
+	// change and silently stay stale. Return the full set with
+	// ForceUpdate=true so the SDK reconciles. Tracked under a distinct
+	// metric label for observability.
 	if len(updatedFeatures) == 0 && len(archivedIDs) == 0 {
 		getFeatureFlagsCounter.WithLabelValues(projectID, envAPIKey.ProjectUrlCode,
 			environmentId, envAPIKey.Environment.UrlCode, req.Tag, codeForceAll).Inc()

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -185,7 +185,7 @@ func WithSegmentUsersMemoryCacheTTL(ttl time.Duration) Option {
 
 // WithFeatureFlagDiffGracePeriod widens the diff filter for the
 // GetFeatureFlags / GetEvaluations APIs by the given duration, so flags
-// updated within (RequestedAt - grace, RequestedAt] are re-included on the
+// updated within [RequestedAt - grace, RequestedAt] are re-included on the
 // next poll. Defends against the partial-diff trap caused by L2 cache
 // propagation lag under rapid back-to-back flag changes.
 func WithFeatureFlagDiffGracePeriod(d time.Duration) Option {

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -187,8 +187,13 @@ func WithSegmentUsersMemoryCacheTTL(ttl time.Duration) Option {
 // GetFeatureFlags / GetEvaluations APIs by the given duration, so flags
 // updated within [RequestedAt - grace, RequestedAt] are re-included on the
 // next poll. Defends against the partial-diff trap caused by L2 cache
-// propagation lag under rapid back-to-back flag changes.
+// propagation lag under rapid back-to-back flag changes. Negative values
+// are clamped to 0 because they would narrow the filter and re-introduce
+// the trap this option is meant to prevent.
 func WithFeatureFlagDiffGracePeriod(d time.Duration) Option {
+	if d < 0 {
+		d = 0
+	}
 	return func(opts *options) {
 		opts.featureFlagDiffGracePeriod = d
 	}

--- a/pkg/api/api/api_grpc.go
+++ b/pkg/api/api/api_grpc.go
@@ -133,12 +133,14 @@ var defaultOptions = options{
 	oldestEventTimestamp: 744 * time.Hour,
 	// 1 hour - handles legitimate clock skew while preventing malicious timestamps
 	furthestEventTimestamp: 1 * time.Hour,
-	// 10 minutes - widens the GetFeatureFlags / GetEvaluations diff filter
-	// (UpdatedAt >= RequestedAt - grace) so changes missed by a previous
-	// diff response due to L2 propagation lag are re-included on the next
-	// poll. Prevents the partial-diff trap where the SDK silently keeps
-	// stale flag values when an unrelated flag update advances its
-	// RequestedAt cursor past a still-stale flag's UpdatedAt.
+	// 10 minutes - widens the diff filters so changes missed by a previous
+	// response due to L2 propagation lag are re-included on the next poll:
+	//   - GetFeatureFlags:  UpdatedAt >= RequestedAt - grace
+	//   - GetEvaluations:   UpdatedAt > evaluatedAt - grace (via
+	//                       evaluation.WithSecondsForAdjustment)
+	// Prevents the partial-diff trap where the SDK silently keeps stale
+	// flag values after an unrelated update advances its time cursor past
+	// a still-stale flag's UpdatedAt.
 	featureFlagDiffGracePeriod: 10 * time.Minute,
 	logger:                     zap.NewNop(),
 	metricsWorkers:             4,
@@ -183,13 +185,16 @@ func WithSegmentUsersMemoryCacheTTL(ttl time.Duration) Option {
 	}
 }
 
-// WithFeatureFlagDiffGracePeriod widens the diff filter for the
-// GetFeatureFlags / GetEvaluations APIs by the given duration, so flags
-// updated within [RequestedAt - grace, RequestedAt] are re-included on the
-// next poll. Defends against the partial-diff trap caused by L2 cache
-// propagation lag under rapid back-to-back flag changes. Negative values
-// are clamped to 0 because they would narrow the filter and re-introduce
-// the trap this option is meant to prevent.
+// WithFeatureFlagDiffGracePeriod widens the diff filters by the given
+// duration so recently updated flags are re-included on the next poll:
+//   - GetFeatureFlags:  UpdatedAt >= RequestedAt - grace  (inclusive)
+//   - GetEvaluations:   UpdatedAt > evaluatedAt - grace   (exclusive, via
+//     evaluation.WithSecondsForAdjustment)
+//
+// Defends against the partial-diff trap caused by L2 cache propagation
+// lag under rapid back-to-back flag changes. Negative values are clamped
+// to 0 because they would narrow the filter and re-introduce the trap
+// this option is meant to prevent.
 func WithFeatureFlagDiffGracePeriod(d time.Duration) Option {
 	if d < 0 {
 		d = 0

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -2080,7 +2080,12 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			desc: "success: with tag and with different feature flags ID, and with old requested at",
+			// With the 10-minute featureFlagDiffGracePeriod default, the
+			// diff filter becomes UpdatedAt >= RequestedAt - 10m, so
+			// feature-id-1 (UpdatedAt=-20m, RequestedAt=-10m) is now
+			// re-included on the boundary (-20m >= -20m). This protects
+			// against the partial-diff trap caused by L2 propagation lag.
+			desc: "success: with tag and with different feature flags ID, and with old requested at (grace re-includes recent flag)",
 			setup: func(gs *grpcGatewayService) {
 				gs.environmentAPIKeyCache.(*cachev3mock.MockEnvironmentAPIKeyCache).EXPECT().Get(apiKey).Return(
 					&accountproto.EnvironmentAPIKey{
@@ -2105,7 +2110,7 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 			},
 			expected: &gwproto.GetFeatureFlagsResponse{
 				FeatureFlagsId:         singleFeatureID,
-				Features:               make([]*featureproto.Feature, 0),
+				Features:               []*featureproto.Feature{multiFeatures[0]},
 				ArchivedFeatureFlagIds: []string{multiFeatures[4].Id},
 				RequestedAt:            timeNow.Unix(),
 				ForceUpdate:            false,

--- a/pkg/api/api/requestedat_staleness_test.go
+++ b/pkg/api/api/requestedat_staleness_test.go
@@ -17,16 +17,21 @@
 // Affected APIs:
 //   - GetFeatureFlags: uses FeatureFlagsId + RequestedAt for None/Diff/All responses
 //   - GetSegmentUsers: uses SegmentIds + RequestedAt for None/Diff/All responses
+//   - GetEvaluations (client SDK): uses UserEvaluationsId + evaluatedAt; the
+//     same partial-diff trap exists in evaluation.EvaluateFeaturesByEvaluatedAt,
+//     and the server widens its grace window (secondsForAdjustment) using the
+//     same featureFlagDiffGracePeriod config.
 //
 // NOT affected:
-//   - GetEvaluation / GetEvaluations: client SDK APIs that evaluate per-request
-//     using evaluatedAt, not the RequestedAt/Diff caching mechanism.
+//   - GetEvaluation (singular): evaluates a single feature per request with
+//     no diff/caching mechanism.
 
 package api
 
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +39,11 @@ import (
 	evaluation "github.com/bucketeer-io/bucketeer/v2/evaluation/go"
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
 )
+
+// testGracePeriodSeconds is the grace window applied to the diff filter
+// in the fixed simulator. It mirrors defaultOptions.featureFlagDiffGracePeriod
+// so the simulation matches production behavior.
+const testGracePeriodSeconds = int64(10 * time.Minute / time.Second)
 
 // ---------------------------------------------------------------------------
 // GetFeatureFlags simulation
@@ -153,16 +163,20 @@ func simulateGetFeatureFlagsFixed(
 		}
 	}
 
-	// Diff: reqRequestedAt is guaranteed within [now-30days, now]
+	// Diff: reqRequestedAt is guaranteed within [now-30days, now].
+	// The grace window widens the filter so flags whose updates reached
+	// L2 only after a previous response advanced the SDK's RequestedAt
+	// past them are re-emitted on the next poll (partial-diff trap).
 	updatedFeatures := make([]*featureproto.Feature, 0)
 	for _, feature := range serverFeatures {
-		if feature.UpdatedAt >= reqRequestedAt {
+		if feature.UpdatedAt >= reqRequestedAt-testGracePeriodSeconds {
 			updatedFeatures = append(updatedFeatures, feature)
 		}
 	}
 
-	// Force-recover fallback: ffID mismatched but the timestamp filter
-	// produced an empty diff. Returning an empty diff would let the SDK
+	// Force-recover fallback: ffID mismatched but even the grace-widened
+	// filter produced an empty diff. Rare with the grace window above but
+	// kept as defense-in-depth: returning an empty diff would let the SDK
 	// accept the new ffID without applying any update, permanently masking
 	// the missed change. Fall back to the full feature set with
 	// ForceUpdate=true so the SDK reconciles.
@@ -923,6 +937,115 @@ func TestGetFeatureFlagsRapidFlipTrap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetFeatureFlagsPartialDiffTrap reproduces the partial-diff variant of
+// the trap, which the empty-diff fallback alone does NOT cover.
+//
+// Failure mode without the grace window:
+//  1. SDK is at ffID_v0 with requestedAt=T0.
+//  2. target-flag updates at T_target. L2 has not yet propagated this.
+//  3. A different flag updates at T_other > T_target. L2 propagates this
+//     first.
+//  4. SDK polls at T_poll > T_other. Diff returns the other flag, advancing
+//     SDK requestedAt to T_poll (now > T_target).
+//  5. L2 catches up; ffID now reflects both flags.
+//  6. A THIRD unrelated flag updates at T_new > T_poll.
+//  7. SDK polls again. ffID mismatched. Diff filter:
+//     - target-flag: UpdatedAt=T_target < requestedAt=T_poll → EXCLUDED
+//     - third-flag: UpdatedAt=T_new >= T_poll → INCLUDED
+//     updatedFeatures is non-empty → empty-diff fallback does NOT fire.
+//  8. SDK applies a partial diff: third-flag is updated, target-flag stays
+//     stale. The new ffID is accepted, masking the missed change.
+//
+// With the grace window (10 minutes), step 7's filter becomes
+// `UpdatedAt >= requestedAt - 10m`, which re-includes target-flag and any
+// other recent updates that may have been missed.
+func TestGetFeatureFlagsPartialDiffTrap(t *testing.T) {
+	t.Parallel()
+
+	baseTime := int64(1710000000)
+
+	targetFlagV1 := &featureproto.Feature{
+		Id:        "target-flag",
+		Version:   1,
+		Enabled:   true,
+		UpdatedAt: baseTime - 3600,
+	}
+	targetFlagV2 := &featureproto.Feature{
+		Id:        "target-flag",
+		Version:   2,
+		Enabled:   false,
+		UpdatedAt: baseTime + 10,
+	}
+	unrelatedFlag := &featureproto.Feature{
+		Id:        "unrelated-flag",
+		Version:   1,
+		Enabled:   true,
+		UpdatedAt: baseTime + 20,
+	}
+	// A third flag whose update arrives AFTER the SDK's advanced
+	// requestedAt. Its presence in the next diff keeps updatedFeatures
+	// non-empty, which would otherwise hide the missed target-flag update
+	// by sidestepping the empty-diff fallback.
+	thirdFlag := &featureproto.Feature{
+		Id:        "third-flag",
+		Version:   1,
+		Enabled:   true,
+		UpdatedAt: baseTime + 90,
+	}
+
+	sdk := &featureFlagsSDKCache{features: make(map[string]*featureproto.Feature)}
+
+	serverFeatures := []*featureproto.Feature{targetFlagV1}
+	resp := simulateGetFeatureFlagsFixed(serverFeatures, sdk.featureFlagsID, sdk.requestedAt, baseTime)
+	require.Equal(t, "all", resp.ResponseType)
+	sdk.applyResponse(resp)
+	require.True(t, sdk.features["target-flag"].Enabled)
+
+	// T=10: target-flag → V2 in DB (not yet in L2)
+	// T=20: unrelated-flag created and reaches L2 first
+	serverFeatures = []*featureproto.Feature{targetFlagV1, unrelatedFlag}
+
+	// T=25: SDK polls. Diff returns unrelated-flag, advancing requestedAt.
+	resp = simulateGetFeatureFlagsFixed(serverFeatures, sdk.featureFlagsID, sdk.requestedAt, baseTime+25)
+	require.Equal(t, "diff", resp.ResponseType)
+	sdk.applyResponse(resp)
+	require.Equal(t, baseTime+25, sdk.requestedAt)
+	require.True(t, sdk.features["target-flag"].Enabled,
+		"target-flag still appears Enabled at this point")
+
+	// T=30: L2 catches up with target-flag V2.
+	// T=90: third-flag is created.
+	serverFeatures = []*featureproto.Feature{targetFlagV2, unrelatedFlag, thirdFlag}
+
+	// T=100: SDK polls. ffID mismatched (state contains target V2 + third).
+	// Without grace window:
+	//   - target-flag V2 UpdatedAt=10 < requestedAt=25 → EXCLUDED
+	//   - unrelated-flag UpdatedAt=20 < requestedAt=25 → EXCLUDED
+	//   - third-flag UpdatedAt=90 >= requestedAt=25 → INCLUDED
+	//   updatedFeatures = [third-flag] → empty-diff fallback NOT triggered.
+	//   SDK applies partial diff → target-flag silently stuck Enabled.
+	// With grace window (10m = 600s):
+	//   - filter becomes UpdatedAt >= 25 - 600 = -575
+	//   - all three flags are included → SDK reconciles target-flag.
+	resp = simulateGetFeatureFlagsFixed(serverFeatures, sdk.featureFlagsID, sdk.requestedAt, baseTime+100)
+	sdk.applyResponse(resp)
+
+	// Subsequent polls observe the long-term effect: once ffID matches
+	// again, only None responses are returned and nothing changes.
+	for _, offset := range []int64{60, 120, 180, 240, 300} {
+		resp = simulateGetFeatureFlagsFixed(serverFeatures, sdk.featureFlagsID, sdk.requestedAt, baseTime+100+offset)
+		sdk.applyResponse(resp)
+	}
+
+	assert.False(t, sdk.features["target-flag"].Enabled,
+		"with grace window: SDK recovered target-flag V2 (Enabled=false) "+
+			"even though a third unrelated update kept updatedFeatures non-empty")
+	assert.Contains(t, sdk.features, "unrelated-flag",
+		"unrelated-flag is also re-included by the grace window")
+	assert.Contains(t, sdk.features, "third-flag",
+		"third-flag (the trigger) is still applied")
 }
 
 // TestGetFeatureFlagsSameSecondAfterDiff verifies the same-second edge case

--- a/pkg/api/api/requestedat_staleness_test.go
+++ b/pkg/api/api/requestedat_staleness_test.go
@@ -41,9 +41,10 @@ import (
 )
 
 // testGracePeriodSeconds is the grace window applied to the diff filter
-// in the fixed simulator. It mirrors defaultOptions.featureFlagDiffGracePeriod
-// so the simulation matches production behavior.
-const testGracePeriodSeconds = int64(10 * time.Minute / time.Second)
+// in the fixed simulator. It is derived from
+// defaultOptions.featureFlagDiffGracePeriod so the simulation stays in sync
+// with the production default even if that default is tuned later.
+var testGracePeriodSeconds = int64(defaultOptions.featureFlagDiffGracePeriod / time.Second)
 
 // ---------------------------------------------------------------------------
 // GetFeatureFlags simulation

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -126,6 +126,7 @@ type server struct {
 	apiKeyMemoryCacheEvictionInterval *time.Duration
 	featuresMemoryCacheTTL            *time.Duration
 	segmentUsersMemoryCacheTTL        *time.Duration
+	featureFlagDiffGracePeriod        *time.Duration
 	// PubSub configurations
 	pubSubType                *string
 	pubSubRedisServerName     *string
@@ -272,6 +273,14 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 			"segment-users-memory-cache-ttl",
 			"TTL for the in-memory segment users cache.",
 		).Default("1m").Duration(),
+		featureFlagDiffGracePeriod: cmd.Flag(
+			"feature-flag-diff-grace-period",
+			"Grace window applied to the GetFeatureFlags / GetEvaluations diff filter "+
+				"(UpdatedAt >= RequestedAt - grace). Defends against the partial-diff trap "+
+				"caused by L2 cache propagation lag under rapid back-to-back flag updates. "+
+				"Increase if pods continue to observe stale flags; decrease to reduce diff "+
+				"response size.",
+		).Default("10m").Duration(),
 		// PubSub configurations
 		pubSubType: cmd.Flag("pubsub-type",
 			"Type of PubSub to use (google or redis-stream).",
@@ -610,6 +619,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		api.WithAPIKeyMemoryCacheEvictionInterval(*s.apiKeyMemoryCacheEvictionInterval),
 		api.WithFeaturesMemoryCacheTTL(*s.featuresMemoryCacheTTL),
 		api.WithSegmentUsersMemoryCacheTTL(*s.segmentUsersMemoryCacheTTL),
+		api.WithFeatureFlagDiffGracePeriod(*s.featureFlagDiffGracePeriod),
 		api.WithOldestEventTimestamp(*s.oldestEventTimestamp),
 		api.WithFurthestEventTimestamp(*s.furthestEventTimestamp),
 		api.WithMetrics(registerer),
@@ -692,6 +702,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		api.WithAPIKeyMemoryCacheEvictionInterval(*s.apiKeyMemoryCacheEvictionInterval),
 		api.WithFeaturesMemoryCacheTTL(*s.featuresMemoryCacheTTL),
 		api.WithSegmentUsersMemoryCacheTTL(*s.segmentUsersMemoryCacheTTL),
+		api.WithFeatureFlagDiffGracePeriod(*s.featureFlagDiffGracePeriod),
 		api.WithOldestEventTimestamp(*s.oldestEventTimestamp),
 		api.WithFurthestEventTimestamp(*s.furthestEventTimestamp),
 		api.WithMetrics(registerer),

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -275,11 +275,12 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 		).Default("1m").Duration(),
 		featureFlagDiffGracePeriod: cmd.Flag(
 			"feature-flag-diff-grace-period",
-			"Grace window applied to the GetFeatureFlags / GetEvaluations diff filter "+
-				"(UpdatedAt >= RequestedAt - grace). Defends against the partial-diff trap "+
-				"caused by L2 cache propagation lag under rapid back-to-back flag updates. "+
-				"Increase if pods continue to observe stale flags; decrease to reduce diff "+
-				"response size.",
+			"Grace window applied to the diff filters for GetFeatureFlags "+
+				"(UpdatedAt >= RequestedAt - grace) and GetEvaluations "+
+				"(UpdatedAt > evaluatedAt - grace). Defends against the partial-diff "+
+				"trap caused by L2 cache propagation lag under rapid back-to-back flag "+
+				"updates. Increase if pods continue to observe stale flags; decrease to "+
+				"reduce diff response size.",
 		).Default("10m").Duration(),
 		// PubSub configurations
 		pubSubType: cmd.Flag("pubsub-type",

--- a/test/e2e/gateway/api_grpc_test.go
+++ b/test/e2e/gateway/api_grpc_test.go
@@ -160,12 +160,12 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 	assert.Equal(t, 0, len(noneResponse.ArchivedFeatureFlagIds))
 	assert.False(t, noneResponse.ForceUpdate)
 
-	// Mismatched FeatureFlagsId with a RequestedAt that's newer than every
-	// feature's UpdatedAt triggers the force-recover fallback: the timestamp
-	// filter would otherwise produce an empty diff while the ffIDs disagree,
-	// which would silently leave the SDK out of sync. The server falls back
-	// to returning the full feature set with ForceUpdate=true so the SDK
-	// reconciles.
+	// Mismatched FeatureFlagsId with a recent RequestedAt: the diff filter
+	// (`UpdatedAt >= RequestedAt - featureFlagDiffGracePeriod`, default 10m)
+	// re-includes both flags because they were created within the grace
+	// window. This is a regular Diff response (ForceUpdate=false) — not the
+	// empty-diff ForceUpdate fallback, which only fires when even the
+	// grace-widened filter excludes every flag.
 	var diffResponse *gatewayproto.GetFeatureFlagsResponse
 	require.Eventually(t, func() bool {
 		baseline := grpcGetFeatureFlags(t, tag, "", 0)
@@ -174,12 +174,12 @@ func TestGrpcGetFeatureFlags(t *testing.T) {
 		return len(diffResponse.Features) == 2 &&
 			findFeatureByID(t, req1.Id, diffResponse.Features) &&
 			findFeatureByID(t, req3.Id, diffResponse.Features) &&
-			diffResponse.ForceUpdate
+			!diffResponse.ForceUpdate
 	}, 30*time.Second, 2*time.Second, "cache should stabilize for different featuresId")
 	assert.Equal(t, ffid, diffResponse.FeatureFlagsId)
 	assert.Equal(t, 0, len(diffResponse.ArchivedFeatureFlagIds))
 	assert.True(t, diffResponse.RequestedAt >= time.Now().Add(-30*time.Second).Unix())
-	assert.True(t, diffResponse.ForceUpdate)
+	assert.False(t, diffResponse.ForceUpdate)
 }
 
 func TestGrpcGetFeatureFlagsWithArchivedIDs(t *testing.T) {
@@ -338,6 +338,89 @@ func TestGrpcGetFeatureFlagsWithRequestedAt31daysAgo(t *testing.T) {
 	assert.Equal(t, 0, len(response.ArchivedFeatureFlagIds))
 	assert.True(t, response.RequestedAt >= time.Now().Add(-30*time.Second).Unix())
 	assert.True(t, response.ForceUpdate)
+}
+
+// TestGrpcGetFeatureFlagsPartialDiffTrap verifies the grace window fix for
+// the partial-diff trap, the production failure mode where SOME flags pass
+// the diff filter (keeping the diff non-empty so the ForceUpdate fallback
+// does NOT fire) while OTHER flags are silently dropped because the SDK's
+// RequestedAt cursor has advanced past their UpdatedAt under L2
+// propagation lag.
+//
+// Setup recreates the trap deterministically:
+//  1. Create flag A → A.UpdatedAt = T_A.
+//  2. Anchor RequestedAt = T_req between T_A and T_B (T_A < T_req < T_B).
+//  3. Create flag B → B.UpdatedAt = T_B.
+//  4. Send a Diff request with random ffID + RequestedAt = T_req.
+//
+// Without the grace window:
+//   - A: UpdatedAt < RequestedAt → EXCLUDED
+//   - B: UpdatedAt >= RequestedAt → INCLUDED
+//   - updatedFeatures = [B] → non-empty → empty-diff fallback NOT triggered
+//   - SDK silently misses A (trap).
+//
+// With the grace window (default 10m, sized to the test's few-second gap):
+//   - A: UpdatedAt >= RequestedAt - 10m → INCLUDED
+//   - B: UpdatedAt >= RequestedAt - 10m → INCLUDED
+//   - SDK reconciles both flags in a regular Diff (ForceUpdate=false).
+func TestGrpcGetFeatureFlagsPartialDiffTrap(t *testing.T) {
+	t.Parallel()
+	client := newFeatureClient(t)
+	defer client.Close()
+
+	uuid := newUUID(t)
+	tag := fmt.Sprintf("%s-tag-%s", prefixTestName, uuid)
+
+	// Create flag A and ensure it is cached.
+	featureIDA := newFeatureID(t, uuid)
+	reqA := createFeatureWithTag(t, tag, featureIDA)
+
+	// Anchor RequestedAt between flag A's UpdatedAt and flag B's
+	// UpdatedAt. The 2s sleeps make the ordering unambiguous despite the
+	// 1-second resolution of UpdatedAt.
+	time.Sleep(2 * time.Second)
+	simulatedRequestedAt := time.Now().Unix()
+	time.Sleep(2 * time.Second)
+
+	// Create flag B and ensure it is cached.
+	uuid2 := newUUID(t)
+	featureIDB := newFeatureID(t, uuid2)
+	reqB := createFeatureWithTag(t, tag, featureIDB)
+
+	// Wait until both flags are visible via the gateway (cache propagated).
+	require.Eventually(t, func() bool {
+		baseline := grpcGetFeatureFlags(t, tag, "", 0)
+		return findFeatureByID(t, reqA.Id, baseline.Features) &&
+			findFeatureByID(t, reqB.Id, baseline.Features)
+	}, 30*time.Second, 2*time.Second, "both flags A and B should be visible after cache propagation")
+
+	// Diff request that recreates the partial-diff trap:
+	//   - random ffID (mismatched → Diff path)
+	//   - RequestedAt = T_req, between A.UpdatedAt and B.UpdatedAt
+	// The grace window must re-include A even though A.UpdatedAt < T_req,
+	// otherwise A would be silently dropped (B alone keeps the diff
+	// non-empty, sidestepping the empty-diff ForceUpdate fallback).
+	var diffResp *gatewayproto.GetFeatureFlagsResponse
+	require.Eventually(t, func() bool {
+		diffResp = grpcGetFeatureFlags(t, tag, "random-id", simulatedRequestedAt)
+		return len(diffResp.Features) == 2 &&
+			findFeatureByID(t, reqA.Id, diffResp.Features) &&
+			findFeatureByID(t, reqB.Id, diffResp.Features)
+	}, 30*time.Second, 2*time.Second,
+		"grace window should re-include flag A (UpdatedAt < RequestedAt) "+
+			"alongside flag B (UpdatedAt >= RequestedAt), so the SDK does "+
+			"not silently lose A to the partial-diff trap")
+
+	// This is the regular Diff path with grace re-inclusion, NOT the
+	// empty-diff fallback (which would set ForceUpdate=true). Verifying
+	// ForceUpdate=false ensures the grace window — not the fallback —
+	// is what recovered flag A.
+	assert.False(t, diffResp.ForceUpdate,
+		"grace re-includes flags within the window; the empty-diff fallback should NOT fire here")
+	assert.Equal(t, 0, len(diffResp.ArchivedFeatureFlagIds))
+	assert.True(t, diffResp.RequestedAt >= time.Now().Add(-30*time.Second).Unix())
+	assert.NotEqual(t, "random-id", diffResp.FeatureFlagsId,
+		"server returns the actual current FeatureFlagsId, not the SDK-supplied one")
 }
 
 func findFeatureByID(t *testing.T, id string, features []*featureproto.Feature) bool {

--- a/test/e2e/gateway/api_grpc_test.go
+++ b/test/e2e/gateway/api_grpc_test.go
@@ -49,6 +49,14 @@ const (
 	prefixTestName        = "e2e-test"
 	timeout               = 60 * time.Second
 	deadlockRetryAttempts = 3
+	// evaluatedAtGracePeriodSeconds mirrors the API server's
+	// --feature-flag-diff-grace-period default (10 minutes). The
+	// GetEvaluations diff filter applies it as
+	//   feature.UpdatedAt > evaluatedAt - evaluatedAtGracePeriodSeconds
+	// (see pkg/api/api/api_grpc.go and
+	// manifests/bucketeer/charts/api/values.yaml). If the server default
+	// changes, update this constant so the e2e tests stay aligned.
+	evaluatedAtGracePeriodSeconds int64 = 600
 )
 
 var (
@@ -566,15 +574,28 @@ func TestGrpcGetEvaluationsByEvaluatedAt(t *testing.T) {
 	t.Parallel()
 	c := newGatewayClient(t, *apiKeyPath)
 	defer c.Close()
+	fc := newFeatureClient(t)
+	defer fc.Close()
 	uuid := newUUID(t)
 	tag := fmt.Sprintf("%s-tag-%s", prefixTestName, uuid)
 	userID := newUserID(t, uuid)
 	featureID := newFeatureID(t, uuid)
 	createFeatureWithTag(t, tag, featureID)
-	time.Sleep(10 * time.Second) // Wait for cache propagation
+	// Read feature 1's server-side UpdatedAt so prevEvalAt can be anchored
+	// to the server clock, independent of any client/server clock skew.
+	feature1UpdatedAt := getFeature(t, featureID, fc).UpdatedAt
+	time.Sleep(3 * time.Second) // ensure feature 2's UpdatedAt > feature 1's
 	featureID2 := newFeatureID(t, newUUID(t))
 	req := createFeatureWithTag(t, tag, featureID2)
-	prevEvalAt := time.Now().Unix()
+	// Place prevEvalAt so the server-side diff filter
+	//   feature.UpdatedAt > evaluatedAt - evaluatedAtGracePeriodSeconds
+	// lands strictly between the two features:
+	//   adjusted = feature1.UpdatedAt + 1
+	//     feature 1: UpdatedAt > adjusted is false -> EXCLUDED
+	//     feature 2: UpdatedAt > adjusted is true  -> INCLUDED
+	// This keeps the "older feature is filtered out" assertion meaningful
+	// even with the wider featureFlagDiffGracePeriod (10 min by default).
+	prevEvalAt := feature1UpdatedAt + evaluatedAtGracePeriodSeconds + 1
 	response := grpcGetEvaluationsByEvaluatedAt(t, tag, userID, "userEvaluationsID", prevEvalAt, false)
 	if response.Evaluations == nil {
 		t.Fatal("Evaluations field is nil")
@@ -626,7 +647,11 @@ func TestGrpcGetEvaluationsByEvaluatedAtIncludingArchivedFeature(t *testing.T) {
 	addTag(t, tag, featureID, fc)
 	enableFeature(t, featureID, fc)
 	archiveFeature(t, featureID, fc)
-	time.Sleep(10 * time.Second) // Wait for cache propagation
+	// Capture feature 1's post-archive UpdatedAt so prevEvalAt can be
+	// anchored to the server clock (see comment in
+	// TestGrpcGetEvaluationsByEvaluatedAt for details).
+	feature1UpdatedAt := getFeature(t, featureID, fc).UpdatedAt
+	time.Sleep(3 * time.Second) // ensure feature 2's UpdatedAt > feature 1's
 
 	uuid2 := newUUID(t)
 	featureID2 := newFeatureID(t, uuid2)
@@ -639,7 +664,10 @@ func TestGrpcGetEvaluationsByEvaluatedAtIncludingArchivedFeature(t *testing.T) {
 	// Update feature flag cache
 	updateFeatueFlagCache(t)
 
-	prevEvalAt := time.Now().Unix()
+	// adjusted = feature1.UpdatedAt + 1, so feature 1 is excluded and
+	// feature 2 (created >=3s later) is included by the diff filter
+	// even with the wider featureFlagDiffGracePeriod (10 min default).
+	prevEvalAt := feature1UpdatedAt + evaluatedAtGracePeriodSeconds + 1
 	response := grpcGetEvaluationsByEvaluatedAt(t, tag, userID, "userEvaluationsID", prevEvalAt, false)
 	if response.Evaluations == nil {
 		t.Fatal("Evaluations field is nil")
@@ -672,15 +700,24 @@ func TestGrpcGetEvaluationsByUserAttributesUpdated(t *testing.T) {
 	t.Parallel()
 	c := newGatewayClient(t, *apiKeyPath)
 	defer c.Close()
+	fc := newFeatureClient(t)
+	defer fc.Close()
 	uuid := newUUID(t)
 	tag := fmt.Sprintf("%s-tag-%s", prefixTestName, uuid)
 	userID := newUserID(t, uuid)
 	featureID := newFeatureID(t, uuid)
 	createFeatureWithTag(t, tag, featureID)
-	time.Sleep(10 * time.Second) // Wait for cache propagation
+	// Anchor prevEvalAt to feature 1's server-side UpdatedAt so the diff
+	// filter excludes feature 1 regardless of the configured
+	// featureFlagDiffGracePeriod (see TestGrpcGetEvaluationsByEvaluatedAt
+	// for the full explanation). With userAttributesUpdated=true the
+	// server still excludes flags that (a) fall outside the grace window
+	// and (b) have no rules, so feature 1 (no rules) must be dropped.
+	feature1UpdatedAt := getFeature(t, featureID, fc).UpdatedAt
+	time.Sleep(3 * time.Second) // ensure feature 2's UpdatedAt > feature 1's
 	featureID2 := newFeatureID(t, newUUID(t))
 	createFeatureWithRule(t, tag, featureID2)
-	prevEvalAt := time.Now().Unix()
+	prevEvalAt := feature1UpdatedAt + evaluatedAtGracePeriodSeconds + 1
 	response := grpcGetEvaluationsByEvaluatedAt(t, tag, userID, "userEvaluationsID", prevEvalAt, true)
 	if response.State != featureproto.UserEvaluations_FULL {
 		t.Fatalf("Different states. Expected: %v, actual: %v", featureproto.UserEvaluations_FULL, response.State)

--- a/test/e2e/gateway/api_grpc_test.go
+++ b/test/e2e/gateway/api_grpc_test.go
@@ -375,11 +375,27 @@ func TestGrpcGetFeatureFlagsPartialDiffTrap(t *testing.T) {
 	featureIDA := newFeatureID(t, uuid)
 	reqA := createFeatureWithTag(t, tag, featureIDA)
 
-	// Anchor RequestedAt between flag A's UpdatedAt and flag B's
-	// UpdatedAt. The 2s sleeps make the ordering unambiguous despite the
-	// 1-second resolution of UpdatedAt.
-	time.Sleep(2 * time.Second)
-	simulatedRequestedAt := time.Now().Unix()
+	// Derive simulatedRequestedAt from flag A's server-side UpdatedAt
+	// rather than the test runner's time.Now(). This avoids client/server
+	// clock skew: if the runner's clock were ahead of the API server, a
+	// time.Now()-based RequestedAt could trigger the future-RequestedAt
+	// "All" path (ForceUpdate=true) instead of the Diff path under test.
+	var simulatedRequestedAt int64
+	require.Eventually(t, func() bool {
+		resp := grpcGetFeatureFlags(t, tag, "", 0)
+		for _, f := range resp.Features {
+			if f.Id == reqA.Id {
+				// +1 places RequestedAt strictly after A.UpdatedAt so A
+				// is filtered out without the grace window.
+				simulatedRequestedAt = f.UpdatedAt + 1
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 2*time.Second, "flag A should be visible to derive UpdatedAt")
+
+	// Sleep so flag B's UpdatedAt is strictly greater than
+	// simulatedRequestedAt (1-second UpdatedAt resolution + safety margin).
 	time.Sleep(2 * time.Second)
 
 	// Create flag B and ensure it is cached.


### PR DESCRIPTION
## Why

The empty-diff `ForceUpdate` fallback added previously only triggers when the diff filter excludes **every** flag. In production we observed cases where one update reaches L2 first and advances the SDK's `RequestedAt` cursor past a sibling flag whose update is still propagating. On the next poll the sibling's `UpdatedAt` falls just below `RequestedAt`, so it is silently dropped from the diff — while another, more recent flag keeps the diff non-empty and prevents the fallback from firing. The SDK accepts the new `FeatureFlagsId` without applying the missed update and stays stale until restart.

## What

- Widen the `GetFeatureFlags` diff filter to
  `UpdatedAt >= RequestedAt - graceWindow` so flags missed by the previous diff under L2 propagation lag are re-included on the next poll.
- Apply the same grace to `GetEvaluations` via the evaluator option (server-side override of `secondsForAdjustment`). `GetEvaluation` (singular) does not have a diff filter and is unaffected.
- Configurable via the new `featureFlagDiffGracePeriod` helm value (default **10 minutes**) so operators can widen it temporarily during long L2 incidents without redeploying.
- Empty-diff `ForceUpdate` fallback kept as defense-in-depth for the case where even the grace window is exceeded.

## Tests

- New unit test `TestGetFeatureFlagsPartialDiffTrap` reproduces the partial-diff scenario the empty-diff fallback alone does not cover.
- New e2e test `TestGrpcGetFeatureFlagsPartialDiffTrap` deterministically exercises the trap end-to-end.
- Updated existing unit/e2e tests whose expectations shift under the new filter.

## Compatibility

- No SDK changes required. The `evaluation` package change is backward-compatible: `NewEvaluator()` with no options preserves the previous 10s default.