### PR TITLE
feat(stream): add per-pod SSE connection limit

### DIFF
--- a/manifests/bucketeer/charts/api/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/api/templates/deployment.yaml
@@ -179,6 +179,10 @@ spec:
             - name: BUCKETEER_API_CACHE_INVALIDATION_TOPIC
               value: "{{ .Values.env.cacheInvalidationTopic }}"
             {{- end }}
+            {{- if .Values.env.sseMaxConnections }}
+            - name: BUCKETEER_API_SSE_MAX_CONNECTIONS
+              value: "{{ .Values.env.sseMaxConnections }}"
+            {{- end }}
             - name: BUCKETEER_API_SERVICE_TOKEN
               value: /usr/local/service-token/token
             - name: BUCKETEER_API_CERT

--- a/manifests/bucketeer/charts/api/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/api/templates/deployment.yaml
@@ -179,6 +179,10 @@ spec:
             - name: BUCKETEER_API_CACHE_INVALIDATION_TOPIC
               value: "{{ .Values.env.cacheInvalidationTopic }}"
             {{- end }}
+            {{- if .Values.env.sseHeartbeatInterval }}
+            - name: BUCKETEER_API_SSE_HEARTBEAT_INTERVAL
+              value: "{{ .Values.env.sseHeartbeatInterval }}"
+            {{- end }}
             {{- if .Values.env.sseMaxConnections }}
             - name: BUCKETEER_API_SSE_MAX_CONNECTIONS
               value: "{{ .Values.env.sseMaxConnections }}"

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -65,6 +65,7 @@ env:
   # (Google Pub/Sub and Redis Streams) auto-create the topic on first
   # publish, so no pre-provisioning step is required.
   cacheInvalidationTopic:
+  sseHeartbeatInterval: 25s
   sseMaxConnections: 10000
   logLevel: info
   grpcGatewayPort: 9089

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -65,6 +65,7 @@ env:
   # (Google Pub/Sub and Redis Streams) auto-create the topic on first
   # publish, so no pre-provisioning step is required.
   cacheInvalidationTopic:
+  sseMaxConnections: 10000
   logLevel: info
   grpcGatewayPort: 9089
   port: 9090

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -736,6 +736,9 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		// This prevents "context deadline exceeded" errors during high traffic.
 		time.Sleep(propagationDelay)
 
+		// Close all active SSE connections so httpServer.Shutdown returns promptly.
+		streamDispatcher.Shutdown()
+
 		// Shutdown order matters due to dependencies:
 		// 1. apiGateway/httpServer make gRPC calls to the backend server
 		// 2. We MUST drain them BEFORE stopping the backend sever

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -137,6 +137,7 @@ type server struct {
 	pubSubRedisMode           *string
 	cacheInvalidationTopic    *string
 	sseHeartbeatInterval      *time.Duration
+	sseMaxConnections         *int
 }
 
 func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
@@ -314,6 +315,9 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 				"endpoint. Must be shorter than the idle timeout of any reverse "+
 				"proxy or load balancer in front of the gateway.",
 		).Default("25s").Duration(),
+		sseMaxConnections: cmd.Flag("sse-max-connections",
+			"Maximum number of concurrent SSE connections per pod.",
+		).Default("10000").Int(),
 	}
 	r.RegisterCommand(server)
 	return server
@@ -547,7 +551,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		cachev3.WithEvictionInterval(*s.apiKeyMemoryCacheEvictionInterval),
 	)
 
-	streamDispatcher := stream.NewDispatcher(logger)
+	streamDispatcher := stream.NewDispatcher(*s.sseMaxConnections, logger)
 	invalidatorCtx, invalidatorCancel := context.WithCancel(context.Background())
 	var invalidatorCleanup func()
 	var stopInvalidatorOnce sync.Once

