### PR TITLE
feat(ui): visualize targeting evaluation order with a vertical flow

### DIFF
--- a/ui/dashboard/src/pages/feature-flag-details/targeting/add-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/add-rule/index.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { hasEditable, useAuth } from 'auth';
 import { useTranslation } from 'i18n';
+import { cn } from 'utils/style';
 import {
   IconPlus,
   IconPrerequisite,
@@ -97,11 +98,18 @@ const AddRule = ({
               align="center"
               hidden={editable}
               trigger={
-                <span className="flex size-5 items-center justify-center rounded-full bg-white border border-dashed border-gray-400 ring-4 ring-white hover:border-primary-500 hover:text-primary-500 transition-colors cursor-pointer">
+                <span
+                  className={cn(
+                    'flex size-5 items-center justify-center rounded-full bg-white border border-dashed ring-4 ring-white transition-colors',
+                    editable
+                      ? 'border-gray-400 text-gray-500 cursor-pointer hover:border-primary-500 hover:text-primary-500'
+                      : 'border-gray-300 text-gray-400 cursor-not-allowed opacity-60'
+                  )}
+                >
                   <span className="sr-only">
                     {t('table:feature-flags.add-rule')}
                   </span>
-                  <Icon icon={IconPlus} size="xxs" color="gray-500" />
+                  <Icon icon={IconPlus} size="xxs" />
                 </span>
               }
             />

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/add-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/add-rule/index.tsx
@@ -64,28 +64,69 @@ const AddRule = ({
     return onAddRule(value);
   };
 
+  const sharedDropdownProps = {
+    isTooltip: true,
+    options,
+    disabled: !editable,
+    showArrow: false,
+    onChange: (value: string | number) =>
+      getRuleCategoryCall(value as RuleCategory)
+  };
+
   return (
-    <Dropdown
-      trigger={
-        <DisabledButtonTooltip
-          align="center"
-          hidden={editable}
+    <>
+      {/* Spine plus — its own dropdown so the menu opens *below the plus
+          circle*, not below the centred "+ Add Rule" button. Absolutely
+          positioned to align with the EvaluationFlow spine. */}
+      <div
+        className="absolute top-1/2 -translate-y-1/2 z-10"
+        style={{ left: '-52px' }}
+      >
+        <Dropdown
+          {...sharedDropdownProps}
+          isTruncate={false}
+          alignContent="start"
+          wrapTriggerStyle="!w-fit"
+          // `[&>div]:overflow-visible` lets the spine plus's `ring-4 ring-white`
+          // halo (which masks the spine line behind it) extend beyond the
+          // dropdown trigger's default overflow-hidden.
+          className="!w-fit !p-0 !border-0 !shadow-none !bg-transparent [&>div]:overflow-visible"
           trigger={
-            <div className="flex items-center gap-x-2 h-6 p-0 typo-para-medium !text-primary-500">
-              <Icon icon={IconPlus} size={'md'} />
-              {t('table:feature-flags.add-rule')}
-            </div>
+            <DisabledButtonTooltip
+              align="center"
+              hidden={editable}
+              trigger={
+                <span
+                  aria-label={t('table:feature-flags.add-rule')}
+                  className="flex size-5 items-center justify-center rounded-full bg-white border border-dashed border-gray-400 ring-4 ring-white hover:border-primary-500 hover:text-primary-500 transition-colors cursor-pointer"
+                >
+                  <Icon icon={IconPlus} size="xxs" color="gray-500" />
+                </span>
+              }
+            />
           }
         />
-      }
-      isTooltip={true}
-      options={options}
-      disabled={!editable}
-      showArrow={false}
-      onChange={value => getRuleCategoryCall(value as RuleCategory)}
-      alignContent="center"
-      className="w-full [&>div]:flex-center border-dashed !shadow-none"
-    />
+      </div>
+
+      {/* Visible "+ Add Rule" dashed button. */}
+      <Dropdown
+        {...sharedDropdownProps}
+        alignContent="center"
+        className="w-full [&>div]:flex-center border-dashed !shadow-none"
+        trigger={
+          <DisabledButtonTooltip
+            align="center"
+            hidden={editable}
+            trigger={
+              <div className="flex items-center gap-x-2 h-6 p-0 typo-para-medium !text-primary-500">
+                <Icon icon={IconPlus} size={'md'} />
+                {t('table:feature-flags.add-rule')}
+              </div>
+            }
+          />
+        }
+      />
+    </>
   );
 };
 

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/add-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/add-rule/index.tsx
@@ -7,9 +7,10 @@ import {
   IconSetting,
   IconUserOutlined
 } from '@icons';
-import Dropdown from 'components/dropdown';
+import Dropdown, { DropdownValue } from 'components/dropdown';
 import Icon from 'components/icon';
 import DisabledButtonTooltip from 'elements/disabled-button-tooltip';
+import { ADD_NODE_LEFT_OFFSET_PX } from '../evaluation-flow';
 import { RuleCategory } from '../types';
 
 const AddRule = ({
@@ -69,7 +70,7 @@ const AddRule = ({
     options,
     disabled: !editable,
     showArrow: false,
-    onChange: (value: string | number) =>
+    onChange: (value: DropdownValue | DropdownValue[]) =>
       getRuleCategoryCall(value as RuleCategory)
   };
 
@@ -80,7 +81,7 @@ const AddRule = ({
           positioned to align with the EvaluationFlow spine. */}
       <div
         className="absolute top-1/2 -translate-y-1/2 z-10"
-        style={{ left: '-52px' }}
+        style={{ left: `${ADD_NODE_LEFT_OFFSET_PX}px` }}
       >
         <Dropdown
           {...sharedDropdownProps}
@@ -96,10 +97,10 @@ const AddRule = ({
               align="center"
               hidden={editable}
               trigger={
-                <span
-                  aria-label={t('table:feature-flags.add-rule')}
-                  className="flex size-5 items-center justify-center rounded-full bg-white border border-dashed border-gray-400 ring-4 ring-white hover:border-primary-500 hover:text-primary-500 transition-colors cursor-pointer"
-                >
+                <span className="flex size-5 items-center justify-center rounded-full bg-white border border-dashed border-gray-400 ring-4 ring-white hover:border-primary-500 hover:text-primary-500 transition-colors cursor-pointer">
+                  <span className="sr-only">
+                    {t('table:feature-flags.add-rule')}
+                  </span>
                   <Icon icon={IconPlus} size="xxs" color="gray-500" />
                 </span>
               }

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/audience-traffic/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/audience-traffic/index.tsx
@@ -1,13 +1,14 @@
 import { useTranslation } from 'i18n';
-import { IconInfo, IconMember } from '@icons';
+import { IconInfo } from '@icons';
 import Icon from 'components/icon';
 import { Tooltip } from 'components/tooltip';
 
 const AudienceTraffic = () => {
   const { t } = useTranslation(['form']);
   return (
-    <div className="flex-center w-full gap-x-2">
-      <Icon icon={IconMember} size="sm" color="gray-500" />
+    // Left-aligned to match the visual rhythm of the cards below: the title
+    // sits flush with the card column, anchored to the start node on the spine.
+    <div className="flex items-center w-full gap-x-2">
       <p className="typo-para-medium text-gray-700">
         {t('targeting.all-audience-traffic')}
       </p>

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
@@ -1,0 +1,233 @@
+import { ReactNode } from 'react';
+import { cn } from 'utils/style';
+import {
+  IconFlagSwitch,
+  IconMember,
+  IconPrerequisite,
+  IconSetting,
+  IconUserOutlined
+} from '@icons';
+import Icon from 'components/icon';
+
+/**
+ * Static labels for the evaluation flow captions. Intentionally not localised
+ * — these read as semantic markers (`IF` / `ELSE IF` / `OTHERWISE`) and stay
+ * the same across UI languages.
+ */
+export const FLOW_LABELS = {
+  required: 'Required',
+  if: 'If',
+  elseIf: 'Else if',
+  otherwise: 'Otherwise'
+} as const;
+
+export type FlowKind =
+  | 'start'
+  | 'gate'
+  | 'gate-off'
+  | 'prerequisite'
+  | 'individual'
+  | 'rule'
+  | 'add'
+  | 'default';
+
+/**
+ * Outer container for the targeting evaluation flow.
+ * Draws a continuous vertical "spine" on the left edge of the content column
+ * so that every step (audience traffic, flag switch, prerequisites, rules,
+ * default rule) reads as a single top-to-bottom evaluation pipeline.
+ *
+ * Each direct child should be a `<FlowStep>` so its node aligns with the spine.
+ */
+export const EvaluationFlow = ({
+  children,
+  muted = false,
+  className
+}: {
+  children: ReactNode;
+  /** When true (e.g. flag is OFF), render the spine in a muted tone. */
+  muted?: boolean;
+  className?: string;
+}) => {
+  return (
+    // Spine sits in the gutter to the left of the cards. Cards keep their
+    // original horizontal position; only the spine moves inward, so 28px-wide
+    // nodes have their left edge flush with the Targeting tab underline.
+    <div
+      className={cn(
+        'relative w-full pl-14',
+        'flex flex-col items-stretch gap-y-8',
+        className
+      )}
+    >
+      <div
+        aria-hidden
+        className={cn(
+          'absolute top-3 bottom-3 w-px pointer-events-none rounded-full',
+          muted ? 'bg-gray-200' : 'bg-gray-300'
+        )}
+        style={{ left: '14px' }}
+      />
+      {children}
+    </div>
+  );
+};
+
+interface FlowStepProps {
+  kind: FlowKind;
+  /** Caption shown between the node and the content (e.g. IF / ELSE IF / OTHERWISE). */
+  stepLabel?: string;
+  /**
+   * Where to anchor the node vertically inside the step. 'top' aligns with the
+   * card header (default for cards), 'center' for thin one-line rows.
+   */
+  align?: 'top' | 'center';
+  /** Visual tone for the node and label. Default flows from kind. */
+  tone?: 'default' | 'muted' | 'accent';
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * A single step in the evaluation flow. Wraps content in a relative container
+ * and renders a `<FlowNode>` that anchors visually on the spine.
+ */
+export const FlowStep = ({
+  kind,
+  stepLabel,
+  align = 'top',
+  tone,
+  children,
+  className
+}: FlowStepProps) => {
+  const resolvedTone =
+    tone ?? (kind === 'add' || kind === 'default' ? 'muted' : 'default');
+
+  return (
+    <div className={cn('relative w-full', className)}>
+      <FlowNode kind={kind} align={align} tone={resolvedTone} />
+      {stepLabel && (
+        <span
+          aria-hidden
+          className={cn(
+            'absolute z-10 uppercase tracking-wide typo-head-bold-tiny',
+            'px-1.5 py-0.5 rounded select-none whitespace-nowrap',
+            // Caption floats fully in the gap above each card so it reads as a
+            // label *for* the card rather than overlapping its top border.
+            align === 'center'
+              ? 'top-1/2 -translate-y-1/2 left-0'
+              : '-top-5 left-0',
+            resolvedTone === 'muted'
+              ? 'bg-gray-100 text-gray-500'
+              : 'bg-primary-50 text-primary-500'
+          )}
+        >
+          {stepLabel}
+        </span>
+      )}
+      {children}
+    </div>
+  );
+};
+
+interface FlowNodeProps {
+  kind: FlowKind;
+  align: 'top' | 'center';
+  tone: 'default' | 'muted' | 'accent';
+}
+
+const FlowNode = ({ kind, align, tone }: FlowNodeProps) => {
+  const baseClasses =
+    'absolute z-10 flex items-center justify-center rounded-full ring-4 ring-white';
+
+  const alignClasses =
+    align === 'center' ? 'top-1/2 -translate-y-1/2' : 'top-4';
+
+  const toneClasses =
+    tone === 'muted'
+      ? 'bg-white border border-gray-300 text-gray-500'
+      : tone === 'accent'
+        ? 'bg-primary-500 text-white'
+        : 'bg-white border border-primary-300 text-primary-500';
+
+  let content: ReactNode = null;
+  let sizeClass = 'size-7';
+  let extraClass = '';
+
+  switch (kind) {
+    case 'start':
+      sizeClass = 'size-7';
+      extraClass = 'bg-primary-500 text-white border-0';
+      content = (
+        <Icon icon={IconMember} size="xxs" className="!text-white" />
+      );
+      break;
+    case 'gate':
+      sizeClass = 'size-7';
+      extraClass = 'bg-primary-50 border-primary-300';
+      content = <Icon icon={IconFlagSwitch} size="xxs" color="primary-500" />;
+      break;
+    case 'gate-off':
+      sizeClass = 'size-7';
+      extraClass = 'bg-gray-100 border-gray-400 text-gray-500';
+      content = <Icon icon={IconFlagSwitch} size="xxs" color="gray-500" />;
+      break;
+    case 'prerequisite':
+      sizeClass = 'size-7';
+      content = <Icon icon={IconPrerequisite} size="xxs" color="primary-500" />;
+      break;
+    case 'individual':
+      sizeClass = 'size-7';
+      content = <Icon icon={IconUserOutlined} size="xxs" color="primary-500" />;
+      break;
+    case 'rule':
+      sizeClass = 'size-7';
+      // Matches the icon used for "Custom Rule" in the AddRule dropdown.
+      content = <Icon icon={IconSetting} size="xxs" color="primary-500" />;
+      break;
+    case 'add':
+      // The spine plus is rendered inside <AddRule>'s dropdown trigger so the
+      // entire plus circle is clickable (same affordance as "+ Add Rule").
+      // FlowStep with kind="add" therefore emits no spine node of its own.
+      return null;
+    case 'default':
+      sizeClass = 'size-7';
+      extraClass = 'border-2';
+      content = (
+        <span className="size-2 rounded-full bg-gray-400" aria-hidden />
+      );
+      break;
+  }
+
+  // Spine is at x=14px from EvaluationFlow's left edge. FlowStep starts at
+  // x=56px (pl-14), so to center a 28px-wide node on the spine its left edge
+  // sits at -56px relative to FlowStep (14 - 14 - 56 = -56). The smaller add
+  // node (20px) uses -52px to stay centered (14 - 10 - 56 = -52).
+  const nodeOffsetByKind: Record<FlowKind, number> = {
+    start: -56,
+    gate: -56,
+    'gate-off': -56,
+    prerequisite: -56,
+    individual: -56,
+    rule: -56,
+    default: -56,
+    add: -52
+  };
+
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        baseClasses,
+        sizeClass,
+        toneClasses,
+        alignClasses,
+        extraClass
+      )}
+      style={{ left: `${nodeOffsetByKind[kind]}px` }}
+    >
+      {content}
+    </span>
+  );
+};
+

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
@@ -21,6 +21,17 @@ export const FLOW_LABELS = {
   otherwise: 'Otherwise'
 } as const;
 
+/**
+ * Horizontal offset (in px) for nodes/markers placed on the EvaluationFlow
+ * spine but rendered outside `<FlowNode>` (e.g. the clickable plus inside
+ * `<AddRule>`). Kept here so the value stays in lock-step with the spine x
+ * position (14 px from the wrapper's left) and the FlowStep gutter (pl-14 →
+ * 56 px). Reused via import to avoid magic numbers in callers.
+ *
+ * Math: spine_x − node_radius − pl_left = 14 − 10 − 56 = −52
+ */
+export const ADD_NODE_LEFT_OFFSET_PX = -52;
+
 export type FlowKind =
   | 'start'
   | 'gate'
@@ -37,7 +48,9 @@ export type FlowKind =
  * so that every step (audience traffic, flag switch, prerequisites, rules,
  * default rule) reads as a single top-to-bottom evaluation pipeline.
  *
- * Each direct child should be a `<FlowStep>` so its node aligns with the spine.
+ * Steps should be wrapped in `<FlowStep>` (directly or nested inside another
+ * component such as `<TargetSegmentRule>`) so their nodes align with the
+ * spine. Non-FlowStep children render in the column without a spine node.
  */
 export const EvaluationFlow = ({
   children,
@@ -200,7 +213,7 @@ const FlowNode = ({ kind, align, tone }: FlowNodeProps) => {
   // Spine is at x=14px from EvaluationFlow's left edge. FlowStep starts at
   // x=56px (pl-14), so to center a 28px-wide node on the spine its left edge
   // sits at -56px relative to FlowStep (14 - 14 - 56 = -56). The smaller add
-  // node (20px) uses -52px to stay centered (14 - 10 - 56 = -52).
+  // node uses ADD_NODE_LEFT_OFFSET_PX (also exported for reuse in <AddRule>).
   const nodeOffsetByKind: Record<FlowKind, number> = {
     start: -56,
     gate: -56,
@@ -209,7 +222,7 @@ const FlowNode = ({ kind, align, tone }: FlowNodeProps) => {
     individual: -56,
     rule: -56,
     default: -56,
-    add: -52
+    add: ADD_NODE_LEFT_OFFSET_PX
   };
 
   return (

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
@@ -212,17 +212,17 @@ const FlowNode = ({ kind, align, tone }: FlowNodeProps) => {
 
   // Spine is at x=14px from EvaluationFlow's left edge. FlowStep starts at
   // x=56px (pl-14), so to center a 28px-wide node on the spine its left edge
-  // sits at -56px relative to FlowStep (14 - 14 - 56 = -56). The smaller add
-  // node uses ADD_NODE_LEFT_OFFSET_PX (also exported for reuse in <AddRule>).
-  const nodeOffsetByKind: Record<FlowKind, number> = {
+  // sits at -56px relative to FlowStep (14 - 14 - 56 = -56). The 'add' kind
+  // returns early above (its plus is rendered inside <AddRule>), so it is
+  // intentionally excluded from this map.
+  const nodeOffsetByKind: Record<Exclude<FlowKind, 'add'>, number> = {
     start: -56,
     gate: -56,
     'gate-off': -56,
     prerequisite: -56,
     individual: -56,
     rule: -56,
-    default: -56,
-    add: ADD_NODE_LEFT_OFFSET_PX
+    default: -56
   };
 
   return (

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
@@ -121,7 +121,6 @@ export const FlowStep = ({
       <FlowNode kind={kind} align={align} tone={resolvedTone} />
       {stepLabel && (
         <span
-          aria-hidden
           className={cn(
             'absolute z-10 uppercase tracking-wide typo-head-bold-tiny',
             'px-1.5 py-0.5 rounded select-none whitespace-nowrap',

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/evaluation-flow/index.tsx
@@ -158,9 +158,7 @@ const FlowNode = ({ kind, align, tone }: FlowNodeProps) => {
     case 'start':
       sizeClass = 'size-7';
       extraClass = 'bg-primary-500 text-white border-0';
-      content = (
-        <Icon icon={IconMember} size="xxs" className="!text-white" />
-      );
+      content = <Icon icon={IconMember} size="xxs" className="!text-white" />;
       break;
     case 'gate':
       sizeClass = 'size-7';
@@ -230,4 +228,3 @@ const FlowNode = ({ kind, align, tone }: FlowNodeProps) => {
     </span>
   );
 };
-

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
@@ -814,10 +814,7 @@ const TargetingPage = ({
             <FlowStep kind="start" align="center">
               <AudienceTraffic />
             </FlowStep>
-            <FlowStep
-              kind={enabledWatch ? 'gate' : 'gate-off'}
-              align="center"
-            >
+            <FlowStep kind={enabledWatch ? 'gate' : 'gate-off'} align="center">
               <FlagSwitch
                 feature={feature}
                 setIsShowRules={setIsShowRules}

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/index.tsx
@@ -47,6 +47,7 @@ import { initialPrerequisite } from './constants';
 import CreateDebuggerForm from './debugger/create-form';
 import TargetingDebuggerResults from './debugger/results';
 import DefaultRule from './default-rule';
+import { EvaluationFlow, FLOW_LABELS, FlowStep } from './evaluation-flow';
 import FlagOffDescription from './flag-off-description';
 import FlagSwitch from './flag-switch';
 import { formSchema, TargetingSchema } from './form-schema';
@@ -82,20 +83,6 @@ import {
   normalizeSegmentRules,
   reorderWithReset
 } from './utils';
-
-export const TargetingDivider = () => (
-  <div className="flex-center py-3 text-gray-400" aria-hidden="true">
-    <svg width="12" height="24" viewBox="0 0 12 24" fill="none">
-      <path
-        d="M6 1v18M2 15l4 4 4-4"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  </div>
-);
 
 const TargetingPage = ({
   feature,
@@ -805,7 +792,7 @@ const TargetingPage = ({
       <FormProvider {...form}>
         <Form
           onSubmit={form.handleSubmit(values => onSubmit(values))}
-          className="flex flex-col w-full items-center"
+          className="flex flex-col w-full"
         >
           {(SCHEDULED_FLAG_CHANGES_ENABLED ||
             hasPrerequisiteFlags?.length > 0) && (
@@ -823,111 +810,140 @@ const TargetingPage = ({
               )}
             </div>
           )}
-          <AudienceTraffic />
-          <TargetingDivider />
-          <FlagSwitch
-            feature={feature}
-            setIsShowRules={setIsShowRules}
-            editable={editable}
-          />
+          <EvaluationFlow muted={!enabledWatch}>
+            <FlowStep kind="start" align="center">
+              <AudienceTraffic />
+            </FlowStep>
+            <FlowStep
+              kind={enabledWatch ? 'gate' : 'gate-off'}
+              align="center"
+            >
+              <FlagSwitch
+                feature={feature}
+                setIsShowRules={setIsShowRules}
+                editable={editable}
+              />
+            </FlowStep>
+            {isShowRules && (
+              <>
+                {prerequisites?.length > 0 && (
+                  <FlowStep
+                    kind="prerequisite"
+                    stepLabel={FLOW_LABELS.required}
+                    tone="muted"
+                  >
+                    <PrerequisiteRule
+                      currentEnvironment={currentEnvironment}
+                      isDisableAddPrerequisite={isDisableAddPrerequisite}
+                      features={activeFeatures}
+                      feature={feature}
+                      prerequisites={prerequisites}
+                      onRemovePrerequisite={prerequisiteRemove}
+                      handleDiscardChanges={handleDiscardChanges}
+                      handleCheckEdit={checkEditRule}
+                      onAddPrerequisite={() =>
+                        onAddRule(RuleCategory.PREREQUISITE)
+                      }
+                    />
+                  </FlowStep>
+                )}
+                {(!prerequisitesWatch?.length || !individualRules?.length) && (
+                  <FlowStep kind="add" align="center">
+                    <AddRule
+                      isDisableAddPrerequisite={prerequisitesWatch?.length > 0}
+                      isDisableAddIndividualRules={individualRules?.length > 0}
+                      isInsertSegmentRule={true}
+                      indexInsertSegmentRule={0}
+                      onAddRule={onAddRule}
+                    />
+                  </FlowStep>
+                )}
+                {individualRules?.length > 0 && (
+                  <>
+                    <FlowStep kind="individual" stepLabel={FLOW_LABELS.if}>
+                      <IndividualRule
+                        individualRules={individualRules}
+                        handleDiscardChanges={handleDiscardChanges}
+                        handleCheckEdit={checkEditRule}
+                      />
+                    </FlowStep>
+                    <FlowStep kind="add" align="center">
+                      <AddRule
+                        isDisableAddPrerequisite={
+                          prerequisitesWatch?.length > 0
+                        }
+                        isDisableAddIndividualRules={
+                          individualRules?.length > 0
+                        }
+                        isInsertSegmentRule={true}
+                        indexInsertSegmentRule={0}
+                        onAddRule={onAddRule}
+                      />
+                    </FlowStep>
+                  </>
+                )}
+                {segmentRules.length > 0 && (
+                  <>
+                    <TargetSegmentRule
+                      feature={feature}
+                      features={activeFeatures}
+                      segmentRules={segmentRules}
+                      isDisableAddPrerequisite={prerequisitesWatch?.length > 0}
+                      isDisableAddIndividualRules={individualRules?.length > 0}
+                      onAddRule={onAddRule}
+                      segmentRulesRemove={handleSegmentRuleRemove}
+                      segmentRulesSwap={handleSwapSegmentRule}
+                      segmentRulesMove={handleMoveSegmentRule}
+                      handleDiscardChanges={handleDiscardChanges}
+                      handleCheckEdit={checkEditRule}
+                      hasIndividualRules={individualRules?.length > 0}
+                    />
+                    <FlowStep kind="add" align="center">
+                      <AddRule
+                        isDisableAddPrerequisite={
+                          prerequisitesWatch?.length > 0
+                        }
+                        isDisableAddIndividualRules={
+                          individualRules?.length > 0
+                        }
+                        isInsertSegmentRule={true}
+                        indexInsertSegmentRule={segmentRulesWatch.length + 1}
+                        onAddRule={onAddRule}
+                      />
+                    </FlowStep>
+                  </>
+                )}
+              </>
+            )}
+            {isShowRules && (
+              <FlowStep
+                kind="default"
+                stepLabel={FLOW_LABELS.otherwise}
+                tone="muted"
+              >
+                <DefaultRule
+                  editable={editable}
+                  urlCode={currentEnvironment.urlCode}
+                  feature={feature}
+                  waitingRunningRollouts={waitingRunningRollouts}
+                  handleDiscardChanges={handleDiscardChanges}
+                  handleCheckEdit={checkEditRule}
+                />
+              </FlowStep>
+            )}
+          </EvaluationFlow>
           {!enabledWatch && (
             <FlagOffDescription
               isShowRules={isShowRules}
               setIsShowRules={setIsShowRules}
             />
           )}
-          {isShowRules && (
-            <>
-              {prerequisites?.length > 0 && (
-                <>
-                  <TargetingDivider />
-                  <PrerequisiteRule
-                    currentEnvironment={currentEnvironment}
-                    isDisableAddPrerequisite={isDisableAddPrerequisite}
-                    features={activeFeatures}
-                    feature={feature}
-                    prerequisites={prerequisites}
-                    onRemovePrerequisite={prerequisiteRemove}
-                    handleDiscardChanges={handleDiscardChanges}
-                    handleCheckEdit={checkEditRule}
-                    onAddPrerequisite={() =>
-                      onAddRule(RuleCategory.PREREQUISITE)
-                    }
-                  />
-                </>
-              )}
-              {(!prerequisitesWatch?.length || !individualRules?.length) && (
-                <>
-                  <TargetingDivider />
-                  <AddRule
-                    isDisableAddPrerequisite={prerequisitesWatch?.length > 0}
-                    isDisableAddIndividualRules={individualRules?.length > 0}
-                    isInsertSegmentRule={true}
-                    indexInsertSegmentRule={0}
-                    onAddRule={onAddRule}
-                  />
-                </>
-              )}
-              {individualRules?.length > 0 && (
-                <>
-                  <TargetingDivider />
-                  <IndividualRule
-                    individualRules={individualRules}
-                    handleDiscardChanges={handleDiscardChanges}
-                    handleCheckEdit={checkEditRule}
-                  />
-                  <TargetingDivider />
-                  <AddRule
-                    isDisableAddPrerequisite={prerequisitesWatch?.length > 0}
-                    isDisableAddIndividualRules={individualRules?.length > 0}
-                    isInsertSegmentRule={true}
-                    indexInsertSegmentRule={0}
-                    onAddRule={onAddRule}
-                  />
-                </>
-              )}
-              {segmentRules.length > 0 && (
-                <>
-                  <TargetingDivider />
-                  <TargetSegmentRule
-                    feature={feature}
-                    features={activeFeatures}
-                    segmentRules={segmentRules}
-                    isDisableAddPrerequisite={prerequisitesWatch?.length > 0}
-                    isDisableAddIndividualRules={individualRules?.length > 0}
-                    onAddRule={onAddRule}
-                    segmentRulesRemove={handleSegmentRuleRemove}
-                    segmentRulesSwap={handleSwapSegmentRule}
-                    segmentRulesMove={handleMoveSegmentRule}
-                    handleDiscardChanges={handleDiscardChanges}
-                    handleCheckEdit={checkEditRule}
-                  />
-                  <TargetingDivider />
-                  <AddRule
-                    isDisableAddPrerequisite={prerequisitesWatch?.length > 0}
-                    isDisableAddIndividualRules={individualRules?.length > 0}
-                    isInsertSegmentRule={true}
-                    indexInsertSegmentRule={segmentRulesWatch.length + 1}
-                    onAddRule={onAddRule}
-                  />
-                </>
-              )}
-            </>
-          )}
-          {isShowRules && (
-            <>
-              <TargetingDivider />
-              <DefaultRule
-                editable={editable}
-                urlCode={currentEnvironment.urlCode}
-                feature={feature}
-                waitingRunningRollouts={waitingRunningRollouts}
-                handleDiscardChanges={handleDiscardChanges}
-                handleCheckEdit={checkEditRule}
-              />
-            </>
-          )}
           <ButtonBar
+            // The top divider line is only meaningful when the flag is OFF —
+            // it separates the off-variation notice from the action buttons.
+            // When the flag is ON, the spine already terminates at the default
+            // rule and no extra divider is needed.
+            className={enabledWatch ? 'border-t-0' : undefined}
             primaryButton={
               <Tooltip
                 side="top"

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import {
   DndContext,
@@ -21,8 +21,8 @@ import { useQueryUserSegments } from '@queries/user-segments';
 import { getCurrentEnvironment, useAuth } from 'auth';
 import { LIST_PAGE_SIZE } from 'constants/app';
 import { Feature } from '@types';
-import { TargetingDivider } from '..';
 import AddRule from '../add-rule';
+import { FLOW_LABELS, FlowStep } from '../evaluation-flow';
 import { RuleSchema, TargetingSchema } from '../form-schema';
 import { DiscardChangesType, RuleCategory } from '../types';
 import SortableCard, { DragOverlayCard } from './sortable-card';
@@ -37,6 +37,12 @@ interface Props {
   segmentRules: RuleSchemaFields[];
   isDisableAddIndividualRules: boolean;
   isDisableAddPrerequisite: boolean;
+  /**
+   * Whether an individual-targeting step precedes this section. When true, the
+   * first segment rule still uses "Else if" since the first match wins
+   * starting from individual targeting.
+   */
+  hasIndividualRules?: boolean;
   onAddRule: (rule: RuleCategory, index?: number) => void;
   segmentRulesRemove: (index: number) => void;
   segmentRulesSwap: (indexA: number, indexB: number) => void;
@@ -51,6 +57,7 @@ const TargetSegmentRule = ({
   segmentRules,
   isDisableAddIndividualRules,
   isDisableAddPrerequisite,
+  hasIndividualRules = false,
   onAddRule,
   segmentRulesRemove,
   segmentRulesSwap,
@@ -158,30 +165,39 @@ const TargetSegmentRule = ({
         items={sortableIds}
         strategy={verticalListSortingStrategy}
       >
-        <div className="flex flex-col w-full">
-          {segmentRules.map((segment, segmentIndex) => (
-            <div key={segment.segmentId} className="flex flex-col w-full">
-              {segmentIndex !== 0 && (
-                <>
-                  <TargetingDivider />
-                  <AddRule
-                    isDisableAddIndividualRules={isDisableAddIndividualRules}
-                    isDisableAddPrerequisite={isDisableAddPrerequisite}
-                    onAddRule={onAddRule}
-                    indexInsertSegmentRule={segmentIndex}
-                    isInsertSegmentRule={true}
+        <div className="flex flex-col w-full gap-y-8">
+          {segmentRules.map((segment, segmentIndex) => {
+            const isFirstMatchStep =
+              segmentIndex === 0 && !hasIndividualRules;
+            return (
+              <Fragment key={segment.segmentId}>
+                {segmentIndex !== 0 && (
+                  <FlowStep kind="add" align="center">
+                    <AddRule
+                      isDisableAddIndividualRules={isDisableAddIndividualRules}
+                      isDisableAddPrerequisite={isDisableAddPrerequisite}
+                      onAddRule={onAddRule}
+                      indexInsertSegmentRule={segmentIndex}
+                      isInsertSegmentRule={true}
+                    />
+                  </FlowStep>
+                )}
+                <FlowStep
+                  kind="rule"
+                  stepLabel={
+                    isFirstMatchStep ? FLOW_LABELS.if : FLOW_LABELS.elseIf
+                  }
+                >
+                  <SortableCard
+                    segment={segment}
+                    segmentIndex={segmentIndex}
+                    ghostHeight={activeDragHeight}
+                    {...sharedCardProps}
                   />
-                  <TargetingDivider />
-                </>
-              )}
-              <SortableCard
-                segment={segment}
-                segmentIndex={segmentIndex}
-                ghostHeight={activeDragHeight}
-                {...sharedCardProps}
-              />
-            </div>
-          ))}
+                </FlowStep>
+              </Fragment>
+            );
+          })}
         </div>
       </SortableContext>
       <DragOverlay>

--- a/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/index.tsx
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/segment-rule/index.tsx
@@ -167,8 +167,7 @@ const TargetSegmentRule = ({
       >
         <div className="flex flex-col w-full gap-y-8">
           {segmentRules.map((segment, segmentIndex) => {
-            const isFirstMatchStep =
-              segmentIndex === 0 && !hasIndividualRules;
+            const isFirstMatchStep = segmentIndex === 0 && !hasIndividualRules;
             return (
               <Fragment key={segment.segmentId}>
                 {segmentIndex !== 0 && (


### PR DESCRIPTION
## Summary

Replaces the small downward-arrow dividers between sections of the feature flag Targeting page with a continuous vertical "evaluation flow" — a thin spine on the left of the page with semantic step nodes (Start, Flag Switch, Prerequisites, Individual Targeting, Custom Rules, Default Rule) and `If` / `Else if` / `Otherwise` captions on each rule card.

The previous arrows did not communicate that targeting rules are evaluated top-to-bottom with first-match-wins semantics. The new flow makes the evaluation order visible at a glance and matches the spine's left edge to the Targeting tab underline so the column reads as one continuous pipeline.

## What changed

- New `targeting/evaluation-flow/` module exporting `EvaluationFlow`, `FlowStep`, `FlowNode`, and a `FLOW_LABELS` constant. Draws the spine, anchors a node per step, and renders the `If` / `Else if` / `Otherwise` / `Required` captions.
- `targeting/index.tsx` wraps each section (Audience Traffic, Flag Switch, Prerequisites, Individual Targeting, Custom Rules, Default Rule) in a `FlowStep` and removes the old `TargetingDivider` arrows.
- `targeting/segment-rule/index.tsx` emits a `FlowStep` per custom rule, plus a small dashed `+` insertion node between rules.
- `FlagOffDescription` is rendered outside the flow so the spine terminates cleanly at the flag-switch when the flag is OFF and rules are hidden. The spine de-saturates to a muted gray tone in that state.
- `+ Add Rule` now has a clickable plus circle on the spine itself; clicking it opens the same options dropdown as the dashed button, anchored below the plus circle (two independent Radix dropdowns sharing the same options so the menu always opens below whichever trigger was clicked).
- The audience-traffic row is left-aligned next to the start node, and the duplicated audience icon inside the row was removed (the spine node already carries it).
- The bottom button-bar's top divider line is hidden when the flag is ON; it only renders when the flag is OFF, where it acts as a separator above the off-variation notice.
- Flow caption labels are intentionally English-only since they're semantic markers (`If` / `Else if` / `Otherwise` / `Required`); no i18n keys were added.

## Sample

<img width="1227" height="1268" alt="Screenshot 2026-06-19 at 6 28 20 PM" src="https://github.com/user-attachments/assets/450a6ea8-31c7-4d9d-b5a9-34aee7659b32" />
