### PR TITLE
fix(ui): auto-invalidate react query cache on mutations to prevent stale data

### DIFF
--- a/.github/workflows/pr-ui-dashboard.yaml
+++ b/.github/workflows/pr-ui-dashboard.yaml
@@ -40,5 +40,7 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn style:all
+      - name: Test
+        run: yarn test
       - name: Build
         run: yarn build

--- a/ui/dashboard/package.json
+++ b/ui/dashboard/package.json
@@ -12,7 +12,8 @@
     "style:lint": "tsc && eslint '**/src/**/*.{js,jsx,ts,tsx}' --fix",
     "style:prettier": "prettier --check '**/*.{js,jsx,ts,tsx}'",
     "make-pretty": "prettier --write '**/*.{js,jsx,ts,tsx}'",
-    "test": "react-scripts test --watchAll --coverage",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "eject": "react-scripts eject",
     "svgo": "npx svgo -f src/@icons/customized-icons -o src/@icons/customized-icons & npx svgo -f src/@icons/sidebar-icons -o src/@icons/sidebar-icons & npx svgo -f src/@icons/special-icons -o src/@icons/special-icons"
   },
@@ -86,8 +87,8 @@
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",
     "@types/lodash": "^4.17.24",
-    "@types/node": "^22.19.19",
     "@types/luxon": "^3.7.1",
+    "@types/node": "^22.19.19",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.0.0",
     "@types/react-window": "^1.8.8",
@@ -121,6 +122,7 @@
     "vite": "^7.3.3",
     "vite-plugin-compression2": "^2.5.3",
     "vite-plugin-svgr": "^4.2.0",
-    "vite-tsconfig-paths": "^5.0.1"
+    "vite-tsconfig-paths": "^5.0.1",
+    "vitest": "3.2.6"
   }
 }

--- a/ui/dashboard/src/@api/axios-client.ts
+++ b/ui/dashboard/src/@api/axios-client.ts
@@ -1,10 +1,9 @@
 import axios from 'axios';
-import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import type { AxiosInstance } from 'axios';
 import { urls } from 'configs';
-import { queryClient } from 'configs/query-client';
 import { getTokenStorage, setTokenStorage } from 'storage/token';
 import { refreshTokenFetcher } from './auth';
-import { resolveInvalidationKeys } from './cache-invalidation-map';
+import { installCacheInvalidationInterceptor } from './cache-invalidation-interceptor';
 
 let isRefreshing = false;
 
@@ -25,20 +24,10 @@ axiosClient.interceptors.request.use(
   }
 );
 
-const invalidateCacheForResponse = (config: InternalAxiosRequestConfig) => {
-  const method = config.method?.toUpperCase();
-  if (!method || method === 'GET') return;
-  const url = config.url ?? '';
-  const keys = resolveInvalidationKeys(url);
-  if (keys.length === 0) return;
-  keys.forEach(key => queryClient.invalidateQueries({ queryKey: [key] }));
-};
+installCacheInvalidationInterceptor(axiosClient);
 
 axiosClient.interceptors.response.use(
-  response => {
-    invalidateCacheForResponse(response.config);
-    return response;
-  },
+  response => response,
   async error => {
     const authToken = getTokenStorage();
     const originalRequest = error.config;

--- a/ui/dashboard/src/@api/axios-client.ts
+++ b/ui/dashboard/src/@api/axios-client.ts
@@ -1,8 +1,10 @@
 import axios from 'axios';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
 import { urls } from 'configs';
+import { queryClient } from 'configs/query-client';
 import { getTokenStorage, setTokenStorage } from 'storage/token';
 import { refreshTokenFetcher } from './auth';
+import { resolveInvalidationKeys } from './cache-invalidation-map';
 
 let isRefreshing = false;
 
@@ -23,8 +25,20 @@ axiosClient.interceptors.request.use(
   }
 );
 
+const invalidateCacheForResponse = (config: InternalAxiosRequestConfig) => {
+  const method = config.method?.toUpperCase();
+  if (!method || method === 'GET') return;
+  const url = config.url ?? '';
+  const keys = resolveInvalidationKeys(url);
+  if (keys.length === 0) return;
+  keys.forEach(key => queryClient.invalidateQueries({ queryKey: [key] }));
+};
+
 axiosClient.interceptors.response.use(
-  response => response,
+  response => {
+    invalidateCacheForResponse(response.config);
+    return response;
+  },
   async error => {
     const authToken = getTokenStorage();
     const originalRequest = error.config;
@@ -55,7 +69,10 @@ axiosClient.interceptors.response.use(
             })
           );
           isRefreshing = false;
-          return axiosClient(originalRequest);
+          return axiosClient(originalRequest).then(retryResponse => {
+            invalidateCacheForResponse(retryResponse.config);
+            return retryResponse;
+          });
         })
         .catch(err => {
           isRefreshing = false;

--- a/ui/dashboard/src/@api/axios-client.ts
+++ b/ui/dashboard/src/@api/axios-client.ts
@@ -69,10 +69,7 @@ axiosClient.interceptors.response.use(
             })
           );
           isRefreshing = false;
