### PR TITLE
feat: validate variation values against schema

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.69.0
 	github.com/redis/go-redis/v9 v9.21.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sashabaranov/go-openai v1.41.2
 	github.com/sendgrid/sendgrid-go v3.16.1+incompatible
 	github.com/slack-go/slack v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -438,6 +438,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/digitalocean/godo v1.78.0/go.mod h1:GBmu8MkjZmNARE7IXRPmkbbnocNN8+uBm0xbEVw2LCs=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
@@ -1246,6 +1248,8 @@ github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIH
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da/go.mod h1:gi+0XIa01GRL2eRQVjQkKGqKF3SF9vZR/HnPullcV2E=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sashabaranov/go-openai v1.41.2 h1:vfPRBZNMpnqu8ELsclWcAvF19lDNgh1t6TVfFFOPiSM=
 github.com/sashabaranov/go-openai v1.41.2/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=

--- a/pkg/feature/api/scheduled_feature_change.go
+++ b/pkg/feature/api/scheduled_feature_change.go
@@ -967,6 +967,29 @@ func (s *FeatureService) validateScheduledChangePayload(
 		}
 	}
 
+	if len(payload.VariationChanges) > 0 {
+		if _, err := (&domain.Feature{Feature: feature}).Update(
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			nil,
+			false,
+			nil,
+			nil,
+			nil,
+			payload.VariationChanges,
+			nil,
+			nil,
+			nil,
+			nil,
+		); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/feature/api/scheduled_feature_change_test.go
+++ b/pkg/feature/api/scheduled_feature_change_test.go
@@ -189,6 +189,7 @@ func TestCreateScheduledFlagChange_WithDetectedConflictsStoredAsConflict(t *test
 			Version: 1,
 			Variations: []*featureproto.Variation{
 				{Id: "var-1", Name: "Variation 1", Value: "true"},
+				{Id: "var-2", Name: "Variation 2", Value: "control"},
 			},
 		},
 	}
@@ -792,6 +793,57 @@ func TestValidateScheduleGap(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateScheduledChangePayloadVariationValueSchema(t *testing.T) {
+	t.Parallel()
+	service := &FeatureService{}
+	feature := &featureproto.Feature{
+		Id:            "feature-id",
+		VariationType: featureproto.Feature_STRING,
+		Variations: []*featureproto.Variation{
+			{Id: "variation-A", Name: "Variation A", Value: "A"},
+			{Id: "variation-B", Name: "Variation B", Value: "B"},
+		},
+		Targets: []*featureproto.Target{
+			{Variation: "variation-A", Users: []string{}},
+			{Variation: "variation-B", Users: []string{}},
+		},
+		DefaultStrategy: &featureproto.Strategy{
+			Type: featureproto.Strategy_FIXED,
+			FixedStrategy: &featureproto.FixedStrategy{
+				Variation: "variation-A",
+			},
+		},
+		OffVariation: "variation-B",
+		VariationValueSchema: &featureproto.VariationValueSchema{
+			Type: featureproto.VariationValueSchema_ENUM,
+			Validator: &featureproto.VariationValueSchema_EnumValidator_{
+				EnumValidator: &featureproto.VariationValueSchema_EnumValidator{
+					Values: []string{"A", "B"},
+				},
+			},
+		},
+	}
+	err := service.validateScheduledChangePayload(
+		context.Background(),
+		&featureproto.ScheduledChangePayload{
+			VariationChanges: []*featureproto.VariationChange{
+				{
+					ChangeType: featureproto.ChangeType_UPDATE,
+					Variation: &featureproto.Variation{
+						Id:    "variation-B",
+						Name:  "Variation B",
+						Value: "C",
+					},
+				},
+			},
+		},
+		feature,
+		"ns0",
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "variation value does not match schema")
 }
 
 func TestCreateScheduledFlagChange_ScheduleGapTooClose(t *testing.T) {

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -96,6 +96,12 @@ var (
 		pkgErr.FeaturePackageName, "feature: variation not found", "variation")
 	errVariationTypeUnmatched = pkgErr.NewErrorInvalidArgNotMatchFormat(
 		pkgErr.FeaturePackageName, "feature: variation value and type are unmatched", "variation")
+	errVariationValueSchemaInvalid = pkgErr.NewErrorInvalidArgNotMatchFormat(
+		pkgErr.FeaturePackageName, "feature: variation value schema is invalid", "variation_value_schema")
+	errVariationValueSchemaTypeUnmatched = pkgErr.NewErrorInvalidArgNotMatchFormat(
+		pkgErr.FeaturePackageName, "feature: variation value schema and type are unmatched", "variation_value_schema")
+	errVariationValueSchemaViolation = pkgErr.NewErrorInvalidArgNotMatchFormat(
+		pkgErr.FeaturePackageName, "feature: variation value does not match schema", "variation_value_schema")
 	errStrategyRequired = pkgErr.NewErrorInvalidArgEmpty(
 		pkgErr.FeaturePackageName, "feature: strategy required", "strategy")
 	errUnsupportedStrategy = pkgErr.NewErrorInvalidArgNotMatchFormat(
@@ -185,6 +191,9 @@ func NewFeature(
 	}}
 	if len(variations) < 2 {
 		return nil, errVariationsMustHaveAtLeastTwoVariations
+	}
+	if err := f.validateVariationValueSchema(); err != nil {
+		return nil, err
 	}
 	if defaultOnVariationIndex < 0 || defaultOnVariationIndex >= len(variations) {
 		return nil, errInvalidDefaultOnVariationIndex
@@ -760,7 +769,7 @@ func (f *Feature) validateVariationValue(id, value string) error {
 		}
 	}
 
-	return nil
+	return f.validateVariationValueAgainstSchema(value)
 }
 
 // normalizeJSON parses JSON and returns a canonical representation.

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -1422,14 +1422,6 @@ func validateRules(rules []*feature.Rule, variations []*feature.Variation) error
 	return nil
 }
 
