### PR TITLE
fix(e2e): remove GET method test case from stream request errors

### DIFF
--- a/test/e2e/gateway/stream_test.go
+++ b/test/e2e/gateway/stream_test.go
@@ -394,13 +394,6 @@ func TestStreamRequestErrors(t *testing.T) {
 			apiKey:         serverKey,
 			expectedStatus: http.StatusUnauthorized,
 		},
-		{
-			desc:           "get method",
-			method:         http.MethodGet,
-			body:           newStreamBody(tag, userID),
-			apiKey:         clientKey,
-			expectedStatus: http.StatusMethodNotAllowed,
-		},
 	}
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
Part of #2152, Follows #2687

## What this PR does

Removes the `get method` test case from `TestStreamRequestErrors`.

## Background

GCP HTTP(S) Load Balancer rejects GET requests with a body as 400 (Bad Request) before the request reaches the Go handler, which would return 405 (Method Not Allowed). This makes the test infrastructure-dependent and flaky in CI.

## Points

- The handler-level method check (`checkStreamEvaluationsRequest`) still exists and is not removed