### PR TITLE
fix(rest): skip logging for HTTP redirect responses

### DIFF
--- a/pkg/rest/log.go
+++ b/pkg/rest/log.go
@@ -40,7 +40,7 @@ func LogServerMiddleware(logger *zap.Logger) middleware {
 						body:           new(bytes.Buffer),
 					}
 					next.ServeHTTP(rr, r)
-					// Skip logging for successful and redirect responses.
+					// Skip logging for 200 OK and redirect (3xx) responses.
 					if rr.statusCode == http.StatusOK || (rr.statusCode >= 300 && rr.statusCode < 400) {
 						return
 					}

--- a/pkg/rest/log.go
+++ b/pkg/rest/log.go
@@ -40,7 +40,8 @@ func LogServerMiddleware(logger *zap.Logger) middleware {
 						body:           new(bytes.Buffer),
 					}
 					next.ServeHTTP(rr, r)
-					if rr.statusCode == http.StatusOK {
+					// Skip logging for successful and redirect responses.
+					if rr.statusCode == http.StatusOK || (rr.statusCode >= 300 && rr.statusCode < 400) {
 						return
 					}
 					var level zapcore.Level

--- a/pkg/rest/log_test.go
+++ b/pkg/rest/log_test.go
@@ -81,13 +81,17 @@ func TestLogServerMiddleware(t *testing.T) {
 			rec := httptest.NewRecorder()
 			handler.ServeHTTP(rec, req)
 
+			out := strings.TrimSpace(buf.String())
+			var logLines []string
+			if out != "" {
+				logLines = strings.Split(out, "\n")
+			}
+			require.Len(t, logLines, p.expectedCount)
 			if p.expectedCount == 0 {
-				assert.Empty(t, buf.String())
 				return
 			}
-			require.NotEmpty(t, buf.String())
-			var logEntry map[string]interface{}
-			require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
+			var logEntry map[string]any
+			require.NoError(t, json.Unmarshal([]byte(logLines[0]), &logEntry))
 			assert.Equal(t, float64(http.StatusNotFound), logEntry["statusCode"])
 		})
 	}

--- a/pkg/rest/log_test.go
+++ b/pkg/rest/log_test.go
@@ -16,12 +16,82 @@ package rest
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
+
+func TestLogServerMiddleware(t *testing.T) {
+	t.Parallel()
+
+	handlerFor := func(logger *zap.Logger) http.Handler {
+		return LogServerMiddleware(logger)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/redirect":
+				w.WriteHeader(http.StatusMovedPermanently)
+			case "/not-found":
+				w.WriteHeader(http.StatusNotFound)
+			default:
+				w.WriteHeader(http.StatusOK)
+			}
+		}))
+	}
+
+	patterns := []struct {
+		desc          string
+		path          string
+		expectedCount int
+	}{
+		{
+			desc:          "success: skip logging for 200",
+			path:          "/ok",
+			expectedCount: 0,
+		},
+		{
+			desc:          "success: skip logging for 301 redirect",
+			path:          "/redirect",
+			expectedCount: 0,
+		},
+		{
+			desc:          "warn: log 404",
+			path:          "/not-found",
+			expectedCount: 1,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			core := zapcore.NewCore(
+				zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+				zapcore.AddSync(&buf),
+				zapcore.WarnLevel,
+			)
+			handler := handlerFor(zap.New(core))
+
+			req := httptest.NewRequest(http.MethodGet, p.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			if p.expectedCount == 0 {
+				assert.Empty(t, buf.String())
+				return
+			}
+			require.NotEmpty(t, buf.String())
+			var logEntry map[string]interface{}
+			require.NoError(t, json.Unmarshal(buf.Bytes(), &logEntry))
+			assert.Equal(t, float64(http.StatusNotFound), logEntry["statusCode"])
+		})
+	}
+}
 
 func TestDecodeBody(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

- Stop `LogServerMiddleware` from logging 3xx redirect responses
- Redirects are expected HTTP behavior (e.g. `/assets` → `/assets/`, scanner probes like `GET /temp/`) and were incorrectly logged at ERROR severity
- Add unit tests covering 200, 301, and 404 logging behavior

## Context

The web service dashboard REST server was emitting many ERROR logs for requests like `GET /temp/` with status 301. These are not application failures — they come from Go's `FileServer` redirect behavior combined with the logging middleware treating any non-2xx/4xx response as an error.

## Test plan

- [x] `go test ./pkg/rest/ -run TestLogServerMiddleware`