### PR TITLE
fix(ui): auto-generation id stops working after 2 characters

### DIFF
--- a/ui/dashboard/src/pages/create-flag/flag-form/general-info.tsx
+++ b/ui/dashboard/src/pages/create-flag/flag-form/general-info.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { useTranslation } from 'i18n';
 import { Tag } from '@types';
@@ -26,7 +26,8 @@ const GeneralInfo = ({
       })),
     [tags]
   );
-  const { control, getFieldState, setValue, getValues } = useFormContext();
+  const isFlagIdEdited = useRef(false);
+  const { control, setValue } = useFormContext();
 
   return (
     <div className="flex flex-col w-full p-5 gap-y-6 bg-white rounded-lg shadow-card">
@@ -48,13 +49,11 @@ const GeneralInfo = ({
                     name="flag-name"
                     onChange={value => {
                       field.onChange(value);
-                      if (!isUpdate) {
-                        const isFlagIdDirty = getFieldState('flagId').isDirty;
-                        const flagId = getValues('flagId');
-                        setValue(
-                          'flagId',
-                          isFlagIdDirty ? flagId : onGenerateSlug(value)
-                        );
+                      if (!isUpdate && !isFlagIdEdited.current) {
+                        setValue('flagId', onGenerateSlug(value), {
+                          shouldDirty: false,
+                          shouldValidate: true
+                        });
                       }
                     }}
                   />
@@ -86,6 +85,11 @@ const GeneralInfo = ({
                     disabled={isUpdate}
                     {...field}
                     name="flag-id"
+                    autoComplete="off"
+                    onChange={value => {
+                      isFlagIdEdited.current = value !== '';
+                      field.onChange(value);
+                    }}
                   />
                 </Form.Control>
                 <Form.Message />

--- a/ui/dashboard/src/pages/demo/demo-form.tsx
+++ b/ui/dashboard/src/pages/demo/demo-form.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 import { organizationDemoCreator } from '@api/organization';
@@ -45,6 +45,7 @@ const DemoForm = ({ isDemoSiteEnabled }: { isDemoSiteEnabled?: boolean }) => {
   const navigate = useNavigate();
 
   const [demoFormError, setDemoFormError] = useState<ServerErrorType>();
+  const isUrlCodeEdited = useRef(false);
 
   const form = useForm({
     resolver: yupResolver(useFormSchema(formSchema)),
@@ -102,14 +103,13 @@ const DemoForm = ({ isDemoSiteEnabled }: { isDemoSiteEnabled?: boolean }) => {
                   {...field}
                   onChange={value => {
                     field.onChange(value);
-                    const isUrlCodeDirty = form.getFieldState(
-                      'organizationUrlCode'
-                    ).isDirty;
-                    const urlCode = form.getValues('organizationUrlCode');
-                    form.setValue(
-                      'organizationUrlCode',
-                      isUrlCodeDirty ? urlCode : onGenerateSlug(value)
-                    );
+                    if (!isUrlCodeEdited.current) {
+                      form.setValue(
+                        'organizationUrlCode',
+                        onGenerateSlug(value),
+                        { shouldDirty: false, shouldValidate: true }
+                      );
+                    }
                   }}
                 />
               </Form.Control>
@@ -127,6 +127,11 @@ const DemoForm = ({ isDemoSiteEnabled }: { isDemoSiteEnabled?: boolean }) => {
                 <Input
                   placeholder={`${t('form:placeholder-code')}`}
                   {...field}
+                  autoComplete="off"
+                  onChange={value => {
+                    isUrlCodeEdited.current = value !== '';
+                    field.onChange(value);
+                  }}
                 />
               </Form.Control>
               <Form.Message />

--- a/ui/dashboard/src/pages/goals/goals-modal/add-goal-modal/index.tsx
+++ b/ui/dashboard/src/pages/goals/goals-modal/add-goal-modal/index.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { goalCreator } from '@api/goal';
 import { yupResolver } from '@hookform/resolvers/yup';
@@ -55,6 +56,8 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
 
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
+
+  const isIdEdited = useRef(false);
 
   const form = useForm({
     resolver: yupResolver(useFormSchema(formSchema)),
@@ -118,16 +121,13 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
                       placeholder={`${t('form:placeholder-name')}`}
                       {...field}
                       onChange={value => {
-                        const isIdDirty = form.getFieldState('id').isDirty;
-                        const id = form.getValues('id');
                         field.onChange(value);
-                        form.setValue(
-                          'id',
-                          isIdDirty ? id : onGenerateSlug(value),
-                          isIdDirty
-                            ? { shouldDirty: true }
-                            : { shouldDirty: false }
-                        );
+                        if (!isIdEdited.current) {
+                          form.setValue('id', onGenerateSlug(value), {
+                            shouldDirty: false,
+                            shouldValidate: true
+                          });
+                        }
                       }}
                       name="goal-name"
                     />
@@ -160,6 +160,11 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
                       placeholder={`${t('form:placeholder-goal-id')}`}
                       {...field}
                       name="goal-id"
+                      autoComplete="off"
+                      onChange={value => {
+                        isIdEdited.current = value !== '';
+                        field.onChange(value);
+                      }}
                     />
                   </Form.Control>
                   <Form.Message />


### PR DESCRIPTION
## Summary

- **Bug**: slug/ID auto-generation from the name field stops updating after 1–2 characters in 6 form modals (create flag, add flag modal, create goal, create project, create environment, demo org).
- **Fix**: Replace the RHF `isDirty` guard with a `useRef` boolean that is explicitly set when the user types in the ID field and reset to `false` when the user clears it.