### PR TITLE
fix(calculator): correct normal-inverse-gamma posterior update for value metrics

### DIFF
--- a/pkg/eventcounter/storage/v2/dwh_database/mysql/sql/goal_event.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/mysql/sql/goal_event.sql
@@ -22,7 +22,7 @@ SELECT
     SUM(event_count) as goalTotal,
     SUM(value_sum) as goalValueTotal,
     AVG(value_sum) as goalValueMean,
-    IFNULL(VARIANCE(value_sum), 0) as goalValueVariance
+    IFNULL(VAR_SAMP(value_sum), 0) as goalValueVariance
 FROM
     grouped_by_user_evaluation
 GROUP BY

--- a/pkg/eventcounter/storage/v2/dwh_database/postgres/sql/goal_event.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/postgres/sql/goal_event.sql
@@ -22,7 +22,7 @@ SELECT
     SUM(event_count) as goalTotal,
     SUM(value_sum) as goalValueTotal,
     AVG(value_sum) as goalValueMean,
-    COALESCE(VARIANCE(value_sum), 0) as goalValueVariance
+    COALESCE(VAR_SAMP(value_sum), 0) as goalValueVariance
 FROM
     grouped_by_user_evaluation
 GROUP BY

--- a/pkg/experimentcalculator/experimentcalc/experiment_calculator.go
+++ b/pkg/experimentcalculator/experimentcalc/experiment_calculator.go
@@ -358,7 +358,8 @@ func (e ExperimentCalculator) calcGoalResult(
 			return goalResult
 		}
 	}
