### PR TITLE
feat(calculator): winsorize per-user goal values at p99 before dwh aggregation

### DIFF
--- a/docs/mechanism/experiment-calculator-math.md
+++ b/docs/mechanism/experiment-calculator-math.md
@@ -419,6 +419,39 @@ variance reach the NIG sampler):
   or the pooled mean comes out non-finite — does it fall back to the full
   generic prior `μ₀=0, κ₀=α₀=β₀=1`.
 
+### Heavy-Tail Robustness: Per-User Winsorization
+
+The NIG model assumes per-user values are approximately Normal. Revenue and
+similar value metrics are heavy-tailed — a few "whales" spend orders of
+magnitude more than typical users. Left unchecked, those few users dominate the
+sample mean and variance, so the posterior becomes both **overconfident** and
+**unstable**: a decisive `ProbBeatBaseline` can be driven by a handful of
+extreme observations and would flip had those users landed in another
+variation.
+
+To guard against this, each user's total value is **winsorized (capped) at the
+99th percentile** of the pooled (across variations) per-user value
+distribution, *before* the mean and variance are aggregated:
+
+```
+cap        = p99 of per-user value_sum, pooled across all variations
+value_capᵢ = min(value_sumᵢ, cap)
+```
+
+The cap is computed and applied **in the DWH aggregation SQL** (the calculator
+only receives the aggregated mean/variance/n, never per-user rows), pooled
+across variations to stay symmetric — consistent with the empirical-Bayes
+prior above. Only value metrics are affected; the conversion-rate (binomial)
+path is unchanged.
+
+This is the standard heavy-tail treatment for online experiments (Kohavi, Tang
+& Xu, *Trustworthy Online Controlled Experiments*, 2020, §4). Trade-off:
+capping deliberately discards extreme tail value, so the reported absolute
+value-per-user is biased slightly low; this is accepted in exchange for stable,
+non-overconfident verdicts. (A log-normal value model is an alternative for
+metrics where the median is the business question, but it estimates the
+geometric mean and is not the default.)
+
 ---
 
 ## 9. Credible Intervals

