### PR TITLE
feat(stream): add SSE-dedicated service and timeout config for streaming

### DIFF
--- a/docker-compose/config/nginx/bucketeer.conf
+++ b/docker-compose/config/nginx/bucketeer.conf
@@ -138,6 +138,21 @@ server {
         grpc_read_timeout 60s;
     }
 
+    # SSE: no buffering / no cache for long-lived streams (heartbeat keeps alive)
+    location /v1/gateway/stream_evaluations {
+        proxy_pass https://api_rest_v1_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
+    }
+
     # API Gateway REST endpoints (deprecated v1/gateway)
     location /v1/gateway {
         proxy_pass https://api_rest_v1_backend;
@@ -675,6 +690,21 @@ server {
         grpc_connect_timeout 60s;
         grpc_send_timeout 60s;
         grpc_read_timeout 60s;
+    }
+
+    # SSE: no buffering / no cache for long-lived streams (heartbeat keeps alive)
+    location /v1/gateway/stream_evaluations {
+        proxy_pass https://api_rest_v1_backend;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 120s;
+        proxy_read_timeout 120s;
     }
 
     # API Gateway REST endpoints (deprecated v1/gateway)

--- a/manifests/bucketeer/charts/api/templates/backend-config-sse.yaml
+++ b/manifests/bucketeer/charts/api/templates/backend-config-sse.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.env.gcpEnabled }}
+# Mirrors backend-config.yaml; only timeoutSec differs.
+apiVersion: cloud.google.com/v1beta1
+kind: BackendConfig
+metadata:
+  name: {{ template "api.fullname" . }}-sse
+  namespace: {{ .Values.namespace }}
+spec:
+  healthCheck:
+    requestPath: /health
+    type: HTTP2
+    checkIntervalSec: 5
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 1
+  # Hard deadline; NOT reset by heartbeat.
+  # https://docs.cloud.google.com/load-balancing/docs/backend-service#timeout-setting
+  timeoutSec: {{ .Values.sse.backendConfig.timeoutSec }}
+  connectionDraining:
+    drainingTimeoutSec: 60
+{{- end }}

--- a/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
@@ -237,6 +237,13 @@ data:
                             route:
                               cluster: api
                               timeout: 60s
+                          # SSE: long-lived stream, no retry
+                          - match:
+                              prefix: /v1/gateway/stream_evaluations
+                            route:
+                              cluster: api-rest-v1
+                              timeout: 0s # hard deadline disabled
+                              idle_timeout: 300s # dead connection cleanup; reset by heartbeat
                           # API REST v1 Gateway routes (Deprecated)
                           - match:
                               prefix: /v1/gateway

--- a/manifests/bucketeer/charts/api/templates/multi-cluster-service-sse.yaml
+++ b/manifests/bucketeer/charts/api/templates/multi-cluster-service-sse.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.gcpMultiCluster.enabled .Values.gcpMultiCluster.configCluster }}
-# Mirrors multi-cluster-service.yaml with changes: 
-# backendConfig->api-sse, no metrics/admin ports.
+# Mirrors multi-cluster-service.yaml with changes:
+# use '-sse' for backendConfig, no metrics/admin ports.
 apiVersion: networking.gke.io/v1
 kind: MultiClusterService
 metadata:

