### PR TITLE
fix(stream): copy singleflight result to prevent data race in SSE path

### DIFF
--- a/pkg/api/api/api.go
+++ b/pkg/api/api/api.go
@@ -406,10 +406,14 @@ func (s *gatewayService) evaluateFeaturesForStream(
 	if e != nil {
 		return "", nil, e
 	}
-	features := f.([]*featureproto.Feature)
-	if len(features) == 0 {
+	shared := f.([]*featureproto.Feature)
+	if len(shared) == 0 {
 		return "", s.emptyUserEvaluations(), nil
 	}
+	// singleflight shares the same slice across concurrent callers.
+	// Copy to avoid data races from in-place sort in UserEvaluationsID.
+	features := make([]*featureproto.Feature, len(shared))
+	copy(features, shared)
 
 	evaluator := evaluation.NewEvaluator(
 		evaluation.WithSecondsForAdjustment(int64(s.opts.featureFlagDiffGracePeriod / time.Second)),


### PR DESCRIPTION
Follows #2684

## What this PR does

Copies the features slice returned by `singleflight.Group.Do` before passing it to evaluation functions in the SSE streaming path (`evaluateFeaturesForStream`).

## Background

`singleflight.Do` returns the same `[]*Feature` slice to all concurrent callers sharing the same environment key. `UserEvaluationsID` (called both directly and internally via `EvaluateFeaturesByEvaluatedAt` -> `evaluate`) performs `sort.SliceStable` in-place on that shared slice. When multiple SSE connections serve the same environment concurrently, they race on the sort, producing non-deterministic UEIDs. This causes SDKs to misinterpret unchanged flags as updated, triggering unnecessary re-evaluations.

The REST polling path is unaffected because `filterOutArchivedFeatures` always allocates a new slice before reaching the sort.

## Points

- Shallow copy (pointer array only) — no Feature struct duplication, negligible allocation
- No regression test: race detection requires `go test -race` across CI, which is too heavy to introduce in this PR