--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/event.go
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/event.go
@@ -125,8 +125,8 @@ func (es *eventStorage) QueryGoalCount(
 		{Name: "goalID", Value: goalID},
 		{Name: "featureID", Value: featureID},
 		{Name: "featureVersion", Value: featureVersion},
-		// Winsorization percentile (integer in [0,100]) for the APPROX_QUANTILES
-		// array offset.
+		// Winsorization percentile (integer in [1,100]) for the APPROX_QUANTILES
+		// array offset (100 effectively disables capping).
 		{Name: "valueCapPercentile", Value: dwhdatabase.DefaultValueCapPercentile},
 	}
 	es.logger.Debug("query goal count",

--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/event.go
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/event.go
@@ -125,6 +125,9 @@ func (es *eventStorage) QueryGoalCount(
 		{Name: "goalID", Value: goalID},
 		{Name: "featureID", Value: featureID},
 		{Name: "featureVersion", Value: featureVersion},
+		// Winsorization percentile (integer in [0,100]) for the APPROX_QUANTILES
+		// array offset.
+		{Name: "valueCapPercentile", Value: dwhdatabase.DefaultValueCapPercentile},
 	}
 	es.logger.Debug("query goal count",
 		zap.String("query", query),

--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
@@ -18,7 +18,7 @@ GROUP BY
 ),
 cap_level AS (
     -- Winsorization threshold: the configurable percentile
-    -- (@valueCapPercentile, an integer in [0,100]) of per-user value_sum pooled
+    -- (@valueCapPercentile, an integer in [1,100]) of per-user value_sum pooled
     -- across all variations. APPROX_QUANTILES(value_sum, 100) returns an array
     -- of 101 elements (quantiles 0..100). We UNNEST WITH OFFSET and select the
     -- requested element via a WHERE predicate rather than @param inside

--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
@@ -15,6 +15,34 @@ WITH grouped_by_user_evaluation AS (
 GROUP BY
     user_id,
     variation_id
+),
+cap_level AS (
+    -- Winsorization threshold: the configurable percentile
+    -- (@valueCapPercentile, an integer in [0,100]) of per-user value_sum pooled
+    -- across all variations. APPROX_QUANTILES(value_sum, 100) returns an array
+    -- of 101 elements (quantiles 0..100). We UNNEST WITH OFFSET and select the
+    -- requested element via a WHERE predicate rather than @param inside
+    -- OFFSET(...) — a bound parameter is not reliably accepted as an array
+    -- subscript in a static query. IFNULL/MAX guards the empty case. Values
+    -- above this threshold are whales whose outsized spend would otherwise make
+    -- the Normal posterior overconfident (Kohavi, Tang & Xu, Trustworthy Online
+    -- Controlled Experiments, 2020, §4).
+    SELECT IFNULL(MAX(q), 0) AS cap
+    FROM (
+        SELECT APPROX_QUANTILES(value_sum, 100) AS quantiles
+        FROM grouped_by_user_evaluation
+    ),
+    UNNEST(quantiles) AS q WITH OFFSET off
+    WHERE off = @valueCapPercentile
+),
+capped_by_user AS (
+    SELECT
+        u.user_id,
+        u.variation_id,
+        u.event_count,
+        LEAST(u.value_sum, c.cap) AS value_sum
+    FROM grouped_by_user_evaluation u
+    CROSS JOIN cap_level c
 )
 SELECT
     variation_id as variationID,
@@ -24,7 +52,7 @@ SELECT
     AVG(value_sum) as goalValueMean,
     IFNULL(VAR_SAMP(value_sum), 0) as goalValueVariance
 FROM
-    grouped_by_user_evaluation
+    capped_by_user
 GROUP BY
     variation_id
 ORDER BY

--- a/pkg/eventcounter/storage/v2/dwh_database/event.go
+++ b/pkg/eventcounter/storage/v2/dwh_database/event.go
@@ -28,6 +28,14 @@ const (
 	DataTypeGoalEvent       = "goal_event"
 )
 
+// DefaultValueCapPercentile is the percentile (1–100) at which per-user goal
+// values are winsorized before the value-metric aggregation, to keep the
+// Normal value model robust to heavy tails (whales). It is bound into the goal
+// query as a parameter rather than hardcoded in the SQL so it has a single
+// source of truth and can later be sourced from config / per-experiment
+// settings. 100 effectively disables capping (cap = max).
+const DefaultValueCapPercentile = 99
+
 var (
 	ErrBQUnexpectedMultipleResults = pkgErr.NewErrorInternal(
 		pkgErr.EventCounterPackageName,

--- a/pkg/eventcounter/storage/v2/dwh_database/mysql/event.go
+++ b/pkg/eventcounter/storage/v2/dwh_database/mysql/event.go
@@ -125,6 +125,8 @@ func (es *eventStorage) QueryGoalCount(
 		goalID,
 		featureID,
 		featureVersion,
+		// Winsorization percentile (integer in [1,100]) for the NTILE cap.
+		dwhdatabase.DefaultValueCapPercentile,
 	)
 	if err != nil {
 		es.logger.Error(

--- a/pkg/eventcounter/storage/v2/dwh_database/mysql/sql/goal_event.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/mysql/sql/goal_event.sql
@@ -15,6 +15,31 @@ WITH grouped_by_user_evaluation AS (
     GROUP BY
         user_id,
         variation_id
+),
+cap_level AS (
+    -- Winsorization threshold: the configurable percentile (?, an integer in
+    -- [1,100]) of per-user value_sum pooled across all variations. NTILE(100)
+    -- divides the sorted rows into 100 buckets; MAX of buckets ≤ the percentile
+    -- gives the cap. Values above it are whales whose outsized spend would
+    -- otherwise make the Normal posterior overconfident (Kohavi, Tang & Xu,
+    -- Trustworthy Online Controlled Experiments, 2020, §4).
+    SELECT MAX(value_sum) AS cap
+    FROM (
+        SELECT
+            value_sum,
+            NTILE(100) OVER (ORDER BY value_sum) AS pct
+        FROM grouped_by_user_evaluation
+    ) ranked
+    WHERE pct <= ?
+),
+capped_by_user AS (
+    SELECT
+        u.user_id,
+        u.variation_id,
+        u.event_count,
+        LEAST(u.value_sum, IFNULL(c.cap, 0)) AS value_sum
+    FROM grouped_by_user_evaluation u
+    CROSS JOIN cap_level c
 )
 SELECT
     variation_id as variationID,
@@ -24,8 +49,8 @@ SELECT
     AVG(value_sum) as goalValueMean,
     IFNULL(VAR_SAMP(value_sum), 0) as goalValueVariance
 FROM
-    grouped_by_user_evaluation
+    capped_by_user
 GROUP BY
     variation_id
 ORDER BY
-    variation_id 
+    variation_id

--- a/pkg/eventcounter/storage/v2/dwh_database/postgres/event.go
+++ b/pkg/eventcounter/storage/v2/dwh_database/postgres/event.go
@@ -128,6 +128,9 @@ func (es *eventStorage) QueryGoalCount(
 		goalID,
 		featureID,
 		featureVersion,
+		// $7: winsorization percentile as a fraction in [0,1] for
+		// PERCENTILE_CONT.
+		float64(dwhdatabase.DefaultValueCapPercentile)/100.0,
 	)
 	if err != nil {
 		es.logger.Error(

--- a/pkg/eventcounter/storage/v2/dwh_database/postgres/sql/goal_event.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/postgres/sql/goal_event.sql
@@ -15,6 +15,28 @@ WITH grouped_by_user_evaluation AS (
     GROUP BY
         user_id,
         variation_id
+),
+cap_level AS (
+    -- Winsorization threshold: the configurable percentile ($7, a fraction in
+    -- [0,1]) of per-user value_sum pooled across all variations.
+    -- PERCENTILE_CONT is an ordered-set aggregate (SQL:2003); COALESCE guards
+    -- the empty-CTE case. Values above this threshold are whales whose outsized
+    -- spend would otherwise make the Normal posterior overconfident (Kohavi,
+    -- Tang & Xu, Trustworthy Online Controlled Experiments, 2020, §4).
+    SELECT COALESCE(
+        PERCENTILE_CONT($7) WITHIN GROUP (ORDER BY value_sum),
+        0
+    ) AS cap
+    FROM grouped_by_user_evaluation
+),
+capped_by_user AS (
+    SELECT
+        u.user_id,
+        u.variation_id,
+        u.event_count,
+        LEAST(u.value_sum, c.cap) AS value_sum
+    FROM grouped_by_user_evaluation u
+    CROSS JOIN cap_level c
 )
 SELECT
     variation_id as variationID,
@@ -24,8 +46,8 @@ SELECT
     AVG(value_sum) as goalValueMean,
     COALESCE(VAR_SAMP(value_sum), 0) as goalValueVariance
 FROM
-    grouped_by_user_evaluation
+    capped_by_user
 GROUP BY
     variation_id
 ORDER BY
-    variation_id 
+    variation_id

--- a/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
+++ b/pkg/experimentcalculator/experimentcalc/normal_inverse_gamma_test.go
@@ -232,6 +232,87 @@ func TestNormalInverseGammaSmallNSubUnit(t *testing.T) {
 	}
 }
 
+// TestWinsorizationRobustness is a regression guard for the per-user p99 cap
+// applied in the DWH aggregation SQL (goal_event.sql / goal_count.sql).
+//
+// The SQL caps each user's total goal value at the 99th percentile of the
+// pooled per-user distribution before computing AVG / VAR_SAMP. This test
+// verifies that the NIG posterior is overconfident when fed uncapped aggregates
+// from a heavy-tailed distribution (3 whales dominate) and non-decisive when
+// fed the post-cap aggregates that the updated SQL produces.
+//
+// Derivation of test constants — scenario: n=1,000 users per variation.
+//
+//	Baseline A:   1,000 users spending ~$10 each (mean=10.0, VAR_SAMP=9.0).
+//	Treatment B:  997 users at $10; 3 whales at $10,000.
+//
+// Uncapped B aggregates (old SQL):
+//
+//	mean = (997×10 + 3×10000)/1000 = 39.97
+//	VAR_SAMP: SS = 997×(10−39.97)² + 3×(10000−39.97)² ≈ 298,499,397
+//	          VAR_SAMP = SS/999 ≈ 298,798
+//
+// Capped B aggregates (new SQL, p99 cap ≈ $15 in this distribution):
+//
+//	mean = (997×10 + 3×15)/1000 = 10.015
+//	VAR_SAMP: SS = 997×(10−10.015)² + 3×(15−10.015)² ≈ 74.775
+//	          VAR_SAMP = SS/999 ≈ 0.0748
+//
+// The EB-prior pooled variance for the uncapped case is dominated by B's
+// whale variance (~149k), inflating A's posterior noise estimate as well.
+// Even so, the mean gap (40 vs 10) produces ProbBeatBaseline ≈ 0.96.
+// After capping the mean gap shrinks to 0.015, giving ProbBeatBaseline ≈ 0.56.
+func TestWinsorizationRobustness(t *testing.T) {
+	t.Parallel()
+
+	const n = int64(1000)
+	const numSamples = 25000
+	vids := []string{"vid_baseline", "vid_treatment"}
+	baselineIdx := 0
+
+	// Pre-computed DWH aggregates WITHOUT the per-user cap (old SQL behaviour).
+	// 3 whales at $10,000 inflate treatment mean from $10 to ~$40 and drive
+	// VAR_SAMP to ~299k, making the NIG posterior falsely decisive.
+	uncappedResult := normalInverseGamma(
+		rand.NewPCG(25, 0),
+		vids,
+		[]float64{10.0, 39.97},
+		[]float64{9.0, 298798.0},
+		[]int64{n, n},
+		baselineIdx,
+		numSamples,
+	)
+	// The whale-inflated mean difference produces overconfident inference:
+	// 3 users out of 1,000 flip the verdict to "treatment wins decisively".
+	assert.Greater(
+		t,
+		uncappedResult["vid_treatment"].GoalValueSumPerUserProbBeatBaseline.Mean,
+		0.90,
+		"uncapped whale scenario must be overconfident (ProbBeatBaseline > 0.90)",
+	)
+
+	// Pre-computed DWH aggregates AFTER the per-user p99 cap (new SQL behaviour).
+	// The 3 whales are capped at $15; the treatment mean shifts from $39.97
+	// to $10.015 — a 1.5-cent lift that is not business-meaningful.
+	cappedResult := normalInverseGamma(
+		rand.NewPCG(26, 0),
+		vids,
+		[]float64{10.0, 10.015},
+		[]float64{9.0, 0.0748},
+		[]int64{n, n},
+		baselineIdx,
+		numSamples,
+	)
+	// After capping the result is non-decisive: whales no longer drive the
+	// posterior and the tiny residual lift is within normal noise.
+	assert.Less(
+		t,
+		cappedResult["vid_treatment"].GoalValueSumPerUserProbBeatBaseline.Mean,
+		0.80,
+		"capped whale scenario must be non-decisive (ProbBeatBaseline < 0.80)",
+	)
+}
+
 func TestComputeEmpiricalBayesPriors(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -717,6 +717,145 @@ func TestExperimentResult(t *testing.T) {
 	}
 }
 
+// TestExperimentGoalCountWinsorization verifies the per-user p99 winsorization
+// applied in the goal-count DWH query (goal_event.sql / goal_count.sql). The
+// cap only bites once there are enough users for the top 1% to exclude the
+// whale (NTILE(100) needs >= 100 rows on MySQL), so this fixture uses 120
+// users: 119 normal goal values plus one "whale" several orders of magnitude
+// larger. The whale's per-user value sits in the top percentile and must be
+// capped down to the bulk level before aggregation.
+//
+//	capped   ValueSum ≈ 119*10 + cap(=10) = 1,200
+//	uncapped ValueSum ≈ 119*10 + 100,000  = 101,190
+//
+// We wait until all 120 users are linked (so the whale is definitely counted)
+// and then assert ValueSum is far below the uncapped figure. The threshold is
+// deliberately loose (< 50,000) so it holds across all three DWH backends,
+// whose percentile implementations differ slightly — only an uncapped result
+// could exceed it.
+func TestExperimentGoalCountWinsorization(t *testing.T) {
+	t.Parallel()
+	featureClient := newFeatureClient(t)
+	defer featureClient.Close()
+	experimentClient := newExperimentClient(t)
+	defer experimentClient.Close()
+	ecClient := newEventCounterClient(t)
+	defer ecClient.Close()
+	uuid := newUUID(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	const (
+		totalUsers  = 120
+		normalValue = float64(10)
+		whaleValue  = float64(100000)
+	)
+
+	tag := fmt.Sprintf("%s-tag-%s", prefixTestName, uuid)
+	userIDs := make([]string, 0, totalUsers)
+	for i := 0; i < totalUsers; i++ {
+		userIDs = append(userIDs, fmt.Sprintf("%s-%d", createUserID(t, uuid), i))
+	}
+	featureID := createFeatureID(t, uuid)
+
+	createFeature(t, featureClient, featureID, tag, "a", "b")
+	f, err := getFeature(t, featureClient, featureID)
+	if err != nil {
+		t.Fatalf("Failed to get feature. ID: %s. Error: %v", featureID, err)
+	}
+
+	// Route every user to variation A via individual targeting (one update for
+	// the whole list), so all goal values land in a single pooled distribution
+	// with a known per-user breakdown and a TARGET evaluation reason.
+	reason := &featureproto.Reason{Type: featureproto.Reason_TARGET}
+	addFeatureIndividualTargetingBulk(t, featureID, f.Variations[0].Id, userIDs, featureClient)
+
+	updateFeatueFlagCache(t)
+
+	f, err = getFeature(t, featureClient, featureID)
+	if err != nil {
+		t.Fatalf("Failed to get feature. ID: %s. Error: %v", featureID, err)
+	}
+
+	goalIDs := createGoals(ctx, t, experimentClient, 1)
+	startAt := time.Now().Add(-time.Hour)
+	stopAt := time.Now().Add(2 * time.Hour)
+	experiment := createExperimentWithMultiGoals(
+		ctx, t, experimentClient, "TestExperimentGoalCountWinsorization", featureID, goalIDs, f.Variations[0].Id, startAt, stopAt)
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		stopExperiment(cleanupCtx, t, experimentClient, experiment.Id)
+	})
+
+	variationIDs := make([]string, 0, len(experiment.Variations))
+	for _, v := range experiment.Variations {
+		variationIDs = append(variationIDs, v.Id)
+	}
+
+	// Wait for the on-demand subscriber to create PubSub subscriptions.
+	time.Sleep(15 * time.Second)
+
+	// Evaluation events must be sent (and land) before goal events so the
+	// subscriber can link each goal event to the user's evaluation.
+	registerEvaluationEventsBatch(t, featureID, experiment.FeatureVersion, userIDs, f.Variations[0].Id, tag, reason)
+
+	// Wait a few seconds so the evaluations become available for linking.
+	time.Sleep(10 * time.Second)
+
+	// One goal event per user: the last user is the whale.
+	goalValues := make(map[string]float64, totalUsers)
+	for i, userID := range userIDs {
+		if i == totalUsers-1 {
+			goalValues[userID] = whaleValue
+		} else {
+			goalValues[userID] = normalValue
+		}
+	}
+	registerGoalEventsBatch(t, goalIDs[0], tag, goalValues, time.Now().Unix())
+
+	for i := 0; i < retryTimes; i++ {
+		if i == retryTimes-1 {
+			t.Fatalf("retry timeout after %d attempts", retryTimes)
+		}
+		time.Sleep(10 * time.Second)
+
+		resp, err := getExperimentGoalCount(t, ecClient, goalIDs[0], featureID, experiment.FeatureVersion, variationIDs)
+		if err != nil {
+			st, _ := status.FromError(err)
+			if st.Code() != codes.NotFound {
+				t.Fatalf("Failed to get the experiment goal count. Error code: %d. Error: %v\n", st.Code(), err)
+			}
+			continue
+		}
+		if resp == nil || len(resp.VariationCounts) == 0 {
+			continue
+		}
+		vcA := getVariationCount(resp.VariationCounts, f.Variations[0].Id)
+		if vcA == nil {
+			continue
+		}
+		// Wait until every user (including the whale) has been linked, so the
+		// whale's value is part of the aggregate we assert on.
+		if vcA.UserCount != totalUsers {
+			t.Logf("Retry %d/%d: linked users %d/%d", i+1, retryTimes, vcA.UserCount, totalUsers)
+			continue
+		}
+		// With the whale present, an uncapped ValueSum would be ~101,190; the
+		// winsorized ValueSum is ~1,200. Anything below 50,000 proves the whale
+		// was capped.
+		if vcA.ValueSum >= 50000 {
+			t.Fatalf(
+				"winsorization did not cap the whale: ValueSum=%f (expected ~1200 capped, ~101190 uncapped)",
+				vcA.ValueSum,
+			)
+		}
+		t.Logf("winsorization OK: capped ValueSum=%f for %d users", vcA.ValueSum, vcA.UserCount)
+		break
+	}
+}
+
 func TestGrpcMultiGoalsEventCounter(t *testing.T) {
 	t.Parallel()
 	featureClient := newFeatureClient(t)
@@ -2051,6 +2190,135 @@ func registerEvaluationEvent(
 	response := util.RegisterEvents(t, events, *gatewayAddr, *apiKeyPath)
 	if len(response.Errors) > 0 {
 		t.Fatalf("Failed to register events. Error: %v", response.Errors)
+	}
+}
+
+// registerEventsInChunks registers events in batches so large fixtures don't
+// require one gateway round-trip per event.
+func registerEventsInChunks(t *testing.T, events []util.Event) {
+	t.Helper()
+	const chunkSize = 50
+	for start := 0; start < len(events); start += chunkSize {
+		end := start + chunkSize
+		if end > len(events) {
+			end = len(events)
+		}
+		response := util.RegisterEvents(t, events[start:end], *gatewayAddr, *apiKeyPath)
+		if len(response.Errors) > 0 {
+			t.Fatalf("Failed to register events. Error: %v", response.Errors)
+		}
+	}
+}
+
+// registerEvaluationEventsBatch registers one evaluation event per user (all
+// mapped to variationID) in batched gateway calls.
+func registerEvaluationEventsBatch(
+	t *testing.T,
+	featureID string,
+	featureVersion int32,
+	userIDs []string,
+	variationID, tag string,
+	reason *featureproto.Reason,
+) {
+	t.Helper()
+	if reason == nil {
+		reason = &featureproto.Reason{}
+	}
+	events := make([]util.Event, 0, len(userIDs))
+	for _, userID := range userIDs {
+		evaluation, err := protojson.Marshal(&eventproto.EvaluationEvent{
+			Timestamp:      time.Now().Unix(),
+			FeatureId:      featureID,
+			FeatureVersion: featureVersion,
+			UserId:         userID,
+			VariationId:    variationID,
+			User: &userproto.User{
+				Id:   userID,
+				Data: map[string]string{"appVersion": "0.1.0"}},
+			Reason: reason,
+			Tag:    tag,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, util.Event{
+			ID:    newUUID(t),
+			Event: evaluation,
+			Type:  gwapi.EvaluationEventType,
+		})
+	}
+	registerEventsInChunks(t, events)
+}
+
+// registerGoalEventsBatch registers one goal event per user (value taken from
+// userValues) in batched gateway calls.
+func registerGoalEventsBatch(
+	t *testing.T,
+	goalID, tag string,
+	userValues map[string]float64,
+	timestamp int64,
+) {
+	t.Helper()
+	events := make([]util.Event, 0, len(userValues))
+	for userID, value := range userValues {
+		goal, err := protojson.Marshal(&eventproto.GoalEvent{
+			Timestamp: timestamp,
+			GoalId:    goalID,
+			UserId:    userID,
+			Value:     value,
+			User: &userproto.User{
+				Id:   userID,
+				Data: map[string]string{"appVersion": "0.1.0"}},
+			Tag: tag,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, util.Event{
+			ID:    newUUID(t),
+			Event: goal,
+			Type:  gwapi.GoalEventType,
+		})
+	}
+	registerEventsInChunks(t, events)
+}
+
+// addFeatureIndividualTargetingBulk sets the full individual-targeting user
+// list for a variation in a single UpdateFeature call (instead of one call per
+// user, which is prohibitive for large fixtures).
+func addFeatureIndividualTargetingBulk(
+	t *testing.T,
+	featureID, variationID string,
+	users []string,
+	client featureclient.Client,
+) {
+	t.Helper()
+	for i := 0; i < deadlockRetryAttempts; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
+		_, err := client.UpdateFeature(ctx, &featureproto.UpdateFeatureRequest{
+			Id:            featureID,
+			EnvironmentId: *environmentID,
+			TargetChanges: []*featureproto.TargetChange{
+				{
+					ChangeType: featureproto.ChangeType_UPDATE,
+					Target: &featureproto.Target{
+						Variation: variationID,
+						Users:     users,
+					},
+				},
+			},
+		})
+		cancel()
+		if err == nil {
+			return
+		}
+		if i < deadlockRetryAttempts-1 && util.IsDeadlockError(err) {
+			t.Logf("Retrying addFeatureIndividualTargetingBulk (attempt %d/%d) for %s: %v",
+				i+1, deadlockRetryAttempts, featureID, err)
+			time.Sleep(time.Duration(i+1) * time.Second)
+			continue
+		}
+		t.Fatalf("Failed to bulk add individual targeting for feature %s: %v", featureID, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Applies per-user p99 winsorization inside the DWH goal aggregation SQL across all three backends (MySQL, Postgres, BigQuery), so the NIG posterior is no longer overconfident on heavy-tailed value metrics. The cap percentile is a bound query parameter (default p99) sourced from a single Go constant, not a SQL literal.

## Problem

A handful of high-value users ("whales") can inflate the per-variation `AVG(value_sum)` and deflate `VAR_SAMP` enough to drive `ProbBeatBaseline` above 0.95 — a decisive-looking verdict that would reverse if those same users had been assigned to the other variation.
The Normal model does exactly what it is designed to do; the issue is that uncapped per-user values violate the light-tail assumption.

## Approach

- **Where**: the cap is applied in SQL, before `SUM`/`AVG`/`VAR_SAMP`,
  because the Go calculator receives only aggregates and cannot access
  per-user rows.
- **What**: new CTEs added to each backend's `goal_event.sql` /
  `goal_count.sql`:
  1. `cap_level` — the configurable percentile (default p99) of per-user
     `value_sum`, pooled across all variations (one cap per experiment
     window, one SQL round-trip).
  2. `capped_by_user` — applies `LEAST(value_sum, cap)` to each row.
  3. Final `SELECT` reads from `capped_by_user` instead of
     `grouped_by_user_evaluation`.
- **Percentile function per backend** (each takes the percentile as a
  bound parameter, not a literal):
  - MySQL: `NTILE(100) ... WHERE pct <= ?` (MySQL 8+).
  - Postgres: `PERCENTILE_CONT($7) WITHIN GROUP (...)` ($7 = fraction).
  - BigQuery: `UNNEST(APPROX_QUANTILES(value_sum, 100)) WITH OFFSET off
    ... WHERE off = @valueCapPercentile`. (A bound parameter is not
    reliably accepted inside an array `OFFSET(...)` in a static query, so
    the element is selected via a `WHERE` predicate instead.)
- **Configurable, single source of truth**: the percentile comes from
  `dwhdatabase.DefaultValueCapPercentile = 99` and is passed into each
  query as a parameter. This removes the hardcoded literal and is the
  seam for later server/per-experiment configuration + UI (`100`
  disables capping). No schema/proto change.
- **No-whale experiments are numerically unchanged**: `LEAST(x, cap)`
  is a no-op when `cap ≥ max(value_sum)`. (Note: because p99 only trims
  the top 1%, the cap is effectively inactive below ~100 goal users —
  acceptable, since small-n + whale inflates variance and stays
  non-decisive anyway.)

## Files changed

| File | Change |
|---|---|
| `.../dwh_database/mysql/sql/goal_event.sql` | Add `cap_level` + `capped_by_user` CTEs (NTILE; param `?`) |
| `.../dwh_database/postgres/sql/goal_event.sql` | Same (`PERCENTILE_CONT($7)`) |
| `.../dwh_database/bigquery/sql/goal_count.sql` | Same (`APPROX_QUANTILES` + `UNNEST ... WITH OFFSET ... WHERE`) |
| `.../dwh_database/event.go` | Add `DefaultValueCapPercentile` constant |
| `.../dwh_database/{mysql,postgres,bigquery}/event.go` | Bind the percentile param into `QueryGoalCount` |
| `.../experimentcalc/normal_inverse_gamma_test.go` | Add `TestWinsorizationRobustness` |
| `test/e2e/eventcounter/eventcounter_test.go` | Add `TestExperimentGoalCountWinsorization` + batch/bulk helpers |
| `docs/mechanism/experiment-calculator-math.md` | Document the winsorization in §8 |

`normal_inverse_gamma.go`, all protos, and all UI files are **unchanged**.

## Test

**Unit — `TestWinsorizationRobustness`** (pre-computed aggregates, no live
dependencies):
- **Uncapped** (997 × $10 + 3 × $10,000; mean 39.97, VAR_SAMP 298,798):
  `ProbBeatBaseline > 0.90` — whales falsely dominate the verdict.
- **Capped at p99** (same users; mean 10.015, VAR_SAMP 0.075):
  `ProbBeatBaseline < 0.80` — non-decisive, whales treated as noise.

**E2E — `TestExperimentGoalCountWinsorization`** (exercises the real SQL):
- Registers 120 users (119 at value 10 + one whale at 100,000), waits for
  all to link, then asserts the goal-count API returns a capped `ValueSum`
  (~1,200 vs ~101,190 uncapped).
- Requires `UserCount == 120` (whale linked) before asserting, so it can
  time out under slow linking but cannot false-pass.
- **Verified green on real MySQL and real BigQuery** (both return exactly
  `ValueSum = 1200`). Postgres `PERCENTILE_CONT($7)` is standard but not
  yet run against a live Postgres DWH.

All existing NIG + empirical-Bayes tests pass unchanged.

## Ops note (not in this PR)

BigQuery table partition expiration is managed outside this repo (infrastructure). That TTL must be ≥ the experiment window length to avoid purging goal events before the calculator reads them. No change needed for this PR, but worth confirming the partition expiry is aligned with the max experiment period when retention is extended (tracked separately).