--- a/manifests/bucketeer/charts/api/templates/multi-cluster-service-sse.yaml
+++ b/manifests/bucketeer/charts/api/templates/multi-cluster-service-sse.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.gcpMultiCluster.enabled .Values.gcpMultiCluster.configCluster }}
+# Mirrors multi-cluster-service.yaml with changes: 
+# backendConfig->api-sse, no metrics/admin ports.
+apiVersion: networking.gke.io/v1
+kind: MultiClusterService
+metadata:
+  name: {{ .Values.gcpMultiCluster.sseService.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ template "api.name" . }}
+    chart: {{ template "api.chart" . }}
+    release: {{ template "api.fullname" . }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    cloud.google.com/backend-config: '{"ports": {"{{ .Values.service.externalPort }}":"{{ template "api.fullname" . }}-sse"}}'
+    networking.gke.io/app-protocols: '{"service":"HTTP2"}'
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  template:
+    spec:
+      selector:
+        app: {{ template "api.name" . }}
+        release: {{ template "api.fullname" . }}
+      ports:
+        - name: service
+          port: {{ .Values.service.externalPort }}
+          targetPort: {{ .Values.envoy.port }}
+          protocol: TCP
+{{- end }}

--- a/manifests/bucketeer/charts/api/templates/service-sse.yaml
+++ b/manifests/bucketeer/charts/api/templates/service-sse.yaml
@@ -1,0 +1,26 @@
+# Mirrors service.yaml with changes:
+# backendConfig->api-sse, no metrics/admin ports, no envoy/metrics labels.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "api.fullname" . }}-sse
+  namespace: {{ .Values.namespace }}
+  annotations:
+    cloud.google.com/app-protocols: '{"service":"HTTP2"}'
+    cloud.google.com/neg: '{"ingress": true}'
+    beta.cloud.google.com/backend-config: '{"default": "{{ template "api.fullname" . }}-sse"}'
+  labels:
+    app: {{ template "api.name" . }}
+    chart: {{ template "api.chart" . }}
+    release: {{ template "api.fullname" . }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: service
+      port: {{ .Values.service.externalPort }}
+      targetPort: {{ .Values.envoy.port }}
+      protocol: TCP
+  selector:
+    app: {{ template "api.name" . }}
+    release: {{ template "api.fullname" . }}

--- a/manifests/bucketeer/charts/api/templates/service-sse.yaml
+++ b/manifests/bucketeer/charts/api/templates/service-sse.yaml
@@ -1,5 +1,5 @@
 # Mirrors service.yaml with changes:
-# backendConfig->api-sse, no metrics/admin ports, no envoy/metrics labels.
+# use '-sse' for backendConfig, no metrics/admin ports, no envoy/metrics labels.
 apiVersion: v1
 kind: Service
 metadata:

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -123,11 +123,21 @@ envoy:
 service:
   type: ClusterIP
   externalPort: 9000
+sse:
+  backendConfig:
+    timeoutSec: 86400
 ingress:
   name: api
   host:
   staticIPName:
   rulePaths:
+    - path: /v1/gateway/stream_evaluations
+      pathType: ImplementationSpecific
+      backend:
+        service:
+          name: api-sse
+          port:
+            number: 9000
     - pathType: ImplementationSpecific
       backend:
         service:
@@ -158,12 +168,18 @@ gcpMultiCluster:
   enabled: false
   service:
     name: api-multi-cluster-service
+  sseService:
+    name: api-sse-multi-cluster-service
   ingress:
     name: api-multi-cluster-ingress
     host:
     staticIPName:
     secretName:
     rulePaths:
+      - path: /v1/gateway/stream_evaluations
+        backend:
+          serviceName: api-sse-multi-cluster-service
+          servicePort: 9000
       - path: /
         backend:
           serviceName: api-multi-cluster-service


### PR DESCRIPTION
Part of #2152, Follows #2684

## What this PR does

Adds SSE-dedicated Kubernetes Service, BackendConfig, and MultiClusterService so that the streaming endpoint (`/v1/gateway/stream_evaluations`) can have its own timeout configuration separate from the main API service.

## Background

The main API service has a 60s timeout, which kills long-lived SSE connections. SSE streams need heartbeat-aware idle timeouts (envoy) and a longer hard deadline (GCP BackendConfig). Splitting into a separate Service lets each path have its own timeout without affecting existing API traffic.

This is one of several infra PRs for the SSE streaming feature — further config and deployment changes will follow.

## Points

- Envoy route for SSE uses `timeout: 0s` (no hard deadline) + `idle_timeout: 300s` (reset by heartbeat)
- GCP BackendConfig `timeoutSec: 86400` is a hard deadline not reset by heartbeat — configurable via `values.yaml`
- nginx config adds SSE-specific location block with `proxy_buffering off` and 120s read/send timeout
- Ingress `rulePaths` places the SSE path before the catch-all so it matches first