-          return axiosClient(originalRequest).then(retryResponse => {
-            invalidateCacheForResponse(retryResponse.config);
-            return retryResponse;
-          });
+          return axiosClient(originalRequest);
         })
         .catch(err => {
           isRefreshing = false;

--- a/ui/dashboard/src/@api/cache-invalidation-interceptor.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-interceptor.ts
@@ -1,0 +1,34 @@
+import type { AxiosInstance, InternalAxiosRequestConfig } from 'axios';
+import { queryClient } from 'configs/query-client';
+import { resolveInvalidationKeys } from './cache-invalidation-map';
+
+/**
+ * Invalidates React Query caches for a single response, based on its request
+ * config. Mutating verbs (POST/PUT/PATCH/DELETE) trigger invalidation; GETs
+ * are skipped. The set of keys to invalidate is resolved from the request
+ * URL via `URL_TO_KEYS` in `cache-invalidation-map.ts`.
+ */
+export const invalidateCacheForResponse = (
+  config: InternalAxiosRequestConfig
+) => {
+  const method = config.method?.toUpperCase();
+  if (!method || method === 'GET') return;
+  const url = config.url ?? '';
+  const keys = resolveInvalidationKeys(url);
+  if (keys.length === 0) return;
+  keys.forEach(key => queryClient.invalidateQueries({ queryKey: [key] }));
+};
+
+/**
+ * Installs the response interceptor that auto-invalidates React Query caches
+ * for mutating requests. ANY axios instance created under `src/@api/` MUST
+ * call this — otherwise its mutations will silently bypass cache invalidation
+ * and leave stale data in the UI. The `cache-invalidation-map.test.ts`
+ * guardrail enforces this for every `axios.create()` site in `src/@api/`.
+ */
+export const installCacheInvalidationInterceptor = (client: AxiosInstance) => {
+  client.interceptors.response.use(response => {
+    invalidateCacheForResponse(response.config);
+    return response;
+  });
+};

--- a/ui/dashboard/src/@api/cache-invalidation-map.test.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-map.test.ts
@@ -64,12 +64,14 @@ const NON_INVALIDATED_QUERY_KEYS: ReadonlySet<string> = new Set([
  *
  * To prevent false positives from unrelated objects (e.g. `array.delete()` or
  * `Map.get()`), the scan is gated on `AXIOS_CLIENT_IMPORT_REGEX` below: only
- * files that actually import the shared `axiosClient` are considered.
+ * files that actually import the shared `axiosClient` — or create their own
+ * instance and install the cache-invalidation interceptor on it — are
+ * considered. Both cases route through the same invalidation logic.
  */
 const AXIOS_CALL_METHOD_REGEX =
   /\.(get|post|put|patch|delete)\b(?:<[^>]*>)?\s*\(/g;
 const AXIOS_CLIENT_IMPORT_REGEX =
-  /from\s+['"](?:@api\/axios-client|\.{1,2}\/(?:[^'"]+\/)?axios-client)['"]/;
+  /from\s+['"](?:@api\/axios-client|\.{1,2}\/(?:[^'"]+\/)?axios-client)['"]|\binstallCacheInvalidationInterceptor\s*\(/;
 const URL_LITERAL_REGEX = /^\s*[`'"]([^`'"]+?)[`'"]/;
 
 type ExtractedCall = {
@@ -271,6 +273,52 @@ describe('cache-invalidation-map: every @queries key is reachable', () => {
           'in `src/@queries/`. Either rename the rule to match the real key',
           'or remove it:',
           ...unknown.map(k => `  - ${k}`)
+        ].join('\n')
+      );
+    }
+  });
+});
+
+describe('cache-invalidation-map: every axios instance installs the interceptor', () => {
+  const AXIOS_CREATE_REGEX = /\baxios\.create\s*\(/;
+  const INSTALL_INTERCEPTOR_REGEX = /\binstallCacheInvalidationInterceptor\s*\(/;
+
+  const findAxiosInstanceFiles = (): string[] =>
+    walk(API_ROOT)
+      .filter(f => !f.endsWith('cache-invalidation-interceptor.ts'))
+      .filter(f => AXIOS_CREATE_REGEX.test(readFileSync(f, 'utf8')));
+
+  it('finds the shared axios client (sanity check)', () => {
+    const files = findAxiosInstanceFiles();
+    // We always expect at least the shared client. If this drops to zero the
+    // test is misconfigured (e.g. wrong path or regex), so fail loudly.
+    expect(
+      files.some(f => f.endsWith('axios-client.ts')),
+      `Expected to find @api/axios-client.ts among axios.create() sites, got:\n${files.join('\n')}`
+    ).toBe(true);
+  });
+
+  it('every axios.create() site under src/@api/ installs the cache-invalidation interceptor', () => {
+    const offenders: string[] = [];
+    for (const file of findAxiosInstanceFiles()) {
+      const source = readFileSync(file, 'utf8');
+      if (!INSTALL_INTERCEPTOR_REGEX.test(source)) {
+        offenders.push(file.replace(SRC_ROOT, 'src'));
+      }
+    }
+    if (offenders.length > 0) {
+      throw new Error(
+        [
+          'The following files create their own axios instance via',
+          '`axios.create()` but do NOT call',
+          '`installCacheInvalidationInterceptor(...)` on it. Mutations made',
+          'through these instances will silently bypass React Query cache',
+          'invalidation and leave stale data in the UI:',
+          ...offenders.map(f => `  - ${f}`),
+          '',
+          'Either route the request through `@api/axios-client` (preferred)',
+          'or call `installCacheInvalidationInterceptor(client)` from',
+          '`@api/cache-invalidation-interceptor` after creating the instance.'
         ].join('\n')
       );
     }

--- a/ui/dashboard/src/@api/cache-invalidation-map.test.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-map.test.ts
@@ -54,6 +54,25 @@ const NON_INVALIDATED_QUERY_KEYS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Files under `src/@api/` that are allowed to use a non-axios HTTP transport
+ * (native `fetch`, `XMLHttpRequest`, etc.). Such requests do NOT pass through
+ * the cache-invalidation interceptor, so each entry must be a read-only
+ * endpoint or have a documented reason to be exempt.
+ *
+ * Add a new entry here ONLY after confirming the endpoint does not need to
+ * invalidate any client-side cache. Anything that mutates user-visible data
+ * MUST be migrated to `@api/axios-client` (or another axios instance with the
+ * interceptor installed) instead.
+ */
+const NON_AXIOS_TRANSPORT_FILES: ReadonlySet<string> = new Set([
+  // POST /v1/aichat/chat – uses native fetch for SSE/ReadableStream support
+  // (axios cannot consume SSE streams). The response is a streamed AI
+  // suggestion, not a persisted mutation; the corresponding query key
+  // `ai-chat-suggestions` is in NON_INVALIDATED_QUERY_KEYS above.
+  'src/@api/ai-chat/chat-streamer.ts'
+]);
+
+/**
  * Matches HTTP-method calls (`.get(`, `.post(`, etc.) on an axios chain. We
  * deliberately match `.method(` rather than `axiosClient.method(` because the
  * codebase formats requests as multi-line chains, e.g.
@@ -149,15 +168,15 @@ const ALL_INVALIDATION_KEYS: ReadonlySet<string> = new Set(
   URL_TO_KEYS.flatMap(rule => rule.keys)
 );
 
-describe('cache-invalidation-map: every mutating @api endpoint is covered', () => {
+describe('cache-invalidation-map: every mutating axios endpoint is covered', () => {
   const allCalls = collectAllApiCalls();
   const mutatingCalls = allCalls.filter(c => c.method !== 'get');
 
-  it('finds at least some mutation endpoints (sanity check)', () => {
+  it('finds at least some axios mutation endpoints (sanity check)', () => {
     expect(mutatingCalls.length).toBeGreaterThan(10);
   });
 
-  it('every non-GET endpoint either matches URL_TO_KEYS or is allow-listed', () => {
+  it('every non-GET axios endpoint either matches URL_TO_KEYS or is allow-listed', () => {
     const uncovered: ExtractedCall[] = [];
 
     for (const call of mutatingCalls) {
@@ -320,6 +339,64 @@ describe('cache-invalidation-map: every axios instance installs the interceptor'
           'Either route the request through `@api/axios-client` (preferred)',
           'or call `installCacheInvalidationInterceptor(client)` from',
           '`@api/cache-invalidation-interceptor` after creating the instance.'
+        ].join('\n')
+      );
+    }
+  });
+});
+
+describe('cache-invalidation-map: non-axios HTTP transports are explicitly allow-listed', () => {
+  // Detects native `fetch(...)` / `new XMLHttpRequest()` / `sendBeacon(...)`
+  // usage. These bypass our axios response interceptor entirely, so the
+  // cache-invalidation guardrails above do not protect them. The only safe
+  // non-axios calls are read-only endpoints captured in
+  // `NON_AXIOS_TRANSPORT_FILES`.
+  const NON_AXIOS_TRANSPORT_REGEX =
+    /\bfetch\s*\(|\bnew\s+XMLHttpRequest\s*\(|\bnavigator\.sendBeacon\s*\(/;
+
+  const findNonAxiosTransportFiles = (): string[] =>
+    walk(API_ROOT)
+      .filter(f => !f.endsWith('cache-invalidation-map.test.ts'))
+      .filter(f => NON_AXIOS_TRANSPORT_REGEX.test(readFileSync(f, 'utf8')));
+
+  it('every non-axios HTTP call site under src/@api/ is in the allowlist', () => {
+    const found = findNonAxiosTransportFiles().map(f =>
+      f.replace(SRC_ROOT, 'src')
+    );
+    const offenders = found.filter(f => !NON_AXIOS_TRANSPORT_FILES.has(f));
+    if (offenders.length > 0) {
+      throw new Error(
+        [
+          'The following files use a non-axios HTTP transport (e.g.',
+          '`fetch`, `XMLHttpRequest`, or `sendBeacon`) and therefore bypass',
+          'the cache-invalidation interceptor:',
+          ...offenders.map(f => `  - ${f}`),
+          '',
+          'If the endpoint is genuinely read-only (or has another reason it',
+          'cannot use axios), add it to `NON_AXIOS_TRANSPORT_FILES` in this',
+          'test file with a comment explaining why. Otherwise, migrate it',
+          'to `@api/axios-client` so its mutations participate in cache',
+          'invalidation.'
+        ].join('\n')
+      );
+    }
+  });
+
+  it('NON_AXIOS_TRANSPORT_FILES only references files that actually exist', () => {
+    const found = new Set(
+      findNonAxiosTransportFiles().map(f => f.replace(SRC_ROOT, 'src'))
+    );
+    const stale: string[] = [];
+    for (const f of NON_AXIOS_TRANSPORT_FILES) {
+      if (!found.has(f)) stale.push(f);
+    }
+    if (stale.length > 0) {
+      throw new Error(
+        [
+          'NON_AXIOS_TRANSPORT_FILES references files that either no longer',
+          'exist or no longer contain a non-axios HTTP call. Remove the',
+          'stale entries:',
+          ...stale.map(f => `  - ${f}`)
         ].join('\n')
       );
     }

--- a/ui/dashboard/src/@api/cache-invalidation-map.test.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-map.test.ts
@@ -281,7 +281,8 @@ describe('cache-invalidation-map: every @queries key is reachable', () => {
 
 describe('cache-invalidation-map: every axios instance installs the interceptor', () => {
   const AXIOS_CREATE_REGEX = /\baxios\.create\s*\(/;
-  const INSTALL_INTERCEPTOR_REGEX = /\binstallCacheInvalidationInterceptor\s*\(/;
+  const INSTALL_INTERCEPTOR_REGEX =
+    /\binstallCacheInvalidationInterceptor\s*\(/;
 
   const findAxiosInstanceFiles = (): string[] =>
     walk(API_ROOT)

--- a/ui/dashboard/src/@api/cache-invalidation-map.test.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-map.test.ts
@@ -1,0 +1,252 @@
+import { readdirSync, readFileSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { describe, expect, it } from 'vitest';
+import { resolveInvalidationKeys, URL_TO_KEYS } from './cache-invalidation-map';
+
+/**
+ * The repo root for this dashboard package, computed relative to this file.
+ * Tests resolve `@api` and `@queries` paths from here so the test stays robust
+ * regardless of where vitest is invoked from.
+ */
+const SRC_ROOT = resolve(__dirname, '..');
+const API_ROOT = resolve(SRC_ROOT, '@api');
+const QUERIES_ROOT = resolve(SRC_ROOT, '@queries');
+
+/**
+ * Endpoints that are intentionally excluded from cache invalidation.
+ *
+ * Add a new entry here ONLY if the endpoint genuinely should not invalidate
+ * any client-side cache (auth handshakes, read-only debug endpoints, etc.).
+ * Anything that mutates user-visible data MUST be covered by a rule in
+ * `URL_TO_KEYS` instead.
+ */
+const NON_INVALIDATING_ENDPOINTS: ReadonlySet<string> = new Set([
+  // Auth handshakes – they mutate session state, not cached data.
+  '/v1/auth/signin',
+  '/v1/auth/refresh_token',
+  '/v1/auth/exchange_token',
+  '/v1/auth/authentication_url',
+  '/v1/auth/switch_organization',
+  '/v1/exchange_demo_token',
+  // Debug/inspection endpoints – they don't change persisted state.
+  '/v1/debug_evaluate_features'
+]);
+
+/**
+ * Query keys defined in `src/@queries/*.ts` that are read-only and have no
+ * known mutating endpoint, so they are NOT expected to appear in
+ * `URL_TO_KEYS`.
+ */
+const NON_INVALIDATED_QUERY_KEYS: ReadonlySet<string> = new Set([
+  'audit-log-details', // immutable historical data; once fetched, never changes
+  'ai-chat-suggestions', // server-side AI suggestions; not user-mutable
+  'demo-site-status', // server-side feature flag; polled, not mutated
+  'insights-monthly-summary',
+  'insights-latency',
+  'insights-requests',
+  'insights-evaluations',
+  'insights-error-rates'
+]);
+
+const HTTP_METHOD_REGEX = /\.(get|post|put|patch|delete)\b(?:<[^>]*>)?\s*\(/g;
+const URL_LITERAL_REGEX = /^\s*[`'"]([^`'"]+?)[`'"]/;
+
+type ExtractedCall = {
+  method: 'get' | 'post' | 'put' | 'patch' | 'delete';
+  url: string;
+  file: string;
+};
+
+const walk = (dir: string, files: string[] = []): string[] => {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      walk(full, files);
+    } else if (stat.isFile() && /\.(ts|tsx)$/.test(entry)) {
+      files.push(full);
+    }
+  }
+  return files;
+};
+
+const extractAxiosCalls = (file: string): ExtractedCall[] => {
+  const source = readFileSync(file, 'utf8');
+  const calls: ExtractedCall[] = [];
+
+  for (const match of source.matchAll(HTTP_METHOD_REGEX)) {
+    const method = match[1] as ExtractedCall['method'];
+    const after = source.slice(match.index! + match[0].length);
+    const urlMatch = URL_LITERAL_REGEX.exec(after);
+    if (!urlMatch) continue;
+    let url = urlMatch[1];
+    // Strip query string and template-literal interpolation tails so we test
+    // the path shape against URL_TO_KEYS' regexes.
+    url = url.replace(/\$\{[^}]+\}/g, '').split('?')[0];
+    calls.push({ method, url, file });
+  }
+
+  return calls;
+};
+
+const collectAllApiCalls = (): ExtractedCall[] => {
+  const files = walk(API_ROOT).filter(
+    f =>
+      !f.endsWith('cache-invalidation-map.ts') &&
+      !f.endsWith('cache-invalidation-map.test.ts') &&
+      !f.endsWith('axios-client.ts')
+  );
+  return files.flatMap(extractAxiosCalls);
+};
+
+const QUERY_KEY_REGEX =
+  /export const [A-Z][A-Z0-9_]*\s*(?::\s*[^=]+)?=\s*[`'"]([^`'"]+)[`'"]/g;
+
+const collectAllQueryKeys = (): {
+  key: string;
+  file: string;
+}[] => {
+  const files = walk(QUERIES_ROOT);
+  const keys: { key: string; file: string }[] = [];
+  for (const file of files) {
+    const source = readFileSync(file, 'utf8');
+    for (const match of source.matchAll(QUERY_KEY_REGEX)) {
+      keys.push({ key: match[1], file });
+    }
+  }
+  return keys;
+};
+
+const ALL_INVALIDATION_KEYS: ReadonlySet<string> = new Set(
+  URL_TO_KEYS.flatMap(rule => rule.keys)
+);
+
+describe('cache-invalidation-map: every mutating @api endpoint is covered', () => {
+  const allCalls = collectAllApiCalls();
+  const mutatingCalls = allCalls.filter(c => c.method !== 'get');
+
+  it('finds at least some mutation endpoints (sanity check)', () => {
+    expect(mutatingCalls.length).toBeGreaterThan(10);
+  });
+
+  it('every non-GET endpoint either matches URL_TO_KEYS or is allow-listed', () => {
+    const uncovered: ExtractedCall[] = [];
+
+    for (const call of mutatingCalls) {
+      if (NON_INVALIDATING_ENDPOINTS.has(call.url)) continue;
+      const keys = resolveInvalidationKeys(call.url);
+      if (keys.length === 0) uncovered.push(call);
+    }
+
+    if (uncovered.length > 0) {
+      const lines = uncovered.map(
+        c =>
+          `  - ${c.method.toUpperCase()} ${c.url}\n      (in ${c.file.replace(SRC_ROOT, 'src')})`
+      );
+      throw new Error(
+        [
+          'The following mutating endpoints have no rule in `URL_TO_KEYS`',
+          'and are not present in `NON_INVALIDATING_ENDPOINTS`:',
+          ...lines,
+          '',
+          'Add a matching entry to `src/@api/cache-invalidation-map.ts` so',
+          'related queries get invalidated automatically. If the endpoint is',
+          'genuinely read-only or session-only, add it to',
+          '`NON_INVALIDATING_ENDPOINTS` in this test file with a comment',
+          'explaining why.'
+        ].join('\n')
+      );
+    }
+  });
+
+  it('NON_INVALIDATING_ENDPOINTS only contains URLs that actually exist', () => {
+    const allUrls = new Set(allCalls.map(c => c.url));
+    const stale: string[] = [];
+    for (const url of NON_INVALIDATING_ENDPOINTS) {
+      if (!allUrls.has(url)) stale.push(url);
+    }
+    if (stale.length > 0) {
+      throw new Error(
+        [
+          'NON_INVALIDATING_ENDPOINTS references URLs that no longer exist',
+          'in `src/@api/`. Remove the stale entries:',
+          ...stale.map(u => `  - ${u}`)
+        ].join('\n')
+      );
+    }
+  });
+});
+
+describe('cache-invalidation-map: every @queries key is reachable', () => {
+  const queryKeys = collectAllQueryKeys();
+
+  it('finds at least some query keys (sanity check)', () => {
+    expect(queryKeys.length).toBeGreaterThan(10);
+  });
+
+  it('every query key is referenced in URL_TO_KEYS or explicitly excluded', () => {
+    const orphaned: { key: string; file: string }[] = [];
+
+    for (const { key, file } of queryKeys) {
+      if (ALL_INVALIDATION_KEYS.has(key)) continue;
+      if (NON_INVALIDATED_QUERY_KEYS.has(key)) continue;
+      orphaned.push({ key, file });
+    }
+
+    if (orphaned.length > 0) {
+      const lines = orphaned.map(
+        ({ key, file }) =>
+          `  - "${key}"\n      (in ${file.replace(SRC_ROOT, 'src')})`
+      );
+      throw new Error(
+        [
+          'The following query keys are defined in `src/@queries/` but are',
+          'never invalidated by any rule in `URL_TO_KEYS`. That means data',
+          'fetched under these keys can go stale silently after a mutation.',
+          '',
+          'Add the key to the relevant rule(s) in',
+          '`src/@api/cache-invalidation-map.ts`, or — if the key is for',
+          'read-only data with no mutating endpoint — add it to',
+          '`NON_INVALIDATED_QUERY_KEYS` in this test file with a comment',
+          'explaining why:',
+          ...lines
+        ].join('\n')
+      );
+    }
+  });
+
+  it('NON_INVALIDATED_QUERY_KEYS only contains keys that actually exist', () => {
+    const allKeyValues = new Set(queryKeys.map(k => k.key));
+    const stale: string[] = [];
+    for (const key of NON_INVALIDATED_QUERY_KEYS) {
+      if (!allKeyValues.has(key)) stale.push(key);
+    }
+    if (stale.length > 0) {
+      throw new Error(
+        [
+          'NON_INVALIDATED_QUERY_KEYS references keys that no longer exist',
+          'in `src/@queries/`. Remove the stale entries:',
+          ...stale.map(k => `  - ${k}`)
+        ].join('\n')
+      );
+    }
+  });
+
+  it('every key listed in URL_TO_KEYS is actually used by a query', () => {
+    const allKeyValues = new Set(queryKeys.map(k => k.key));
+    const unknown: string[] = [];
+    for (const key of ALL_INVALIDATION_KEYS) {
+      if (!allKeyValues.has(key)) unknown.push(key);
+    }
+    if (unknown.length > 0) {
+      throw new Error(
+        [
+          'URL_TO_KEYS references keys that are not exported by any module',
+          'in `src/@queries/`. Either rename the rule to match the real key',
+          'or remove it:',
+          ...unknown.map(k => `  - ${k}`)
+        ].join('\n')
+      );
+    }
+  });
+});

--- a/ui/dashboard/src/@api/cache-invalidation-map.test.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-map.test.ts
@@ -1,13 +1,18 @@
 import { readdirSync, readFileSync, statSync } from 'fs';
-import { join, resolve } from 'path';
+import { dirname, join, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { describe, expect, it } from 'vitest';
 import { resolveInvalidationKeys, URL_TO_KEYS } from './cache-invalidation-map';
 
 /**
  * The repo root for this dashboard package, computed relative to this file.
  * Tests resolve `@api` and `@queries` paths from here so the test stays robust
- * regardless of where vitest is invoked from.
+ * regardless of where vitest is invoked from. The package is ESM
+ * (`"type": "module"`), so we derive the path from `import.meta.url` instead
+ * of relying on the CommonJS `__dirname` shim.
  */
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 const SRC_ROOT = resolve(__dirname, '..');
 const API_ROOT = resolve(SRC_ROOT, '@api');
 const QUERIES_ROOT = resolve(SRC_ROOT, '@queries');
@@ -48,7 +53,23 @@ const NON_INVALIDATED_QUERY_KEYS: ReadonlySet<string> = new Set([
   'insights-error-rates'
 ]);
 
-const HTTP_METHOD_REGEX = /\.(get|post|put|patch|delete)\b(?:<[^>]*>)?\s*\(/g;
+/**
+ * Matches HTTP-method calls (`.get(`, `.post(`, etc.) on an axios chain. We
+ * deliberately match `.method(` rather than `axiosClient.method(` because the
+ * codebase formats requests as multi-line chains, e.g.
+ *
+ *     return axiosClient
+ *       .post('/v1/foo', body)
+ *       .then(...);
+ *
+ * To prevent false positives from unrelated objects (e.g. `array.delete()` or
+ * `Map.get()`), the scan is gated on `AXIOS_CLIENT_IMPORT_REGEX` below: only
+ * files that actually import the shared `axiosClient` are considered.
+ */
+const AXIOS_CALL_METHOD_REGEX =
+  /\.(get|post|put|patch|delete)\b(?:<[^>]*>)?\s*\(/g;
+const AXIOS_CLIENT_IMPORT_REGEX =
+  /from\s+['"](?:@api\/axios-client|\.{1,2}\/(?:[^'"]+\/)?axios-client)['"]/;
 const URL_LITERAL_REGEX = /^\s*[`'"]([^`'"]+?)[`'"]/;
 
 type ExtractedCall = {
@@ -72,9 +93,14 @@ const walk = (dir: string, files: string[] = []): string[] => {
 
 const extractAxiosCalls = (file: string): ExtractedCall[] => {
   const source = readFileSync(file, 'utf8');
+  // Skip files that don't actually use the shared axios instance. Only calls
+  // routed through `@api/axios-client` go through the response interceptor
+  // that triggers cache invalidation, so any `.get/.post(` matches in other
+  // files are irrelevant (and could be false positives on unrelated objects).
+  if (!AXIOS_CLIENT_IMPORT_REGEX.test(source)) return [];
   const calls: ExtractedCall[] = [];
 
-  for (const match of source.matchAll(HTTP_METHOD_REGEX)) {
+  for (const match of source.matchAll(AXIOS_CALL_METHOD_REGEX)) {
     const method = match[1] as ExtractedCall['method'];
     const after = source.slice(match.index! + match[0].length);
     const urlMatch = URL_LITERAL_REGEX.exec(after);

--- a/ui/dashboard/src/@api/cache-invalidation-map.ts
+++ b/ui/dashboard/src/@api/cache-invalidation-map.ts
@@ -1,0 +1,276 @@
+/**
+ * Single source of truth for cross-entity cache invalidation.
+ *
+ * Every successful non-GET response that goes through the shared `axiosClient`
+ * is matched against this table by the response interceptor in
+ * `axios-client.ts`, and every matching query key is invalidated on the shared
+ * `queryClient`.
+ *
+ * Adding a new mutating endpoint or a new cross-entity dependency only
+ * requires editing this file.
+ *
+ * Notes:
+ * - Keys are the literal strings used as the first element of `queryKey`
+ *   tuples in `src/@queries/*.ts`. Adding a new query module means the new key
+ *   should be referenced here for any endpoint that mutates data it depends
+ *   on.
+ * - `audit-logs` (and `admin-audit-logs` for org-level admin actions) is
+ *   listed for almost every mutation because the audit log is a global feed
+ *   of every change; under-invalidating leads to stale audit log views.
+ */
+export type CacheInvalidationRule = {
+  match: RegExp;
+  keys: readonly string[];
+};
+
+export const URL_TO_KEYS: readonly CacheInvalidationRule[] = [
+  // Feature flags (create / update / clone / bulk_clone)
+  {
+    match: /\/v1\/feature(\/clone|\/bulk_clone)?(\?|$)/,
+    keys: [
+      'features',
+      'feature-details',
+      'experiments',
+      'experiment-details',
+      'evaluation-timeseries',
+      'auto-ops-rules',
+      'auto-ops-count',
+      'rollouts',
+      'triggers',
+      'scheduled-flag-changes-query-key',
+      'scheduled-flag-change-query-key',
+      'scheduled-flag-change-summary-query-key',
+      'schedule-flags-query-key',
+      'tags',
+      'user-segments',
+      'segment-details',
+      'code-refs',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Scheduled flag change (create / update / delete / execute)
+  {
+    match: /\/v1\/scheduled_flag_change(\/execute)?(\?|$)/,
+    keys: [
+      'scheduled-flag-changes-query-key',
+      'scheduled-flag-change-query-key',
+      'scheduled-flag-change-summary-query-key',
+      'features',
+      'feature-details',
+      'evaluation-timeseries',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Legacy schedule flag (create / update / delete)
+  {
+    match: /\/v1\/schedule_flag(\?|$)/,
+    keys: [
+      'schedule-flags-query-key',
+      'features',
+      'feature-details',
+      'evaluation-timeseries',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Goals
+  {
+    match: /\/v1\/goal(\?|$)/,
+    keys: [
+      'goals',
+      'goal-details',
+      'experiments',
+      'experiment-details',
+      'experiment-result-details',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Experiments
+  {
+    match: /\/v1\/experiment(\?|$)/,
+    keys: [
+      'experiments',
+      'experiment-details',
+      'experiment-result-details',
+      'evaluation-timeseries',
+      'features',
+      'feature-details',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // User segments
+  {
+    match: /\/v1\/segment(\?|$)/,
+    keys: [
+      'user-segments',
+      'segment-details',
+      'features',
+      'feature-details',
+      'histories',
+      'audit-logs'
+    ]
+  },
+  {
+    match: /\/v1\/segment_users\//,
+    keys: [
+      'user-segments',
+      'segment-details',
+      'user-attribute-keys',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Auto-ops rules (create / update / delete / stop)
+  {
+    match: /\/v1\/auto_ops_rule(\/stop)?(\?|$)/,
+    keys: [
+      'auto-ops-rules',
+      'auto-ops-count',
+      'features',
+      'feature-details',
+      'evaluation-timeseries',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Progressive rollouts (create / stop / execute / delete)
+  {
+    match: /\/v1\/progressive_rollout(\/stop|\/execute)?(\?|$)/,
+    keys: [
+      'rollouts',
+      'features',
+      'feature-details',
+      'evaluation-timeseries',
+      'auto-ops-count',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Triggers
+  {
+    match: /\/v1\/flag_trigger(\?|$)/,
+    keys: ['triggers', 'features', 'feature-details', 'histories', 'audit-logs']
+  },
+
+  // Tags
+  {
+    match: /\/v1\/tag(\?|$)/,
+    keys: ['tags', 'features', 'feature-details', 'audit-logs']
+  },
+
+  // Notification subscriptions
+  {
+    match: /\/v1\/subscription(\?|$)/,
+    keys: ['notifications', 'notification-details', 'audit-logs']
+  },
+
+  // Pushes
+  {
+    match: /\/v1\/push(\?|$)/,
+    keys: ['pushes', 'push-details', 'audit-logs']
+  },
+
+  // Environments (create / update / archive / unarchive all hit these endpoints)
+  {
+    match: /\/v1\/environment\/(create|update)_environment/,
+    keys: [
+      'environments',
+      'environment-details',
+      'environments-multiple-ids',
+      'projects',
+      'project-details',
+      'organizations',
+      'organization-details',
+      'accounts',
+      'api-keys',
+      'histories',
+      'audit-logs'
+    ]
+  },
+
+  // Projects
+  {
+    match: /\/v1\/environment\/(create|update)_project/,
+    keys: [
+      'projects',
+      'project-details',
+      'environments',
+      'environment-details',
+      'organizations',
+      'organization-details',
+      'accounts',
+      'audit-logs'
+    ]
+  },
+
+  // Organizations (incl. archive / unarchive / demo)
+  {
+    match: /\/v1\/environment\/(create|update|archive|unarchive)_organization/,
+    keys: [
+      'organizations',
+      'organization-details',
+      'projects',
+      'project-details',
+      'accounts',
+      'audit-logs',
+      'admin-audit-logs'
+    ]
+  },
+  {
+    match: /\/v1\/environment\/create_demo_organization/,
+    keys: [
+      'organizations',
+      'organization-details',
+      'projects',
+      'project-details',
+      'accounts',
+      'audit-logs',
+      'admin-audit-logs'
+    ]
+  },
+
+  // Accounts (create / update / enable / disable / delete)
+  {
+    match: /\/v1\/account\/(create|update|enable|disable|delete)_account/,
+    keys: ['accounts', 'teams', 'audit-logs']
+  },
+
+  // API keys
+  {
+    match: /\/v1\/account\/(create|update)_api_key/,
+    keys: ['api-keys', 'api-keys-details', 'audit-logs']
+  },
+
+  // Teams
+  {
+    match: /\/v1\/team(\?|$)/,
+    keys: ['teams', 'accounts', 'audit-logs']
+  }
+];
+
+/**
+ * Resolve the union of query keys to invalidate for a given request URL.
+ * Returns an empty array when no rule matches (e.g. read-only endpoints,
+ * auth/exchange flows, AI chat suggestions, etc.).
+ */
+export const resolveInvalidationKeys = (url: string): string[] => {
+  const keys = new Set<string>();
+  for (const { match, keys: ruleKeys } of URL_TO_KEYS) {
+    if (match.test(url)) {
+      ruleKeys.forEach(key => keys.add(key));
+    }
+  }
+  return Array.from(keys);
+};

--- a/ui/dashboard/src/@api/organization/organization-demo-creator.ts
+++ b/ui/dashboard/src/@api/organization/organization-demo-creator.ts
@@ -2,6 +2,7 @@ import axios, { AxiosInstance } from 'axios';
 import { urls } from 'configs';
 import { getDemoTokenStorage } from 'storage/demo-token';
 import { Organization } from '@types';
+import { installCacheInvalidationInterceptor } from '../cache-invalidation-interceptor';
 
 export interface OrganizationDemoCreatorPayload {
   name: string;
@@ -30,6 +31,8 @@ axiosClient.interceptors.request.use(
     return Promise.reject(error);
   }
 );
+
+installCacheInvalidationInterceptor(axiosClient);
 
 export const organizationDemoCreator = async (
   payload?: OrganizationDemoCreatorPayload

--- a/ui/dashboard/src/@queries/accounts.ts
+++ b/ui/dashboard/src/@queries/accounts.ts
@@ -51,12 +51,6 @@ export const prefetchAccounts = (
   });
 };
 
-export const invalidateAccounts = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [ACCOUNTS_QUERY_KEY]
-  });
-};
-
 type InfiniteQueryOptions = {
   params?: Omit<AccountsFetcherParams, 'cursor'>;
   enabled?: boolean;

--- a/ui/dashboard/src/@queries/admin-audit-logs.ts
+++ b/ui/dashboard/src/@queries/admin-audit-logs.ts
@@ -48,9 +48,3 @@ export const prefetchAdminAuditLogs = (
     ...queryOptions
   });
 };
-
-export const invalidateAdminAuditLogs = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [ADMIN_AUDIT_LOGS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/api-key-details.ts
+++ b/ui/dashboard/src/@queries/api-key-details.ts
@@ -49,9 +49,3 @@ export const prefetchAPIKey = (
     ...queryOptions
   });
 };
-
-export const invalidateAPIKey = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [API_KEY_DETAILS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/api-keys.ts
+++ b/ui/dashboard/src/@queries/api-keys.ts
@@ -45,9 +45,3 @@ export const prefetchAPIKeys = (
     ...queryOptions
   });
 };
-
-export const invalidateAPIKeys = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [API_KEYS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/attribute-keys.ts
+++ b/ui/dashboard/src/@queries/attribute-keys.ts
@@ -45,9 +45,3 @@ export const prefetchAttributeKeys = (
     ...queryOptions
   });
 };
-
-export const invalidateAttributeKeys = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [USER_ATTRIBUTE_KEYS]
-  });
-};

--- a/ui/dashboard/src/@queries/audit-log-details.ts
+++ b/ui/dashboard/src/@queries/audit-log-details.ts
@@ -49,9 +49,3 @@ export const prefetchAuditLogDetails = (
     ...queryOptions
   });
 };
-
-export const invalidateAuditLogDetails = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [AUDIT_LOG_DETAILS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/audit-logs.ts
+++ b/ui/dashboard/src/@queries/audit-logs.ts
@@ -45,9 +45,3 @@ export const prefetchAuditLogs = (
     ...queryOptions
   });
 };
-
-export const invalidateAuditLogs = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [AUDIT_LOGS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/auto-ops-count.ts
+++ b/ui/dashboard/src/@queries/auto-ops-count.ts
@@ -45,9 +45,3 @@ export const prefetchAutoOpsCount = (
     ...queryOptions
   });
 };
-
-export const invalidateAutoOpsCount = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [AUTO_OPS_COUNT_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/auto-ops-rules.ts
+++ b/ui/dashboard/src/@queries/auto-ops-rules.ts
@@ -45,9 +45,3 @@ export const prefetchAutoOpsRules = (
     ...queryOptions
   });
 };
-
-export const invalidateAutoOpsRules = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [AUTO_OPS_RULES_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/code-refs.ts
+++ b/ui/dashboard/src/@queries/code-refs.ts
@@ -45,9 +45,3 @@ export const prefetchCodeRefs = (
     ...queryOptions
   });
 };
-
-export const invalidateCodeRefs = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [CODE_REFS_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/environments-details.ts
+++ b/ui/dashboard/src/@queries/environments-details.ts
@@ -2,7 +2,7 @@ import {
   environmentResultDetailsFetcher,
   EnvironmentResultDetailsFetcherParams
 } from '@api/environment-result/environment-result-details';
-import { QueryClient, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import type { EnvironmentResponse, QueryOptionsRespond } from '@types';
 
 type QueryOptions = QueryOptionsRespond<EnvironmentResponse> & {
@@ -21,10 +21,4 @@ export const useQueryEnvironmentDetails = (options?: QueryOptions) => {
     ...queryOptions
   });
   return query;
-};
-
-export const invalidateEnvironmentDetails = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [ENVIRONMENTS_DETAILS_QUERY_KEY]
-  });
 };

--- a/ui/dashboard/src/@queries/environments.ts
+++ b/ui/dashboard/src/@queries/environments.ts
@@ -11,6 +11,7 @@ type QueryOptions = QueryOptionsRespond<EnvironmentCollection> & {
 };
 
 export const ENVIRONMENTS_QUERY_KEY = 'environments';
+export const ENVIRONMENTS_MULTIPLE_IDS_QUERY_KEY = 'environments-multiple-ids';
 
 export const useQueryEnvironments = (options?: QueryOptions) => {
   const { params, ...queryOptions } = options || {};
@@ -26,7 +27,7 @@ export const useQueryEnvironments = (options?: QueryOptions) => {
 
 export const useEnvironmentsMultiIds = (ids: string[], enabled?: boolean) => {
   return useQuery({
-    queryKey: ['environments-multiple-ids', ids],
+    queryKey: [ENVIRONMENTS_MULTIPLE_IDS_QUERY_KEY, ids],
     queryFn: async () => {
       return Promise.all(ids.map(id => environmentFetcher({ id })));
     },
@@ -57,11 +58,5 @@ export const prefetchEnvironments = (
       return environmentsFetcher(params);
     },
     ...queryOptions
-  });
-};
-
-export const invalidateEnvironments = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [ENVIRONMENTS_QUERY_KEY]
   });
 };

--- a/ui/dashboard/src/@queries/evaluation.ts
+++ b/ui/dashboard/src/@queries/evaluation.ts
@@ -48,9 +48,3 @@ export const prefetchEvaluation = (
     ...queryOptions
   });
 };
-
-export const invalidateEvaluation = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [EVALUATION_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/experiment-details.ts
+++ b/ui/dashboard/src/@queries/experiment-details.ts
@@ -49,12 +49,3 @@ export const prefetchExperimentDetails = (
     ...queryOptions
   });
 };
-
-export const invalidateExperimentDetails = (
-  queryClient: QueryClient,
-  params: ExperimentFetcherParams
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [EXPERIMENT_DETAILS_QUERY_KEY, params]
-  });
-};

--- a/ui/dashboard/src/@queries/experiment-result.ts
+++ b/ui/dashboard/src/@queries/experiment-result.ts
@@ -48,12 +48,3 @@ export const prefetchExperimentResultDetails = (
     ...queryOptions
   });
 };
-
-export const invalidateExperimentResultDetails = (
-  queryClient: QueryClient,
-  params: ExperimentResultDetailsFetcherParams
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [EXPERIMENT_RESULT_DETAILS_QUERY_KEY, params]
-  });
-};

--- a/ui/dashboard/src/@queries/experiments.ts
+++ b/ui/dashboard/src/@queries/experiments.ts
@@ -45,9 +45,3 @@ export const prefetchExperiments = (
     ...queryOptions
   });
 };
-
-export const invalidateExperiments = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [EXPERIMENTS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/feature-details.ts
+++ b/ui/dashboard/src/@queries/feature-details.ts
@@ -50,12 +50,14 @@ export const prefetchFeature = (
   });
 };
 
-export const invalidateFeature = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [FEATURE_QUERY_KEY]
-  });
-};
-
+/**
+ * Optimistic in-place update of a single feature-details cache entry.
+ *
+ * The axios response interceptor invalidates the query for free on every
+ * non-GET response, but invalidation triggers a refetch. Use this helper
+ * when the mutation response already contains the new feature payload and
+ * you want the UI to update without waiting for the round-trip.
+ */
 export const updateFeatureCache = (
   queryClient: QueryClient,
   params: FeatureFetcherParams,

--- a/ui/dashboard/src/@queries/features.ts
+++ b/ui/dashboard/src/@queries/features.ts
@@ -45,9 +45,3 @@ export const prefetchFeatures = (
     ...queryOptions
   });
 };
