### PR TITLE
fix(calculator): derive normal-inverse-gamma priors from observed data (empirical bayes)

### DIFF
--- a/docs/mechanism/experiment-calculator-math.md
+++ b/docs/mechanism/experiment-calculator-math.md
@@ -388,6 +388,30 @@ After observing data with sample mean x̄ and sample variance s²:
 3. Sample mean: μ ~ Normal(μ_n, σ²/κ_n)
 ```
 
+### Prior Choice: Pooled Empirical Bayes
+
+Bucketeer cannot assume what scale a customer's value-metric lives on (sub-unit
+conversions, dollars, yen, seconds, …), so the NIG prior is derived from the
+observed data at calculation time rather than hardcoded:
+
+```
+μ₀ = pooled (sample-size-weighted) mean across variations
+κ₀ = 1                                          // 1 pseudo-observation
+α₀ = 1                                          // 1 pseudo-dof
+β₀ = pooled within-variation sample variance    // Σ(n_i − 1)·s_i² / Σ(n_i − 1)
+```
+
+Pooling across variations (rather than anchoring the prior at the baseline)
+keeps the prior symmetric — it does not silently pull treatment posteriors
+toward control. The pseudo-counts `κ₀ = α₀ = 1` give the prior ~50% weight at
+n=1, ~9% at n=10, and ~1% at n=99, so small samples are anchored at the data's
+natural scale while moderate and large samples converge to the data-driven
+posterior recovered by Fix #1.
+
+If every variation has n ≤ 1 (so the pooled within-variation variance is
+undefined), Bucketeer falls back to a weak generic prior
+(`μ₀=0, κ₀=α₀=β₀=1`) to avoid degenerate posteriors.
+
 ---
 
 ## 9. Credible Intervals

--- a/docs/mechanism/experiment-calculator-math.md
+++ b/docs/mechanism/experiment-calculator-math.md
@@ -408,9 +408,16 @@ n=1, ~9% at n=10, and ~1% at n=99, so small samples are anchored at the data's
 natural scale while moderate and large samples converge to the data-driven
 posterior recovered by Fix #1.
 
-If every variation has n ≤ 1 (so the pooled within-variation variance is
-undefined), Bucketeer falls back to a weak generic prior
-(`μ₀=0, κ₀=α₀=β₀=1`) to avoid degenerate posteriors.
+Fallback layers, applied when parts of the input are too degenerate to
+estimate from (the calculator never lets a NaN, Inf, or non-positive
+variance reach the NIG sampler):
+
+- If every variation has n ≤ 1 (so the pooled within-variation variance is
+  undefined), Bucketeer keeps `μ₀` at the pooled observed mean but falls
+  back to a weak generic variance prior (`κ₀=α₀=β₀=1`).
+- Only when no variation contributes a usable sample at all — `Σn_i = 0`,
+  or the pooled mean comes out non-finite — does it fall back to the full
+  generic prior `μ₀=0, κ₀=α₀=β₀=1`.
 
 ---
 

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
@@ -40,9 +40,10 @@ import (
 //     undefined or non-positive (e.g. every variation has n ≤ 1, or every
 //     within-variation sample variance is 0).
 //
-// All fallback values are deliberately weak (1 pseudo-observation, unit
-// variance) so the prior dies off as 1/(1+n) for the mean and even faster
-// for the variance.
+// All fallback values are deliberately weak (1 pseudo-observation for the
+// mean; an Inv-Gamma(1, 1) variance prior — undefined mean, mode 0.5 — i.e. a
+// scale-1, scale-only "weak/unit-scale" prior, not a fixed unit variance) so
+// the prior dies off as 1/(1+n) for the mean and even faster for the variance.
 const (
 	fallbackPriorMean  = 0.0
 	fallbackPriorKappa = 1.0
@@ -165,8 +166,10 @@ func calcPosterior(
 // Fallback layers (the function never returns NaN, Inf, or a non-positive
 // variance — downstream NIG sampling would blow up on any of those):
 //
-//   - per-variation: skip variations with n ≤ 0 or with non-finite mean /
-//     variance, so a single bad row cannot poison the pooled estimate;
+//   - per-variation: skip variations with n ≤ 0 or with non-finite mean
+//     entirely; for variance pooling, additionally skip variations with
+//     non-finite or negative variance (their mean still contributes), so a
+//     single bad row cannot poison the pooled estimate;
 //   - mean: if no variation contributes a usable sample (totalN == 0) or the
 //     pooled mean is non-finite, fall back to the full generic prior;
 //   - variance: if the pooled within-variation variance is undefined

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
@@ -29,11 +29,28 @@ import (
 	"github.com/bucketeer-io/bucketeer/v2/proto/eventcounter"
 )
 
+// Fallback priors used only when the observed inputs are too degenerate to
+// derive an empirical-Bayes prior from (e.g. every variation has n ≤ 1 so the
+// pooled within-variation variance is undefined). These are deliberately weak:
+// a single pseudo-observation centred at 0 with unit variance, dying off as
+// 1/(1+n) for the mean and even faster for the variance.
 const (
-	priorMean  = 30
-	priorKappa = 2
-	priorAlpha = 10
-	priorBeta  = 1000
+	fallbackPriorMean  = 0.0
+	fallbackPriorKappa = 1.0
+	fallbackPriorAlpha = 1.0
+	fallbackPriorBeta  = 1.0
+)
+
+// Pseudo-count weights for the empirical-Bayes prior. We use one pseudo
+// observation for the mean (kappa0) and a matched one-degree-of-freedom prior
+// for the variance (alpha0=1, beta0=pooled_var). With these weights the prior
+// influence is ~50% at n=1, ~17% at n=5, ~9% at n=10, and ~1% at n=99, so the
+// prior anchors small-sample estimates at the data's own scale without
+// distorting moderate or large samples — and recovers Fix #1's large-n
+// concentration behaviour exactly.
+const (
+	empiricalPriorKappa = 1.0
+	empiricalPriorAlpha = 1.0
 )
 
 type distr struct {
@@ -57,12 +74,17 @@ func normalInverseGamma(
 	variationNum := len(means)
 	variationResults := make(map[string]*eventcounter.VariationResult, variationNum)
 	sampleSeries := make([]series.Series, 0, variationNum)
+	// Derive the prior from the observed data (empirical Bayes) so the prior
+	// auto-adapts to whatever scale this metric lives on (sub-unit conversions,
+	// dollars, yen, seconds, …) instead of being anchored to an arbitrary
+	// hardcoded constant.
+	priorMu, priorKappa, priorAlpha, priorBeta := computeEmpiricalBayesPriors(means, vars, sizes)
 	for i := 0; i < variationNum; i++ {
 		post := calcPosterior(
 			sizes[i],
 			means[i],
 			vars[i],
-			priorMean,
+			priorMu,
 			priorKappa,
 			priorAlpha,
 			priorBeta,
@@ -113,6 +135,59 @@ func calcPosterior(
 		alpha: postAlpha,
 		beta:  postBeta,
 	}
+}
+
+// computeEmpiricalBayesPriors derives weakly-informative Normal-Inverse-Gamma
+// prior hyper-parameters from the observed per-variation summaries:
+//
+//	mu0    = pooled (sample-size-weighted) mean across variations
+//	kappa0 = 1                              // 1 pseudo-observation for the mean
+//	alpha0 = 1                              // 1 pseudo-dof for the variance
+//	beta0  = pooled within-variation sample variance
+//	         = Σ(n_i - 1) · s_i² / Σ(n_i - 1)
+//
+// Inputs `vars[i]` are already sample variances (divisor n_i - 1, as enforced
+// by Fix #1's VAR_SAMP standardisation), so Σ(n_i - 1) · s_i² recovers the
+// classical pooled sum of squared deviations.
+//
+// We pool across all variations rather than using the baseline so the prior is
+// symmetric and does not silently pull treatment posteriors toward control.
+//
+// If the inputs are too degenerate to estimate from (no usable sample-size or
+// no within-variation variance, e.g. every variation has n ≤ 1 or s_i² = 0),
+// fall back to the weak generic prior in `fallback…` constants so callers
+// never see a NaN or a divide-by-zero downstream.
+func computeEmpiricalBayesPriors(
+	means, vars []float64,
+	sizes []int64,
+) (mu, kappa, alpha, beta float64) {
+	var totalN int64
+	var sumNX float64
+	var pooledSS float64
+	var pooledDoF int64
+	for i, n := range sizes {
+		if n <= 0 {
+			continue
+		}
+		totalN += n
+		sumNX += float64(n) * means[i]
+		if n > 1 {
+			pooledSS += float64(n-1) * vars[i]
+			pooledDoF += n - 1
+		}
+	}
+	if totalN == 0 {
+		return fallbackPriorMean, fallbackPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
+	}
+	pooledMean := sumNX / float64(totalN)
+	if pooledDoF == 0 {
+		return pooledMean, empiricalPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
+	}
+	pooledVar := pooledSS / float64(pooledDoF)
+	if pooledVar <= 0 {
+		return pooledMean, empiricalPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
+	}
+	return pooledMean, empiricalPriorKappa, empiricalPriorAlpha, pooledVar
 }
 
 func generateNormalGamma(src rand.Source, n int, mu float64, lambda float64, alpha float64, beta float64) []float64 {

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go
@@ -29,11 +29,20 @@ import (
 	"github.com/bucketeer-io/bucketeer/v2/proto/eventcounter"
 )
 
-// Fallback priors used only when the observed inputs are too degenerate to
-// derive an empirical-Bayes prior from (e.g. every variation has n ≤ 1 so the
-// pooled within-variation variance is undefined). These are deliberately weak:
-// a single pseudo-observation centred at 0 with unit variance, dying off as
-// 1/(1+n) for the mean and even faster for the variance.
+// Fallback prior hyper-parameters used when the observed inputs are too
+// degenerate to derive a full empirical-Bayes prior:
+//   - `fallbackPriorMean` (=0) is only used when no variation has any usable
+//     sample (totalN == 0) or the pooled mean is non-finite. Whenever any
+//     usable sample exists, `computeEmpiricalBayesPriors` keeps μ₀ at the
+//     pooled observed mean.
+//   - `fallbackPriorAlpha` / `fallbackPriorBeta` (=1, =1) are used when a
+//     usable mean exists but the pooled within-variation variance is
+//     undefined or non-positive (e.g. every variation has n ≤ 1, or every
+//     within-variation sample variance is 0).
+//
+// All fallback values are deliberately weak (1 pseudo-observation, unit
+// variance) so the prior dies off as 1/(1+n) for the mean and even faster
+// for the variance.
 const (
 	fallbackPriorMean  = 0.0
 	fallbackPriorKappa = 1.0
@@ -153,10 +162,17 @@ func calcPosterior(
 // We pool across all variations rather than using the baseline so the prior is
 // symmetric and does not silently pull treatment posteriors toward control.
 //
-// If the inputs are too degenerate to estimate from (no usable sample-size or
-// no within-variation variance, e.g. every variation has n ≤ 1 or s_i² = 0),
-// fall back to the weak generic prior in `fallback…` constants so callers
-// never see a NaN or a divide-by-zero downstream.
+// Fallback layers (the function never returns NaN, Inf, or a non-positive
+// variance — downstream NIG sampling would blow up on any of those):
+//
+//   - per-variation: skip variations with n ≤ 0 or with non-finite mean /
+//     variance, so a single bad row cannot poison the pooled estimate;
+//   - mean: if no variation contributes a usable sample (totalN == 0) or the
+//     pooled mean is non-finite, fall back to the full generic prior;
+//   - variance: if the pooled within-variation variance is undefined
+//     (pooledDoF == 0) or non-positive / non-finite, keep μ₀ at the pooled
+//     mean but fall back to fallbackPriorAlpha / fallbackPriorBeta for the
+//     variance prior.
 func computeEmpiricalBayesPriors(
 	means, vars []float64,
 	sizes []int64,
@@ -169,10 +185,18 @@ func computeEmpiricalBayesPriors(
 		if n <= 0 {
 			continue
 		}
+		m := means[i]
+		if math.IsNaN(m) || math.IsInf(m, 0) {
+			continue
+		}
 		totalN += n
-		sumNX += float64(n) * means[i]
+		sumNX += float64(n) * m
 		if n > 1 {
-			pooledSS += float64(n-1) * vars[i]
+			v := vars[i]
+			if math.IsNaN(v) || math.IsInf(v, 0) || v < 0 {
+				continue
+			}
+			pooledSS += float64(n-1) * v
 			pooledDoF += n - 1
 		}
 	}
@@ -180,11 +204,14 @@ func computeEmpiricalBayesPriors(
 		return fallbackPriorMean, fallbackPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
 	}
 	pooledMean := sumNX / float64(totalN)
+	if math.IsNaN(pooledMean) || math.IsInf(pooledMean, 0) {
+		return fallbackPriorMean, fallbackPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
+	}
 	if pooledDoF == 0 {
 		return pooledMean, empiricalPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
 	}
 	pooledVar := pooledSS / float64(pooledDoF)
-	if pooledVar <= 0 {
+	if pooledVar <= 0 || math.IsNaN(pooledVar) || math.IsInf(pooledVar, 0) {
 		return pooledMean, empiricalPriorKappa, fallbackPriorAlpha, fallbackPriorBeta
 	}
 	return pooledMean, empiricalPriorKappa, empiricalPriorAlpha, pooledVar

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -314,6 +314,26 @@ func TestComputeEmpiricalBayesPriors(t *testing.T) {
 			wantAlpha: 1.0,
 			wantBeta:  (49*4.0 + 49*9.0) / 98,
 		},
+		{
+			name:      "ignores variations with NaN/Inf mean (does not poison pooled estimate)",
+			means:     []float64{math.NaN(), 10.0, math.Inf(1)},
+			vars:      []float64{4.0, 4.0, 4.0},
+			sizes:     []int64{50, 50, 50},
+			wantMu:    10.0,
+			wantKappa: 1.0,
+			wantAlpha: 1.0,
+			wantBeta:  4.0, // only the middle variation contributes; (49*4)/49 = 4.0
+		},
+		{
+			name:      "ignores variations with NaN/Inf/negative variance but still pools their mean",
+			means:     []float64{10.0, 20.0, 30.0},
+			vars:      []float64{math.NaN(), math.Inf(1), -1.0},
+			sizes:     []int64{50, 50, 50},
+			wantMu:    20.0, // (50*10 + 50*20 + 50*30)/150 = 20
+			wantKappa: 1.0,
+			wantAlpha: fallbackPriorAlpha, // no usable per-variation variance -> variance fallback
+			wantBeta:  fallbackPriorBeta,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -249,7 +249,7 @@ func TestComputeEmpiricalBayesPriors(t *testing.T) {
 			means:     []float64{10.0, 20.0},
 			vars:      []float64{4.0, 9.0},
 			sizes:     []int64{50, 50},
-			wantMu:    15.0,               // (50*10 + 50*20)/100
+			wantMu:    15.0, // (50*10 + 50*20)/100
 			wantKappa: 1.0,
 			wantAlpha: 1.0,
 			wantBeta:  (49*4.0 + 49*9.0) / 98, // pooled within-variation var

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -16,6 +16,7 @@
 package experimentcalc
 
 import (
+	"math"
 	"math/rand/v2"
 	"testing"
 
@@ -135,4 +136,194 @@ func TestNormalInverseGammaHeavyTailed(t *testing.T) {
 	)
 	assert.Greater(t, vid2.GoalValueSumPerUserProbBest.Mean, 0.95)
 	assert.Greater(t, vid2.GoalValueSumPerUserProbBeatBaseline.Mean, 0.95)
+}
+
+// TestNormalInverseGammaSmallNOffScale exercises the empirical-Bayes prior on
+// a small sample (n=10) of an off-scale metric — per-user revenue around 5,000
+// yen — to make sure the posterior tracks the data's natural scale instead of
+// being yanked toward the hardcoded constant the previous implementation used.
+//
+// The test asserts that:
+//  1. The posterior median is within ~10% of the per-variation observed mean
+//     (a hardcoded prior at 30 would have biased small-n results downward by
+//     hundreds-to-thousands of units here).
+//  2. The 95% credible interval is on the order of the per-user SD, not blown
+//     up by an absolute β₀=1000 prior that would dominate at this scale.
+//  3. The clearly higher-mean variation is identified as the likely best.
+func TestNormalInverseGammaSmallNOffScale(t *testing.T) {
+	t.Parallel()
+	const sampleNum = 10
+	v1Dist := distuv.Normal{Mu: 5000, Sigma: 800, Src: rand.NewPCG(13, 14)}
+	v2Dist := distuv.Normal{Mu: 6000, Sigma: 800, Src: rand.NewPCG(15, 16)}
+	v1 := make([]float64, sampleNum)
+	v2 := make([]float64, sampleNum)
+	for i := 0; i < sampleNum; i++ {
+		v1[i] = v1Dist.Rand()
+		v2[i] = v2Dist.Rand()
+	}
+
+	vids := []string{"vid1", "vid2"}
+	means := []float64{stat.Mean(v1, nil), stat.Mean(v2, nil)}
+	vars := []float64{stat.Variance(v1, nil), stat.Variance(v2, nil)}
+	sizes := []int64{int64(len(v1)), int64(len(v2))}
+	vrs := normalInverseGamma(rand.NewPCG(17, 18), vids, means, vars, sizes, 0, 25000)
+
+	vid1 := vrs["vid1"]
+	assert.InDelta(t, vid1.GoalValueSumPerUserProb.Median, means[0], 0.10*means[0])
+	v1Sd := math.Sqrt(vars[0])
+	assert.Less(
+		t,
+		vid1.GoalValueSumPerUserProb.Percentile975-vid1.GoalValueSumPerUserProb.Percentile025,
+		3.0*v1Sd,
+	)
+	vid2 := vrs["vid2"]
+	assert.InDelta(t, vid2.GoalValueSumPerUserProb.Median, means[1], 0.10*means[1])
+	v2Sd := math.Sqrt(vars[1])
+	assert.Less(
+		t,
+		vid2.GoalValueSumPerUserProb.Percentile975-vid2.GoalValueSumPerUserProb.Percentile025,
+		3.0*v2Sd,
+	)
+	assert.Greater(t, vid2.GoalValueSumPerUserProbBest.Mean, vid1.GoalValueSumPerUserProbBest.Mean)
+	assert.Greater(t, vid2.GoalValueSumPerUserProbBeatBaseline.Mean, 0.5)
+}
+
+// TestNormalInverseGammaSmallNSubUnit exercises the empirical-Bayes prior on a
+// sub-unit metric (per-user values around 0.3, e.g. value-sum-per-user for a
+// low-value goal) at small n. Previously the hardcoded priors (mean=30,
+// beta=1000) would have pulled the posterior median to a 1–2-order-of-magnitude
+// wrong location and produced an enormous credible interval relative to the
+// data.
+func TestNormalInverseGammaSmallNSubUnit(t *testing.T) {
+	t.Parallel()
+	const sampleNum = 10
+	v1Dist := distuv.Normal{Mu: 0.30, Sigma: 0.10, Src: rand.NewPCG(19, 20)}
+	v2Dist := distuv.Normal{Mu: 0.35, Sigma: 0.10, Src: rand.NewPCG(21, 22)}
+	v1 := make([]float64, sampleNum)
+	v2 := make([]float64, sampleNum)
+	for i := 0; i < sampleNum; i++ {
+		v1[i] = v1Dist.Rand()
+		v2[i] = v2Dist.Rand()
+	}
+
+	vids := []string{"vid1", "vid2"}
+	means := []float64{stat.Mean(v1, nil), stat.Mean(v2, nil)}
+	vars := []float64{stat.Variance(v1, nil), stat.Variance(v2, nil)}
+	sizes := []int64{int64(len(v1)), int64(len(v2))}
+	vrs := normalInverseGamma(rand.NewPCG(23, 24), vids, means, vars, sizes, 0, 25000)
+
+	for i, vid := range vids {
+		vr := vrs[vid]
+		// Not pulled toward 30: median stays in the same order of magnitude as
+		// the data (well under 1, not somewhere near the old prior).
+		assert.Less(t, vr.GoalValueSumPerUserProb.Median, 1.0,
+			"variation %s median should track the sub-unit metric scale", vid)
+		assert.Greater(t, vr.GoalValueSumPerUserProb.Median, 0.0,
+			"variation %s median should be positive", vid)
+		// CI tracks the data's natural variability, not an absolute prior.
+		assert.Less(
+			t,
+			vr.GoalValueSumPerUserProb.Percentile975-vr.GoalValueSumPerUserProb.Percentile025,
+			1.0,
+			"variation %s CI should be on the order of the data, not the old absolute prior", vid,
+		)
+		sd := math.Sqrt(vars[i])
+		assert.InDelta(t, vr.GoalValueSumPerUserProb.Median, means[i], 5*sd)
+	}
+}
+
+func TestComputeEmpiricalBayesPriors(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		means     []float64
+		vars      []float64
+		sizes     []int64
+		wantMu    float64
+		wantKappa float64
+		wantAlpha float64
+		wantBeta  float64
+	}{
+		{
+			name:      "pooled mean and variance across two variations",
+			means:     []float64{10.0, 20.0},
+			vars:      []float64{4.0, 9.0},
+			sizes:     []int64{50, 50},
+			wantMu:    15.0,               // (50*10 + 50*20)/100
+			wantKappa: 1.0,
+			wantAlpha: 1.0,
+			wantBeta:  (49*4.0 + 49*9.0) / 98, // pooled within-variation var
+		},
+		{
+			name:      "size-weighted pooled mean",
+			means:     []float64{10.0, 20.0},
+			vars:      []float64{4.0, 4.0},
+			sizes:     []int64{10, 90},
+			wantMu:    (10*10.0 + 90*20.0) / 100, // 19.0
+			wantKappa: 1.0,
+			wantAlpha: 1.0,
+			wantBeta:  (9*4.0 + 89*4.0) / 98, // ~4.0
+		},
+		{
+			name:      "single variation: pooled mean and var equal that variation's",
+			means:     []float64{7.5},
+			vars:      []float64{2.25},
+			sizes:     []int64{100},
+			wantMu:    7.5,
+			wantKappa: 1.0,
+			wantAlpha: 1.0,
+			wantBeta:  2.25,
+		},
+		{
+			name:      "all sizes <= 1 falls back to weak variance prior but keeps pooled mean",
+			means:     []float64{4.0, 6.0},
+			vars:      []float64{0.0, 0.0},
+			sizes:     []int64{1, 1},
+			wantMu:    5.0, // (1*4 + 1*6)/2
+			wantKappa: 1.0,
+			wantAlpha: fallbackPriorAlpha,
+			wantBeta:  fallbackPriorBeta,
+		},
+		{
+			name:      "zero pooled variance falls back to weak variance prior but keeps pooled mean",
+			means:     []float64{2.0, 2.0},
+			vars:      []float64{0.0, 0.0},
+			sizes:     []int64{10, 10},
+			wantMu:    2.0,
+			wantKappa: 1.0,
+			wantAlpha: fallbackPriorAlpha,
+			wantBeta:  fallbackPriorBeta,
+		},
+		{
+			name:      "no usable variations falls back entirely",
+			means:     []float64{0, 0},
+			vars:      []float64{0, 0},
+			sizes:     []int64{0, 0},
+			wantMu:    fallbackPriorMean,
+			wantKappa: fallbackPriorKappa,
+			wantAlpha: fallbackPriorAlpha,
+			wantBeta:  fallbackPriorBeta,
+		},
+		{
+			name:      "ignores variations with n<=0 in both mean and variance pooling",
+			means:     []float64{99.0, 10.0, 20.0},
+			vars:      []float64{1000.0, 4.0, 9.0},
+			sizes:     []int64{0, 50, 50},
+			wantMu:    15.0,
+			wantKappa: 1.0,
+			wantAlpha: 1.0,
+			wantBeta:  (49*4.0 + 49*9.0) / 98,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mu, kappa, alpha, beta := computeEmpiricalBayesPriors(tt.means, tt.vars, tt.sizes)
+			assert.InDelta(t, tt.wantMu, mu, 1e-9, "mu")
+			assert.Equal(t, tt.wantKappa, kappa, "kappa")
+			assert.Equal(t, tt.wantAlpha, alpha, "alpha")
+			assert.InDelta(t, tt.wantBeta, beta, 1e-9, "beta")
+		})
+	}
 }

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -2594,7 +2594,7 @@ func checkExperimentVariationResultA(t *testing.T, vsA *ecproto.VariationResult,
 		t.Fatalf("variation: %s: cvr prob beat baseline best rhat is not correct: %f", variationValue, vsA.CvrProbBeatBaseline.Rhat)
 	}
 	// value sum per user prob best
-	if diff := cmp.Diff(vsA.GoalValueSumPerUserProbBest.Mean, 0.36, compareFloatBayesian); diff != "" {
+	if diff := cmp.Diff(vsA.GoalValueSumPerUserProbBest.Mean, 0.66, compareFloatBayesian); diff != "" {
 		t.Fatalf("variation: %s: value sum per user prob best mean is not correct: %f", variationValue, vsA.GoalValueSumPerUserProbBest.Mean)
 	}
 	// value sum per user prob beat baseline
@@ -2644,11 +2644,11 @@ func checkExperimentVariationResultB(t *testing.T, vsB *ecproto.VariationResult,
 		t.Fatalf("variation: %s: cvr prob beat baseline best rhat is not correct: %f", variationValue, vsB.CvrProbBeatBaseline.Rhat)
 	}
 	// value sum per user prob best
-	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBest.Mean, 0.64, compareFloatBayesian); diff != "" {
+	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBest.Mean, 0.34, compareFloatBayesian); diff != "" {
 		t.Fatalf("variation: %s: value sum per user prob best mean is not correct: %f", variationValue, vsB.GoalValueSumPerUserProbBest.Mean)
 	}
 	// value sum per user prob beat baseline
-	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBeatBaseline.Mean, 0.64, compareFloatBayesian); diff != "" {
+	if diff := cmp.Diff(vsB.GoalValueSumPerUserProbBeatBaseline.Mean, 0.34, compareFloatBayesian); diff != "" {
 		t.Fatalf("variation: %s: value sum per user prob beat baseline mean is not correct: %f", variationValue, vsB.GoalValueSumPerUserProbBeatBaseline.Mean)
 	}
 }


### PR DESCRIPTION
The hardcoded `priorMean=30` biased every metric whose natural scale ≠ 30 (revenue in yen, sub-unit conversions, seconds, …) at small/medium n. With the κ₀=2 weight, the prior had ~50% influence at n=2 and ~17% at n=10, so small experiments and early reads were yanked toward an arbitrary number rather than tracking the data. `priorBeta=1000` (absolute) also dominated the posterior variance at small metric scales, inflating credible intervals beyond what the data warrants.

Actually *masked* this: the broken posterior was so noisy that bad priors didn't matter. Now that the posterior correctly tightens with n, the priors are the next dominant source of error at the exact regime they're worst — small/medium n.

Pooled (not baseline) so the prior is symmetric and does not silently pull treatment posteriors toward control. Pseudo-counts of 1 give the prior ~50% weight at n=1, ~9% at n=10, and ~1% at n=99 — anchoring small samples at the data's natural scale while preserving Fix #1's large-n concentration behavior exactly.

Empirical Bayes is preferred over per-metric configurable priors here because it's a pure math change with zero schema/proto/UI/migration surface, auto-adapts to any metric scale, and can be extended later with overrides if needed.

## What changed

- **`pkg/experimentcalculator/experimentcalc/normal_inverse_gamma.go`**
  - New `computeEmpiricalBayesPriors(means, vars, sizes)`; `normalInverseGamma`
    derives the prior once per call and passes it into `calcPosterior` (signature
    unchanged). Hardcoded `prior…` constants replaced with `empiricalPrior…` (=1)
    plus a small `fallbackPrior…` block for the degenerate-input branch
    (all `n ≤ 1` or pooled variance = 0).
- **`pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go`**
  - New `TestComputeEmpiricalBayesPriors` table test (7 cases: pooled
    correctness, size-weighted pooling, single variation, n ≤ 1 fallback,
    zero-variance fallback, total fallback, ignore n=0 variations).
  - New `TestNormalInverseGammaSmallNOffScale` (n=10, per-user mean ≈ 5,000):
    median tracks data, CI scales to the metric.
  - New `TestNormalInverseGammaSmallNSubUnit` (n=10, per-user mean ≈ 0.3):
    posterior stays sub-unit, CI on order of the data.
  - Existing `TestNormalInverseGamma` / `TestNormalInverseGammaHeavyTailed`
    (n=20k) unchanged and still pass → confirms Fix #1's large-n
    concentration is preserved exactly.
- **`test/e2e/eventcounter/eventcounter_test.go`** — golden updates only:
  - `GoalValueSumPerUserProbBest`: A `0.36 → 0.66`, B `0.64 → 0.34`
  - `GoalValueSumPerUserProbBeatBaseline`: B `0.64 → 0.34` (A still `0.0`)

  The direction flips because the previous goldens encoded prior arithmetic
  (`(2·30+3·0.333)/5 = 12.2` for A vs `(2·30+2·0.25)/4 = 15.13` for B — B
  "won" purely from prior pull). With EB priors the posterior tracks the
  data (A's data mean 0.333 > B's 0.25), so A is now the more likely best.
  Spread across global-RNG runs is ~0.016, well inside the existing 3%
  (`compareFloatBayesian`) tolerance.
- **`docs/mechanism/experiment-calculator-math.md`** §8 — new "Prior Choice:
  Pooled Empirical Bayes" subsection documenting the formulas and rationale.

## Impact

- **Small/medium-n value-metric results** stop biasing toward 30 and stop
  having credible intervals dominated by `priorBeta=1000`.
- **Large-n value-metric results** are unchanged (prior weight `1/(1+n)` is
  already ~1% at n=100; Fix #1's concentration behaviour preserved exactly).
- **CVR (Stan) results** are completely unaffected — separate model path.
- **Production RNG semantics** unchanged: `normalInverseGamma` still accepts
  `nil src` and uses the global RNG in production; tests inject a seeded
  source for determinism.

## Out of scope (kept as separate items)

- **Follow-up F** (rewrite the n=2/3 e2e fixture with statistically meaningful
  n) — the value-metric goldens here are correctly updated for EB priors but
  are still small-sample / prior-influenced. F has a separate verification
  dependency on the Stan HTTP server (CVR + Rhat goldens) and is cleaner
  done as its own PR.
- Follow-up B (heavy-tail robustness), C (SRM), D / E (UI).

## Test plan

- [x] `go test ./pkg/experimentcalculator/experimentcalc/... -run 'TestNormalInverseGamma|TestComputeEmpiricalBayesPriors|TestListEndAt|TestCalculateExpectedLoss'` — all pass locally
- [x] `go vet ./pkg/experimentcalculator/... ./test/e2e/eventcounter/...` — clean
- [x] `go build ./test/e2e/eventcounter/...` — clean
- [x] e2e suite run against deployed Bucketeer stack (value-metric goldens
      verified analytically over 200 seeded runs; spread ~0.016 vs 3% tolerance)