--- a/pkg/api/stream/dispatcher.go
+++ b/pkg/api/stream/dispatcher.go
@@ -29,8 +29,10 @@ import (
 type Dispatcher struct {
 	mu sync.Mutex
 	// envID -> tag -> set of conns
-	conns  map[string]map[string]map[*conn]struct{}
-	logger *zap.Logger
+	conns        map[string]map[string]map[*conn]struct{}
+	shutdownCh   chan struct{}
+	shutdownOnce sync.Once
+	logger       *zap.Logger
 }
 
 type event struct {
@@ -49,9 +51,15 @@ type conn struct {
 
 func NewDispatcher(logger *zap.Logger) *Dispatcher {
 	return &Dispatcher{
-		conns:  make(map[string]map[string]map[*conn]struct{}),
-		logger: logger.Named("stream-dispatcher"),
+		conns:      make(map[string]map[string]map[*conn]struct{}),
+		shutdownCh: make(chan struct{}),
+		logger:     logger.Named("stream-dispatcher"),
 	}
+}
+
+// Shutdown signals all active SSE handlers to exit immediately.
+func (d *Dispatcher) Shutdown() {
+	d.shutdownOnce.Do(func() { close(d.shutdownCh) })
 }
 
 // register adds a connection to the dispatcher. The caller must invoke the returned

--- a/pkg/api/stream/dispatcher.go
+++ b/pkg/api/stream/dispatcher.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"encoding/json"
+	"errors"
 	"sync"
 	"time"
 
@@ -25,11 +26,15 @@ import (
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
 )
 
+var errTooManyConnections = errors.New("stream: too many connections")
+
 // Dispatcher forwards relevant domain events to SSE connections.
 type Dispatcher struct {
 	mu sync.Mutex
 	// envID -> tag -> set of conns
 	conns        map[string]map[string]map[*conn]struct{}
+	totalConns   int
+	maxConns     int
 	shutdownCh   chan struct{}
 	shutdownOnce sync.Once
 	logger       *zap.Logger
@@ -49,9 +54,10 @@ type conn struct {
 	createdAt time.Time
 }
 
-func NewDispatcher(logger *zap.Logger) *Dispatcher {
+func NewDispatcher(maxConns int, logger *zap.Logger) *Dispatcher {
 	return &Dispatcher{
 		conns:      make(map[string]map[string]map[*conn]struct{}),
+		maxConns:   maxConns,
 		shutdownCh: make(chan struct{}),
 		logger:     logger.Named("stream-dispatcher"),
 	}
@@ -64,15 +70,20 @@ func (d *Dispatcher) Shutdown() {
 
 // register adds a connection to the dispatcher. The caller must invoke the returned
 // deregister func on disconnect to free the slot.
-func (d *Dispatcher) register(envID, tag, sourceID string) (events <-chan event, deregister func()) {
+// Returns errTooManyConnections when maxConns is set and already reached.
+func (d *Dispatcher) register(envID, tag, sourceID string) (events <-chan event, deregister func(), err error) {
+	d.mu.Lock()
+	if d.totalConns >= d.maxConns {
+		d.mu.Unlock()
+		sseErrorsCounter.WithLabelValues(envID, tag, sourceID, errorTypeConnectionRefusedByLimit).Inc()
+		return nil, nil, errTooManyConnections
+	}
 	c := &conn{
-		// Only the latest event is needed to evaluate with the latest config.
 		ch:        make(chan event, 1),
 		tag:       tag,
 		sourceID:  sourceID,
 		createdAt: time.Now(),
 	}
-	d.mu.Lock()
 	tagConns, ok := d.conns[envID]
 	if !ok {
 		tagConns = make(map[string]map[*conn]struct{})
@@ -84,11 +95,12 @@ func (d *Dispatcher) register(envID, tag, sourceID string) (events <-chan event,
 		tagConns[tag] = conns
 	}
 	conns[c] = struct{}{}
+	d.totalConns++
 	// Update the gauge inside the lock so it stays consistent with the conn map.
 	sseActiveConnectionsGauge.WithLabelValues(envID, tag, sourceID).Inc()
 	d.mu.Unlock()
 
-	return c.ch, func() { d.deregister(envID, c) }
+	return c.ch, func() { d.deregister(envID, c) }, nil
 }
 
 func (d *Dispatcher) deregister(envID string, target *conn) {
@@ -104,6 +116,7 @@ func (d *Dispatcher) deregister(envID string, target *conn) {
 		return
 	}
 	delete(conns, target)
+	d.totalConns--
 	sseActiveConnectionsGauge.WithLabelValues(envID, target.tag, target.sourceID).Dec()
 	if len(conns) == 0 {
 		delete(tagConns, target.tag)

--- a/pkg/api/stream/dispatcher_test.go
+++ b/pkg/api/stream/dispatcher_test.go
@@ -84,14 +84,72 @@ func TestDispatcherRegister(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			d := NewDispatcher(zap.NewNop())
+			d := NewDispatcher(10000, zap.NewNop())
 			for _, r := range tc.clients {
-				_, cancel := d.register(r.envID, r.tag, "source1")
+				_, cancel, err := d.register(r.envID, r.tag, "source1")
+				require.NoError(t, err)
 				defer cancel()
 			}
 			assert.Equal(t, tc.wantConnCounts, snapshotConnCounts(d))
 		})
 	}
+}
+
+func TestDispatcherRegisterMaxConns(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		desc       string
+		maxConns   int
+		register   int
+		wantErrors int
+	}{
+		{
+			desc:       "within limit",
+			maxConns:   3,
+			register:   3,
+			wantErrors: 0,
+		},
+		{
+			desc:       "exceeds limit",
+			maxConns:   2,
+			register:   5,
+			wantErrors: 3,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+			d := NewDispatcher(tc.maxConns, zap.NewNop())
+			var errCount int
+			for i := 0; i < tc.register; i++ {
+				_, cancel, err := d.register("env-1", "tag-A", "source1")
+				if err != nil {
+					errCount++
+					assert.ErrorIs(t, err, errTooManyConnections)
+				} else {
+					defer cancel()
+				}
+			}
+			assert.Equal(t, tc.wantErrors, errCount)
+		})
+	}
+}
+
+func TestDispatcherRegisterSlotFreedByDeregister(t *testing.T) {
+	t.Parallel()
+	maxConns := 1
+	d := NewDispatcher(maxConns, zap.NewNop())
+	_, cancel1, err := d.register("env-1", "tag-A", "source1")
+	require.NoError(t, err)
+
+	_, _, err = d.register("env-1", "tag-A", "source1")
+	assert.ErrorIs(t, err, errTooManyConnections)
+
+	cancel1() // conns: 1->0
+
+	_, cancel3, err := d.register("env-1", "tag-A", "source1")
+	require.NoError(t, err)
+	defer cancel3()
 }
 
 func TestDispatcherDeregister(t *testing.T) {
@@ -130,13 +188,13 @@ func TestDispatcherDeregister(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			d := NewDispatcher(zap.NewNop())
+			d := NewDispatcher(10000, zap.NewNop())
 			cancels := make(map[testConnSpec]func())
 			for env, tagConns := range tc.conns {
 				for tag := range tagConns {
 					for i := 0; i < tagConns[tag]; i++ {
-						var cancel func()
-						_, cancel = d.register(env, tag, "source1")
+						_, cancel, err := d.register(env, tag, "source1")
+						require.NoError(t, err)
 						defer cancel()
 						cancels[testConnSpec{env, tag}] = cancel
 					}
@@ -185,10 +243,11 @@ func TestDispatcherDispatch(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			d := NewDispatcher(zap.NewNop())
+			d := NewDispatcher(10000, zap.NewNop())
 			chs := make([]<-chan event, len(tc.conns))
 			for i, c := range tc.conns {
-				ch, cancel := d.register(c.envID, c.tag, "source1")
+				ch, cancel, err := d.register(c.envID, c.tag, "source1")
+				require.NoError(t, err)
 				defer cancel()
 				chs[i] = ch
 			}
@@ -349,8 +408,9 @@ func TestDispatcherHandleEvent(t *testing.T) {
 	}
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			d := NewDispatcher(zap.NewNop())
-			ch, cancel := d.register(envID, p.clientTag, "source1")
+			d := NewDispatcher(10000, zap.NewNop())
+			ch, cancel, err := d.register(envID, p.clientTag, "source1")
+			require.NoError(t, err)
 			defer cancel()
 
 			d.HandleEvent(p.event)

--- a/pkg/api/stream/evaluations.go
+++ b/pkg/api/stream/evaluations.go
@@ -151,6 +151,8 @@ func (h *EvaluationsHandler) Handle(w http.ResponseWriter, httpReq *http.Request
 		select {
 		case <-ctx.Done():
 			return
+		case <-h.dispatcher.shutdownCh:
+			return
 		case <-ticker.C:
 			if err := sendHeartbeat(w, flusher); err != nil {
 				// We cannot send an error event here because

--- a/pkg/api/stream/evaluations.go
+++ b/pkg/api/stream/evaluations.go
@@ -41,11 +41,12 @@ const (
 )
 
 var (
-	errInvalidHttpMethod = rest.NewErrStatus(http.StatusMethodNotAllowed, "gateway: invalid http method")
-	errInternal          = rest.NewErrStatus(http.StatusInternalServerError, "gateway: internal")
-	errTagRequired       = rest.NewErrStatus(http.StatusBadRequest, "gateway: tag is required")
-	errUserRequired      = rest.NewErrStatus(http.StatusBadRequest, "gateway: user is required")
-	errUserIDRequired    = rest.NewErrStatus(http.StatusBadRequest, "gateway: user id is required")
+	errInvalidHttpMethod  = rest.NewErrStatus(http.StatusMethodNotAllowed, "gateway: invalid http method")
+	errInternal           = rest.NewErrStatus(http.StatusInternalServerError, "gateway: internal")
+	errTagRequired        = rest.NewErrStatus(http.StatusBadRequest, "gateway: tag is required")
+	errUserRequired       = rest.NewErrStatus(http.StatusBadRequest, "gateway: user is required")
+	errUserIDRequired     = rest.NewErrStatus(http.StatusBadRequest, "gateway: user id is required")
+	errServiceUnavailable = rest.NewErrStatus(http.StatusServiceUnavailable, "gateway: SSE connection limit reached")
 )
 
 // sseUnmarshalOpts ignores unknown fields like the polling endpoints' encoding/json decoder.
@@ -109,6 +110,15 @@ func (h *EvaluationsHandler) Handle(w http.ResponseWriter, httpReq *http.Request
 		envID, envAPIKey.Environment.UrlCode,
 		methodStreamEvaluations, sourceID).Inc()
 
+	// Register before writing headers so we can still return an HTTP error on
+	// connection limit.
+	events, deregister, err := h.dispatcher.register(envID, req.Tag, sourceID)
+	if err != nil {
+		rest.ReturnFailureResponse(w, errServiceUnavailable)
+		return
+	}
+	defer deregister()
+
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		rest.ReturnFailureResponse(w, errInternal)
@@ -122,11 +132,6 @@ func (h *EvaluationsHandler) Handle(w http.ResponseWriter, httpReq *http.Request
 	flusher.Flush()
 
 	ctx := httpReq.Context()
-
-	// Register before the initial `put` so updates dispatched during the PUT
-	// computation are delivered as the first patch.
-	events, deregister := h.dispatcher.register(envID, req.Tag, sourceID)
-	defer deregister()
 
 	prevUEID := req.GetUserEvaluationsId()
 	evaluatedAt := req.GetEvaluatedAt()

--- a/pkg/api/stream/metrics.go
+++ b/pkg/api/stream/metrics.go
@@ -23,8 +23,9 @@ import (
 const (
 	methodStreamEvaluations = "StreamEvaluations"
 
-	errorTypeEvaluationPut   = "evaluation_put"
-	errorTypeEvaluationPatch = "evaluation_patch"
+	errorTypeEvaluationPut            = "evaluation_put"
+	errorTypeEvaluationPatch          = "evaluation_patch"
+	errorTypeConnectionRefusedByLimit = "connection_refused_by_limit"
 
 	patchCodeDiff = "Diff"
 	patchCodeNone = "None"


### PR DESCRIPTION
Part of #2152, Follows #2675

## What this PR does

Add a configurable maximum number of concurrent SSE connections per API pod.
When the limit is reached, new connections receive HTTP 503 so the SDK can retry on another pod.

| Flag | Helm value | Default | Description |
|------|------------|---------|-------------|
| `--sse-max-connections` | `env.sseMaxConnections` | 10000 | Maximum concurrent SSE connections per pod |

## Background

The SSE stream_evaluations endpoint holds long-lived connections.
Without a per-pod cap, a single pod can accumulate unbounded connections, leading to memory pressure and CPU spikes when feature changes trigger mass evaluations.

## Others

I added `env.sseHeartbeatInterval` to the Helm Chart because it was missed in #2630.