### PR TITLE
fix(ui): correct split-equally weights and show variation allocation bar

### DIFF
--- a/ui/dashboard/src/pages/feature-flag-details/targeting/form-schema.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/form-schema.ts
@@ -84,7 +84,8 @@ const strategySchema = yup.object().shape({
           .reduce((total, current) => {
             return total + (current || 0);
           }, 0);
-        if (total !== 100)
+        // Round before comparing to absorb floating-point summation drift
+        if (Math.round(total * 100) / 100 !== 100)
           return this.createError({
             message: translation('message:validation.should-be-percent'),
             path: `${this.path}.variations`
@@ -165,7 +166,8 @@ export const defaultRuleSchema = yup.object().shape({
           .reduce((total, current) => {
             return total + (current || 0);
           }, 0);
-        if (total !== 100)
+        // Round before comparing to absorb floating-point summation drift
+        if (Math.round(total * 100) / 100 !== 100)
           return this.createError({
             message: translation('message:validation.should-be-percent'),
             path: `${this.path}.variations`

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/strategy.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/strategy.tsx
@@ -56,6 +56,12 @@ const Strategy = ({
   const experimentPercentage = rolloutStrategy?.audience?.percentage || 0;
   const variations = (rolloutStrategy?.variations as StrategyVariation) || [];
 
+  const weightedVariationCount = variations.filter(
+    item => Number(item.weight) > 0
+  ).length;
+  const showPercentageBar =
+    weightedVariationCount > 0 || percentageValueCount > 0;
+
   const [isCustomExperiment, setIsCustomExperiment] = useState(false);
   const [splitOptionType, setSplitOptionType] = useState<SplitOptionType>();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -67,7 +73,8 @@ const Strategy = ({
         return acc + (current || 0);
       }, 0);
 
-    if (total !== 100) {
+    // Round to 2 decimals before comparing so floating-point summation drift
+    if (Math.round((total || 0) * 100) / 100 !== 100) {
       return setError(`${rootName}.${strategyName}.variations`, {
         message: t('message:validation.should-be-percent')
       });
@@ -144,7 +151,8 @@ const Strategy = ({
 
       const equallyVariations = variations.map((item, index) => ({
         ...item,
-        weight: index < remainder ? base + 0.01 : base
+        // Round to 2 decimals to avoid floating-point drift
+        weight: Math.round((index < remainder ? base + 0.01 : base) * 100) / 100
       }));
 
       setValue(`${rootName}.${strategyName}.variations`, equallyVariations, {
@@ -419,15 +427,15 @@ const Strategy = ({
                 <Form.Item className="flex flex-col w-full gap-y-2">
                   <Form.Control>
                     <div>
-                      {percentageValueCount > 0 && (
+                      {showPercentageBar && (
                         <div className="flex items-center w-full p-0.5 border border-gray-400 rounded-full">
-                          {rolloutStrategy?.variations?.map(
+                          {(field.value as RuleStrategyVariation[])?.map(
                             (item: RuleStrategyVariation, index: number) => (
                               <PercentageBar
                                 key={index}
                                 weight={item.weight}
                                 currentIndex={index}
-                                isRoundedFull={percentageValueCount === 1}
+                                isRoundedFull={weightedVariationCount === 1}
                               />
                             )
                           )}
@@ -451,14 +459,14 @@ const Strategy = ({
                               name={`${rootName}.${strategyName}.variations.${index}.weight`}
                               variationId={rollout.variation}
                               handleChangeRolloutWeight={value => {
-                                field.value[index] = {
-                                  ...field.value[index],
-                                  weight: +value
-                                };
-                                field.onChange(field.value, {
+                                const updated = field.value.map(
+                                  (v: RuleStrategyVariation, i: number) =>
+                                    i === index ? { ...v, weight: +value } : v
+                                );
+                                field.onChange(updated, {
                                   shouldValidate: true
                                 });
-                                handleCheckError(field.value);
+                                handleCheckError(updated);
                               }}
                             />
                           )

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
@@ -480,7 +480,8 @@ export const isEquallyVariations = (
   const remainder = Math.round((100 - base * count) * 100);
 
   return variations.every((item, index) => {
-    const expected = index < remainder ? base + 0.01 : base;
+    const expected =
+      Math.round((index < remainder ? base + 0.01 : base) * 100) / 100;
     return Math.abs(item.weight - expected) < 0.0001;
   });
 };


### PR DESCRIPTION
## Fix "Split equally" weights & show variation allocation bar

**Problems**
1. "Split equally between all variations" produced weights with floating-point drift so they didn't sum to 100 and triggered a false *"should be 100%"* error.
2. The variation allocation bar never showed, because its visibility relied on a stale memo (weight edits mutated the form array in place).

**Changes**
- Round split weights to 2 decimals and tolerate summation drift in all total checks (`handleCheckError` + both Yup validators + `isEquallyVariations`).
- Derive the bar's count locally and render from the live field value so it stays in sync.
- Build a new array on weight edits so the bar re-renders per keystroke.