### PR TITLE
refactor(chart): source envoy ports from Helm values instead of hardcoding

### DIFF
--- a/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
@@ -19,7 +19,7 @@ data:
       address:
         socket_address:
           address: 0.0.0.0
-          port_value: 8001
+          port_value: {{ .Values.envoy.adminPort }}
     static_resources:
       clusters:
         - name: api
@@ -179,7 +179,7 @@ data:
           address:
               socket_address:
                 address: 0.0.0.0
-                port_value: 9000
+                port_value: {{ .Values.envoy.port }}
           filter_chains:
             - filters:
               - name: envoy.filters.network.http_connection_manager

--- a/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/batch/templates/envoy-configmap.yaml
@@ -20,7 +20,7 @@ data:
       address:
         socket_address:
           address: 0.0.0.0
-          port_value: 8001
+          port_value: {{ .Values.envoy.adminPort }}
     static_resources:
       clusters:
         - name: batch
@@ -135,7 +135,7 @@ data:
           address:
             socket_address:
               address: 0.0.0.0
-              port_value: 9000
+              port_value: {{ .Values.envoy.port }}
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager

--- a/manifests/bucketeer/charts/subscriber/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/subscriber/templates/envoy-configmap.yaml
@@ -20,7 +20,7 @@ data:
       address:
         socket_address:
           address: 0.0.0.0
-          port_value: 8001
+          port_value: {{ .Values.envoy.adminPort }}
     static_resources:
       clusters:
         - name: batch

--- a/manifests/bucketeer/charts/web/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/web/templates/envoy-configmap.yaml
@@ -19,7 +19,7 @@ data:
       address:
         socket_address:
           address: 0.0.0.0
-          port_value: 8001
+          port_value: {{ .Values.envoy.adminPort }}
     static_resources:
       clusters:
         - name: healthcheck
@@ -35,7 +35,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 8000
+                          port_value: {{ .Values.env.healthCheckServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -66,7 +66,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9091
+                          port_value: {{ .Values.env.accountServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -98,7 +98,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9092
+                          port_value: {{ .Values.env.authServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -129,7 +129,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9093
+                          port_value: {{ .Values.env.auditLogServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -161,7 +161,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9094
+                          port_value: {{ .Values.env.autoOpsServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -225,7 +225,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9095
+                          port_value: {{ .Values.env.environmentServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -257,7 +257,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9096
+                          port_value: {{ .Values.env.eventCounterServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -289,7 +289,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9097
+                          port_value: {{ .Values.env.experimentServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -321,7 +321,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9098
+                          port_value: {{ .Values.env.featureServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -353,7 +353,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9100
+                          port_value: {{ .Values.env.subscriptionServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -385,7 +385,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9101
+                          port_value: {{ .Values.env.pushServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -417,7 +417,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9105
+                          port_value: {{ .Values.env.coderefServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -449,7 +449,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9103
+                          port_value: {{ .Values.env.dashboardServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -481,7 +481,7 @@ data:
                       address:
                         socket_address:
                           address: localhost
-                          port_value: 9104
+                          port_value: {{ .Values.env.tagServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -512,7 +512,7 @@ data:
                     address:
                       socket_address:
                         address: localhost
-                        port_value: 9107
+                        port_value: {{ .Values.env.teamServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -544,7 +544,7 @@ data:
                     address:
                       socket_address:
                         address: localhost
-                        port_value: 9108
+                        port_value: {{ .Values.env.insightsServicePort }}
           transport_socket:
             name: envoy.transport_sockets.tls
             typed_config:
@@ -600,7 +600,7 @@ data:
           address:
             socket_address:
               address: 0.0.0.0
-              port_value: 9000
+              port_value: {{ .Values.envoy.grpcPort }}
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager
@@ -797,7 +797,7 @@ data:
           address:
             socket_address:
               address: 0.0.0.0
-              port_value: 9003
+              port_value: {{ .Values.envoy.httpPort }}
           filter_chains:
             - filters:
                 - name: envoy.filters.network.http_connection_manager

--- a/manifests/bucketeer/charts/web/values.yaml
+++ b/manifests/bucketeer/charts/web/values.yaml
@@ -73,6 +73,7 @@ env:
   dashboardServicePort: 9103
   tagServicePort: 9104
   coderefServicePort: 9105
+  teamServicePort: 9107
   insightsServicePort: 9108
   unifiedGatewayPort: 9106
   metricsPort: 9002


### PR DESCRIPTION
Follow-up to review feedback on #2690 (the notification envoy cluster port was templatized there; this applies the same treatment everywhere else).

## What this PR does

The envoy configmaps hardcoded ports that the charts already expose as values and inject into the binaries — overriding such a value would desync envoy routing from the actual bind port. This templatizes them:

- **web**: all sidecar service cluster ports (`account` … `insights`, `healthcheck`) now use `env.*ServicePort`; grpc/transcoder ingress listeners use `envoy.grpcPort`/`envoy.httpPort`
- **web**: adds the missing `env.teamServicePort: 9107` value — `deployment.yaml` already referenced it, so `BUCKETEER_WEB_TEAM_SERVICE_PORT` rendered as an empty string (the binary silently fell back to its flag default)
- **api/batch**: ingress listener uses `envoy.port`
- **all charts**: envoy admin listener uses `envoy.adminPort`

Left hardcoded intentionally: cross-service cluster ports (`web`/`batch` upstreams in other charts), egress listeners (9001), and `api-rest-v1` (8000) — no same-chart value exists to bind them to.

## Points

- No behavior change with default values: rendered output of all four envoy configmaps verified **byte-identical** before/after via `helm template`.
- `BUCKETEER_WEB_TEAM_SERVICE_PORT` changes from `""` to `"9107"`, which equals the binary's flag default.