-func (f *Feature) validateVariationChanges(variationChanges []*feature.VariationChange) error {
-	validateValue, err := f.newVariationValueValidator()
-	if err != nil {
-		return err
-	}
-	return f.validateVariationChangesWithValidator(variationChanges, validateValue)
-}
-
 func (f *Feature) validateVariationChangesWithValidator(
 	variationChanges []*feature.VariationChange,
 	validateValue func(string) error,

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -192,7 +192,8 @@ func NewFeature(
 	if len(variations) < 2 {
 		return nil, errVariationsMustHaveAtLeastTwoVariations
 	}
-	if err := f.validateVariationValueSchema(); err != nil {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
 		return nil, err
 	}
 	if defaultOnVariationIndex < 0 || defaultOnVariationIndex >= len(variations) {
@@ -206,7 +207,13 @@ func NewFeature(
 		if err != nil {
 			return nil, err
 		}
-		if err = f.AddVariation(id.String(), variation.Value, variation.Name, variation.Description); err != nil {
+		if err = f.addVariationWithValidator(
+			id.String(),
+			variation.Value,
+			variation.Name,
+			variation.Description,
+			validateValue,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -672,7 +679,27 @@ func (f *Feature) AddVariation(id string, value string, name string, description
 	if name == "" {
 		return errVariationNameRequired
 	}
-	if err := f.validateVariationValue(id, value); err != nil {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return f.addVariationWithValidator(id, value, name, description, validateValue)
+}
+
+func (f *Feature) addVariationWithValidator(
+	id string,
+	value string,
+	name string,
+	description string,
+	validateValue func(string) error,
+) error {
+	if id == "" {
+		return errVariationIDRequired
+	}
+	if name == "" {
+		return errVariationNameRequired
+	}
+	if err := f.validateVariationValueWithValidator(id, value, validateValue); err != nil {
 		return err
 	}
 	variation := &feature.Variation{

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -690,6 +690,14 @@ func (f *Feature) AddVariation(id string, value string, name string, description
 }
 
 func (f *Feature) validateVariationValue(id, value string) error {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return f.validateVariationValueWithValidator(id, value, validateValue)
+}
+
+func (f *Feature) validateVariationValueWithValidator(id, value string, validateValue func(string) error) error {
 	if value == "" {
 		return errVariationValueRequired
 	}
@@ -769,7 +777,7 @@ func (f *Feature) validateVariationValue(id, value string) error {
 		}
 	}
 
-	return f.validateVariationValueAgainstSchema(value)
+	return validateValue(value)
 }
 
 // normalizeJSON parses JSON and returns a canonical representation.
@@ -1415,6 +1423,17 @@ func validateRules(rules []*feature.Rule, variations []*feature.Variation) error
 }
 
 func (f *Feature) validateVariationChanges(variationChanges []*feature.VariationChange) error {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return f.validateVariationChangesWithValidator(variationChanges, validateValue)
+}
+
+func (f *Feature) validateVariationChangesWithValidator(
+	variationChanges []*feature.VariationChange,
+	validateValue func(string) error,
+) error {
 	for _, change := range variationChanges {
 		// For individual variation changes, only validate the variation value and type
 		if change.Variation == nil {
@@ -1429,7 +1448,11 @@ func (f *Feature) validateVariationChanges(variationChanges []*feature.Variation
 			if change.Variation.Name == "" {
 				return errVariationNameRequired
 			}
-			if err := f.validateVariationValue(change.Variation.Id, change.Variation.Value); err != nil {
+			if err := f.validateVariationValueWithValidator(
+				change.Variation.Id,
+				change.Variation.Value,
+				validateValue,
+			); err != nil {
 				return err
 			}
 		case feature.ChangeType_UPDATE:
@@ -1443,7 +1466,11 @@ func (f *Feature) validateVariationChanges(variationChanges []*feature.Variation
 			if change.Variation.Name == "" {
 				return errVariationNameRequired
 			}
-			if err := f.validateVariationValue(change.Variation.Id, change.Variation.Value); err != nil {
+			if err := f.validateVariationValueWithValidator(
+				change.Variation.Id,
+				change.Variation.Value,
+				validateValue,
+			); err != nil {
 				return err
 			}
 		case feature.ChangeType_DELETE:

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -220,7 +220,7 @@ func TestNewFeature(t *testing.T) {
 			id:            "test-feature",
 			name:          "test feature",
 			description:   "test feature description",
-			variationType: ftproto.Feature_BOOLEAN,
+			variationType: ftproto.Feature_STRING,
 			variationValueSchema: &ftproto.VariationValueSchema{
 				Type: ftproto.VariationValueSchema_ENUM,
 				Validator: &ftproto.VariationValueSchema_EnumValidator_{

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -86,11 +86,21 @@ func (f *Feature) Update(
 	}
 
 	updated.applyVariationValueSchemaUpdate(variationValueSchemaUpdate)
-
-	if err := updated.validateVariationChanges(variationCreationsAndUpdates); err != nil {
+	validateVariationValue, err := updated.newVariationValueValidator()
+	if err != nil {
 		return nil, err
 	}
-	if err := updated.applyVariationChanges(variationCreationsAndUpdates); err != nil {
+
+	if err := updated.validateVariationChangesWithValidator(
+		variationCreationsAndUpdates,
+		validateVariationValue,
+	); err != nil {
+		return nil, err
+	}
+	if err := updated.applyVariationChangesWithValidator(
+		variationCreationsAndUpdates,
+		validateVariationValue,
+	); err != nil {
 		return nil, err
 	}
 
@@ -140,15 +150,23 @@ func (f *Feature) Update(
 	}
 
 	// Step 3: variation deletions last
-	if err := updated.validateVariationChanges(variationDeletions); err != nil {
+	if err := updated.validateVariationChangesWithValidator(
+		variationDeletions,
+		validateVariationValue,
+	); err != nil {
 		return nil, err
 	}
-	if err := updated.applyVariationChanges(variationDeletions); err != nil {
+	if err := updated.applyVariationChangesWithValidator(
+		variationDeletions,
+		validateVariationValue,
+	); err != nil {
 		return nil, err
 	}
 
-	if err := updated.validateAllVariationValuesAgainstSchema(); err != nil {
-		return nil, err
+	if variationValueSchemaUpdate != nil || len(variationChanges) > 0 {
+		if err := updated.validateAllVariationValuesAgainstSchema(); err != nil {
+			return nil, err
+		}
 	}
 
 	// Increment version and update timestamp if there are changes
@@ -280,19 +298,31 @@ func (f *Feature) applyVariationValueSchemaUpdate(update *VariationValueSchemaUp
 func (f *Feature) applyVariationChanges(
 	variationChanges []*feature.VariationChange,
 ) error {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return f.applyVariationChangesWithValidator(variationChanges, validateValue)
+}
+
+func (f *Feature) applyVariationChangesWithValidator(
+	variationChanges []*feature.VariationChange,
+	validateValue func(string) error,
+) error {
 	for _, change := range variationChanges {
 		switch change.ChangeType {
 		case feature.ChangeType_CREATE:
-			if err := f.updateAddVariation(
+			if err := f.updateAddVariationWithValidator(
 				change.Variation.Id,
 				change.Variation.Value,
 				change.Variation.Name,
 				change.Variation.Description,
+				validateValue,
 			); err != nil {
 				return err
 			}
 		case feature.ChangeType_UPDATE:
-			if err := f.updateChangeVariation(change.Variation); err != nil {
+			if err := f.updateChangeVariationWithValidator(change.Variation, validateValue); err != nil {
 				return err
 			}
 		case feature.ChangeType_DELETE:
@@ -416,6 +446,17 @@ func (f *Feature) updateUnarchive() error {
 }
 
 func (f *Feature) updateAddVariation(id, value, name, description string) error {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return f.updateAddVariationWithValidator(id, value, name, description, validateValue)
+}
+
+func (f *Feature) updateAddVariationWithValidator(
+	id, value, name, description string,
+	validateValue func(string) error,
+) error {
 	if id == "" {
 		return errVariationIDRequired
 	}
@@ -425,7 +466,7 @@ func (f *Feature) updateAddVariation(id, value, name, description string) error 
 	if name == "" {
 		return errVariationNameRequired
 	}
-	if err := f.validateVariationValue(id, value); err != nil {
+	if err := f.validateVariationValueWithValidator(id, value, validateValue); err != nil {
 		return err
 	}
 	if _, err := f.findVariationIndex(id); err == nil {
@@ -444,6 +485,17 @@ func (f *Feature) updateAddVariation(id, value, name, description string) error 
 }
 
 func (f *Feature) updateChangeVariation(variation *feature.Variation) error {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return f.updateChangeVariationWithValidator(variation, validateValue)
+}
+
+func (f *Feature) updateChangeVariationWithValidator(
+	variation *feature.Variation,
+	validateValue func(string) error,
+) error {
 	if variation == nil {
 		return errVariationRequired
 	}
@@ -454,7 +506,7 @@ func (f *Feature) updateChangeVariation(variation *feature.Variation) error {
 	if variation.Name == "" {
 		return errVariationNameRequired
 	}
-	if err := f.validateVariationValue(variation.Id, variation.Value); err != nil {
+	if err := f.validateVariationValueWithValidator(variation.Id, variation.Value, validateValue); err != nil {
 		return err
 	}
 

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -85,6 +85,8 @@ func (f *Feature) Update(
 		}
 	}
 
+	updated.applyVariationValueSchemaUpdate(variationValueSchemaUpdate)
+
 	if err := updated.validateVariationChanges(variationCreationsAndUpdates); err != nil {
 		return nil, err
 	}
@@ -120,8 +122,6 @@ func (f *Feature) Update(
 		return nil, err
 	}
 
-	updated.applyVariationValueSchemaUpdate(variationValueSchemaUpdate)
-
 	if err := updated.applyGranularCRUDChanges(
 		prerequisiteChanges,
 		targetChanges,
@@ -144,6 +144,10 @@ func (f *Feature) Update(
 		return nil, err
 	}
 	if err := updated.applyVariationChanges(variationDeletions); err != nil {
+		return nil, err
+	}
+
+	if err := updated.validateAllVariationValuesAgainstSchema(); err != nil {
 		return nil, err
 	}
 

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -294,17 +294,6 @@ func (f *Feature) applyVariationValueSchemaUpdate(update *VariationValueSchemaUp
 	}
 }
 
-// applyVariationChanges handles only variation creations, updates, and deletions.
-func (f *Feature) applyVariationChanges(
-	variationChanges []*feature.VariationChange,
-) error {
-	validateValue, err := f.newVariationValueValidator()
-	if err != nil {
-		return err
-	}
-	return f.applyVariationChangesWithValidator(variationChanges, validateValue)
-}
-
 func (f *Feature) applyVariationChangesWithValidator(
 	variationChanges []*feature.VariationChange,
 	validateValue func(string) error,
@@ -445,14 +434,6 @@ func (f *Feature) updateUnarchive() error {
 	return nil
 }
 
-func (f *Feature) updateAddVariation(id, value, name, description string) error {
-	validateValue, err := f.newVariationValueValidator()
-	if err != nil {
-		return err
-	}
-	return f.updateAddVariationWithValidator(id, value, name, description, validateValue)
-}
-
 func (f *Feature) updateAddVariationWithValidator(
 	id, value, name, description string,
 	validateValue func(string) error,
@@ -482,14 +463,6 @@ func (f *Feature) updateAddVariationWithValidator(
 	f.updateAddVariationToRules(id)
 	f.updateAddVariationToDefaultStrategy(id)
 	return nil
-}
-
-func (f *Feature) updateChangeVariation(variation *feature.Variation) error {
-	validateValue, err := f.newVariationValueValidator()
-	if err != nil {
-		return err
-	}
-	return f.updateChangeVariationWithValidator(variation, validateValue)
 }
 
 func (f *Feature) updateChangeVariationWithValidator(

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -674,7 +674,15 @@ func TestUpdateAddVariation(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			actual := p.inputFunc()
-			err := actual.updateAddVariation(p.id, p.value, p.name, p.description)
+			validateValue, err := actual.newVariationValueValidator()
+			require.NoError(t, err)
+			err = actual.updateAddVariationWithValidator(
+				p.id,
+				p.value,
+				p.name,
+				p.description,
+				validateValue,
+			)
 			if p.expectedErr != nil {
 				assert.Equal(t, p.expectedErr, err)
 			} else {
@@ -799,7 +807,15 @@ func TestUpdateAddVariationToDefaultStrategy(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			actual := p.setupFunc()
-			err := actual.updateAddVariation(p.id, p.value, p.name, p.description)
+			validateValue, err := actual.newVariationValueValidator()
+			require.NoError(t, err)
+			err = actual.updateAddVariationWithValidator(
+				p.id,
+				p.value,
+				p.name,
+				p.description,
+				validateValue,
+			)
 			if p.expectedErr != nil {
 				assert.Equal(t, p.expectedErr, err)
 			} else {
@@ -922,7 +938,9 @@ func TestUpdateChangeVariation(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			actual := p.inputFunc()
-			err := actual.updateChangeVariation(p.variation)
+			validateValue, err := actual.newVariationValueValidator()
+			require.NoError(t, err)
+			err = actual.updateChangeVariationWithValidator(p.variation, validateValue)
 			if p.expectedErr != nil {
 				assert.Equal(t, p.expectedErr, err)
 			} else {

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -185,7 +185,7 @@ func TestUpdateVariationValueSchema(t *testing.T) {
 		Description: "Allowed size values",
 		Validator: &feature.VariationValueSchema_EnumValidator_{
 			EnumValidator: &feature.VariationValueSchema_EnumValidator{
-				Values: []string{"small", "large"},
+				Values: []string{"A", "B", "C"},
 			},
 		},
 	}

--- a/pkg/feature/domain/variation_value_schema.go
+++ b/pkg/feature/domain/variation_value_schema.go
@@ -30,14 +30,15 @@ func (f *Feature) validateVariationValueSchema() error {
 }
 
 func (f *Feature) validateAllVariationValuesAgainstSchema() error {
-	if err := f.validateVariationValueSchema(); err != nil {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
 		return err
 	}
 	for _, variation := range f.Variations {
 		if variation == nil {
 			return errVariationRequired
 		}
-		if err := f.validateVariationValueAgainstSchema(variation.Value); err != nil {
+		if err := validateValue(variation.Value); err != nil {
 			return err
 		}
 	}
@@ -98,22 +99,55 @@ func validateVariationValueSchemaDefinition(
 }
 
 func (f *Feature) validateVariationValueAgainstSchema(value string) error {
+	validateValue, err := f.newVariationValueValidator()
+	if err != nil {
+		return err
+	}
+	return validateValue(value)
+}
+
+func (f *Feature) newVariationValueValidator() (func(string) error, error) {
 	schema := f.VariationValueSchema
 	if schema == nil {
-		return nil
+		return func(string) error { return nil }, nil
 	}
 	if err := f.validateVariationValueSchema(); err != nil {
-		return err
+		return nil, err
 	}
 	switch schema.Type {
 	case featureproto.VariationValueSchema_ENUM:
-		return f.validateEnumVariationValue(schema.GetEnumValidator(), value)
+		validator := schema.GetEnumValidator()
+		return func(value string) error {
+			return f.validateEnumVariationValue(validator, value)
+		}, nil
 	case featureproto.VariationValueSchema_REGEX:
-		return validateRegexVariationValue(schema.GetRegexValidator(), value)
+		pattern, err := compileRegexVariationValueValidator(schema.GetRegexValidator())
+		if err != nil {
+			return nil, err
+		}
+		return func(value string) error {
+			if !pattern.MatchString(value) {
+				return errVariationValueSchemaViolation
+			}
+			return nil
+		}, nil
 	case featureproto.VariationValueSchema_JSON_SCHEMA:
-		return validateJSONSchemaVariationValue(schema.GetJsonSchemaValidator(), value)
+		compiled, err := compileJSONSchemaVariationValueValidator(schema.GetJsonSchemaValidator())
+		if err != nil {
+			return nil, err
+		}
+		return func(value string) error {
+			jsonValue, err := jsonschema.UnmarshalJSON(strings.NewReader(value))
+			if err != nil {
+				return errVariationTypeUnmatched
+			}
+			if err := compiled.Validate(jsonValue); err != nil {
+				return errVariationValueSchemaViolation
+			}
+			return nil
+		}, nil
 	default:
-		return errVariationValueSchemaInvalid
+		return nil, errVariationValueSchemaInvalid
 	}
 }
 
@@ -149,42 +183,30 @@ func (f *Feature) validateEnumVariationValue(
 	return errVariationValueSchemaViolation
 }
 
-func validateRegexVariationValue(
+func compileRegexVariationValueValidator(
 	validator *featureproto.VariationValueSchema_RegexValidator,
-	value string,
-) error {
+) (*regexp.Regexp, error) {
 	if validator == nil {
-		return errVariationValueSchemaInvalid
+		return nil, errVariationValueSchemaInvalid
 	}
-	matched, err := regexp.MatchString(validator.Pattern, value)
+	pattern, err := regexp.Compile(validator.Pattern)
 	if err != nil {
-		return errVariationValueSchemaInvalid
+		return nil, errVariationValueSchemaInvalid
 	}
-	if !matched {
-		return errVariationValueSchemaViolation
-	}
-	return nil
+	return pattern, nil
 }
 
-func validateJSONSchemaVariationValue(
+func compileJSONSchemaVariationValueValidator(
 	validator *featureproto.VariationValueSchema_JsonSchemaValidator,
-	value string,
-) error {
+) (*jsonschema.Schema, error) {
 	if validator == nil {
-		return errVariationValueSchemaInvalid
+		return nil, errVariationValueSchemaInvalid
 	}
 	schema, err := compileJSONSchema(validator.Schema)
 	if err != nil {
-		return errVariationValueSchemaInvalid
+		return nil, errVariationValueSchemaInvalid
 	}
-	jsonValue, err := jsonschema.UnmarshalJSON(strings.NewReader(value))
-	if err != nil {
-		return errVariationTypeUnmatched
-	}
-	if err := schema.Validate(jsonValue); err != nil {
-		return errVariationValueSchemaViolation
-	}
-	return nil
+	return schema, nil
 }
 
 func compileJSONSchema(schema string) (*jsonschema.Schema, error) {

--- a/pkg/feature/domain/variation_value_schema.go
+++ b/pkg/feature/domain/variation_value_schema.go
@@ -26,10 +26,6 @@ import (
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
 )
 
-func (f *Feature) validateVariationValueSchema() error {
-	return validateVariationValueSchemaDefinition(f.VariationType, f.VariationValueSchema)
-}
-
 func (f *Feature) validateAllVariationValuesAgainstSchema() error {
 	validateValue, err := f.newVariationValueValidator()
 	if err != nil {
@@ -44,39 +40,6 @@ func (f *Feature) validateAllVariationValuesAgainstSchema() error {
 		}
 	}
 	return nil
-}
-
-func validateVariationValueSchemaDefinition(
-	variationType featureproto.Feature_VariationType,
-	schema *featureproto.VariationValueSchema,
-) error {
-	if schema == nil {
-		return nil
-	}
-	switch schema.Type {
-	case featureproto.VariationValueSchema_ENUM:
-		return validateEnumSchemaDefinition(variationType, schema.GetEnumValidator())
-	case featureproto.VariationValueSchema_REGEX:
-		validator := schema.GetRegexValidator()
-		if err := validateRegexSchemaDefinition(variationType, validator); err != nil {
-			return err
-		}
-		if _, err := compileRegexVariationValueValidator(validator); err != nil {
-			return errVariationValueSchemaInvalid
-		}
-		return nil
-	case featureproto.VariationValueSchema_JSON_SCHEMA:
-		validator := schema.GetJsonSchemaValidator()
-		if err := validateJSONSchemaDefinition(variationType, validator); err != nil {
-			return err
-		}
-		if _, err := compileJSONSchema(validator.Schema); err != nil {
-			return errVariationValueSchemaInvalid
-		}
-		return nil
-	default:
-		return errVariationValueSchemaInvalid
-	}
 }
 
 func (f *Feature) newVariationValueValidator() (func(string) error, error) {

--- a/pkg/feature/domain/variation_value_schema.go
+++ b/pkg/feature/domain/variation_value_schema.go
@@ -1,0 +1,208 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	jsonschema "github.com/santhosh-tekuri/jsonschema/v6"
+
+	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
+)
+
+func (f *Feature) validateVariationValueSchema() error {
+	return validateVariationValueSchemaDefinition(f.VariationType, f.VariationValueSchema)
+}
+
+func (f *Feature) validateAllVariationValuesAgainstSchema() error {
+	if err := f.validateVariationValueSchema(); err != nil {
+		return err
+	}
+	for _, variation := range f.Variations {
+		if variation == nil {
+			return errVariationRequired
+		}
+		if err := f.validateVariationValueAgainstSchema(variation.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateVariationValueSchemaDefinition(
+	variationType featureproto.Feature_VariationType,
+	schema *featureproto.VariationValueSchema,
+) error {
+	if schema == nil {
+		return nil
+	}
+	switch schema.Type {
+	case featureproto.VariationValueSchema_ENUM:
+		if variationType != featureproto.Feature_STRING && variationType != featureproto.Feature_NUMBER {
+			return errVariationValueSchemaTypeUnmatched
+		}
+		validator := schema.GetEnumValidator()
+		if validator == nil || len(validator.Values) == 0 {
+			return errVariationValueSchemaInvalid
+		}
+		if variationType == featureproto.Feature_NUMBER {
+			for _, value := range validator.Values {
+				if _, err := strconv.ParseFloat(value, 64); err != nil {
+					return errVariationValueSchemaInvalid
+				}
+			}
+		}
+		return nil
+	case featureproto.VariationValueSchema_REGEX:
+		if variationType != featureproto.Feature_STRING {
+			return errVariationValueSchemaTypeUnmatched
+		}
+		validator := schema.GetRegexValidator()
+		if validator == nil || validator.Pattern == "" {
+			return errVariationValueSchemaInvalid
+		}
+		if _, err := regexp.Compile(validator.Pattern); err != nil {
+			return errVariationValueSchemaInvalid
+		}
+		return nil
+	case featureproto.VariationValueSchema_JSON_SCHEMA:
+		if variationType != featureproto.Feature_JSON {
+			return errVariationValueSchemaTypeUnmatched
+		}
+		validator := schema.GetJsonSchemaValidator()
+		if validator == nil || validator.Schema == "" {
+			return errVariationValueSchemaInvalid
+		}
+		if _, err := compileJSONSchema(validator.Schema); err != nil {
+			return errVariationValueSchemaInvalid
+		}
+		return nil
+	default:
+		return errVariationValueSchemaInvalid
+	}
+}
+
+func (f *Feature) validateVariationValueAgainstSchema(value string) error {
+	schema := f.VariationValueSchema
+	if schema == nil {
+		return nil
+	}
+	if err := f.validateVariationValueSchema(); err != nil {
+		return err
+	}
+	switch schema.Type {
+	case featureproto.VariationValueSchema_ENUM:
+		return f.validateEnumVariationValue(schema.GetEnumValidator(), value)
+	case featureproto.VariationValueSchema_REGEX:
+		return validateRegexVariationValue(schema.GetRegexValidator(), value)
+	case featureproto.VariationValueSchema_JSON_SCHEMA:
+		return validateJSONSchemaVariationValue(schema.GetJsonSchemaValidator(), value)
+	default:
+		return errVariationValueSchemaInvalid
+	}
+}
+
+func (f *Feature) validateEnumVariationValue(
+	validator *featureproto.VariationValueSchema_EnumValidator,
+	value string,
+) error {
+	if validator == nil {
+		return errVariationValueSchemaInvalid
+	}
+	switch f.VariationType {
+	case featureproto.Feature_NUMBER:
+		target, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			return errVariationTypeUnmatched
+		}
+		for _, enumValue := range validator.Values {
+			allowed, err := strconv.ParseFloat(enumValue, 64)
+			if err != nil {
+				return errVariationValueSchemaInvalid
+			}
+			if target == allowed {
+				return nil
+			}
+		}
+	case featureproto.Feature_STRING:
+		for _, enumValue := range validator.Values {
+			if value == enumValue {
+				return nil
+			}
+		}
+	}
+	return errVariationValueSchemaViolation
+}
+
+func validateRegexVariationValue(
+	validator *featureproto.VariationValueSchema_RegexValidator,
+	value string,
+) error {
+	if validator == nil {
+		return errVariationValueSchemaInvalid
+	}
+	matched, err := regexp.MatchString(validator.Pattern, value)
+	if err != nil {
+		return errVariationValueSchemaInvalid
+	}
+	if !matched {
+		return errVariationValueSchemaViolation
+	}
+	return nil
+}
+
+func validateJSONSchemaVariationValue(
+	validator *featureproto.VariationValueSchema_JsonSchemaValidator,
+	value string,
+) error {
+	if validator == nil {
+		return errVariationValueSchemaInvalid
+	}
+	schema, err := compileJSONSchema(validator.Schema)
+	if err != nil {
+		return errVariationValueSchemaInvalid
+	}
+	jsonValue, err := jsonschema.UnmarshalJSON(strings.NewReader(value))
+	if err != nil {
+		return errVariationTypeUnmatched
+	}
+	if err := schema.Validate(jsonValue); err != nil {
+		return errVariationValueSchemaViolation
+	}
+	return nil
+}
+
+func compileJSONSchema(schema string) (*jsonschema.Schema, error) {
+	document, err := jsonschema.UnmarshalJSON(strings.NewReader(schema))
+	if err != nil {
+		return nil, err
+	}
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft2020)
+	if err := compiler.AddResource("schema.json", document); err != nil {
+		return nil, err
+	}
+	compiled, err := compiler.Compile("schema.json")
+	if err != nil {
+		return nil, err
+	}
+	if compiled == nil {
+		return nil, fmt.Errorf("feature: compiled JSON schema is nil")
+	}
+	return compiled, nil
+}

--- a/pkg/feature/domain/variation_value_schema.go
+++ b/pkg/feature/domain/variation_value_schema.go
@@ -79,14 +79,6 @@ func validateVariationValueSchemaDefinition(
 	}
 }
 
-func (f *Feature) validateVariationValueAgainstSchema(value string) error {
-	validateValue, err := f.newVariationValueValidator()
-	if err != nil {
-		return err
-	}
-	return validateValue(value)
-}
-
 func (f *Feature) newVariationValueValidator() (func(string) error, error) {
 	schema := f.VariationValueSchema
 	if schema == nil {

--- a/pkg/feature/domain/variation_value_schema.go
+++ b/pkg/feature/domain/variation_value_schema.go
@@ -16,6 +16,7 @@ package domain
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -54,40 +55,20 @@ func validateVariationValueSchemaDefinition(
 	}
 	switch schema.Type {
 	case featureproto.VariationValueSchema_ENUM:
-		if variationType != featureproto.Feature_STRING && variationType != featureproto.Feature_NUMBER {
-			return errVariationValueSchemaTypeUnmatched
-		}
-		validator := schema.GetEnumValidator()
-		if validator == nil || len(validator.Values) == 0 {
-			return errVariationValueSchemaInvalid
-		}
-		if variationType == featureproto.Feature_NUMBER {
-			for _, value := range validator.Values {
-				if _, err := strconv.ParseFloat(value, 64); err != nil {
-					return errVariationValueSchemaInvalid
-				}
-			}
-		}
-		return nil
+		return validateEnumSchemaDefinition(variationType, schema.GetEnumValidator())
 	case featureproto.VariationValueSchema_REGEX:
-		if variationType != featureproto.Feature_STRING {
-			return errVariationValueSchemaTypeUnmatched
-		}
 		validator := schema.GetRegexValidator()
-		if validator == nil || validator.Pattern == "" {
-			return errVariationValueSchemaInvalid
+		if err := validateRegexSchemaDefinition(variationType, validator); err != nil {
+			return err
 		}
-		if _, err := regexp.Compile(validator.Pattern); err != nil {
+		if _, err := compileRegexVariationValueValidator(validator); err != nil {
 			return errVariationValueSchemaInvalid
 		}
 		return nil
 	case featureproto.VariationValueSchema_JSON_SCHEMA:
-		if variationType != featureproto.Feature_JSON {
-			return errVariationValueSchemaTypeUnmatched
-		}
 		validator := schema.GetJsonSchemaValidator()
-		if validator == nil || validator.Schema == "" {
-			return errVariationValueSchemaInvalid
+		if err := validateJSONSchemaDefinition(variationType, validator); err != nil {
+			return err
 		}
 		if _, err := compileJSONSchema(validator.Schema); err != nil {
 			return errVariationValueSchemaInvalid
@@ -111,17 +92,21 @@ func (f *Feature) newVariationValueValidator() (func(string) error, error) {
 	if schema == nil {
 		return func(string) error { return nil }, nil
 	}
-	if err := f.validateVariationValueSchema(); err != nil {
-		return nil, err
-	}
 	switch schema.Type {
 	case featureproto.VariationValueSchema_ENUM:
 		validator := schema.GetEnumValidator()
+		if err := validateEnumSchemaDefinition(f.VariationType, validator); err != nil {
+			return nil, err
+		}
 		return func(value string) error {
 			return f.validateEnumVariationValue(validator, value)
 		}, nil
 	case featureproto.VariationValueSchema_REGEX:
-		pattern, err := compileRegexVariationValueValidator(schema.GetRegexValidator())
+		validator := schema.GetRegexValidator()
+		if err := validateRegexSchemaDefinition(f.VariationType, validator); err != nil {
+			return nil, err
+		}
+		pattern, err := compileRegexVariationValueValidator(validator)
 		if err != nil {
 			return nil, err
 		}
@@ -132,9 +117,13 @@ func (f *Feature) newVariationValueValidator() (func(string) error, error) {
 			return nil
 		}, nil
 	case featureproto.VariationValueSchema_JSON_SCHEMA:
-		compiled, err := compileJSONSchemaVariationValueValidator(schema.GetJsonSchemaValidator())
-		if err != nil {
+		validator := schema.GetJsonSchemaValidator()
+		if err := validateJSONSchemaDefinition(f.VariationType, validator); err != nil {
 			return nil, err
+		}
+		compiled, err := compileJSONSchema(validator.Schema)
+		if err != nil {
+			return nil, errVariationValueSchemaInvalid
 		}
 		return func(value string) error {
 			jsonValue, err := jsonschema.UnmarshalJSON(strings.NewReader(value))
@@ -151,6 +140,26 @@ func (f *Feature) newVariationValueValidator() (func(string) error, error) {
 	}
 }
 
+func validateEnumSchemaDefinition(
+	variationType featureproto.Feature_VariationType,
+	validator *featureproto.VariationValueSchema_EnumValidator,
+) error {
+	if variationType != featureproto.Feature_STRING && variationType != featureproto.Feature_NUMBER {
+		return errVariationValueSchemaTypeUnmatched
+	}
+	if validator == nil || len(validator.Values) == 0 {
+		return errVariationValueSchemaInvalid
+	}
+	if variationType == featureproto.Feature_NUMBER {
+		for _, value := range validator.Values {
+			if _, err := parseFiniteFloat(value); err != nil {
+				return errVariationValueSchemaInvalid
+			}
+		}
+	}
+	return nil
+}
+
 func (f *Feature) validateEnumVariationValue(
 	validator *featureproto.VariationValueSchema_EnumValidator,
 	value string,
@@ -160,12 +169,12 @@ func (f *Feature) validateEnumVariationValue(
 	}
 	switch f.VariationType {
 	case featureproto.Feature_NUMBER:
-		target, err := strconv.ParseFloat(value, 64)
+		target, err := parseFiniteFloat(value)
 		if err != nil {
 			return errVariationTypeUnmatched
 		}
 		for _, enumValue := range validator.Values {
-			allowed, err := strconv.ParseFloat(enumValue, 64)
+			allowed, err := parseFiniteFloat(enumValue)
 			if err != nil {
 				return errVariationValueSchemaInvalid
 			}
@@ -183,6 +192,30 @@ func (f *Feature) validateEnumVariationValue(
 	return errVariationValueSchemaViolation
 }
 
+func validateRegexSchemaDefinition(
+	variationType featureproto.Feature_VariationType,
+	validator *featureproto.VariationValueSchema_RegexValidator,
+) error {
+	if variationType != featureproto.Feature_STRING {
+		return errVariationValueSchemaTypeUnmatched
+	}
+	if validator == nil || validator.Pattern == "" {
+		return errVariationValueSchemaInvalid
+	}
+	return nil
+}
+
+func parseFiniteFloat(value string) (float64, error) {
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+	if math.IsNaN(parsed) || math.IsInf(parsed, 0) {
+		return 0, fmt.Errorf("feature: number must be finite")
+	}
+	return parsed, nil
+}
+
 func compileRegexVariationValueValidator(
 	validator *featureproto.VariationValueSchema_RegexValidator,
 ) (*regexp.Regexp, error) {
@@ -196,17 +229,20 @@ func compileRegexVariationValueValidator(
 	return pattern, nil
 }
 
-func compileJSONSchemaVariationValueValidator(
+func validateJSONSchemaDefinition(
+	variationType featureproto.Feature_VariationType,
 	validator *featureproto.VariationValueSchema_JsonSchemaValidator,
-) (*jsonschema.Schema, error) {
+) error {
+	if variationType != featureproto.Feature_JSON {
+		return errVariationValueSchemaTypeUnmatched
+	}
 	if validator == nil {
-		return nil, errVariationValueSchemaInvalid
+		return errVariationValueSchemaInvalid
 	}
-	schema, err := compileJSONSchema(validator.Schema)
-	if err != nil {
-		return nil, errVariationValueSchemaInvalid
+	if validator.Schema == "" {
+		return errVariationValueSchemaInvalid
 	}
-	return schema, nil
+	return nil
 }
 
 func compileJSONSchema(schema string) (*jsonschema.Schema, error) {

--- a/pkg/feature/domain/variation_value_schema_test.go
+++ b/pkg/feature/domain/variation_value_schema_test.go
@@ -1,0 +1,278 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/bucketeer-io/bucketeer/v2/pkg/uuid"
+	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
+)
+
+func enumSchema(values ...string) *featureproto.VariationValueSchema {
+	return &featureproto.VariationValueSchema{
+		Type: featureproto.VariationValueSchema_ENUM,
+		Validator: &featureproto.VariationValueSchema_EnumValidator_{
+			EnumValidator: &featureproto.VariationValueSchema_EnumValidator{
+				Values: values,
+			},
+		},
+	}
+}
+
+func regexSchema(pattern string) *featureproto.VariationValueSchema {
+	return &featureproto.VariationValueSchema{
+		Type: featureproto.VariationValueSchema_REGEX,
+		Validator: &featureproto.VariationValueSchema_RegexValidator_{
+			RegexValidator: &featureproto.VariationValueSchema_RegexValidator{
+				Pattern: pattern,
+			},
+		},
+	}
+}
+
+func jsonSchema(schema string) *featureproto.VariationValueSchema {
+	return &featureproto.VariationValueSchema{
+		Type: featureproto.VariationValueSchema_JSON_SCHEMA,
+		Validator: &featureproto.VariationValueSchema_JsonSchemaValidator_{
+			JsonSchemaValidator: &featureproto.VariationValueSchema_JsonSchemaValidator{
+				Schema: schema,
+			},
+		},
+	}
+}
+
+func TestValidateVariationValueSchemaDefinition(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		desc          string
+		variationType featureproto.Feature_VariationType
+		schema        *featureproto.VariationValueSchema
+		expected      error
+	}{
+		{
+			desc:          "string enum is valid",
+			variationType: featureproto.Feature_STRING,
+			schema:        enumSchema("small", "large"),
+		},
+		{
+			desc:          "number enum is valid",
+			variationType: featureproto.Feature_NUMBER,
+			schema:        enumSchema("1", "2.5"),
+		},
+		{
+			desc:          "number enum rejects non-number option",
+			variationType: featureproto.Feature_NUMBER,
+			schema:        enumSchema("one"),
+			expected:      errVariationValueSchemaInvalid,
+		},
+		{
+			desc:          "boolean enum is not supported",
+			variationType: featureproto.Feature_BOOLEAN,
+			schema:        enumSchema("true", "false"),
+			expected:      errVariationValueSchemaTypeUnmatched,
+		},
+		{
+			desc:          "string regex is valid",
+			variationType: featureproto.Feature_STRING,
+			schema:        regexSchema(`^[a-z]+$`),
+		},
+		{
+			desc:          "number regex is not supported",
+			variationType: featureproto.Feature_NUMBER,
+			schema:        regexSchema(`^[0-9]+$`),
+			expected:      errVariationValueSchemaTypeUnmatched,
+		},
+		{
+			desc:          "invalid regex is rejected",
+			variationType: featureproto.Feature_STRING,
+			schema:        regexSchema(`[`),
+			expected:      errVariationValueSchemaInvalid,
+		},
+		{
+			desc:          "json schema is valid",
+			variationType: featureproto.Feature_JSON,
+			schema: jsonSchema(`{
+				"type": "object",
+				"properties": {"theme": {"type": "string"}},
+				"required": ["theme"]
+			}`),
+		},
+		{
+			desc:          "string json schema is not supported",
+			variationType: featureproto.Feature_STRING,
+			schema:        jsonSchema(`{"type":"object"}`),
+			expected:      errVariationValueSchemaTypeUnmatched,
+		},
+		{
+			desc:          "invalid json schema is rejected",
+			variationType: featureproto.Feature_JSON,
+			schema:        jsonSchema(`{"type":`),
+			expected:      errVariationValueSchemaInvalid,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			err := validateVariationValueSchemaDefinition(p.variationType, p.schema)
+			assert.Equal(t, p.expected, err)
+		})
+	}
+}
+
+func TestValidateVariationValueAgainstSchema(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		desc          string
+		variationType featureproto.Feature_VariationType
+		schema        *featureproto.VariationValueSchema
+		value         string
+		expected      error
+	}{
+		{
+			desc:          "string enum accepts allowed value",
+			variationType: featureproto.Feature_STRING,
+			schema:        enumSchema("small", "large"),
+			value:         "small",
+		},
+		{
+			desc:          "string enum rejects disallowed value",
+			variationType: featureproto.Feature_STRING,
+			schema:        enumSchema("small", "large"),
+			value:         "medium",
+			expected:      errVariationValueSchemaViolation,
+		},
+		{
+			desc:          "number enum compares normalized numbers",
+			variationType: featureproto.Feature_NUMBER,
+			schema:        enumSchema("1", "2"),
+			value:         "1.0",
+		},
+		{
+			desc:          "regex accepts matching string",
+			variationType: featureproto.Feature_STRING,
+			schema:        regexSchema(`^[a-z]+-[0-9]+$`),
+			value:         "item-1",
+		},
+		{
+			desc:          "regex rejects non-matching string",
+			variationType: featureproto.Feature_STRING,
+			schema:        regexSchema(`^[a-z]+-[0-9]+$`),
+			value:         "item",
+			expected:      errVariationValueSchemaViolation,
+		},
+		{
+			desc:          "json schema accepts valid value",
+			variationType: featureproto.Feature_JSON,
+			schema: jsonSchema(`{
+				"type": "object",
+				"properties": {
+					"theme": {"type": "string", "enum": ["light", "dark"]},
+					"maxItems": {"type": "integer", "minimum": 1}
+				},
+				"required": ["theme", "maxItems"],
+				"additionalProperties": false
+			}`),
+			value: `{"theme":"dark","maxItems":20}`,
+		},
+		{
+			desc:          "json schema rejects invalid value",
+			variationType: featureproto.Feature_JSON,
+			schema: jsonSchema(`{
+				"type": "object",
+				"properties": {"theme": {"type": "string", "enum": ["light", "dark"]}},
+				"required": ["theme"],
+				"additionalProperties": false
+			}`),
+			value:    `{"theme":"blue","extraField":"x"}`,
+			expected: errVariationValueSchemaViolation,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			f := &Feature{Feature: &featureproto.Feature{
+				VariationType:        p.variationType,
+				VariationValueSchema: p.schema,
+			}}
+			err := f.validateVariationValueAgainstSchema(p.value)
+			assert.Equal(t, p.expected, err)
+		})
+	}
+}
+
+func TestNewFeatureValidatesVariationValueSchema(t *testing.T) {
+	t.Parallel()
+	v1, err := uuid.NewUUID()
+	require.NoError(t, err)
+	v2, err := uuid.NewUUID()
+	require.NoError(t, err)
+	_, err = NewFeature(
+		"feature-id",
+		"feature name",
+		"",
+		featureproto.Feature_STRING,
+		enumSchema("A"),
+		[]*featureproto.Variation{
+			{Id: v1.String(), Value: "A", Name: "A"},
+			{Id: v2.String(), Value: "B", Name: "B"},
+		},
+		[]string{"tag"},
+		0,
+		1,
+		"test@example.com",
+	)
+	assert.Equal(t, errVariationValueSchemaViolation, err)
+}
+
+func TestUpdateVariationValueSchemaValidatesFinalValues(t *testing.T) {
+	t.Parallel()
+	t.Run("rejects schema that existing variations violate", func(t *testing.T) {
+		t.Parallel()
+		original := makeFeature("test-feature")
+		_, err := original.Update(
+			nil, nil, nil, nil, nil, nil, nil, false,
+			nil, nil, nil, nil, nil, nil, nil,
+			&VariationValueSchemaUpdate{Schema: enumSchema("A", "B")},
+		)
+		assert.Equal(t, errVariationValueSchemaViolation, err)
+	})
+	t.Run("validates values against schema changed in same update", func(t *testing.T) {
+		t.Parallel()
+		original := makeFeature("test-feature")
+		updated, err := original.Update(
+			nil, nil, nil, nil, nil, nil, nil, false,
+			nil, nil, nil,
+			[]*featureproto.VariationChange{
+				{
+					ChangeType: featureproto.ChangeType_UPDATE,
+					Variation: &featureproto.Variation{
+						Id:          "variation-C",
+						Value:       "D",
+						Name:        "Variation C",
+						Description: "Thing does C",
+					},
+				},
+			},
+			nil, nil, nil,
+			&VariationValueSchemaUpdate{Schema: enumSchema("A", "B", "D")},
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "D", updated.Variations[2].Value)
+	})
+}

--- a/pkg/feature/domain/variation_value_schema_test.go
+++ b/pkg/feature/domain/variation_value_schema_test.go
@@ -58,7 +58,7 @@ func jsonSchema(schema string) *featureproto.VariationValueSchema {
 	}
 }
 
-func TestValidateVariationValueSchemaDefinition(t *testing.T) {
+func TestNewVariationValueValidatorValidatesSchemaDefinition(t *testing.T) {
 	t.Parallel()
 	patterns := []struct {
 		desc          string
@@ -136,7 +136,11 @@ func TestValidateVariationValueSchemaDefinition(t *testing.T) {
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			t.Parallel()
-			err := validateVariationValueSchemaDefinition(p.variationType, p.schema)
+			f := &Feature{Feature: &featureproto.Feature{
+				VariationType:        p.variationType,
+				VariationValueSchema: p.schema,
+			}}
+			_, err := f.newVariationValueValidator()
 			assert.Equal(t, p.expected, err)
 		})
 	}

--- a/pkg/feature/domain/variation_value_schema_test.go
+++ b/pkg/feature/domain/variation_value_schema_test.go
@@ -82,6 +82,12 @@ func TestValidateVariationValueSchemaDefinition(t *testing.T) {
 			expected:      errVariationValueSchemaInvalid,
 		},
 		{
+			desc:          "number enum rejects NaN option",
+			variationType: featureproto.Feature_NUMBER,
+			schema:        enumSchema("NaN"),
+			expected:      errVariationValueSchemaInvalid,
+		},
+		{
 			desc:          "boolean enum is not supported",
 			variationType: featureproto.Feature_BOOLEAN,
 			schema:        enumSchema("true", "false"),
@@ -162,6 +168,13 @@ func TestValidateVariationValueAgainstSchema(t *testing.T) {
 			variationType: featureproto.Feature_NUMBER,
 			schema:        enumSchema("1", "2"),
 			value:         "1.0",
+		},
+		{
+			desc:          "number enum rejects NaN value",
+			variationType: featureproto.Feature_NUMBER,
+			schema:        enumSchema("1", "2"),
+			value:         "NaN",
+			expected:      errVariationTypeUnmatched,
 		},
 		{
 			desc:          "regex accepts matching string",

--- a/pkg/feature/domain/variation_value_schema_test.go
+++ b/pkg/feature/domain/variation_value_schema_test.go
@@ -224,7 +224,9 @@ func TestValidateVariationValueAgainstSchema(t *testing.T) {
 				VariationType:        p.variationType,
 				VariationValueSchema: p.schema,
 			}}
-			err := f.validateVariationValueAgainstSchema(p.value)
+			validateValue, err := f.newVariationValueValidator()
+			require.NoError(t, err)
+			err = validateValue(p.value)
 			assert.Equal(t, p.expected, err)
 		})
 	}

--- a/pkg/feature/domain/variation_value_schema_test.go
+++ b/pkg/feature/domain/variation_value_schema_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/uuid"
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
@@ -287,5 +288,18 @@ func TestUpdateVariationValueSchemaValidatesFinalValues(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.Equal(t, "D", updated.Variations[2].Value)
+	})
+	t.Run("skips final value validation for unrelated updates", func(t *testing.T) {
+		t.Parallel()
+		original := makeFeature("test-feature")
+		original.VariationValueSchema = enumSchema("A")
+		updated, err := original.Update(
+			wrapperspb.String("updated name"),
+			nil, nil, nil, nil, nil, nil, false,
+			nil, nil, nil, nil, nil, nil, nil,
+			nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "updated name", updated.Name)
 	})
 }


### PR DESCRIPTION
Implements the backend validation behavior for variation value schemas from #2499.

This PR builds on the merged model/persistence PR #2578. It does not include UI changes.

## Changes

- Validate variation value schema definitions for enum, regex, and JSON Schema validators
- Validate existing variation values when a schema is created or updated
- Validate new or updated variation values against the configured schema
- Validate scheduled variation changes before they are persisted
- Add backend tests for schema definitions, value validation, feature creation/update, and scheduled changes

## Dependency

- Adds `github.com/santhosh-tekuri/jsonschema/v6` for JSON Schema validation

## Related Issue

Refs #2499

## Related PRs

- RFC: #2577
- Model and persistence: #2578

## Tests

- `go test -count=1 ./pkg/feature/...`
- `git diff --check HEAD~1 HEAD`