### PR TITLE
feat(stream): add graceful shutdown for SSE connections

### DIFF
--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -736,6 +736,9 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		// This prevents "context deadline exceeded" errors during high traffic.
 		time.Sleep(propagationDelay)
 
+		// Close all active SSE connections so httpServer.Shutdown returns promptly.
+		streamDispatcher.Shutdown()
+
 		// Shutdown order matters due to dependencies:
 		// 1. apiGateway/httpServer make gRPC calls to the backend server
 		// 2. We MUST drain them BEFORE stopping the backend sever

--- a/pkg/api/stream/dispatcher.go
+++ b/pkg/api/stream/dispatcher.go
@@ -29,8 +29,10 @@ import (
 type Dispatcher struct {
 	mu sync.Mutex
 	// envID -> tag -> set of conns
-	conns  map[string]map[string]map[*conn]struct{}
-	logger *zap.Logger
+	conns        map[string]map[string]map[*conn]struct{}
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
+	logger       *zap.Logger
 }
 
 type event struct {
@@ -49,9 +51,15 @@ type conn struct {
 
 func NewDispatcher(logger *zap.Logger) *Dispatcher {
 	return &Dispatcher{
-		conns:  make(map[string]map[string]map[*conn]struct{}),
-		logger: logger.Named("stream-dispatcher"),
+		conns:      make(map[string]map[string]map[*conn]struct{}),
+		shutdownCh: make(chan struct{}),
+		logger:     logger.Named("stream-dispatcher"),
 	}
+}
+
+// Shutdown signals all active SSE handlers to exit immediately.
+func (d *Dispatcher) Shutdown() {
+	d.shutdownOnce.Do(func() { close(d.shutdownCh) })
 }
 
 // register adds a connection to the dispatcher. The caller must invoke the returned

--- a/pkg/api/stream/dispatcher_test.go
+++ b/pkg/api/stream/dispatcher_test.go
@@ -94,6 +94,22 @@ func TestDispatcherRegister(t *testing.T) {
 	}
 }
 
+func TestDispatcherShutdown(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(zap.NewNop())
+
+	d.Shutdown()
+	// Second call must not panic.
+	d.Shutdown()
+
+	select {
+	case <-d.shutdownCh:
+		// Success: shutdownCh is closed, so receivers are unblocked.
+	default:
+		t.Fatal("shutdownCh must be closed after Shutdown")
+	}
+}
+
 func TestDispatcherDeregister(t *testing.T) {
 	t.Parallel()
 	cases := []struct {

--- a/pkg/api/stream/evaluations.go
+++ b/pkg/api/stream/evaluations.go
@@ -151,6 +151,8 @@ func (h *EvaluationsHandler) Handle(w http.ResponseWriter, httpReq *http.Request
 		select {
 		case <-ctx.Done():
 			return
+		case <-h.dispatcher.shutdownCh:
+			return
 		case <-ticker.C:
 			if err := sendHeartbeat(w, flusher); err != nil {
 				// We cannot send an error event here because

--- a/pkg/api/stream/evaluations_test.go
+++ b/pkg/api/stream/evaluations_test.go
@@ -19,13 +19,21 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
+	accountproto "github.com/bucketeer-io/bucketeer/v2/proto/account"
+	environmentproto "github.com/bucketeer-io/bucketeer/v2/proto/environment"
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
 	gatewayproto "github.com/bucketeer-io/bucketeer/v2/proto/gateway"
 	userproto "github.com/bucketeer-io/bucketeer/v2/proto/user"
@@ -222,4 +230,66 @@ func TestPatch(t *testing.T) {
 			assert.Equal(t, "new-ueid", got.GetUserEvaluationsId())
 		})
 	}
+}
+
+// Handle blocks in its event loop while the SSE connection is active.
+// Shutdown must unblock it so httpServer.Shutdown is not delayed.
+func TestHandleExitsOnDispatcherShutdown(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(zap.NewNop())
+	handleReturned := startBlockedStreamHandle(t, d)
+
+	d.Shutdown()
+
+	select {
+	case <-handleReturned:
+		// Success: Shutdown unblocked the handler.
+	case <-time.After(time.Second):
+		t.Fatal("Handle is still blocked in its event loop after Dispatcher.Shutdown")
+	}
+}
+
+// startBlockedStreamHandle runs Handle for one SSE connection in a goroutine and waits
+// until the connection is registered. The returned channel is closed when Handle returns.
+func startBlockedStreamHandle(t *testing.T, d *Dispatcher) <-chan struct{} {
+	t.Helper()
+	h := NewEvaluationsHandler(
+		d,
+		time.Hour, // ensure the heartbeat ticker never fires during the test
+		func(_ context.Context, _ *userproto.User, _, _ string, _ string, _ int64) (string, *featureproto.UserEvaluations, error) {
+			return "ueid-1", &featureproto.UserEvaluations{
+				Id:          "ueid-1",
+				Evaluations: []*featureproto.Evaluation{},
+			}, nil
+		},
+		func(_ context.Context, _ *http.Request) (*accountproto.EnvironmentAPIKey, error) {
+			return &accountproto.EnvironmentAPIKey{
+				Environment: &environmentproto.EnvironmentV2{Id: "env-1"},
+			}, nil
+		},
+		prometheus.NewCounterVec(prometheus.CounterOpts{Name: "test_request_total"},
+			[]string{"organization_id", "project_id", "project_url_code",
+				"environment_id", "environment_url_code", "method", "source_id"}),
+		zap.NewNop(),
+	)
+
+	body, err := protojson.Marshal(&gatewayproto.StreamEvaluationsRequest{
+		Tag:  "tag-A",
+		User: &userproto.User{Id: "u-1"},
+	})
+	require.NoError(t, err)
+	httpReq := httptest.NewRequest(http.MethodPost, "/stream_evaluations", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	handleReturned := make(chan struct{})
+	go func() {
+		defer close(handleReturned)
+		h.Handle(rec, httpReq)
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(snapshotConnCounts(d)) > 0
+	}, time.Second, 10*time.Millisecond)
+
+	return handleReturned
 }


### PR DESCRIPTION
Part of #2152, Follows #2665

Add graceful shutdown support for SSE stream connections so the API server can shut down cleanly.

SSE handlers block indefinitely in their event loop, which prevents `httpServer.Shutdown()` from returning until the shutdown timeout expires. Without explicit signaling, all active SSE connections remain open and delay the shutdown sequence.

- `Dispatcher.Shutdown()` closes a shared channel (`shutdownCh`) that all SSE handler goroutines select on, causing them to return immediately
- Called after the propagation delay but before `httpServer.Shutdown()`, so the HTTP server finds no active handlers and returns promptly
- Uses `sync.Once` to make `Shutdown()` idempotent — safe to call multiple times without panic on double-close