### PR TITLE
test: fix e2e test feature variation id

### DIFF
--- a/test/e2e/feature/feature_test.go
+++ b/test/e2e/feature/feature_test.go
@@ -249,8 +249,9 @@ func TestEnableFeature(t *testing.T) {
 		aoCLient,
 		req.Id,
 		&aoproto.ProgressiveRolloutManualScheduleClause{
-			Schedules:   schedules,
-			VariationId: f.Variations[0].Id,
+			Schedules:          schedules,
+			ControlVariationId: f.Variations[0].Id,
+			TargetVariationId:  f.Variations[1].Id,
 		},
 		nil,
 	)
@@ -683,7 +684,8 @@ func TestListFeaturesFilterAutoOps(t *testing.T) {
 					ExecuteAt: time.Now().Add(10 * time.Minute).Unix(),
 				},
 			},
-			VariationId: progressiveRolloutFeature.Variations[0].Id,
+			ControlVariationId: progressiveRolloutFeature.Variations[0].Id,
+			TargetVariationId:  progressiveRolloutFeature.Variations[1].Id,
 		},
 		nil,
 	)


### PR DESCRIPTION
## Problem

PR #2199 added support for 3+ variations in progressive rollout, which introduced required `control_variation_id` and `target_variation_id` fields. The old `variation_id` field alone is no longer accepted, so two E2E tests started failing:

- `TestEnableFeature`
- `TestListFeaturesFilterAutoOps`

```
rpc error: code = InvalidArgument desc = autoops:control variation id must be specified for a progressive rollout
```

## Fix

Updated the two failing tests to use the new `ControlVariationId` + `TargetVariationId` fields instead of the old deprecated `VariationId` field when creating a `ProgressiveRolloutManualScheduleClause`.