### PR TITLE
fix(stream): prevent buffer overflow in SSE streaming middleware

### DIFF
--- a/pkg/api/stream/evaluations.go
+++ b/pkg/api/stream/evaluations.go
@@ -118,6 +118,7 @@ func (h *EvaluationsHandler) Handle(w http.ResponseWriter, httpReq *http.Request
 	w.Header().Set("Cache-Control", "no-cache")
 	// Disable proxy buffering so heartbeat and patch events reach the client immediately.
 	w.Header().Set("X-Accel-Buffering", "no")
+	rest.DisableBodyRecording(w)
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
 

--- a/pkg/rest/middleware.go
+++ b/pkg/rest/middleware.go
@@ -45,8 +45,9 @@ func (ms *middlewares) Handle(handler http.Handler) http.Handler {
 
 type responseRecorder struct {
 	http.ResponseWriter
-	statusCode int
-	body       *bytes.Buffer
+	statusCode    int
+	body          *bytes.Buffer
+	skipBodyWrite bool
 }
 
 func (rr *responseRecorder) WriteHeader(statusCode int) {
@@ -55,8 +56,23 @@ func (rr *responseRecorder) WriteHeader(statusCode int) {
 }
 
 func (rr *responseRecorder) Write(b []byte) (int, error) {
-	rr.body.Write(b)
+	if !rr.skipBodyWrite {
+		rr.body.Write(b)
+	}
 	return rr.ResponseWriter.Write(b)
+}
+
+// DisableBodyRecording stops accumulating response bytes in this recorder
+// and any wrapped responseRecorder in the chain.
+func DisableBodyRecording(w http.ResponseWriter) {
+	for {
+		rr, ok := w.(*responseRecorder)
+		if !ok {
+			return
+		}
+		rr.skipBodyWrite = true
+		w = rr.ResponseWriter
+	}
 }
 
 // Flush implements http.Flusher by delegating to the underlying ResponseWriter

--- a/pkg/rest/middleware_test.go
+++ b/pkg/rest/middleware_test.go
@@ -15,6 +15,7 @@
 package rest
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -65,6 +66,55 @@ func TestHandle(t *testing.T) {
 	assert.True(t, firstRun)
 	assert.True(t, secondRun)
 	assert.True(t, handlerRun)
+}
+
+func TestDisableBodyRecording(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		desc     string
+		disable  bool
+		wantBody string
+	}{
+		{
+			desc:     "body is recorded by default",
+			disable:  false,
+			wantBody: "test data",
+		},
+		{
+			desc:     "body recording is disabled",
+			disable:  true,
+			wantBody: "",
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			w := httptest.NewRecorder()
+			rr := &responseRecorder{
+				ResponseWriter: w,
+				body:           new(bytes.Buffer),
+			}
+			if p.disable {
+				DisableBodyRecording(rr)
+			}
+			rr.WriteHeader(http.StatusOK)
+			rr.Write([]byte("test data"))
+			assert.Equal(t, p.wantBody, rr.body.String())
+			assert.Equal(t, "test data", w.Body.String())
+		})
+	}
+}
+
+func TestDisableBodyRecordingNestedRecorders(t *testing.T) {
+	t.Parallel()
+	w := httptest.NewRecorder()
+	inner := &responseRecorder{ResponseWriter: w, body: new(bytes.Buffer)}
+	outer := &responseRecorder{ResponseWriter: inner, body: new(bytes.Buffer)}
+	DisableBodyRecording(outer)
+	outer.Write([]byte("hello"))
+	assert.Equal(t, "", outer.body.String())
+	assert.Equal(t, "", inner.body.String()) // also not written
+	assert.Equal(t, "hello", w.Body.String())
 }
 
 func TestSplitURLPath(t *testing.T) {


### PR DESCRIPTION
Part of #2152, Follows #2679

## What this PR does

Prevents unbounded memory growth in the streaming middleware's `responseRecorder` during long-lived SSE connections.

## Background

The `responseRecorder` middleware copies every `Write()` into an internal `bytes.Buffer` for logging. For short-lived HTTP requests this is fine, but SSE connections are long-lived — heartbeats and patch events accumulate in the buffer indefinitely, eventually exhausting memory. The SSE handler needs a way to opt out of body recording after headers are written.

## Points

- `DisableBodyRecording` walks the full recorder chain (middleware can nest recorders) to ensure no layer accumulates bytes
- The SSE handler calls `DisableBodyRecording` before `WriteHeader` so no event data is ever buffered