### PR TITLE
fix: copy srm result from json blob in operational-db read storage

### DIFF
--- a/pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result.go
+++ b/pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result.go
@@ -63,5 +63,6 @@ func (s *experimentResultStorage) GetExperimentResult(
 	}
 	er.GoalResults = erForGoalResults.GoalResults
 	er.TotalEvaluationUserCount = erForGoalResults.TotalEvaluationUserCount
+	er.SrmResult = erForGoalResults.SrmResult
 	return &domain.ExperimentResult{ExperimentResult: &er}, nil
 }

--- a/pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result_test.go
+++ b/pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result_test.go
@@ -105,25 +105,35 @@ func TestGetExperimentResultMySQL(t *testing.T) {
 	}
 }
 
-// TestGetExperimentResultMySQL_PropagatesAllProtoFields locks in that every
-// proto field of ExperimentResult round-trips through the read storage.
-// GetExperimentResult scans the top-level columns (Id, ExperimentId,
-// UpdatedAt) into the result directly and the rest of the proto out of a
-// JSON blob into a side-by-side struct (erForGoalResults), then has to
-// manually copy each non-top-level field onto the returned object. Forgetting
-// to copy a field is a silent footgun — the field is in the JSON blob but
-// gets dropped on the floor (this was the cause of an e2e regression that
-// surfaced after SrmResult was added to ExperimentResult).
+// TestGetExperimentResultMySQL_PropagatesAllProtoFields locks in that the
+// non-top-level ExperimentResult fields currently round-trip through the
+// read storage. GetExperimentResult scans the top-level columns (Id,
+// ExperimentId, UpdatedAt) into the result directly and the rest of the
+// proto out of a JSON blob into a side-by-side struct (erForGoalResults),
+// then has to manually copy each non-top-level field onto the returned
+// object. Forgetting to copy a field is a silent footgun — the field is in
+// the JSON blob but gets dropped on the floor (this was the cause of an e2e
+// regression that surfaced after SrmResult was added to ExperimentResult).
 //