-
-export const invalidateFeatures = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [FEATURES_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/goal-details.ts
+++ b/ui/dashboard/src/@queries/goal-details.ts
@@ -49,12 +49,3 @@ export const prefetchGoalDetails = (
     ...queryOptions
   });
 };
-
-export const invalidateGoalDetails = (
-  queryClient: QueryClient,
-  params: GoalDetailsFetcherParams
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [GOAL_DETAILS_QUERY_KEY, params]
-  });
-};

--- a/ui/dashboard/src/@queries/goals.ts
+++ b/ui/dashboard/src/@queries/goals.ts
@@ -45,9 +45,3 @@ export const prefetchGoals = (
     ...queryOptions
   });
 };
-
-export const invalidateGoals = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [GOALS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/histories.ts
+++ b/ui/dashboard/src/@queries/histories.ts
@@ -45,9 +45,3 @@ export const prefetchHistories = (
     ...queryOptions
   });
 };
-
-export const invalidateHistories = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [HISTORIES_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/notification-details.ts
+++ b/ui/dashboard/src/@queries/notification-details.ts
@@ -49,18 +49,3 @@ export const prefetchNotification = (
     ...queryOptions
   });
 };
-
-export const invalidateNotificationDetails = (
-  queryClient: QueryClient,
-  params: NotificationFetcherPayload
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [NOTIFICATION_DETAILS_QUERY_KEY, params]
-  });
-};
-
-export const invalidateNotification = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [NOTIFICATION_DETAILS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/notifications.ts
+++ b/ui/dashboard/src/@queries/notifications.ts
@@ -48,9 +48,3 @@ export const prefetchNotifications = (
     ...queryOptions
   });
 };
-
-export const invalidateNotifications = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [NOTIFICATIONS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/organization-details.ts
+++ b/ui/dashboard/src/@queries/organization-details.ts
@@ -49,12 +49,3 @@ export const prefetchOrganizationDetails = (
     ...queryOptions
   });
 };
-
-export const invalidateOrganizationDetails = (
-  queryClient: QueryClient,
-  params: OrganizationDetailsFetcherParams
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [ORGANIZATION_DETAILS_QUERY_KEY, params]
-  });
-};

--- a/ui/dashboard/src/@queries/organizations.ts
+++ b/ui/dashboard/src/@queries/organizations.ts
@@ -48,9 +48,3 @@ export const prefetchOrganizations = (
     ...queryOptions
   });
 };