-	valueResult := normalInverseGamma(ctx, vids, valueMeans, valueVars, goalUc, baseLineIdx, 25000)
+	// nil src uses the global RNG; tests inject a seeded source for determinism.
+	valueResult := normalInverseGamma(nil, vids, valueMeans, valueVars, goalUc, baseLineIdx, 25000)
 	for vid, vr := range valueResult {
 		vrs[vid].GoalValueSumPerUserProb = copyDistributionSummary(vr.GoalValueSumPerUserProb)
 		vrs[vid].GoalValueSumPerUserProbBest = copyDistributionSummary(vr.GoalValueSumPerUserProbBest)

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
@@ -88,25 +88,32 @@ func normalInverseGamma(
 	return variationResults
 }
 
+// calcPosterior performs the conjugate Normal-Inverse-Gamma update.
+// priorKappa is the prior pseudo-count for the mean (kappa_0); thisVar is the
+// per-user sample variance (divided by n-1), so the sum of squared deviations
+// is (n-1) * thisVar.
 func calcPosterior(
 	thisN int64,
-	thisMu, thisSigma float64,
+	thisMu, thisVar float64,
 	priorN int64,
-	priorMu, priorNu, priorAlpha, priorBeta float64) distr {
-	retN := thisN + priorN
-	n2 := math.Log(float64(thisN)) / math.Log(1.1)
-	postMu := (priorNu*priorMu + n2*thisMu) / (priorNu + n2)
-	postNu := priorNu + n2
-	postAlpha := priorAlpha + (n2 / 2)
+	priorMu, priorKappa, priorAlpha, priorBeta float64) distr {
+	n := float64(thisN)
+	kappaN := priorKappa + n
+	postMu := (priorKappa*priorMu + n*thisMu) / kappaN
+	postAlpha := priorAlpha + (n / 2)
+	sumSquaredDev := 0.0
+	if thisN > 1 {
+		sumSquaredDev = float64(thisN-1) * thisVar
+	}
 	postBeta := priorBeta +
-		(0.5 * thisSigma * thisSigma * n2) +
-		((n2 * priorNu / (priorNu * n2)) * ((thisMu - priorMu) * (thisMu - priorMu)) / 2)
+		(0.5 * sumSquaredDev) +
+		((priorKappa * n / kappaN) * (thisMu - priorMu) * (thisMu - priorMu) / 2)
 	return distr{
 		mu:    postMu,
-		nu:    postNu,
+		nu:    kappaN,
 		alpha: postAlpha,
 		beta:  postBeta,
-		n:     int(retN),
+		n:     int(thisN + priorN),
 	}
 }
 

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
@@ -32,7 +32,6 @@ import (
 const (
 	priorMean  = 30
 	priorKappa = 2
-	priorSize  = 20
 	priorAlpha = 10
 	priorBeta  = 1000
 )
@@ -42,7 +41,6 @@ type distr struct {
 	nu    float64
 	alpha float64
 	beta  float64
-	n     int
 }
 
 // normalInverseGamma computes the value-metric posterior summaries. src seeds
@@ -64,7 +62,6 @@ func normalInverseGamma(
 			sizes[i],
 			means[i],
 			vars[i],
-			priorSize,
 			priorMean,
 			priorKappa,
 			priorAlpha,
@@ -98,7 +95,6 @@ func normalInverseGamma(
 func calcPosterior(
 	thisN int64,
 	thisMu, thisVar float64,
-	priorN int64,
 	priorMu, priorKappa, priorAlpha, priorBeta float64) distr {
 	n := float64(thisN)
 	kappaN := priorKappa + n
@@ -116,7 +112,6 @@ func calcPosterior(
 		nu:    kappaN,
 		alpha: postAlpha,
 		beta:  postBeta,
-		n:     int(thisN + priorN),
 	}
 }
 

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
@@ -16,9 +16,9 @@
 package experimentcalc
 
 import (
-	"context"
 	"fmt"
 	"math"
+	"math/rand/v2"
 	"time"
 
 	"github.com/go-gota/gota/dataframe"
@@ -31,7 +31,7 @@ import (
 
 const (
 	priorMean  = 30
-	priorVar   = 2
+	priorKappa = 2
 	priorSize  = 20
 	priorAlpha = 10
 	priorBeta  = 1000
@@ -45,8 +45,11 @@ type distr struct {
 	n     int
 }
 
+// normalInverseGamma computes the value-metric posterior summaries. src seeds
+// the Monte Carlo sampling; pass nil to use the global RNG (production) or a
+// seeded source for deterministic tests.
 func normalInverseGamma(
-	ctx context.Context,
+	src rand.Source,
 	vids []string,
 	means, vars []float64,
 	sizes []int64,
@@ -63,11 +66,11 @@ func normalInverseGamma(
 			vars[i],
 			priorSize,
 			priorMean,
-			priorVar,
+			priorKappa,
 			priorAlpha,
 			priorBeta,
 		)
-		nums := generateNormalGamma(postGenNum, post.mu, post.nu, post.alpha, post.beta)
+		nums := generateNormalGamma(src, postGenNum, post.mu, post.nu, post.alpha, post.beta)
 		sampleSeries = append(sampleSeries, series.Floats(nums))
 	}
 	samples := dataframe.New(sampleSeries...)
@@ -117,17 +120,18 @@ func calcPosterior(
 	}
 }
 
-func generateNormalGamma(n int, mu float64, lambda float64, alpha float64, beta float64) []float64 {
-	tauDist := distuv.Gamma{Alpha: alpha, Beta: beta}
+func generateNormalGamma(src rand.Source, n int, mu float64, lambda float64, alpha float64, beta float64) []float64 {
+	tauDist := distuv.Gamma{Alpha: alpha, Beta: beta, Src: src}
 
 	tauSamples := make([]float64, n)
 	for i := 0; i < n; i++ {
 		tauSamples[i] = tauDist.Rand()
 	}
 
+	normDist := distuv.Normal{Mu: 0, Sigma: 1, Src: src}
 	x := make([]float64, n)
 	for i, tau := range tauSamples {
-		x[i] = mu + math.Sqrt(1/(tau*lambda))*distuv.Normal{Mu: 0, Sigma: 1}.Rand()
+		x[i] = mu + math.Sqrt(1/(tau*lambda))*normDist.Rand()
 	}
 
 	return x

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -54,24 +54,82 @@ func TestNormalInverseGamma(t *testing.T) {
 	baselineIdx := 0
 	vrs := normalInverseGamma(context.TODO(), vids, means, vars, sizes, baselineIdx, 25000)
 
-	assert.Greater(t, vrs["vid1"].GoalValueSumPerUserProb.Median, 12.0)
-	assert.Less(t, vrs["vid1"].GoalValueSumPerUserProb.Median, 13.5)
-	assert.Greater(t, vrs["vid1"].GoalValueSumPerUserProb.Percentile025, -2.0)
-	assert.Less(t, vrs["vid1"].GoalValueSumPerUserProb.Percentile025, -1.0)
-	assert.Greater(t, vrs["vid1"].GoalValueSumPerUserProb.Percentile975, 26.5)
-	assert.Less(t, vrs["vid1"].GoalValueSumPerUserProb.Percentile975, 28.0)
-	assert.Greater(t, vrs["vid1"].GoalValueSumPerUserProbBest.Mean, 0.39)
-	assert.Less(t, vrs["vid1"].GoalValueSumPerUserProbBest.Mean, 0.5)
-	assert.Equal(t, vrs["vid1"].GoalValueSumPerUserProbBeatBaseline.Mean, 0.0)
+	// With the conjugate update using the real sample size, the posterior for the
+	// mean concentrates around the observed per-user mean and the 95% credible
+	// interval is narrow (well under 1 unit wide for ~20k samples), instead of the
+	// previous behaviour where the interval spanned roughly [-2, 28].
+	vid1 := vrs["vid1"]
+	assert.Greater(t, vid1.GoalValueSumPerUserProb.Median, 11.5)
+	assert.Less(t, vid1.GoalValueSumPerUserProb.Median, 13.5)
+	assert.Less(
+		t,
+		vid1.GoalValueSumPerUserProb.Percentile975-vid1.GoalValueSumPerUserProb.Percentile025,
+		1.5,
+	)
+	// vid1 (baseline) has the lower mean, so it is almost never the best variation.
+	assert.Less(t, vid1.GoalValueSumPerUserProbBest.Mean, 0.05)
+	assert.Equal(t, vid1.GoalValueSumPerUserProbBeatBaseline.Mean, 0.0)
 
-	assert.Greater(t, vrs["vid2"].GoalValueSumPerUserProb.Median, 15.0)
-	assert.Less(t, vrs["vid2"].GoalValueSumPerUserProb.Median, 17.0)
-	assert.Greater(t, vrs["vid2"].GoalValueSumPerUserProb.Percentile025, -6.0)
-	assert.Less(t, vrs["vid2"].GoalValueSumPerUserProb.Percentile025, -4.0)
-	assert.Greater(t, vrs["vid2"].GoalValueSumPerUserProb.Percentile975, 36.0)
-	assert.Less(t, vrs["vid2"].GoalValueSumPerUserProb.Percentile975, 37.6)
-	assert.Greater(t, vrs["vid2"].GoalValueSumPerUserProbBest.Mean, 0.4)
-	assert.Less(t, vrs["vid2"].GoalValueSumPerUserProbBest.Mean, 0.61)
-	assert.Greater(t, vrs["vid2"].GoalValueSumPerUserProbBeatBaseline.Mean, 0.4)
-	assert.Less(t, vrs["vid2"].GoalValueSumPerUserProbBeatBaseline.Mean, 0.61)
+	vid2 := vrs["vid2"]
+	assert.Greater(t, vid2.GoalValueSumPerUserProb.Median, 14.5)
+	assert.Less(t, vid2.GoalValueSumPerUserProb.Median, 16.5)
+	assert.Less(
+		t,
+		vid2.GoalValueSumPerUserProb.Percentile975-vid2.GoalValueSumPerUserProb.Percentile025,
+		1.5,
+	)
+	// vid2 has the clearly higher mean, so it is essentially certain to be the
+	// best and to beat the baseline.
+	assert.Greater(t, vid2.GoalValueSumPerUserProbBest.Mean, 0.95)
+	assert.Greater(t, vid2.GoalValueSumPerUserProbBeatBaseline.Mean, 0.95)
+}
+
+// TestNormalInverseGammaHeavyTailed verifies the posterior stays sensible on
+// heavy-tailed, strictly-positive value data (log-normal revenue per user):
+// the posterior mean concentrates near the observed per-user mean, the credible
+// interval is narrow and stays positive (no nonsensical negative-revenue
+// bounds), and the higher-revenue variation is identified decisively.
+func TestNormalInverseGammaHeavyTailed(t *testing.T) {
+	t.Parallel()
+	// True means are exp(mu + sigma^2/2): ~12.18 for vid1 and ~16.44 for vid2.
+	v1Dist := distuv.LogNormal{Mu: 2.0, Sigma: 1.0}
+	v2Dist := distuv.LogNormal{Mu: 2.3, Sigma: 1.0}
+	sampleNum := 20000
+	v1 := make([]float64, sampleNum)
+	v2 := make([]float64, sampleNum)
+	for i := 0; i < sampleNum; i++ {
+		v1[i] = v1Dist.Rand()
+		v2[i] = v2Dist.Rand()
+	}
+
+	vids := []string{"vid1", "vid2"}
+	means := []float64{stat.Mean(v1, nil), stat.Mean(v2, nil)}
+	vars := []float64{stat.Variance(v1, nil), stat.Variance(v2, nil)}
+	sizes := []int64{int64(len(v1)), int64(len(v2))}
+	baselineIdx := 0
+	vrs := normalInverseGamma(context.TODO(), vids, means, vars, sizes, baselineIdx, 25000)
+
+	vid1 := vrs["vid1"]
+	// Posterior median tracks the observed per-user mean.
+	assert.InDelta(t, vid1.GoalValueSumPerUserProb.Median, means[0], 1.0)
+	// Strictly-positive credible bounds (heavy tails must not push them negative).
+	assert.Greater(t, vid1.GoalValueSumPerUserProb.Percentile025, 0.0)
+	assert.Less(
+		t,
+		vid1.GoalValueSumPerUserProb.Percentile975-vid1.GoalValueSumPerUserProb.Percentile025,
+		2.0,
+	)
+	assert.Less(t, vid1.GoalValueSumPerUserProbBest.Mean, 0.05)
+	assert.Equal(t, vid1.GoalValueSumPerUserProbBeatBaseline.Mean, 0.0)
+
+	vid2 := vrs["vid2"]
+	assert.InDelta(t, vid2.GoalValueSumPerUserProb.Median, means[1], 1.0)
+	assert.Greater(t, vid2.GoalValueSumPerUserProb.Percentile025, 0.0)
+	assert.Less(
+		t,
+		vid2.GoalValueSumPerUserProb.Percentile975-vid2.GoalValueSumPerUserProb.Percentile025,
+		2.0,
+	)
+	assert.Greater(t, vid2.GoalValueSumPerUserProbBest.Mean, 0.95)
+	assert.Greater(t, vid2.GoalValueSumPerUserProbBeatBaseline.Mean, 0.95)
 }

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -17,6 +17,7 @@ package experimentcalc
 
 import (
 	"context"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,8 +29,10 @@ func TestNormalInverseGamma(t *testing.T) {
 	t.Parallel()
 	v1Mean, v1Sd := 12.0, 10.0
 	v2Mean, v2Sd := 15.0, 12.0
-	v1Dist := distuv.Normal{Mu: v1Mean, Sigma: v1Sd}
-	v2Dist := distuv.Normal{Mu: v2Mean, Sigma: v2Sd}
+	// Seed local RNG sources so the generated data is deterministic and the test
+	// stays stable under t.Parallel() regardless of other concurrent tests.
+	v1Dist := distuv.Normal{Mu: v1Mean, Sigma: v1Sd, Src: rand.NewPCG(1, 2)}
+	v2Dist := distuv.Normal{Mu: v2Mean, Sigma: v2Sd, Src: rand.NewPCG(3, 4)}
 	sampleNum := 20000
 	v1 := make([]float64, sampleNum)
 	v2 := make([]float64, sampleNum)
@@ -92,8 +95,9 @@ func TestNormalInverseGamma(t *testing.T) {
 func TestNormalInverseGammaHeavyTailed(t *testing.T) {
 	t.Parallel()
 	// True means are exp(mu + sigma^2/2): ~12.18 for vid1 and ~16.44 for vid2.
-	v1Dist := distuv.LogNormal{Mu: 2.0, Sigma: 1.0}
-	v2Dist := distuv.LogNormal{Mu: 2.3, Sigma: 1.0}
+	// Seed local RNG sources for deterministic, parallel-safe sampling.
+	v1Dist := distuv.LogNormal{Mu: 2.0, Sigma: 1.0, Src: rand.NewPCG(5, 6)}
+	v2Dist := distuv.LogNormal{Mu: 2.3, Sigma: 1.0, Src: rand.NewPCG(7, 8)}
 	sampleNum := 20000
 	v1 := make([]float64, sampleNum)
 	v2 := make([]float64, sampleNum)

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -16,7 +16,6 @@
 package experimentcalc
 
 import (
-	"context"
 	"math/rand/v2"
 	"testing"
 
@@ -55,7 +54,7 @@ func TestNormalInverseGamma(t *testing.T) {
 	vars := []float64{stat.Variance(v1, nil), stat.Variance(v2, nil)}
 	sizes := []int64{int64(len(v1)), int64(len(v2))}
 	baselineIdx := 0
-	vrs := normalInverseGamma(context.TODO(), vids, means, vars, sizes, baselineIdx, 25000)
+	vrs := normalInverseGamma(rand.NewPCG(9, 10), vids, means, vars, sizes, baselineIdx, 25000)
 
 	// With the conjugate update using the real sample size, the posterior for the
 	// mean concentrates around the observed per-user mean and the 95% credible
@@ -111,7 +110,7 @@ func TestNormalInverseGammaHeavyTailed(t *testing.T) {
 	vars := []float64{stat.Variance(v1, nil), stat.Variance(v2, nil)}
 	sizes := []int64{int64(len(v1)), int64(len(v2))}
 	baselineIdx := 0
-	vrs := normalInverseGamma(context.TODO(), vids, means, vars, sizes, baselineIdx, 25000)
+	vrs := normalInverseGamma(rand.NewPCG(11, 12), vids, means, vars, sizes, baselineIdx, 25000)
 
 	vid1 := vrs["vid1"]
 	// Posterior median tracks the observed per-user mean.

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -2594,7 +2594,7 @@ func checkExperimentVariationResultA(t *testing.T, vsA *ecproto.VariationResult,
 		t.Fatalf("variation: %s: cvr prob beat baseline best rhat is not correct: %f", variationValue, vsA.CvrProbBeatBaseline.Rhat)
 	}
 	// value sum per user prob best
-	if diff := cmp.Diff(vsA.GoalValueSumPerUserProbBest.Mean, 0.32, compareFloatBayesian); diff != "" {
+	if diff := cmp.Diff(vsA.GoalValueSumPerUserProbBest.Mean, 0.36, compareFloatBayesian); diff != "" {
 		t.Fatalf("variation: %s: value sum per user prob best mean is not correct: %f", variationValue, vsA.GoalValueSumPerUserProbBest.Mean)
 	}
 	// value sum per user prob beat baseline
@@ -2644,11 +2644,11 @@ func checkExperimentVariationResultB(t *testing.T, vsB *ecproto.VariationResult,
 		t.Fatalf("variation: %s: cvr prob beat baseline best rhat is not correct: %f", variationValue, vsB.CvrProbBeatBaseline.Rhat)
 	}
 	// value sum per user prob best
-	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBest.Mean, 0.67, compareFloatBayesian); diff != "" {
+	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBest.Mean, 0.64, compareFloatBayesian); diff != "" {
 		t.Fatalf("variation: %s: value sum per user prob best mean is not correct: %f", variationValue, vsB.GoalValueSumPerUserProbBest.Mean)
 	}
 	// value sum per user prob beat baseline
-	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBeatBaseline.Mean, 0.67, compareFloatBayesian); diff != "" {
+	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBeatBaseline.Mean, 0.64, compareFloatBayesian); diff != "" {
 		t.Fatalf("variation: %s: value sum per user prob beat baseline mean is not correct: %f", variationValue, vsB.GoalValueSumPerUserProbBeatBaseline.Mean)
 	}
 }


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/bucketeer/issues/2638

Fixes the Bayesian posterior update used for **value metrics** (value/user, e.g. revenue) in the experiment calculator. The implementation in `calcPosterior` did not match the conjugate **Normal-Inverse-Gamma** update that the project's own math doc specifies, which made value-metric credible intervals fail to shrink as data accumulated. Also standardizes the per-user variance definition across data-warehouse backends, on which the posterior update depends.

## Why / Problem

For value metrics, `ExperimentResult` credible intervals stayed extremely wide regardless of sample size, so `ProbBeatBaseline` / `ProbBest` rarely became decisive. In practice, this meant **value/revenue experiments almost never reached a confident verdict**, even with very large samples. (The conversion-rate path is separate — it uses Stan — and is unaffected.)

In addition, the per-user variance that feeds the posterior was computed with a different definition per backend (population vs sample variance), so identical data could yield slightly different results depending on the data warehouse.

## Root cause

`calcPosterior` deviated from the documented model (`docs/mechanism/experiment-calculator-math.md` §8) in three ways:

| Documented formula | Previous code | Fix |
|---|---|---|
| use sample size `n` | `n2 = log₁.₁(n)` (compressed 20,000 → ~104) | use real `n` |
| `½·Σ(xᵢ−x̄)² = ½·(n−1)·s²` | `0.5 · s² · s² · n2` (variance squared; `s` was actually a variance) | `0.5 · (n−1)·s²` |
| `(κ₀·n)/(κ₀+n)` | `(n2·κ₀)/(κ₀·n2)` → algebraically `1` | `(κ₀·n)/(κ₀+n)` |

The `thisSigma` parameter was actually being passed a **variance** (`ValueSumPerUserVariance`), so it was both mis-scaled and squared. Parameters were renamed (`thisSigma → thisVar`, `priorNu → priorKappa`) to prevent this confusion.

Separately, `ValueSumPerUserVariance` was computed inconsistently across backends:

| Backend  | Was                          | Divisor (was) | After      | Divisor (after) |
|----------|------------------------------|---------------|------------|-----------------|
| BigQuery | `VAR_SAMP`                   | n−1           | `VAR_SAMP` | n−1             |
| Postgres | `VARIANCE` (alias of `VAR_SAMP`) | n−1       | `VAR_SAMP` | n−1             |
| MySQL    | `VARIANCE` (alias of `VAR_POP`)  | **n**     | `VAR_SAMP` | **n−1**         |

Because the corrected posterior recovers the sum of squares as `(n-1)·s²`, it is exact only when `s²` is the sample variance (`VAR_SAMP`). On MySQL it was off by a factor of `(n-1)/n`.

A useful side effect of the `n` fix: with the real `n`, the hardcoded priors (`μ₀=30`, etc.) become negligible for any realistic sample size, so the previously raised prior-bias concern dissolves without changing the constants.

## Changes

- `pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go`: rewrite `calcPosterior` to the documented conjugate update; rename parameters for clarity; guard `n ≤ 1`.
- `pkg/eventcounter/storage/v2/dwh_database/mysql/sql/goal_event.sql`: `VARIANCE → VAR_SAMP` (behavior change: now divides by n−1, consistent with the other backends and with the posterior math).
- `pkg/eventcounter/storage/v2/dwh_database/postgres/sql/goal_event.sql`: `VARIANCE → VAR_SAMP` (explicit; no behavior change).
- `pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go`: update `TestNormalInverseGamma` (old assertions encoded the bug — a ~`[-2, 28]` interval for a mean of ~12), add `TestNormalInverseGammaHeavyTailed` (log-normal revenue) to confirm the posterior concentrates on the mean, keeps strictly-positive credible bounds, and decisively ranks variations, and seed local RNG sources (`rand.NewPCG`) so the data-driven tests are deterministic and parallel-safe.
- `test/e2e/eventcounter/eventcounter_test.go`: update value-metric golden values to match the corrected posterior (`GoalValueSumPerUserProbBest` A `0.32 → 0.36`, B `0.67 → 0.64`; `GoalValueSumPerUserProbBeatBaseline` B `0.67 → 0.64`). Shared by `TestExperimentResult` and `TestGrpcExperimentResult`.

## Impact

- Value-metric results change for **all** experiments (historical and live): credible intervals now tighten correctly, and `ProbBeatBaseline` / `ProbBest` for value metrics will shift, becoming decisive where they previously weren't. Recomputed results for in-flight value experiments should be expected to change.
- **MySQL-backed deployments** see an additional small shift in value-metric results from the `VAR_POP → VAR_SAMP` change (factor `(n-1)/n`) — negligible at scale, larger only for very small sample sizes.
- Conversion-rate metrics are unchanged.

## Testing

- `go test ./pkg/experimentcalculator/experimentcalc/ -run TestNormalInverseGamma -count=10` — passes, stable across runs (now deterministic via seeded RNG).
- New heavy-tailed (log-normal) test passes 10/10.
- e2e `TestExperimentResult` / `TestGrpcExperimentResult` golden values updated to the corrected posterior output.
- The unrelated `TestExperimentCalculatorBinomialModelSample` requires an external Stan server (`localhost:8080`) and is not affected by this change.

## Follow-up (not in this PR)

- The model still assumes per-user values are roughly Normal. For heavy-tailed revenue this can be overconfident. A separate enhancement (winsorization/outlier capping or a log-normal model) is recommended for robustness. This is an existing modeling limitation, not introduced by this change.
- The value-metric priors are still hardcoded constants. Replacing them with data-driven (empirical-Bayes) or configurable priors would remove scale assumptions for small-sample value metrics — recommended as a separate change with stats-owner input.