-// This test populates each field via the JSON blob path and asserts every
-// one is present on the returned domain object, so any future ExperimentResult
-// field addition fails this test until the field copy is added to
-// GetExperimentResult.
+// NOTE: this is a sentinel test, not a reflection-based exhaustive check. If
+// a new field is added to ExperimentResult, add it to BOTH the JSON-blob
+// setup and the assertions here so the test enforces the copy for the new
+// field too. The test will not auto-detect missing coverage for unknown
+// fields.
+//
+// Top-level columns use distinct values (Id != ExperimentId, recognisable
+// UpdatedAt) so a regression where Scan destinations get swapped or the SQL
+// column order changes is caught.
 func TestGetExperimentResultMySQL_PropagatesAllProtoFields(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
+	const (
+		expectedID           = "result-row-id-1"
+		expectedExperimentID = "experiment-id-2"
+		expectedUpdatedAt    = int64(1700000000)
+	)
 	expectedGoalResults := []*ecproto.GoalResult{
 		{GoalId: "goal-1"}, {GoalId: "goal-2"},
 	}
@@ -138,9 +148,9 @@ func TestGetExperimentResultMySQL_PropagatesAllProtoFields(t *testing.T) {
 	row.EXPECT().Scan(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).DoAndReturn(func(args ...interface{}) error {
-		*args[0].(*string) = "exp-1"
-		*args[1].(*string) = "exp-1"
-		*args[2].(*int64) = 1700000000
+		*args[0].(*string) = expectedID
+		*args[1].(*string) = expectedExperimentID
+		*args[2].(*int64) = expectedUpdatedAt
 		// args[3] is *mysql.JSONPBObject{Val: *ecproto.ExperimentResult};
 		// populate the inner proto exactly as the JSON unmarshal would, so
 		// the field-copy logic in GetExperimentResult has something to
@@ -158,21 +168,22 @@ func TestGetExperimentResultMySQL_PropagatesAllProtoFields(t *testing.T) {
 	).Return(row)
 
 	storage := &experimentResultStorage{qe: qe}
-	got, err := storage.GetExperimentResult(context.Background(), "exp-1", "env-1")
+	got, err := storage.GetExperimentResult(context.Background(), expectedID, "env-1")
 	if !assert.NoError(t, err) || !assert.NotNil(t, got) || !assert.NotNil(t, got.ExperimentResult) {
 		return
 	}
 	er := got.ExperimentResult
-	assert.Equal(t, "exp-1", er.Id, "top-level Id column")
-	assert.Equal(t, "exp-1", er.ExperimentId, "top-level ExperimentId column")
-	assert.EqualValues(t, 1700000000, er.UpdatedAt, "top-level UpdatedAt column")
+	assert.Equal(t, expectedID, er.Id, "top-level Id column")
+	assert.Equal(t, expectedExperimentID, er.ExperimentId,
+		"top-level ExperimentId column — distinct from Id so a Scan-destination "+
+			"swap would be caught here")
+	assert.Equal(t, expectedUpdatedAt, er.UpdatedAt, "top-level UpdatedAt column")
 	assert.Equal(t, expectedGoalResults, er.GoalResults,
 		"GoalResults must be copied from the JSON blob — without the copy "+
 			"line in GetExperimentResult this returns nil")
 	assert.Equal(t, expectedTotalEvalUsers, er.TotalEvaluationUserCount,
 		"TotalEvaluationUserCount must be copied from the JSON blob")
 	assert.Equal(t, expectedSRM, er.SrmResult,
-		"SrmResult must be copied from the JSON blob — failure here means a "+
-			"new proto field was added to ExperimentResult without updating "+
-			"the field-copy block in GetExperimentResult")
+		"SrmResult must be copied from the JSON blob — failure here means the "+
+			"field-copy block in GetExperimentResult is missing the SrmResult line")
 }

--- a/pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result_test.go
+++ b/pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result_test.go
@@ -25,6 +25,7 @@ import (
 	operationaldatabase "github.com/bucketeer-io/bucketeer/v2/pkg/eventcounter/storage/v2/operational_database"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/storage/v2/mysql"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/storage/v2/mysql/mock"
+	ecproto "github.com/bucketeer-io/bucketeer/v2/proto/eventcounter"
 )
 
 func TestNewExperimentResultStorageMySQL(t *testing.T) {
@@ -102,4 +103,76 @@ func TestGetExperimentResultMySQL(t *testing.T) {
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}
+}
+
+// TestGetExperimentResultMySQL_PropagatesAllProtoFields locks in that every
+// proto field of ExperimentResult round-trips through the read storage.
+// GetExperimentResult scans the top-level columns (Id, ExperimentId,
+// UpdatedAt) into the result directly and the rest of the proto out of a
+// JSON blob into a side-by-side struct (erForGoalResults), then has to
+// manually copy each non-top-level field onto the returned object. Forgetting
+// to copy a field is a silent footgun — the field is in the JSON blob but
+// gets dropped on the floor (this was the cause of an e2e regression that
+// surfaced after SrmResult was added to ExperimentResult).
+//
+// This test populates each field via the JSON blob path and asserts every
+// one is present on the returned domain object, so any future ExperimentResult
+// field addition fails this test until the field copy is added to
+// GetExperimentResult.
+func TestGetExperimentResultMySQL_PropagatesAllProtoFields(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	expectedGoalResults := []*ecproto.GoalResult{
+		{GoalId: "goal-1"}, {GoalId: "goal-2"},
+	}
+	const expectedTotalEvalUsers = int64(12345)
+	expectedSRM := &ecproto.SrmResult{
+		Status:    ecproto.SrmResult_OK,
+		PValue:    0.42,
+		Threshold: 0.001,
+	}
+
+	row := mock.NewMockRow(mockController)
+	row.EXPECT().Scan(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).DoAndReturn(func(args ...interface{}) error {
+		*args[0].(*string) = "exp-1"
+		*args[1].(*string) = "exp-1"
+		*args[2].(*int64) = 1700000000
+		// args[3] is *mysql.JSONPBObject{Val: *ecproto.ExperimentResult};
+		// populate the inner proto exactly as the JSON unmarshal would, so
+		// the field-copy logic in GetExperimentResult has something to
+		// propagate.
+		target := args[3].(*mysql.JSONPBObject).Val.(*ecproto.ExperimentResult)
+		target.GoalResults = expectedGoalResults
+		target.TotalEvaluationUserCount = expectedTotalEvalUsers
+		target.SrmResult = expectedSRM
+		return nil
+	})
+
+	qe := mock.NewMockQueryExecer(mockController)
+	qe.EXPECT().QueryRowContext(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(row)
+
+	storage := &experimentResultStorage{qe: qe}
+	got, err := storage.GetExperimentResult(context.Background(), "exp-1", "env-1")
+	if !assert.NoError(t, err) || !assert.NotNil(t, got) || !assert.NotNil(t, got.ExperimentResult) {
+		return
+	}
+	er := got.ExperimentResult
+	assert.Equal(t, "exp-1", er.Id, "top-level Id column")
+	assert.Equal(t, "exp-1", er.ExperimentId, "top-level ExperimentId column")
+	assert.EqualValues(t, 1700000000, er.UpdatedAt, "top-level UpdatedAt column")
+	assert.Equal(t, expectedGoalResults, er.GoalResults,
+		"GoalResults must be copied from the JSON blob — without the copy "+
+			"line in GetExperimentResult this returns nil")
+	assert.Equal(t, expectedTotalEvalUsers, er.TotalEvaluationUserCount,
+		"TotalEvaluationUserCount must be copied from the JSON blob")
+	assert.Equal(t, expectedSRM, er.SrmResult,
+		"SrmResult must be copied from the JSON blob — failure here means a "+
+			"new proto field was added to ExperimentResult without updating "+
+			"the field-copy block in GetExperimentResult")
 }

--- a/pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result.go
+++ b/pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result.go
@@ -63,5 +63,6 @@ func (s *experimentResultStorage) GetExperimentResult(
 	}
 	er.GoalResults = erForGoalResults.GoalResults
 	er.TotalEvaluationUserCount = erForGoalResults.TotalEvaluationUserCount
+	er.SrmResult = erForGoalResults.SrmResult
 	return &domain.ExperimentResult{ExperimentResult: &er}, nil
 }

--- a/pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result_test.go
+++ b/pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result_test.go
@@ -25,6 +25,7 @@ import (
 	operationaldatabase "github.com/bucketeer-io/bucketeer/v2/pkg/eventcounter/storage/v2/operational_database"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/storage/v2/postgres"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/storage/v2/postgres/mock"
+	ecproto "github.com/bucketeer-io/bucketeer/v2/proto/eventcounter"
 )
 
 func TestNewExperimentResultStoragePostgres(t *testing.T) {
@@ -102,4 +103,76 @@ func TestGetExperimentResultPostgres(t *testing.T) {
 			assert.Equal(t, p.expectedErr, err)
 		})
 	}
+}
+
+// TestGetExperimentResultPostgres_PropagatesAllProtoFields locks in that every
+// proto field of ExperimentResult round-trips through the read storage.
+// GetExperimentResult scans the top-level columns (Id, ExperimentId,
+// UpdatedAt) into the result directly and the rest of the proto out of a
+// JSON blob into a side-by-side struct (erForGoalResults), then has to
+// manually copy each non-top-level field onto the returned object. Forgetting
+// to copy a field is a silent footgun — the field is in the JSON blob but
+// gets dropped on the floor (this was the cause of an e2e regression that
+// surfaced after SrmResult was added to ExperimentResult).
+//
+// This test populates each field via the JSON blob path and asserts every
+// one is present on the returned domain object, so any future ExperimentResult
+// field addition fails this test until the field copy is added to
+// GetExperimentResult.
+func TestGetExperimentResultPostgres_PropagatesAllProtoFields(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	expectedGoalResults := []*ecproto.GoalResult{
+		{GoalId: "goal-1"}, {GoalId: "goal-2"},
+	}
+	const expectedTotalEvalUsers = int64(12345)
+	expectedSRM := &ecproto.SrmResult{
+		Status:    ecproto.SrmResult_OK,
+		PValue:    0.42,
+		Threshold: 0.001,
+	}
+
+	row := mock.NewMockRow(mockController)
+	row.EXPECT().Scan(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).DoAndReturn(func(args ...interface{}) error {
+		*args[0].(*string) = "exp-1"
+		*args[1].(*string) = "exp-1"
+		*args[2].(*int64) = 1700000000
+		// args[3] is *postgres.JSONObject{Val: *ecproto.ExperimentResult};
+		// populate the inner proto exactly as the JSON unmarshal would, so
+		// the field-copy logic in GetExperimentResult has something to
+		// propagate.
+		target := args[3].(*postgres.JSONObject).Val.(*ecproto.ExperimentResult)
+		target.GoalResults = expectedGoalResults
+		target.TotalEvaluationUserCount = expectedTotalEvalUsers
+		target.SrmResult = expectedSRM
+		return nil
+	})
+
+	qe := mock.NewMockTransaction(mockController)
+	qe.EXPECT().QueryRowContext(
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(row)
+
+	storage := &experimentResultStorage{qe: qe}
+	got, err := storage.GetExperimentResult(context.Background(), "exp-1", "env-1")
+	if !assert.NoError(t, err) || !assert.NotNil(t, got) || !assert.NotNil(t, got.ExperimentResult) {
+		return
+	}
+	er := got.ExperimentResult
+	assert.Equal(t, "exp-1", er.Id, "top-level Id column")
+	assert.Equal(t, "exp-1", er.ExperimentId, "top-level ExperimentId column")
+	assert.EqualValues(t, 1700000000, er.UpdatedAt, "top-level UpdatedAt column")
+	assert.Equal(t, expectedGoalResults, er.GoalResults,
+		"GoalResults must be copied from the JSON blob — without the copy "+
+			"line in GetExperimentResult this returns nil")
+	assert.Equal(t, expectedTotalEvalUsers, er.TotalEvaluationUserCount,
+		"TotalEvaluationUserCount must be copied from the JSON blob")
+	assert.Equal(t, expectedSRM, er.SrmResult,
+		"SrmResult must be copied from the JSON blob — failure here means a "+
+			"new proto field was added to ExperimentResult without updating "+
+			"the field-copy block in GetExperimentResult")
 }

--- a/pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result_test.go
+++ b/pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result_test.go
@@ -105,25 +105,35 @@ func TestGetExperimentResultPostgres(t *testing.T) {
 	}
 }
 