-
-export const invalidateOrganizations = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [ORGANIZATIONS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/project-details.ts
+++ b/ui/dashboard/src/@queries/project-details.ts
@@ -10,12 +10,12 @@ type QueryOptions = QueryOptionsRespond<ProjectDetailsResponse> & {
   params?: ProjectDetailsFetcherParams;
 };
 
-export const ORGANIZATION_DETAILS_QUERY_KEY = 'project-details';
+export const PROJECT_DETAILS_QUERY_KEY = 'project-details';
 
 export const useQueryProjectDetails = (options?: QueryOptions) => {
   const { params, ...queryOptions } = options || {};
   const query = useQuery({
-    queryKey: [ORGANIZATION_DETAILS_QUERY_KEY, params],
+    queryKey: [PROJECT_DETAILS_QUERY_KEY, params],
     queryFn: async () => {
       return projectDetailsFetcher(params);
     },
@@ -28,7 +28,7 @@ export const usePrefetchProjectDetails = (options?: QueryOptions) => {
   const { params, ...queryOptions } = options || {};
   const queryClient = useQueryClient();
   queryClient.prefetchQuery({
-    queryKey: [ORGANIZATION_DETAILS_QUERY_KEY, params],
+    queryKey: [PROJECT_DETAILS_QUERY_KEY, params],
     queryFn: async () => {
       return projectDetailsFetcher(params);
     },
@@ -42,19 +42,10 @@ export const prefetchProjectDetails = (
 ) => {
   const { params, ...queryOptions } = options || {};
   queryClient.prefetchQuery({
-    queryKey: [ORGANIZATION_DETAILS_QUERY_KEY, params],
+    queryKey: [PROJECT_DETAILS_QUERY_KEY, params],
     queryFn: async () => {
       return projectDetailsFetcher(params);
     },
     ...queryOptions
-  });
-};
-
-export const invalidateProjectDetails = (
-  queryClient: QueryClient,
-  params: ProjectDetailsFetcherParams
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [ORGANIZATION_DETAILS_QUERY_KEY, params]
   });
 };

--- a/ui/dashboard/src/@queries/projects.ts
+++ b/ui/dashboard/src/@queries/projects.ts
@@ -45,9 +45,3 @@ export const prefetchProjects = (
     ...queryOptions
   });
 };
-
-export const invalidateProjects = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [PROJECTS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/push-details.ts
+++ b/ui/dashboard/src/@queries/push-details.ts
@@ -45,9 +45,3 @@ export const prefetchPush = (
     ...queryOptions
   });
 };
-
-export const invalidatePush = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [PUSH_DETAILS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/pushes.ts
+++ b/ui/dashboard/src/@queries/pushes.ts
@@ -45,9 +45,3 @@ export const prefetchPushes = (
     ...queryOptions
   });
 };
-
-export const invalidatePushes = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [PUSHES_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/rollouts.ts
+++ b/ui/dashboard/src/@queries/rollouts.ts
@@ -48,9 +48,3 @@ export const prefetchRollouts = (
     ...queryOptions
   });
 };
-
-export const invalidateRollouts = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [ROLLOUTS_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/schedule-flags.ts
+++ b/ui/dashboard/src/@queries/schedule-flags.ts
@@ -48,9 +48,3 @@ export const prefetchScheduleFlags = (
     ...queryOptions
   });
 };
-
-export const invalidateScheduleFlags = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [SCHEDULE_FLAGS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/scheduled-flag-changes.ts
+++ b/ui/dashboard/src/@queries/scheduled-flag-changes.ts
@@ -26,12 +26,7 @@ import {
   scheduledFlagChangesFetcher,
   ScheduledFlagChangesFetcherParams
 } from '@api/features/scheduled-flag-changes-fetch';
-import {
-  QueryClient,
-  useMutation,
-  useQuery,
-  useQueryClient
-} from '@tanstack/react-query';
+import { QueryClient, useMutation, useQuery } from '@tanstack/react-query';
 import type {
   QueryOptionsRespond,
   ScheduledFlagChangeCollection,
@@ -78,12 +73,6 @@ export const prefetchScheduledFlagChanges = (
   });
 };
 
-export const invalidateScheduledFlagChanges = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [SCHEDULED_FLAG_CHANGES_QUERY_KEY]
-  });
-};
-
 type GetQueryOptions = QueryOptionsRespond<GetScheduledFlagChangeResponse> & {
   params?: ScheduledFlagChangeGetParams;
 };
@@ -117,82 +106,42 @@ export const useGetScheduledFlagChangeSummary = (
   });
 };
 
-export const invalidateScheduledFlagChangeSummary = (
-  queryClient: QueryClient
-) => {
-  queryClient.invalidateQueries({
-    queryKey: [SCHEDULED_FLAG_CHANGE_SUMMARY_QUERY_KEY]
-  });
-};
-
-export const invalidateScheduledFlagChange = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [SCHEDULED_FLAG_CHANGE_QUERY_KEY]
-  });
-};
-
-const invalidateAllScheduledFlagChangeQueries = (queryClient: QueryClient) => {
-  invalidateScheduledFlagChanges(queryClient);
-  invalidateScheduledFlagChangeSummary(queryClient);
-  invalidateScheduledFlagChange(queryClient);
-};
-
-export const useCreateScheduledFlagChange = () => {
-  const queryClient = useQueryClient();
-  return useMutation<
+export const useCreateScheduledFlagChange = () =>
+  useMutation<
     CreateScheduledFlagChangeResponse,
     Error,
     ScheduledFlagChangeCreatorParams
   >({
     mutationFn: async (params: ScheduledFlagChangeCreatorParams) => {
       return scheduledFlagChangeCreator(params);
-    },
-    onSuccess: () => {
-      invalidateAllScheduledFlagChangeQueries(queryClient);
     }
   });
-};
 
-export const useUpdateScheduledFlagChange = () => {
-  const queryClient = useQueryClient();
-  return useMutation<
+export const useUpdateScheduledFlagChange = () =>
+  useMutation<
     UpdateScheduledFlagChangeResponse,
     Error,
     ScheduledFlagChangeUpdaterParams
   >({
     mutationFn: async (params: ScheduledFlagChangeUpdaterParams) => {
       return scheduledFlagChangeUpdater(params);
-    },
-    onSuccess: () => {
-      invalidateAllScheduledFlagChangeQueries(queryClient);
     }
   });
-};
 
-export const useDeleteScheduledFlagChange = () => {
-  const queryClient = useQueryClient();
-  return useMutation<void, Error, ScheduledFlagChangeDeleteParams>({
+export const useDeleteScheduledFlagChange = () =>
+  useMutation<void, Error, ScheduledFlagChangeDeleteParams>({
     mutationFn: async (params: ScheduledFlagChangeDeleteParams) => {
       return scheduledFlagChangeDelete(params);
-    },
-    onSuccess: () => {
-      invalidateAllScheduledFlagChangeQueries(queryClient);
     }
   });
-};
 
-export const useExecuteScheduledFlagChange = () => {
-  const queryClient = useQueryClient();
-  return useMutation<
+export const useExecuteScheduledFlagChange = () =>
+  useMutation<
     ExecuteScheduledFlagChangeResponse,
     Error,
     ScheduledFlagChangeExecuteParams
   >({
     mutationFn: async (params: ScheduledFlagChangeExecuteParams) => {
       return scheduledFlagChangeExecutor(params);
-    },
-    onSuccess: () => {
-      invalidateAllScheduledFlagChangeQueries(queryClient);
     }
   });
-};

--- a/ui/dashboard/src/@queries/tags.ts
+++ b/ui/dashboard/src/@queries/tags.ts
@@ -45,9 +45,3 @@ export const prefetchTags = (
     ...queryOptions
   });
 };
-
-export const invalidateTags = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [TAGS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/teams.ts
+++ b/ui/dashboard/src/@queries/teams.ts
@@ -45,9 +45,3 @@ export const prefetchTeams = (
     ...queryOptions
   });
 };
-
-export const invalidateTeams = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [TEAMS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/triggers.ts
+++ b/ui/dashboard/src/@queries/triggers.ts
@@ -45,9 +45,3 @@ export const prefetchTriggers = (
     ...queryOptions
   });
 };
-
-export const invalidateTriggers = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [TRIGGERS_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/user-segment-details.ts
+++ b/ui/dashboard/src/@queries/user-segment-details.ts
@@ -49,9 +49,3 @@ export const prefetchUserSegment = (
     ...queryOptions
   });
 };
-
-export const invalidateUserSegment = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [SEGMENT_DETAILS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/@queries/user-segments.ts
+++ b/ui/dashboard/src/@queries/user-segments.ts
@@ -48,9 +48,3 @@ export const prefetchUserSegments = (
     ...queryOptions
   });
 };
-
-export const invalidateUserSegments = (queryClient: QueryClient) => {
-  queryClient.invalidateQueries({
-    queryKey: [USER_SEGMENTS_QUERY_KEY]
-  });
-};