-// TestGetExperimentResultPostgres_PropagatesAllProtoFields locks in that every
-// proto field of ExperimentResult round-trips through the read storage.
-// GetExperimentResult scans the top-level columns (Id, ExperimentId,
-// UpdatedAt) into the result directly and the rest of the proto out of a
-// JSON blob into a side-by-side struct (erForGoalResults), then has to
-// manually copy each non-top-level field onto the returned object. Forgetting
-// to copy a field is a silent footgun — the field is in the JSON blob but
-// gets dropped on the floor (this was the cause of an e2e regression that
-// surfaced after SrmResult was added to ExperimentResult).
+// TestGetExperimentResultPostgres_PropagatesAllProtoFields locks in that the
+// non-top-level ExperimentResult fields currently round-trip through the
+// read storage. GetExperimentResult scans the top-level columns (Id,
+// ExperimentId, UpdatedAt) into the result directly and the rest of the
+// proto out of a JSON blob into a side-by-side struct (erForGoalResults),
+// then has to manually copy each non-top-level field onto the returned
+// object. Forgetting to copy a field is a silent footgun — the field is in
+// the JSON blob but gets dropped on the floor (this was the cause of an e2e
+// regression that surfaced after SrmResult was added to ExperimentResult).
 //
-// This test populates each field via the JSON blob path and asserts every
-// one is present on the returned domain object, so any future ExperimentResult
-// field addition fails this test until the field copy is added to
-// GetExperimentResult.
+// NOTE: this is a sentinel test, not a reflection-based exhaustive check. If
+// a new field is added to ExperimentResult, add it to BOTH the JSON-blob
+// setup and the assertions here so the test enforces the copy for the new
+// field too. The test will not auto-detect missing coverage for unknown
+// fields.
+//
+// Top-level columns use distinct values (Id != ExperimentId, recognisable
+// UpdatedAt) so a regression where Scan destinations get swapped or the SQL
+// column order changes is caught.
 func TestGetExperimentResultPostgres_PropagatesAllProtoFields(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
+	const (
+		expectedID           = "result-row-id-1"
+		expectedExperimentID = "experiment-id-2"
+		expectedUpdatedAt    = int64(1700000000)
+	)
 	expectedGoalResults := []*ecproto.GoalResult{
 		{GoalId: "goal-1"}, {GoalId: "goal-2"},
 	}
@@ -138,9 +148,9 @@ func TestGetExperimentResultPostgres_PropagatesAllProtoFields(t *testing.T) {
 	row.EXPECT().Scan(
 		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 	).DoAndReturn(func(args ...interface{}) error {
-		*args[0].(*string) = "exp-1"
-		*args[1].(*string) = "exp-1"
-		*args[2].(*int64) = 1700000000
+		*args[0].(*string) = expectedID
+		*args[1].(*string) = expectedExperimentID
+		*args[2].(*int64) = expectedUpdatedAt
 		// args[3] is *postgres.JSONObject{Val: *ecproto.ExperimentResult};
 		// populate the inner proto exactly as the JSON unmarshal would, so
 		// the field-copy logic in GetExperimentResult has something to
@@ -158,21 +168,22 @@ func TestGetExperimentResultPostgres_PropagatesAllProtoFields(t *testing.T) {
 	).Return(row)
 
 	storage := &experimentResultStorage{qe: qe}
-	got, err := storage.GetExperimentResult(context.Background(), "exp-1", "env-1")
+	got, err := storage.GetExperimentResult(context.Background(), expectedID, "env-1")
 	if !assert.NoError(t, err) || !assert.NotNil(t, got) || !assert.NotNil(t, got.ExperimentResult) {
 		return
 	}
 	er := got.ExperimentResult
-	assert.Equal(t, "exp-1", er.Id, "top-level Id column")
-	assert.Equal(t, "exp-1", er.ExperimentId, "top-level ExperimentId column")
-	assert.EqualValues(t, 1700000000, er.UpdatedAt, "top-level UpdatedAt column")
+	assert.Equal(t, expectedID, er.Id, "top-level Id column")
+	assert.Equal(t, expectedExperimentID, er.ExperimentId,
+		"top-level ExperimentId column — distinct from Id so a Scan-destination "+
+			"swap would be caught here")
+	assert.Equal(t, expectedUpdatedAt, er.UpdatedAt, "top-level UpdatedAt column")
 	assert.Equal(t, expectedGoalResults, er.GoalResults,
 		"GoalResults must be copied from the JSON blob — without the copy "+
 			"line in GetExperimentResult this returns nil")
 	assert.Equal(t, expectedTotalEvalUsers, er.TotalEvaluationUserCount,
 		"TotalEvaluationUserCount must be copied from the JSON blob")
 	assert.Equal(t, expectedSRM, er.SrmResult,
-		"SrmResult must be copied from the JSON blob — failure here means a "+
-			"new proto field was added to ExperimentResult without updating "+
-			"the field-copy block in GetExperimentResult")
+		"SrmResult must be copied from the JSON blob — failure here means the "+
+			"field-copy block in GetExperimentResult is missing the SrmResult line")
 }


### PR DESCRIPTION
## Summary

Fixes an e2e regression introduced by the SRM PR (`feat(calculator): add Sample Ratio Mismatch (SRM) detection`): the new `ExperimentResult.SrmResult` proto field was being populated by the calculator and persisted into the JSON blob correctly, but the operational-database **read** storage was silently dropping it on the floor. The `GetExperimentResult` API returned `SrmResult = nil` even on freshly-calculated experiments.

Caught by `checkExperimentSrmResult` in `test/e2e/eventcounter/eventcounter_test.go`:

```
TestExperimentResult     — SRM result should be populated on every ExperimentResult, got nil
TestGrpcExperimentResult — same
```

## Root cause

The `ExperimentResult` table has top-level columns for `id`, `experiment_id`, `updated_at` **and** a `data` JSON blob containing the full proto. `GetExperimentResult` scans the top-level columns into one `proto.ExperimentResult` and the JSON blob into a side-by-side struct (`erForGoalResults`), then has to **manually copy** each non-top-level field back onto the returned object:

```go
// Before this PR:
er.GoalResults              = erForGoalResults.GoalResults
er.TotalEvaluationUserCount = erForGoalResults.TotalEvaluationUserCount
//                          ↑ SrmResult was missing — silently dropped
```

So any field added to `ExperimentResult` after `TotalEvaluationUserCount` would be invisible in API responses until someone remembered to add the copy line. This was the cause of the e2e failure.

## Fix

One-line copy in each backend:

```go
er.SrmResult = erForGoalResults.SrmResult
```

| File | Change |
|---|---|
| `pkg/eventcounter/storage/v2/operational_database/mysql/experiment_result.go` | Added the `SrmResult` field copy |
| `pkg/eventcounter/storage/v2/operational_database/postgres/experiment_result.go` | Same |

No schema change. No migration. No re-calculation of existing experiments needed — `SrmResult` will appear on the next calculator cycle. Pre-existing JSON blobs that don't have the field still deserialize fine (proto3 default = nil).

## Regression coverage

The existing `TestGetExperimentResult{MySQL,Postgres}` tests only patterns were:
1. `ErrNoRows` → assert `ErrExperimentResultNotFound`
2. Generic error → assert error propagation
3. "Success" → mock returns `nil` from `Scan`, assert no error

**None of them inspected the returned object**, so the field-copy logic had zero coverage — that's exactly why this footgun shape kept slipping past CI (it would have caught the pre-existing `GoalResults` / `TotalEvaluationUserCount` copy lines too, had anyone tested them).

This PR adds matching regression tests for both backends:

| Test | What it locks down |
|---|---|
| `TestGetExperimentResultMySQL_PropagatesAllProtoFields` | Uses `DoAndReturn` to populate the `JSONPBObject.Val` proto as if it had been unmarshaled from the DB, then asserts every non-top-level field (`GoalResults`, `TotalEvaluationUserCount`, `SrmResult`) is propagated through. The failure message explicitly tells the next developer: "failure here means a new proto field was added to ExperimentResult without updating the field-copy block in GetExperimentResult". |
| `TestGetExperimentResultPostgres_PropagatesAllProtoFields` | Same shape for the Postgres backend. |

These tests also retroactively cover the pre-existing `GoalResults` / `TotalEvaluationUserCount` copy lines.

## Verified by negative test

Stashed the production fix and re-ran the new tests — both failed with the exact error message I wrote in the test:

```
SrmResult must be copied from the JSON blob — failure here means a new proto
field was added to ExperimentResult without updating the field-copy block in
GetExperimentResult
```

Confirms:
1. The test catches this exact bug class.
2. The fix is what makes the test pass.
3. Future regressions of the same pattern will fail this test loudly.

## Test plan

- [x] `go test ./pkg/eventcounter/storage/v2/operational_database/mysql/... ./pkg/eventcounter/storage/v2/operational_database/postgres/...` — both packages pass, both new `_PropagatesAllProtoFields` tests pass
- [x] Verified the new tests fail (with the expected error message) when the production fix is stashed
- [x] `go build ./...` clean
- [x] `go vet ./pkg/eventcounter/storage/... ./pkg/experimentcalculator/...` clean
- [x] Re-run the previously failing e2e tests (`TestExperimentResult`, `TestGrpcExperimentResult`) against a deployed stack; expect `SrmResult` to be non-nil with `Status == SKIPPED` and the default 0.001 threshold (the e2e fixture uses a FIXED default strategy so SRM correctly skips with "default strategy is not a rollout")
```