--- a/ui/dashboard/src/app/index.tsx
+++ b/ui/dashboard/src/app/index.tsx
@@ -8,7 +8,7 @@ import {
   useNavigate,
   useLocation
 } from 'react-router';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider } from '@tanstack/react-query';
 import {
   AuthCallbackPage,
   AuthProvider,
@@ -18,6 +18,7 @@ import {
   AuthDemoCallbackPage
 } from 'auth';
 import { AI_CHAT_ENABLED } from 'configs';
+import { queryClient } from 'configs/query-client';
 import { ENVIRONMENT_WITH_EMPTY_ID } from 'constants/app';
 import {
   PAGE_PATH_APIKEYS,
@@ -92,14 +93,6 @@ export const AppLoading = () => (
     <Spinner size="md" />
   </div>
 );
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      staleTime: 30 * 60 * 1000 // Set the global stale time to 30 minutes
-    }
-  }
-});
 
 function App() {
   return (

--- a/ui/dashboard/src/configs/query-client.ts
+++ b/ui/dashboard/src/configs/query-client.ts
@@ -3,20 +3,29 @@ import { QueryClient } from '@tanstack/react-query';
 /**
  * Shared `QueryClient` for the entire dashboard.
  *
- * - `staleTime` is intentionally short. Together with the axios response
- *   interceptor (see `@api/cache-invalidation-map.ts`), this ensures that
- *   data the user sees is at most a few seconds old without requiring every
- *   mutation site to remember which queries to invalidate.
- * - `gcTime` keeps queries in memory for a while so back/forward navigation
- *   stays snappy.
- * - `refetchOnWindowFocus` / `refetchOnReconnect` rely on `staleTime` to
- *   decide when to actually refetch; with the short stale window above they
- *   become useful again.
+ * Freshness strategy:
+ * - The axios response interceptor (see `@api/cache-invalidation-map.ts`)
+ *   is the PRIMARY freshness mechanism: every mutation routed through
+ *   `@api/axios-client` automatically invalidates the relevant queries, so
+ *   the user's own writes are reflected immediately on the next render.
+ * - `staleTime` is therefore set generously (5 min). It is no longer the
+ *   safety net for write-driven freshness — it only controls how often
+ *   "background" refetches (focus, reconnect, mount) actually hit the
+ *   network. A 30-second value would cause 8–10 simultaneous refetches on
+ *   every tab return for multi-query pages like feature-flag details.
+ * - `refetchOnWindowFocus` / `refetchOnReconnect` stay enabled to cover
+ *   changes the interceptor cannot see: edits by other admins, scheduled
+ *   flag updates, auto-ops / progressive rollout side effects, and other
+ *   server-driven state changes. Combined with the 5-minute `staleTime`,
+ *   they only refetch queries that are actually stale, so the cost stays
+ *   bounded.
+ * - `gcTime` keeps queries in memory for a while so back/forward
+ *   navigation stays snappy.
  */
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      staleTime: 30 * 1000,
+      staleTime: 5 * 60 * 1000,
       gcTime: 10 * 60 * 1000,
       refetchOnWindowFocus: true,
       refetchOnReconnect: true,

--- a/ui/dashboard/src/configs/query-client.ts
+++ b/ui/dashboard/src/configs/query-client.ts
@@ -1,0 +1,26 @@
+import { QueryClient } from '@tanstack/react-query';
+
+/**
+ * Shared `QueryClient` for the entire dashboard.
+ *
+ * - `staleTime` is intentionally short. Together with the axios response
+ *   interceptor (see `@api/cache-invalidation-map.ts`), this ensures that
+ *   data the user sees is at most a few seconds old without requiring every
+ *   mutation site to remember which queries to invalidate.
+ * - `gcTime` keeps queries in memory for a while so back/forward navigation
+ *   stays snappy.
+ * - `refetchOnWindowFocus` / `refetchOnReconnect` rely on `staleTime` to
+ *   decide when to actually refetch; with the short stale window above they
+ *   become useful again.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 30 * 1000,
+      gcTime: 10 * 60 * 1000,
+      refetchOnWindowFocus: true,
+      refetchOnReconnect: true,
+      refetchOnMount: true
+    }
+  }
+});

--- a/ui/dashboard/src/elements/create-goal-modal/index.tsx
+++ b/ui/dashboard/src/elements/create-goal-modal/index.tsx
@@ -2,8 +2,6 @@ import { useCallback } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { goalCreator } from '@api/goal';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateGoals } from '@queries/goals';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -48,7 +46,6 @@ const CreateGoalModal = ({
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const form = useForm({
     resolver: yupResolver(useFormSchema(formSchema)),
@@ -85,7 +82,6 @@ const CreateGoalModal = ({
             })
           });
           onCompleted?.(resp.goal);
-          invalidateGoals(queryClient);
           onClose();
           form.reset();
         }

--- a/ui/dashboard/src/pages/api-keys/api-key-modal/api-key-create-update-modal/index.tsx
+++ b/ui/dashboard/src/pages/api-keys/api-key-modal/api-key-create-update-modal/index.tsx
@@ -2,8 +2,6 @@ import { useCallback, useMemo } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { apiKeyCreator, APIKeyResponse, apiKeyUpdater } from '@api/api-key';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateAPIKeys } from '@queries/api-keys';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuthAccess } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -62,7 +60,6 @@ const APIKeyCreateUpdateModal = ({
   onClose,
   onCreatedWithSecret
 }: APIKeyCreateUpdateModalProps) => {
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify } = useToast();
   const { apiKeyOptions } = useOptions();
@@ -132,11 +129,10 @@ const APIKeyCreateUpdateModal = ({
             action: t(apiKey ? 'updated' : 'created')
           })
         });
-        invalidateAPIKeys(queryClient);
         handleClose(true);
       }
     },
-    [apiKey, isEditApiKey, onCreatedWithSecret, queryClient, t, notify]
+    [apiKey, isEditApiKey, onCreatedWithSecret, t, notify]
   );
 
   useUnsavedLeavePage({

--- a/ui/dashboard/src/pages/api-keys/page-loader.tsx
+++ b/ui/dashboard/src/pages/api-keys/page-loader.tsx
@@ -3,8 +3,7 @@ import { Trans } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { apiKeyUpdater } from '@api/api-key';
 import { useQueryAPIKey } from '@queries/api-key-details';
-import { invalidateAPIKeys } from '@queries/api-keys';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import {
   getAccountAccess,
   getCurrentEnvironment,
@@ -26,7 +25,6 @@ import { APIKeyActionsType } from './types';
 
 const PageLoader = () => {
   const { t } = useTranslation(['table', 'message', 'common']);
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const { editorEnvironments } = getEditorEnvironments(consoleAccount!);
@@ -126,7 +124,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseConfirmModal();
-      invalidateAPIKeys(queryClient);
       mutationState.reset();
       notify({
         message: t('message:collection-action-success', {

--- a/ui/dashboard/src/pages/create-flag/flag-form/index.tsx
+++ b/ui/dashboard/src/pages/create-flag/flag-form/index.tsx
@@ -3,9 +3,7 @@ import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router';
 import { featureCreator } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateFeatures } from '@queries/features';
-import { invalidateTags, useQueryTags } from '@queries/tags';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryTags } from '@queries/tags';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import {
   PAGE_PATH_FEATURE_TARGETING,
@@ -44,7 +42,6 @@ const FlagForm = () => {
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
 
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
   const navigate = useNavigate();
@@ -120,8 +117,6 @@ const FlagForm = () => {
             action: t('created')
           })
         });
-        invalidateFeatures(queryClient);
-        invalidateTags(queryClient);
         navigate(
           `/${currentEnvironment.urlCode}${PAGE_PATH_FEATURES}/${resp.feature.id}${PAGE_PATH_FEATURE_TARGETING}`
         );

--- a/ui/dashboard/src/pages/experiment-details/collection-loader/results/goal-results/index.tsx
+++ b/ui/dashboard/src/pages/experiment-details/collection-loader/results/goal-results/index.tsx
@@ -1,10 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { featureUpdater } from '@api/features';
-import { invalidateExperimentDetails } from '@queries/experiment-details';
-import { invalidateExperimentResultDetails } from '@queries/experiment-result';
-import { invalidateFeature } from '@queries/feature-details';
-import { useQueryClient } from '@tanstack/react-query';
 import { useToast, useToggleOpen } from 'hooks';
 import { Experiment, Feature, GoalResult, StrategyType } from '@types';
 import { getData, getTimeSeries } from 'utils/chart';
@@ -51,7 +47,6 @@ const GoalResultItem = ({
   const conversionRateChartRef = useRef<ChartToggleLegendRef>(null);
   const evaluationChartRef = useRef<ChartToggleLegendRef>(null);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const [conversionRateDataSets, setConversionRateDataSets] = useState<
     DatasetReduceType[]
@@ -101,15 +96,6 @@ const GoalResultItem = ({
                 collection: t('rollout-variant'),
                 action: t('updated')
               })
-            });
-            invalidateFeature(queryClient);
-            invalidateExperimentDetails(queryClient, {
-              environmentId,
-              id: experiment.id
-            });
-            invalidateExperimentResultDetails(queryClient, {
-              environmentId,
-              experimentId: experiment.id
             });
             onCloseRolloutVariant();
           }

--- a/ui/dashboard/src/pages/experiment-details/collection-loader/settings/experiment-state/index.tsx
+++ b/ui/dashboard/src/pages/experiment-details/collection-loader/settings/experiment-state/index.tsx
@@ -1,9 +1,7 @@
 import { useMemo } from 'react';
 import { Trans } from 'react-i18next';
 import { experimentUpdater, ExperimentUpdaterParams } from '@api/experiment';
-import { invalidateExperimentDetails } from '@queries/experiment-details';
-import { invalidateExperiments } from '@queries/experiments';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { useToast, useToggleOpen } from 'hooks';
 import { useTranslation } from 'i18n';
@@ -32,7 +30,6 @@ const ExperimentState = ({
   experimentResult?: ExperimentResult;
 }) => {
   const { t } = useTranslation(['table', 'form', 'common', 'message']);
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const editable = hasEditable(consoleAccount!);
@@ -67,14 +64,9 @@ const ExperimentState = ({
     mutationFn: async (params: ExperimentUpdaterParams) => {
       return experimentUpdater(params);
     },
-    onSuccess: ({ experiment }, params) => {
+    onSuccess: (_data, params) => {
       onCloseToggleExperimentModal();
 
-      invalidateExperiments(queryClient);
-      invalidateExperimentDetails(queryClient, {
-        environmentId: currentEnvironment.id,
-        id: experiment?.id ?? ''
-      });
       mutation.reset();
       notify({
         message: t('message:collection-action-success', {

--- a/ui/dashboard/src/pages/experiment-details/collection-loader/settings/index.tsx
+++ b/ui/dashboard/src/pages/experiment-details/collection-loader/settings/index.tsx
@@ -7,11 +7,9 @@ import {
 } from 'react-hook-form';
 import { experimentUpdater, ExperimentUpdaterParams } from '@api/experiment';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateExperimentDetails } from '@queries/experiment-details';
-import { invalidateExperiments } from '@queries/experiments';
 import { useQueryFeatures } from '@queries/features';
 import { useQueryGoals } from '@queries/goals';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema from 'hooks/use-form-schema';
@@ -62,8 +60,6 @@ const ExperimentSettings = ({ experiment }: { experiment: Experiment }) => {
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const editable = hasEditable(consoleAccount!);
-
-  const queryClient = useQueryClient();
 
   const isEnabledEdit = useMemo(
     () => ['WAITING', 'NOT_STARTED'].includes(experiment?.status as string),
@@ -166,11 +162,6 @@ const ExperimentSettings = ({ experiment }: { experiment: Experiment }) => {
       return experimentUpdater(params);
     },
     onSuccess: data => {
-      invalidateExperimentDetails(queryClient, {
-        id: data.experiment.id,
-        environmentId: currentEnvironment.id
-      });
-      invalidateExperiments(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('common:source-type.experiment'),

--- a/ui/dashboard/src/pages/experiments/experiments-modal/experiment-create-update/index.tsx
+++ b/ui/dashboard/src/pages/experiments/experiments-modal/experiment-create-update/index.tsx
@@ -11,14 +11,9 @@ import {
   experimentUpdater
 } from '@api/experiment';
 import { yupResolver } from '@hookform/resolvers/yup';
-import {
-  invalidateExperimentDetails,
-  useQueryExperimentDetails
-} from '@queries/experiment-details';
-import { invalidateExperiments } from '@queries/experiments';
+import { useQueryExperimentDetails } from '@queries/experiment-details';
 import { useQueryFeatures } from '@queries/features';
 import { useQueryGoals } from '@queries/goals';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_EXPERIMENTS } from 'constants/routing';
 import { useToast, useToggleOpen } from 'hooks';
@@ -109,7 +104,6 @@ const ExperimentCreateUpdateModal = ({
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const editable = hasEditable(consoleAccount!);
-  const queryClient = useQueryClient();
 
   const [
     isOpenCreateGoalModal,
@@ -292,11 +286,6 @@ const ExperimentCreateUpdateModal = ({
               collection: t('common:source-type.experiment'),
               action: t(isEdit ? 'common:updated' : 'common:created')
             })
-          });
-          invalidateExperiments(queryClient);
-          invalidateExperimentDetails(queryClient, {
-            id: experimentId as string,
-            environmentId: currentEnvironment.id
           });
           onClose();
         }

--- a/ui/dashboard/src/pages/experiments/page-loader.tsx
+++ b/ui/dashboard/src/pages/experiments/page-loader.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { experimentUpdater, ExperimentUpdaterParams } from '@api/experiment';
-import { invalidateExperiments } from '@queries/experiments';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_EXPERIMENTS } from 'constants/routing';
 import { useToast, useToggleOpen } from 'hooks';
@@ -21,7 +20,6 @@ import { ExperimentActionsType } from './types';
 
 const PageLoader = () => {
   const { t } = useTranslation(['common', 'table', 'message']);
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const editable = hasEditable(consoleAccount!);
@@ -73,7 +71,6 @@ const PageLoader = () => {
     onSuccess: () => {
       onCloseConfirmModal();
       onCloseToggleExperimentModal();
-      invalidateExperiments(queryClient);
       mutation.reset();
       notify({
         message: t('message:collection-action-success', {

--- a/ui/dashboard/src/pages/feature-flag-details/elements/scheduled-changes-banner/apply-now-dialog.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/elements/scheduled-changes-banner/apply-now-dialog.tsx
@@ -1,8 +1,5 @@
 import { Trans } from 'react-i18next';
-import { invalidateFeature } from '@queries/feature-details';
-import { invalidateFeatures } from '@queries/features';
 import { useExecuteScheduledFlagChange } from '@queries/scheduled-flag-changes';
-import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from 'hooks';
 import { useTranslation } from 'i18n';
 import { ScheduledFlagChange } from '@types';
@@ -20,7 +17,6 @@ interface ApplyNowDialogProps {
 const ApplyNowDialog = ({ schedule, isOpen, onClose }: ApplyNowDialogProps) => {
   const { t } = useTranslation(['common', 'form']);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
   const executeMutation = useExecuteScheduledFlagChange();
 
   const handleConfirm = async () => {
@@ -32,8 +28,6 @@ const ApplyNowDialog = ({ schedule, isOpen, onClose }: ApplyNowDialogProps) => {
       notify({
         message: t('form:feature-flags.schedule-applied-now')
       });
-      invalidateFeature(queryClient);
-      invalidateFeatures(queryClient);
       onClose();
     } catch (error) {
       errorNotify(error);

--- a/ui/dashboard/src/pages/feature-flag-details/operations/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/operations/index.tsx
@@ -3,12 +3,8 @@ import { useNavigate } from 'react-router';
 import { autoOpsDelete, autoOpsStop } from '@api/auto-ops';
 import { rolloutDelete, rolloutStopped } from '@api/rollouts';
 import { useQueryAutoOpsCount } from '@queries/auto-ops-count';
-import {
-  invalidateAutoOpsRules,
-  useQueryAutoOpsRules
-} from '@queries/auto-ops-rules';
-import { invalidateRollouts, useQueryRollouts } from '@queries/rollouts';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryAutoOpsRules } from '@queries/auto-ops-rules';
+import { useQueryRollouts } from '@queries/rollouts';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
 import {
@@ -56,7 +52,6 @@ const Operations = ({
   const { t } = useTranslation(['common', 'table', 'form', 'message']);
   const navigate = useNavigate();
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
@@ -174,12 +169,8 @@ const Operations = ({
   );
 
   const onSubmitOperationSuccess = useCallback(() => {
-    invalidateAutoOpsRules(queryClient);
-    invalidateRollouts(queryClient);
-    // Auto navigate to ACTIVE tab when creating operation from FINISHED tab
     if (currentTab === OperationTab.FINISHED) {
       setCurrentTab(OperationTab.ACTIVE);
-      // Update search params to ACTIVE tab before closing modal
       const updatedSearchOptions = {
         ...searchOptions,
         tab: OperationTab.ACTIVE
@@ -199,7 +190,6 @@ const Operations = ({
     searchOptions,
     navigate,
     getPathName,
-    queryClient,
     onCloseActionModal
   ]);
 

--- a/ui/dashboard/src/pages/feature-flag-details/settings/archive-flag/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/settings/archive-flag/index.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useMemo } from 'react';
 import { Trans } from 'react-i18next';
 import { featureUpdater } from '@api/features';
-import { invalidateFeature } from '@queries/feature-details';
-import { invalidateFeatures, useQueryFeatures } from '@queries/features';
-import { invalidateHistories } from '@queries/histories';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryFeatures } from '@queries/features';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { useToast, useToggleOpen } from 'hooks';
 import { useTranslation } from 'i18n';
@@ -27,7 +25,6 @@ const ArchiveFlag = ({
 }) => {
   const { t } = useTranslation(['common', 'form', 'table', 'message']);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
 
@@ -66,9 +63,6 @@ const ArchiveFlag = ({
           action: t('updated')
         })
       });
-      invalidateFeature(queryClient);
-      invalidateFeatures(queryClient);
-      invalidateHistories(queryClient);
       mutation.reset();
     },
     onError: error => errorNotify(error)

--- a/ui/dashboard/src/pages/feature-flag-details/settings/general-info-form/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/settings/general-info-form/index.tsx
@@ -3,12 +3,8 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { IconLaunchOutlined } from 'react-icons-material-design';
 import { featureUpdater } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateFeature } from '@queries/feature-details';
-import { invalidateFeatures } from '@queries/features';
-import { invalidateHistories } from '@queries/histories';
 import { useCreateScheduledFlagChange } from '@queries/scheduled-flag-changes';
-import { invalidateTags, useQueryTags } from '@queries/tags';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryTags } from '@queries/tags';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { SCHEDULED_FLAG_CHANGES_ENABLED } from 'configs';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
@@ -48,7 +44,6 @@ const GeneralInfoForm = ({
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const [isOpenSaveModal, onOpenSaveModal, onCloseSaveModal] =
     useToggleOpen(false);
@@ -214,10 +209,6 @@ const GeneralInfoForm = ({
                   Math.floor((new Date().getTime() + 3600000) / 1000)
                 )
               });
-              invalidateFeature(queryClient);
-              invalidateFeatures(queryClient);
-              invalidateTags(queryClient);
-              invalidateHistories(queryClient);
               onCloseSaveModal();
             }
           }

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
@@ -2,17 +2,11 @@ import { useCallback, useMemo, useState } from 'react';
 import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import { featureUpdater } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
-import {
-  invalidateFeature,
-  updateFeatureCache
-} from '@queries/feature-details';
-import { invalidateFeatures, useQueryFeatures } from '@queries/features';
+import { updateFeatureCache } from '@queries/feature-details';
+import { useQueryFeatures } from '@queries/features';
 import { useQueryRollouts } from '@queries/rollouts';
 import { useCreateScheduledFlagChange } from '@queries/scheduled-flag-changes';
-import {
-  invalidateUserSegments,
-  useQueryUserSegments
-} from '@queries/user-segments';
+import { useQueryUserSegments } from '@queries/user-segments';
 import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { SCHEDULED_FLAG_CHANGES_ENABLED } from 'configs';
@@ -779,9 +773,6 @@ const TargetingPage = ({
                 { id: feature.id, environmentId: currentEnvironment.id },
                 updatedFeature
               );
-              invalidateFeature(queryClient);
-              invalidateFeatures(queryClient);
-              invalidateUserSegments(queryClient);
               reset(handleCreateDefaultValues(updatedFeature));
               setTrackedFeature(cloneDeep(updatedFeature));
               onCloseConfirmModal();

--- a/ui/dashboard/src/pages/feature-flag-details/trigger/create-trigger-form/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/trigger/create-trigger-form/index.tsx
@@ -4,8 +4,6 @@ import { Trans } from 'react-i18next';
 import { triggerCreator } from '@api/trigger';
 import { triggerUpdate } from '@api/trigger/triggers-update';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateTriggers } from '@queries/triggers';
-import { useQueryClient } from '@tanstack/react-query';
 import { useToast } from 'hooks';
 import useFormSchema from 'hooks/use-form-schema';
 import { useUnsavedLeavePage } from 'hooks/use-unsaved-leave-page';
@@ -41,7 +39,6 @@ const CreateTriggerForm = forwardRef(
     ref: Ref<HTMLDivElement>
   ) => {
     const { t } = useTranslation(['table', 'form', 'common', 'message']);
-    const queryClient = useQueryClient();
 
     const { notify, errorNotify } = useToast();
 
@@ -128,7 +125,6 @@ const CreateTriggerForm = forwardRef(
             }
 
             if (resp) {
-              invalidateTriggers(queryClient);
               notify({
                 message: t('message:collection-action-success', {
                   collection: t('feature-flags.trigger'),

--- a/ui/dashboard/src/pages/feature-flag-details/trigger/trigger-section/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/trigger/trigger-section/index.tsx
@@ -7,8 +7,8 @@ import {
   triggerUpdate,
   TriggerUpdateParams
 } from '@api/trigger/triggers-update';
-import { invalidateTriggers, useQueryTriggers } from '@queries/triggers';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryTriggers } from '@queries/triggers';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
 import { useToast } from 'hooks';
@@ -41,7 +41,6 @@ const TriggerList = ({
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const formRef = useRef<HTMLDivElement>(null);
-  const queryClient = useQueryClient();
   const { notify, errorNotify } = useToast();
 
   const [triggerNewlyCreated, setTriggerNewlyCreated] = useState<
@@ -129,7 +128,6 @@ const TriggerList = ({
         })
       });
       onReset();
-      invalidateTriggers(queryClient);
       mutationState.reset();
     },
     onError: error => errorNotify(error)

--- a/ui/dashboard/src/pages/feature-flag-details/variation/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/variation/index.tsx
@@ -5,11 +5,8 @@ import { Link } from 'react-router';
 import { featureUpdater } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useQueryExperiments } from '@queries/experiments';
-import { invalidateFeature } from '@queries/feature-details';
-import { invalidateFeatures } from '@queries/features';
 import { useQueryRollouts } from '@queries/rollouts';
 import { useCreateScheduledFlagChange } from '@queries/scheduled-flag-changes';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { SCHEDULED_FLAG_CHANGES_ENABLED } from 'configs';
 import {
@@ -52,7 +49,6 @@ const Variation = ({ feature, editable }: VariationProps) => {
   const { t } = useTranslation(['common', 'message', 'form']);
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
-  const queryClient = useQueryClient();
 
   const [openConfirmDialog, onOpenConfirmDialog, onCloseConfirmDialog] =
     useToggleOpen(false);
@@ -192,8 +188,6 @@ const Variation = ({ feature, editable }: VariationProps) => {
                   action: t('updated')
                 })
               });
-              invalidateFeature(queryClient);
-              invalidateFeatures(queryClient);
               onCloseConfirmDialog();
             }
           }

--- a/ui/dashboard/src/pages/feature-flags/flags-modal/add-flag-modal/create-flag-form.tsx
+++ b/ui/dashboard/src/pages/feature-flags/flags-modal/add-flag-modal/create-flag-form.tsx
@@ -3,9 +3,7 @@ import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { Trans } from 'react-i18next';
 import { featureCreator } from '@api/features/feature-creator';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateFeatures } from '@queries/features';
 import { useQueryTags } from '@queries/tags';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { getDefaultYamlValue } from 'constants/feature-flag';
 import { useToast } from 'hooks';
@@ -73,7 +71,7 @@ const CreateFlagForm = ({
   const formSchema = useFormSchema(createFlagFormSchema);
   const { flagTypeOptions } = useOptions();
   const refFormModel = useRef<HTMLDivElement>(null);
-  const queryClient = useQueryClient();
+  const isFlagIdEdited = useRef(false);
   const isJapaneseLanguage = getLanguage() === Language.JAPANESE;
 
   const { t } = useTranslation(['common', 'form', 'message']);
@@ -194,7 +192,6 @@ const CreateFlagForm = ({
             action: t('created')
           })
         });
-        invalidateFeatures(queryClient);
         onCompleted?.(resp.feature);
         onClose();
       }
@@ -235,14 +232,13 @@ const CreateFlagForm = ({
                       placeholder={`${t('form:placeholder-name')}`}
                       {...field}
                       onChange={value => {
-                        const isFlagIdDirty =
-                          form.getFieldState('flagId').isDirty;
-                        const flagId = form.getValues('flagId');
                         field.onChange(value);
-                        form.setValue(
-                          'flagId',
-                          isFlagIdDirty ? flagId : onGenerateSlug(value)
-                        );
+                        if (!isFlagIdEdited.current) {
+                          form.setValue('flagId', onGenerateSlug(value), {
+                            shouldDirty: false,
+                            shouldValidate: true
+                          });
+                        }
                       }}
                       name="flag-name"
                     />
@@ -275,6 +271,11 @@ const CreateFlagForm = ({
                       placeholder={`${t('form:feature-flags.placeholder-flag')}`}
                       {...field}
                       name="flag-id"
+                      autoComplete="off"
+                      onChange={value => {
+                        isFlagIdEdited.current = value !== '';
+                        field.onChange(value);
+                      }}
                     />
                   </Form.Control>
                   <Form.Message />

--- a/ui/dashboard/src/pages/feature-flags/flags-modal/clone-flag-modal/index.tsx
+++ b/ui/dashboard/src/pages/feature-flags/flags-modal/clone-flag-modal/index.tsx
@@ -4,8 +4,6 @@ import { useNavigate } from 'react-router';
 import { featureBulkClone } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useQueryFeature } from '@queries/feature-details';
-import { invalidateFeatures } from '@queries/features';
-import { useQueryClient } from '@tanstack/react-query';
 import {
   getCurrentEnvironment,
   getEditorEnvironments,
@@ -64,7 +62,6 @@ const CloneFlagModal = ({ flagId, isOpen, onClose }: CloneFlagModalProps) => {
   );
   const { emptyEnvironmentId, formattedEnvironments } =
     onFormatEnvironments(editorEnvironments);
-  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
@@ -166,9 +163,7 @@ const CloneFlagModal = ({ flagId, isOpen, onClose }: CloneFlagModalProps) => {
             });
           });
 
-          invalidateFeatures(queryClient);
           onClose();
-
           if (
             successes.length === 1 &&
             destinationEnvironmentIds.length === 1

--- a/ui/dashboard/src/pages/feature-flags/flags-modal/confirm-required-modal/index.tsx
+++ b/ui/dashboard/src/pages/feature-flags/flags-modal/confirm-required-modal/index.tsx
@@ -5,10 +5,7 @@ import { useNavigate } from 'react-router';
 import { autoOpsCreator } from '@api/auto-ops';
 import { featureUpdater } from '@api/features';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateFeature } from '@queries/feature-details';
-import { invalidateFeatures } from '@queries/features';
 import { useQueryRollouts } from '@queries/rollouts';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import {
   PAGE_PATH_FEATURE_AUTOOPS,
@@ -53,7 +50,6 @@ const ConfirmationRequiredModal = ({
 }: ConfirmationRequiredModalProps) => {
   const { t } = useTranslation(['common', 'form', 'table', 'message']);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
 
@@ -164,8 +160,6 @@ const ConfirmationRequiredModal = ({
               />
             )
           });
-          invalidateFeatures(queryClient);
-          invalidateFeature(queryClient);
           onClose();
         }
       } catch (error) {

--- a/ui/dashboard/src/pages/feature-flags/page-loader.tsx
+++ b/ui/dashboard/src/pages/feature-flags/page-loader.tsx
@@ -2,9 +2,8 @@ import { useCallback, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router';
 import { featureUpdater } from '@api/features';
-import { invalidateFeature } from '@queries/feature-details';
-import { invalidateFeatures, useQueryFeatures } from '@queries/features';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQueryFeatures } from '@queries/features';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { PAGE_PATH_FEATURE_CLONE, PAGE_PATH_FEATURES } from 'constants/routing';
 import { useToast, useToggleOpen } from 'hooks';
@@ -24,7 +23,6 @@ import { FeatureActivityStatus, FlagActionType } from './types';
 
 const PageLoader = () => {
   const { t } = useTranslation(['common', 'table', 'message']);
-  const queryClient = useQueryClient();
   const { notify, errorNotify } = useToast();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
@@ -103,8 +101,6 @@ const PageLoader = () => {
           action: t('updated')
         })
       });
-      invalidateFeatures(queryClient);
-      invalidateFeature(queryClient);
       mutation.reset();
     },
     onError: error => errorNotify(error)
@@ -149,8 +145,6 @@ const PageLoader = () => {
                 />
               )
             });
-            invalidateFeatures(queryClient);
-            invalidateFeature(queryClient);
             onCloseConfirmRequiredModal();
           }
         }

--- a/ui/dashboard/src/pages/goal-details/page-content.tsx
+++ b/ui/dashboard/src/pages/goal-details/page-content.tsx
@@ -2,9 +2,7 @@ import { Trans } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { goalDeleter } from '@api/goal';
 import { goalUpdater, GoalUpdaterPayload } from '@api/goal/goal-updater';
-import { invalidateGoalDetails } from '@queries/goal-details';
-import { invalidateGoals } from '@queries/goals';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_GOALS } from 'constants/routing';
 import { useToast, useToggleOpen } from 'hooks';
@@ -23,7 +21,6 @@ const PageContent = ({ goal }: { goal: Goal }) => {
   const { t } = useTranslation(['common', 'form', 'table']);
 
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
@@ -43,7 +40,6 @@ const PageContent = ({ goal }: { goal: Goal }) => {
     },
     onSuccess: () => {
       onCloseDeleteModal();
-      invalidateGoals(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('source-type.goal'),
@@ -60,11 +56,6 @@ const PageContent = ({ goal }: { goal: Goal }) => {
     },
     onSuccess: () => {
       onCloseConfirmModal();
-      invalidateGoalDetails(queryClient, {
-        id: goal.id,
-        environmentId: currentEnvironment.id
-      });
-      invalidateGoals(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('source-type.goal'),

--- a/ui/dashboard/src/pages/goals/goals-modal/add-goal-modal/index.tsx
+++ b/ui/dashboard/src/pages/goals/goals-modal/add-goal-modal/index.tsx
@@ -1,8 +1,6 @@
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { goalCreator } from '@api/goal';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateGoals } from '@queries/goals';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -55,7 +53,6 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
 
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
 
@@ -77,7 +74,6 @@ const AddGoalModal = ({ isOpen, onClose }: AddGoalModalProps) => {
           action: t('created')
         })
       });
-      invalidateGoals(queryClient);
       onClose();
     }
   };

--- a/ui/dashboard/src/pages/goals/page-loader.tsx
+++ b/ui/dashboard/src/pages/goals/page-loader.tsx
@@ -2,8 +2,7 @@ import { useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { goalDeleter } from '@api/goal';
 import { goalUpdater, GoalUpdaterPayload } from '@api/goal/goal-updater';
-import { invalidateGoals } from '@queries/goals';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_GOALS } from 'constants/routing';
 import { useToast, useToggleOpen } from 'hooks';
@@ -19,7 +18,6 @@ import { GoalActions } from './types';
 const PageLoader = () => {
   const { t } = useTranslation(['common', 'table', 'message']);
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
@@ -64,7 +62,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseDeleteModal();
-      invalidateGoals(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('source-type.goal'),
@@ -86,7 +83,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseConfirmModal();
-      invalidateGoals(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('source-type.goal'),

--- a/ui/dashboard/src/pages/members/member-modal/add-member-modal/index.tsx
+++ b/ui/dashboard/src/pages/members/member-modal/add-member-modal/index.tsx
@@ -10,9 +10,7 @@ import {
   EnvironmentRoleItem
 } from '@api/account/account-creator';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateAccounts } from '@queries/accounts';
-import { invalidateTeams, useQueryTeams } from '@queries/teams';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryTeams } from '@queries/teams';
 import { getCurrentEnvironment, getEditorEnvironments, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -105,7 +103,6 @@ export const formSchema = ({ requiredMessage }: FormSchemaProps) =>
 
 const AddMemberModal = ({ isOpen, onClose }: AddMemberModalProps) => {
   const { consoleAccount } = useAuth();
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form']);
   const { notify, errorNotify } = useToast();
   const { organizationRoles } = useOptions();
@@ -186,8 +183,6 @@ const AddMemberModal = ({ isOpen, onClose }: AddMemberModalProps) => {
             action: t('created')
           })
         });
-        invalidateAccounts(queryClient);
-        invalidateTeams(queryClient);
         onClose();
       })
       .catch(error => errorNotify(error));

--- a/ui/dashboard/src/pages/members/member-modal/edit-member-modal/index.tsx
+++ b/ui/dashboard/src/pages/members/member-modal/edit-member-modal/index.tsx
@@ -8,9 +8,7 @@ import {
 import { EnvironmentRoleItem } from '@api/account/account-creator';
 import { accountUpdater } from '@api/account/account-updater';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateAccounts } from '@queries/accounts';
-import { invalidateTeams, useQueryTeams } from '@queries/teams';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryTeams } from '@queries/teams';
 import { getCurrentEnvironment, getEditorEnvironments, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -100,7 +98,6 @@ export const formSchema = ({ requiredMessage }: FormSchemaProps) =>
 
 const EditMemberModal = ({ isOpen, onClose, member }: EditMemberModalProps) => {
   const { consoleAccount } = useAuth();
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify } = useToast();
   const { organizationRoles } = useOptions();
@@ -207,8 +204,6 @@ const EditMemberModal = ({ isOpen, onClose, member }: EditMemberModalProps) => {
           action: t('updated')
         })
       });
-      invalidateAccounts(queryClient);
-      invalidateTeams(queryClient);
       onClose();
     });
   };

--- a/ui/dashboard/src/pages/members/page-loader.tsx
+++ b/ui/dashboard/src/pages/members/page-loader.tsx
@@ -2,8 +2,7 @@ import { useCallback, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { accountDisable, accountEnable } from '@api/account';
 import { accountDeleter } from '@api/account/account-deleter';
-import { invalidateAccounts } from '@queries/accounts';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import { useToggleOpen } from 'hooks/use-toggle-open';
@@ -19,7 +18,6 @@ import { MemberActionsType } from './types';
 const PageLoader = () => {
   const { notify } = useToast();
   const { t } = useTranslation(['table', 'message', 'common']);
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
 
@@ -50,7 +48,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseDeleteModal();
-      invalidateAccounts(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('common:member'),
@@ -78,7 +75,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseConfirmModal();
-      invalidateAccounts(queryClient);
       mutationState.reset();
     }
   });

--- a/ui/dashboard/src/pages/notifications/notification-modal/notification-create-update-modal/index.tsx
+++ b/ui/dashboard/src/pages/notifications/notification-modal/notification-create-update-modal/index.tsx
@@ -11,9 +11,6 @@ import {
   notificationUpdater
 } from '@api/notification';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateNotificationDetails } from '@queries/notification-details';
-import { invalidateNotifications } from '@queries/notifications';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from 'auth';
 import { languageList } from 'constants/notification';
 import { ID_NEW } from 'constants/routing';
@@ -89,12 +86,10 @@ const NotificationCreateUpdateModal = ({
   isOpen,
   isLoadingNotification,
   notification,
-  notificationEnvironmentId,
   resetNotification,
   onClose
 }: NotificationCreateUpdateModalProps) => {
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
 
   const { consoleAccount } = useAuth();
@@ -205,11 +200,6 @@ const NotificationCreateUpdateModal = ({
               collection: t('notification'),
               action: t(isEditNotification ? 'updated' : 'created')
             })
-          });
-          invalidateNotifications(queryClient);
-          invalidateNotificationDetails(queryClient, {
-            id: notificationId as string,
-            environmentId: notificationEnvironmentId as string
           });
           onClose();
         }

--- a/ui/dashboard/src/pages/notifications/page-loader.tsx
+++ b/ui/dashboard/src/pages/notifications/page-loader.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { notificationDelete, notificationUpdater } from '@api/notification';
 import { useQueryNotification } from '@queries/notification-details';
-import { invalidateNotifications } from '@queries/notifications';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_NOTIFICATIONS } from 'constants/routing';
 import { useToast } from 'hooks';
@@ -19,7 +18,6 @@ import { NotificationActionsType } from './types';
 
 const PageLoader = () => {
   const { t } = useTranslation(['table', 'message', 'common']);
-  const queryClient = useQueryClient();
   const { notify, errorNotify } = useToast();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
@@ -117,7 +115,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       handleOnCloseModal();
-      invalidateNotifications(queryClient);
       mutationState.reset();
       notify({
         message: t('message:collection-action-success', {

--- a/ui/dashboard/src/pages/organization-details/settings/index.tsx
+++ b/ui/dashboard/src/pages/organization-details/settings/index.tsx
@@ -2,9 +2,7 @@ import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { useParams } from 'react-router';
 import { organizationUpdater } from '@api/organization';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateAccounts, useQueryAccounts } from '@queries/accounts';
-import { invalidateOrganizationDetails } from '@queries/organization-details';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryAccounts } from '@queries/accounts';
 import { LIST_PAGE_SIZE } from 'constants/app';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -38,7 +36,6 @@ const OrganizationSettings = ({
   organization: Organization;
 }) => {
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
   const params = useParams();
   const orgDetailsId = params.organizationId!;
@@ -69,8 +66,6 @@ const OrganizationSettings = ({
         description: values.description
       });
       if (resp) {
-        invalidateOrganizationDetails(queryClient, { id: orgDetailsId });
-        invalidateAccounts(queryClient);
         notify({
           message: t('message:collection-action-success', {
             collection: t('organization'),

--- a/ui/dashboard/src/pages/organizations/organization-modal/organization-create-update-modal/index.tsx
+++ b/ui/dashboard/src/pages/organizations/organization-modal/organization-create-update-modal/index.tsx
@@ -9,8 +9,6 @@ import {
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useQueryAccounts } from '@queries/accounts';
 import { useQueryOrganizationDetails } from '@queries/organization-details';
-import { invalidateOrganizations } from '@queries/organizations';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from 'auth';
 import { LIST_PAGE_SIZE } from 'constants/app';
 import { useToast } from 'hooks';
@@ -68,7 +66,6 @@ const OrganizationCreateUpdateModal = ({
   onClose,
   organization
 }: OrganizationCreateUpdateModalProps) => {
-  const queryClient = useQueryClient();
   const { refreshOrganizations } = useAuth();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
@@ -141,7 +138,6 @@ const OrganizationCreateUpdateModal = ({
               action: t(organization ? 'updated' : 'created')
             })
           });
-          invalidateOrganizations(queryClient);
           refreshOrganizations();
           onClose();
         }

--- a/ui/dashboard/src/pages/organizations/page-loader.tsx
+++ b/ui/dashboard/src/pages/organizations/page-loader.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { organizationArchive, organizationUnarchive } from '@api/organization';
-import { invalidateOrganizations } from '@queries/organizations';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { PAGE_PATH_ORGANIZATIONS } from 'constants/routing';
 import useActionWithURL from 'hooks/use-action-with-url';
 import { useToggleOpen } from 'hooks/use-toggle-open';
@@ -15,7 +14,6 @@ import { OrganizationActionsType } from './types';
 
 const PageLoader = () => {
   const { t } = useTranslation(['common', 'table']);
-  const queryClient = useQueryClient();
   const [selectedOrganization, setSelectedOrganization] =
     useState<Organization>();
 
@@ -41,7 +39,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseConfirmModal();
-      invalidateOrganizations(queryClient);
       mutation.reset();
     }
   });

--- a/ui/dashboard/src/pages/project-details/environments/environment-modal/environment-create-update-modal/index.tsx
+++ b/ui/dashboard/src/pages/project-details/environments/environment-modal/environment-create-update-modal/index.tsx
@@ -7,15 +7,8 @@ import {
   environmentUpdater
 } from '@api/environment';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateEnvironments } from '@queries/environments';
-import {
-  invalidateEnvironmentDetails,
-  useQueryEnvironmentDetails
-} from '@queries/environments-details';
-import { invalidateOrganizations } from '@queries/organizations';
+import { useQueryEnvironmentDetails } from '@queries/environments-details';
 import { useQueryProjectDetails } from '@queries/project-details';
-import { invalidateProjects } from '@queries/projects';
-import { useQueryClient } from '@tanstack/react-query';
 import { getAccountAccess, getCurrentEnvironment, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema, { FormSchemaProps } from 'hooks/use-form-schema';
@@ -103,7 +96,7 @@ const EnvironmentCreateUpdateModal = ({
   isOpen,
   onClose
 }: EnvironmentCreateUpdateModalProps) => {
-  const queryClient = useQueryClient();
+  const isUrlEdited = useRef(false);
   const { projectId, environmentId } = useParams();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
@@ -205,10 +198,6 @@ const EnvironmentCreateUpdateModal = ({
               action: t(environmentDetail ? 'updated' : 'created')
             })
           });
-          invalidateOrganizations(queryClient);
-          invalidateProjects(queryClient);
-          invalidateEnvironments(queryClient);
-          invalidateEnvironmentDetails(queryClient);
           onMeFetcher({ organizationId: currentEnvironment.organizationId });
           onClose();
         }
@@ -264,14 +253,11 @@ const EnvironmentCreateUpdateModal = ({
                         {...field}
                         onChange={value => {
                           field.onChange(value);
-                          if (!environmentDetail) {
-                            const isUrlCodeDirty =
-                              form.getFieldState('urlCode').isDirty;
-                            const urlCode = form.getValues('urlCode');
-                            form.setValue(
-                              'urlCode',
-                              isUrlCodeDirty ? urlCode : onGenerateSlug(value)
-                            );
+                          if (!environmentDetail && !isUrlEdited.current) {
+                            form.setValue('urlCode', onGenerateSlug(value), {
+                              shouldDirty: false,
+                              shouldValidate: true
+                            });
                           }
                         }}
                         name="environment-name"
@@ -312,6 +298,11 @@ const EnvironmentCreateUpdateModal = ({
                         placeholder={`${t('form:placeholder-code')}`}
                         disabled={disabled || !!environmentDetail}
                         name="environment-code"
+                        autoComplete="off"
+                        onChange={value => {
+                          isUrlEdited.current = value !== '';
+                          field.onChange(value);
+                        }}
                       />
                     </Form.Control>
                     <Form.Message />

--- a/ui/dashboard/src/pages/project-details/environments/index.tsx
+++ b/ui/dashboard/src/pages/project-details/environments/index.tsx
@@ -2,8 +2,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { Trans } from 'react-i18next';
 import { useParams } from 'react-router';
 import { environmentArchive, environmentUnarchive } from '@api/environment';
-import { invalidateEnvironments } from '@queries/environments';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth, useAuthAccess } from 'auth';
 import {
   PAGE_PATH_ENVIRONMENTS,
@@ -25,7 +24,6 @@ const ProjectEnvironments = ({
   organizationId: string;
 }) => {
   const { t } = useTranslation(['common', 'table']);
-  const queryClient = useQueryClient();
   const { envEditable, isOrganizationAdmin } = useAuthAccess();
   const params = useParams();
   const { consoleAccount, onMeFetcher } = useAuth();
@@ -59,7 +57,6 @@ const ProjectEnvironments = ({
     onSuccess: async () => {
       await onMeFetcher({ organizationId: currentEnvironment.organizationId });
       onCloseConfirmModal();
-      invalidateEnvironments(queryClient);
       mutation.reset();
     }
   });

--- a/ui/dashboard/src/pages/project-details/settings/index.tsx
+++ b/ui/dashboard/src/pages/project-details/settings/index.tsx
@@ -1,13 +1,9 @@
 import { useMemo } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { IconLaunchOutlined } from 'react-icons-material-design';
-import { Link, useParams, useSearchParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 import { projectUpdater } from '@api/project';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateAccounts } from '@queries/accounts';
-import { invalidateProjectDetails } from '@queries/project-details';
-import { invalidateProjects } from '@queries/projects';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuthAccess } from 'auth';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
 import { useToast } from 'hooks';
@@ -38,14 +34,11 @@ export interface ProjectSettingsForm {
 
 const ProjectSettings = ({ project }: { project: Project }) => {
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
-  const [searchParams] = useSearchParams();
   const params = useParams();
   const { envEditable, isOrganizationAdmin } = useAuthAccess();
 
   const projectDetailsId = params.projectId!;
-  const organizationId = searchParams.get('organizationId');
 
   const disabled = useMemo(
     () => !envEditable || !isOrganizationAdmin,
@@ -69,13 +62,6 @@ const ProjectSettings = ({ project }: { project: Project }) => {
         name: values.name
       });
       if (resp) {
-        invalidateProjects(queryClient);
-        invalidateProjectDetails(queryClient, {
-          id: projectDetailsId,
-          organizationId: organizationId!
-        });
-
-        invalidateAccounts(queryClient);
         notify({
           message: t('message:collection-action-success', {
             collection: t('project'),

--- a/ui/dashboard/src/pages/projects/project-modal/project-create-update-modal/index.tsx/index.tsx
+++ b/ui/dashboard/src/pages/projects/project-modal/project-create-update-modal/index.tsx/index.tsx
@@ -176,7 +176,8 @@ const ProjectCreateUpdateModal = ({
                           field.onChange(value);
                           if (!projectDetail && !isUrlEdited.current) {
                             form.setValue('urlCode', onGenerateSlug(value), {
-                              shouldDirty: false
+                              shouldDirty: false,
+                              shouldValidate: true
                             });
                           }
                         }}

--- a/ui/dashboard/src/pages/projects/project-modal/project-create-update-modal/index.tsx/index.tsx
+++ b/ui/dashboard/src/pages/projects/project-modal/project-create-update-modal/index.tsx/index.tsx
@@ -212,6 +212,7 @@ const ProjectCreateUpdateModal = ({
                     </Form.Label>
                     <Form.Control>
                       <Input
+                        {...field}
                         value={field.value}
                         placeholder={`${t('form:placeholder-code')}`}
                         disabled={!!projectDetail || disabled}

--- a/ui/dashboard/src/pages/projects/project-modal/project-create-update-modal/index.tsx/index.tsx
+++ b/ui/dashboard/src/pages/projects/project-modal/project-create-update-modal/index.tsx/index.tsx
@@ -1,14 +1,8 @@
-import { useCallback, useEffect, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { projectCreator, ProjectResponse, projectUpdater } from '@api/project';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateOrganizations } from '@queries/organizations';
-import {
-  invalidateProjectDetails,
-  useQueryProjectDetails
-} from '@queries/project-details';
-import { invalidateProjects } from '@queries/projects';
-import { useQueryClient } from '@tanstack/react-query';
+import { useQueryProjectDetails } from '@queries/project-details';
 import { getAccountAccess, getCurrentEnvironment, useAuth } from 'auth';
 import { PAGE_PATH_PROJECTS } from 'constants/routing';
 import { useToast } from 'hooks';
@@ -59,7 +53,7 @@ const ProjectCreateUpdateModal = ({
   isOpen,
   onClose
 }: ProjectCreateUpdateModalProps) => {
-  const queryClient = useQueryClient();
+  const isUrlEdited = useRef(false);
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
   const { consoleAccount } = useAuth();
@@ -121,10 +115,6 @@ const ProjectCreateUpdateModal = ({
             description: values.description,
             name: values.name
           });
-          invalidateProjectDetails(queryClient, {
-            id: projectDetail?.id,
-            organizationId: projectDetail?.organizationId
-          });
         } else {
           resp = await projectCreator({
             ...values,
@@ -133,8 +123,6 @@ const ProjectCreateUpdateModal = ({
         }
 
         if (resp) {
-          invalidateProjects(queryClient);
-          invalidateOrganizations(queryClient);
           notify({
             message: t('message:collection-action-success', {
               collection: t('project'),
@@ -186,15 +174,10 @@ const ProjectCreateUpdateModal = ({
                         {...field}
                         onChange={value => {
                           field.onChange(value);
-
-                          if (!projectDetail) {
-                            const isUrlCodeDirty =
-                              form.getFieldState('urlCode').isDirty;
-                            const urlCode = form.getValues('urlCode');
-                            form.setValue(
-                              'urlCode',
-                              isUrlCodeDirty ? urlCode : onGenerateSlug(value)
-                            );
+                          if (!projectDetail && !isUrlEdited.current) {
+                            form.setValue('urlCode', onGenerateSlug(value), {
+                              shouldDirty: false
+                            });
                           }
                         }}
                         name="project-name"
@@ -233,6 +216,11 @@ const ProjectCreateUpdateModal = ({
                         placeholder={`${t('form:placeholder-code')}`}
                         disabled={!!projectDetail || disabled}
                         name="project-code"
+                        autoComplete="off"
+                        onChange={value => {
+                          isUrlEdited.current = value !== '';
+                          field.onChange(value);
+                        }}
                       />
                     </Form.Control>
                     <Form.Message />

--- a/ui/dashboard/src/pages/pushes/page-loader.tsx
+++ b/ui/dashboard/src/pages/pushes/page-loader.tsx
@@ -3,8 +3,7 @@ import { Trans } from 'react-i18next';
 import { pushUpdater } from '@api/push';
 import { pushDelete } from '@api/push/push-delete';
 import { useQueryPush } from '@queries/push-details';
-import { invalidatePushes } from '@queries/pushes';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_PUSHES } from 'constants/routing';
 import { useToast } from 'hooks';
@@ -20,7 +19,6 @@ import { PushActionsType } from './types';
 
 const PageLoader = () => {
   const { t } = useTranslation(['table', 'message', 'common']);
-  const queryClient = useQueryClient();
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const editable = hasEditable(consoleAccount!);
@@ -117,7 +115,6 @@ const PageLoader = () => {
         })
       });
       handleOnCloseModal();
-      invalidatePushes(queryClient);
       mutationState.reset();
     },
     onError: errorNotify

--- a/ui/dashboard/src/pages/pushes/push-modal/push-create-update-modal/index.tsx
+++ b/ui/dashboard/src/pages/pushes/push-modal/push-create-update-modal/index.tsx
@@ -2,8 +2,6 @@ import { useCallback, useMemo, useState } from 'react';
 import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { pushCreator, PushResponse, pushUpdater, TagChange } from '@api/push';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidatePushes } from '@queries/pushes';
-import { useQueryClient } from '@tanstack/react-query';
 import { useAuth } from 'auth';
 import { ID_NEW } from 'constants/routing';
 import { useToast } from 'hooks';
@@ -71,7 +69,6 @@ const PushCreateUpdateModal = ({
   onClose
 }: PushCreateUpdateModalProps) => {
   const { consoleAccount } = useAuth();
-  const queryClient = useQueryClient();
   const { t } = useTranslation(['common', 'form', 'message']);
   const { notify, errorNotify } = useToast();
   const [files, setFiles] = useState<File[]>([]);
@@ -184,7 +181,6 @@ const PushCreateUpdateModal = ({
               action: t('updated')
             })
           });
-          invalidatePushes(queryClient);
           onClose();
         }
       } catch (error) {

--- a/ui/dashboard/src/pages/settings/page-content.tsx
+++ b/ui/dashboard/src/pages/settings/page-content.tsx
@@ -4,9 +4,6 @@ import { IconLaunchOutlined } from 'react-icons-material-design';
 import { Link } from 'react-router';
 import { organizationUpdater } from '@api/organization';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateOrganizationDetails } from '@queries/organization-details';
-import { invalidateOrganizations } from '@queries/organizations';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth, useAuthAccess } from 'auth';
 import { DOCUMENTATION_LINKS } from 'constants/documentation-links';
 import { useToast } from 'hooks';
@@ -45,7 +42,6 @@ const PageContent = ({ organization }: { organization: Organization }) => {
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
   const { envEditable, isOrganizationAdmin } = useAuthAccess();
-  const queryClient = useQueryClient();
 
   const { t } = useTranslation(['common', 'form', 'message']);
   const {
@@ -89,10 +85,6 @@ const PageContent = ({ organization }: { organization: Organization }) => {
             action: t('updated')
           })
         });
-        invalidateOrganizationDetails(queryClient, {
-          id: currentEnvironment.organizationId
-        });
-        invalidateOrganizations(queryClient);
       }
     } catch (error) {
       errorNotify(error);

--- a/ui/dashboard/src/pages/user-segments/page-loader.tsx
+++ b/ui/dashboard/src/pages/user-segments/page-loader.tsx
@@ -2,8 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { userSegmentBulkDownload } from '@api/user-segment';
 import { userSegmentDelete } from '@api/user-segment/user-segment-delete';
 import { useQueryUserSegment } from '@queries/user-segment-details';
-import { invalidateUserSegments } from '@queries/user-segments';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { getCurrentEnvironment, hasEditable, useAuth } from 'auth';
 import { PAGE_PATH_USER_SEGMENTS } from 'constants/routing';
 import { useToast } from 'hooks';
@@ -60,7 +59,6 @@ const PageLoader = () => {
   });
 
   const { notify, errorNotify } = useToast();
-  const queryClient = useQueryClient();
 
   const mutation = useMutation({
     mutationFn: async (selectedSegment: UserSegment) => {
@@ -72,7 +70,6 @@ const PageLoader = () => {
     },
     onSuccess: () => {
       onCloseDeleteModal();
-      invalidateUserSegments(queryClient);
       notify({
         message: t('message:collection-action-success', {
           collection: t('source-type.segment'),

--- a/ui/dashboard/src/pages/user-segments/user-segment-modal/segment-create-update-form/index.tsx
+++ b/ui/dashboard/src/pages/user-segments/user-segment-modal/segment-create-update-form/index.tsx
@@ -3,8 +3,6 @@ import { FormProvider, SubmitHandler, useForm } from 'react-hook-form';
 import { userSegmentBulkUpload, userSegmentCreator } from '@api/user-segment';
 import { userSegmentUpdater } from '@api/user-segment/user-segment-updater';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { invalidateUserSegments } from '@queries/user-segments';
-import { useQueryClient } from '@tanstack/react-query';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { useToast } from 'hooks';
 import useFormSchema from 'hooks/use-form-schema';
@@ -52,7 +50,6 @@ const SegmentCreateUpdateModal = ({
   const { t } = useTranslation(['common', 'form', 'message']);
   const { consoleAccount } = useAuth();
   const currentEnvironment = getCurrentEnvironment(consoleAccount!);
-  const queryClient = useQueryClient();
   const { notify, errorNotify } = useToast();
 
   const isDisabledUserIds = useMemo(
@@ -103,7 +100,6 @@ const SegmentCreateUpdateModal = ({
       handleClose();
     }
     if (isUpload) setSegmentUploading(null);
-    invalidateUserSegments(queryClient);
   };
 
   const onUpdateSuccess = (isUpload = false) => {

--- a/ui/dashboard/vitest.config.ts
+++ b/ui/dashboard/vitest.config.ts
@@ -1,0 +1,11 @@
+import viteTsconfigPaths from 'vite-tsconfig-paths';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [viteTsconfigPaths()],
+  test: {
+    environment: 'node',
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    reporters: 'default'
+  }
+});

--- a/ui/dashboard/yarn.lock
+++ b/ui/dashboard/yarn.lock
@@ -645,7 +645,7 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
-"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0":
+"@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz#6912b00d2c631c0d15ce1a7ab57cd657f2a8f8ba"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
@@ -1396,6 +1396,14 @@
   dependencies:
     "@babel/types" "^7.28.2"
 
+"@types/chai@^5.2.2":
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-5.2.3.tgz#8e9cd9e1c3581fa6b341a5aed5588eb285be0b4a"
+  integrity sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
+  dependencies:
+    "@types/deep-eql" "*"
+    assertion-error "^2.0.1"
+
 "@types/chart.js@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@types/chart.js/-/chart.js-4.0.1.tgz#fcc303637b5759e9cab9ae39c3a3f1e9dc1077b1"
@@ -1409,6 +1417,11 @@
   integrity sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==
   dependencies:
     "@types/ms" "*"
+
+"@types/deep-eql@*":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/deep-eql/-/deep-eql-4.0.2.tgz#334311971d3a07121e7eb91b684a605e7eea9cbd"
+  integrity sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==
 
 "@types/estree-jsx@^1.0.0":
   version "1.0.5"
@@ -1699,6 +1712,67 @@
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
 
+"@vitest/expect@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-3.2.6.tgz#dc3a617acc1f29c132ed6be15456adb75c94a7a4"
+  integrity sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/spy" "3.2.6"
+    "@vitest/utils" "3.2.6"
+    chai "^5.2.0"
+    tinyrainbow "^2.0.0"
+
+"@vitest/mocker@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/mocker/-/mocker-3.2.6.tgz#fd0f2bc2a86d82b6013b3456ad662d04a3551434"
+  integrity sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==
+  dependencies:
+    "@vitest/spy" "3.2.6"
+    estree-walker "^3.0.3"
+    magic-string "^0.30.17"
+
+"@vitest/pretty-format@3.2.6", "@vitest/pretty-format@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/pretty-format/-/pretty-format-3.2.6.tgz#5d1272700abe317f24b88009337b2b5cdaa68bf6"
+  integrity sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==
+  dependencies:
+    tinyrainbow "^2.0.0"
+
+"@vitest/runner@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-3.2.6.tgz#6d9fb047b1430431987782e779aa889819a2e964"
+  integrity sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==
+  dependencies:
+    "@vitest/utils" "3.2.6"
+    pathe "^2.0.3"
+    strip-literal "^3.0.0"
+
+"@vitest/snapshot@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-3.2.6.tgz#3a9cb56389289028a511e97bbfd41d914004f3f5"
+  integrity sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==
+  dependencies:
+    "@vitest/pretty-format" "3.2.6"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+
+"@vitest/spy@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-3.2.6.tgz#c255ab84df924b28d6fbec60a37a7f693db4ea41"
+  integrity sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==
+  dependencies:
+    tinyspy "^4.0.3"
+
+"@vitest/utils@3.2.6":
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-3.2.6.tgz#6fad3368e48b7a1d058827eb9b4bbc650a3f9402"
+  integrity sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==
+  dependencies:
+    "@vitest/pretty-format" "3.2.6"
+    loupe "^3.1.4"
+    tinyrainbow "^2.0.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -1868,6 +1942,11 @@ arraybuffer.prototype.slice@^1.0.4:
     get-intrinsic "^1.2.6"
     is-array-buffer "^3.0.4"
 
+assertion-error@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-2.0.1.tgz#f641a196b335690b1070bf00b6e7593fec190bf7"
+  integrity sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==
+
 async-function@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/async-function/-/async-function-1.0.0.tgz#509c9fca60eaf85034c6829838188e4e4c8ffb2b"
@@ -1978,6 +2057,11 @@ browserslist@^4.24.0, browserslist@^4.28.2:
     node-releases "^2.0.36"
     update-browserslist-db "^1.2.3"
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -2029,6 +2113,17 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
+chai@^5.2.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.3.3.tgz#dd3da955e270916a4bd3f625f4b919996ada7e06"
+  integrity sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==
+  dependencies:
+    assertion-error "^2.0.1"
+    check-error "^2.1.1"
+    deep-eql "^5.0.1"
+    loupe "^3.1.0"
+    pathval "^2.0.0"
+
 chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -2073,6 +2168,11 @@ chartjs-adapter-luxon@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.3.1.tgz#8ad8be7cc1521bacd6cd2ff4b013669d4dd49364"
   integrity sha512-yxHov3X8y+reIibl1o+j18xzrcdddCLqsXhriV2+aQ4hCR66IYFchlRXUvrJVoxglJ380pgytU7YWtoqdIgqhg==
+
+check-error@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-2.1.3.tgz#2427361117b70cca8dc89680ead32b157019caf5"
+  integrity sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==
 
 chokidar@^3.6.0:
   version "3.6.0"
@@ -2340,7 +2440,7 @@ dayjs@^1.11.21:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
   integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
 
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.3:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.4.0, debug@^4.4.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -2358,6 +2458,11 @@ decode-uri-component@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.4.1.tgz#2ac4859663c704be22bf7db760a1494a49ab2cc5"
   integrity sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==
+
+deep-eql@^5.0.1:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-5.0.2.tgz#4b756d8d770a9257300825d52a2c2cff99c3a341"
+  integrity sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==
 
 deep-is@^0.1.3:
   version "0.1.4"
@@ -2619,6 +2724,11 @@ es-iterator-helpers@^1.2.1:
     math-intrinsics "^1.1.0"
     safe-array-concat "^1.1.3"
 
+es-module-lexer@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
+  integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
+
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
@@ -2862,6 +2972,13 @@ estree-walker@^2.0.2:
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
   integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
+estree-walker@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-3.0.3.tgz#67c3e549ec402a487b4fc193d1953a524752340d"
+  integrity sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==
+  dependencies:
+    "@types/estree" "^1.0.0"
+
 esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
@@ -2886,6 +3003,11 @@ execa@^8.0.1:
     onetime "^6.0.0"
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
+
+expect-type@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-1.3.0.tgz#0d58ed361877a31bbc4dd6cf71bbfef7faf6bd68"
+  integrity sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==
 
 expect@^29.0.0:
   version "29.7.0"
@@ -3681,6 +3803,11 @@ js-cookie@^3.0.8:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-tokens@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-9.0.1.tgz#2ec43964658435296f6761b34e10671c2d9527f4"
+  integrity sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==
+
 js-yaml@^4.1.0, js-yaml@^4.1.1, js-yaml@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.2.0.tgz#2bd9e85682dd91bd469afb809d816043b3d49524"
@@ -3840,6 +3967,11 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+loupe@^3.1.0, loupe@^3.1.4:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-3.2.1.tgz#0095cf56dc5b7a9a7c08ff5b1a8796ec8ad17e76"
+  integrity sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==
+
 lower-case@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-2.0.2.tgz#6fa237c63dbdc4a82ca0fd882e4722dc5e634e28"
@@ -3863,6 +3995,13 @@ luxon@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/luxon/-/luxon-3.7.2.tgz#d697e48f478553cca187a0f8436aff468e3ba0ba"
   integrity sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==
+
+magic-string@^0.30.17:
+  version "0.30.21"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
 
 matchmediaquery@^0.4.2:
   version "0.4.2"
@@ -4523,6 +4662,11 @@ pathe@^2.0.1, pathe@^2.0.3:
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
   integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
 
+pathval@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
+  integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
+
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
@@ -4533,7 +4677,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
   integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
-picomatch@^4.0.2, picomatch@^4.0.3:
+picomatch@^4.0.2, picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
@@ -5223,6 +5367,11 @@ side-channel@^1.1.0:
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
@@ -5284,10 +5433,20 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 state-local@^1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/state-local/-/state-local-1.0.7.tgz#da50211d07f05748d53009bee46307a37db386d5"
   integrity sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==
+
+std-env@^3.9.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 stop-iteration-iterator@^1.1.0:
   version "1.1.0"
@@ -5401,6 +5560,13 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-literal@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-3.1.0.tgz#222b243dd2d49c0bcd0de8906adbd84177196032"
+  integrity sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==
+  dependencies:
+    js-tokens "^9.0.1"
 
 style-to-js@^1.0.0:
   version "1.1.21"
@@ -5552,6 +5718,16 @@ tiny-case@^1.0.3:
   resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
   integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
 
+tinybench@^2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinyexec@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-0.3.2.tgz#941794e657a85e496577995c6eef66f53f42b3d2"
+  integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
+
 tinyglobby@^0.2.11, tinyglobby@^0.2.15:
   version "0.2.15"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.15.tgz#e228dd1e638cea993d2fdb4fcd2d4602a79951c2"
@@ -5559,6 +5735,29 @@ tinyglobby@^0.2.11, tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.3"
+
+tinyglobby@^0.2.14:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
+
+tinypool@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-1.1.1.tgz#059f2d042bd37567fbc017d3d426bdd2a2612591"
+  integrity sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==
+
+tinyrainbow@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tinyrainbow/-/tinyrainbow-2.0.0.tgz#9509b2162436315e80e3eee0fcce4474d2444294"
+  integrity sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==
+
+tinyspy@^4.0.3:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-4.0.4.tgz#d77a002fb53a88aa1429b419c1c92492e0c81f78"
+  integrity sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -5838,6 +6037,17 @@ vfile@^6.0.0:
     "@types/unist" "^3.0.0"
     vfile-message "^4.0.0"
 
+vite-node@3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-3.2.4.tgz#f3676d94c4af1e76898c162c92728bca65f7bb07"
+  integrity sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.4.1"
+    es-module-lexer "^1.7.0"
+    pathe "^2.0.3"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+
 vite-plugin-compression2@^2.5.3:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/vite-plugin-compression2/-/vite-plugin-compression2-2.5.3.tgz#cd8b4f8e0fcbc21d937b3b8f39895bdd475c5dd9"
@@ -5864,6 +6074,20 @@ vite-tsconfig-paths@^5.0.1:
     globrex "^0.1.2"
     tsconfck "^3.0.3"
 
+"vite@^5.0.0 || ^6.0.0 || ^7.0.0-0":
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.5.tgz#90c2d0b7b94a224e7e7dcf22d2912ff0b5291165"
+  integrity sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==
+  dependencies:
+    esbuild "^0.27.0"
+    fdir "^6.5.0"
+    picomatch "^4.0.3"
+    postcss "^8.5.6"
+    rollup "^4.43.0"
+    tinyglobby "^0.2.15"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^7.3.3:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/vite/-/vite-7.3.3.tgz#d7e07a52b5873fb86f902a3f4b3d17410337450f"
@@ -5877,6 +6101,35 @@ vite@^7.3.3:
     tinyglobby "^0.2.15"
   optionalDependencies:
     fsevents "~2.3.3"
+
+vitest@3.2.6:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-3.2.6.tgz#de42ebfb58e16faba4e5a314fe35e146e03cb340"
+  integrity sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==
+  dependencies:
+    "@types/chai" "^5.2.2"
+    "@vitest/expect" "3.2.6"
+    "@vitest/mocker" "3.2.6"
+    "@vitest/pretty-format" "^3.2.6"
+    "@vitest/runner" "3.2.6"
+    "@vitest/snapshot" "3.2.6"
+    "@vitest/spy" "3.2.6"
+    "@vitest/utils" "3.2.6"
+    chai "^5.2.0"
+    debug "^4.4.1"
+    expect-type "^1.2.1"
+    magic-string "^0.30.17"
+    pathe "^2.0.3"
+    picomatch "^4.0.2"
+    std-env "^3.9.0"
+    tinybench "^2.9.0"
+    tinyexec "^0.3.2"
+    tinyglobby "^0.2.14"
+    tinypool "^1.1.1"
+    tinyrainbow "^2.0.0"
+    vite "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+    vite-node "3.2.4"
+    why-is-node-running "^2.3.0"
 
 void-elements@3.1.0:
   version "3.1.0"
@@ -5965,6 +6218,14 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+why-is-node-running@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
 
 word-wrap@^1.2.5:
   version "1.2.5"


### PR DESCRIPTION
## Summary

Fix https://github.com/bucketeer-io/bucketeer/issues/2623

Users were reporting stale data on multiple console pages even though we use React Query for caching. The root cause was a combination of:

- A 30-minute global `staleTime` that effectively pinned cached data until a manual invalidation.
- Cache invalidation scattered across components/hooks via per-call `invalidate*()` helpers and `onSuccess` handlers.
- Cross-entity dependencies were easy to forget — for example, mutating a feature flag also affects experiments, evaluation timeseries, auto-ops, rollouts, triggers, scheduled changes, audit logs, etc., but most call sites only invalidated `features` / `feature-details`.
- New endpoints added by future PRs would have to remember the same bookkeeping, so the problem was guaranteed to keep recurring.

This PR replaces all of that with a single, declarative source of truth and adds CI guardrails so the system can't silently drift again.

### What changed

1. **Single shared `QueryClient`** (`src/configs/query-client.ts`)
   - `staleTime` lowered from 30 min → 30 s; `gcTime` set to 10 min.
   - `refetchOnWindowFocus`, `refetchOnReconnect`, `refetchOnMount` enabled.
   - With short staleness, leftover stale data has a hard upper bound even if a rule is missed.

2. **Declarative cache-invalidation map** (`src/@api/cache-invalidation-map.ts`)
   - A single `URL_TO_KEYS` table that maps mutation URL regexes to the React Query keys that depend on them, including all cross-entity dependencies (e.g. flag mutations also bust `experiments`, `evaluation-timeseries`, `auto-ops-rules`, `auto-ops-count`, `rollouts`, `triggers`, scheduled-flag-change keys, `tags`, `user-segments`, `code-refs`, `histories`, `audit-logs`).
   - `resolveInvalidationKeys(url)` returns the union of keys for any URL.

3. **Global axios response interceptor** (`src/@api/axios-client.ts`)
   - Every successful non-`GET` response (and retried response after a 401 token refresh) runs `resolveInvalidationKeys` and calls `queryClient.invalidateQueries` for each key.
   - Components and mutations no longer need to know which queries to invalidate.

4. **Removed all the old per-component invalidation**
   - All `invalidate*` exports were deleted from `src/@queries/*.ts` (kept `useQuery*`, `usePrefetch*`, `prefetch*`, and `updateFeatureCache` for the optimistic feature-detail update).
   - `onSuccess` invalidation handlers were stripped from the scheduled-flag-change mutations.
   - All call sites that imported and called `invalidate*` were cleaned up; `useQueryClient()` was removed wherever it became unused.

5. **CI safety nets** (`src/@api/cache-invalidation-map.test.ts`, Vitest)
   - Statically scans `src/@api/**/*.ts` for `axiosClient.<method>` calls and asserts that **every non-GET endpoint** either matches a rule in `URL_TO_KEYS` or is in an explicit `NON_INVALIDATING_ENDPOINTS` allowlist (auth handshakes, debug endpoints).
   - Statically scans `src/@queries/**/*.ts` for exported `*_KEY` / `*_QUERY_KEY` constants and asserts that **every query key is reachable** from at least one rule in `URL_TO_KEYS`, or is in an explicit `NON_INVALIDATED_QUERY_KEYS` allowlist (read-only data: insights, AI chat suggestions, immutable audit-log details, demo site status).
   - Both allowlists are themselves checked for stale entries, and `URL_TO_KEYS` is checked for typos against the real key constants.
   - Wired into `pr-ui-dashboard.yaml` as a `yarn test` step between lint and build, so a forgotten rule fails the PR check with an actionable message.

### Why this is better

- **Stale data has a defined upper bound.** Even if a new endpoint slips through, the 30 s `staleTime` + focus/reconnect refetching limits visible staleness to seconds.
- **One place to edit.** Cross-entity invalidation lives in `cache-invalidation-map.ts`. Adding a new mutation URL or a new query key only requires editing that file.
- **No more "did I remember to invalidate?" thinking at the call site.** The interceptor handles it for every mutation, including retried requests after token refresh.
- **CI prevents the problem from coming back.** New endpoints/keys without a rule fail a typed, descriptive test that points the engineer to the exact file to update.
- **Net code reduction.** Dozens of `invalidate*()` exports, helper imports, and ad-hoc `useQueryClient()` hooks are gone.

### Future work (out of scope)

- Real-time sync (SSE/WebSocket) is a separate, complementary track. Once shipped, it can drive `setQueryData` / targeted invalidations directly, while this PR's interceptor remains the safety net for actions originating from the same tab.

## Test plan

- [x] `yarn style:lint` passes (`tsc` + ESLint).
- [x] `yarn test` passes (7 tests, ~250 ms).
- [x] `yarn build` passes.
- [x] Verified the safety-net tests fail with a clear error when:
  - A new mutation endpoint is added without a `URL_TO_KEYS` rule (injected `POST /v1/totally_new_endpoint`).
  - A new `*_QUERY_KEY` is added without being referenced by any rule (injected `FAKE_QUERY_KEY = 'fake-key-not-in-map'`).
  - Allowlists or the map reference URLs/keys that no longer exist.
- [x] Manual smoke test in the dashboard:
  - [x] Create / update / archive / unarchive a feature flag → flag list, flag detail, experiments tab, audit logs all reflect the change without a manual reload.
  - [x] Create / update / delete a goal → goal list, goal details, related experiments update.
  - [x] Create / update / stop an auto-ops rule and a progressive rollout → flag detail and operations tab update.
  - [x] Create / update / delete a scheduled flag change → scheduled-changes banner and flag detail update.
  - [x] Update an environment / project / organization → list and detail pages update; account / api-key lists update where relevant.
  - [x] Add / edit / disable / delete an account; create / edit a team; create / update an api key → respective lists update.
  - [x] Upload segment users → segment detail and user-attribute keys update.
  - [x] Verify a 401 → token refresh → retried mutation still invalidates the right caches.