### PR TITLE
feat(stream): add Envoy circuit breaker and connection budget for SSE

### DIFF
--- a/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
@@ -107,6 +107,7 @@ data:
                 max_connections: {{ .Values.envoy.sseCircuitBreaker.maxConnections }}
                 max_pending_requests: {{ .Values.envoy.sseCircuitBreaker.maxPendingRequests }}
                 max_requests: {{ .Values.envoy.sseCircuitBreaker.maxRequests }}
+                max_retries: 0
           load_assignment:
             cluster_name: api-sse
             endpoints:

--- a/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
+++ b/manifests/bucketeer/charts/api/templates/envoy-configmap.yaml
@@ -98,6 +98,43 @@ data:
                     private_key:
                       filename: /usr/local/certs/service/tls.key
           type: strict_dns
+        - name: api-sse
+          connect_timeout: 5s
+          ignore_health_on_host_removal: true
+          circuit_breakers:
+            thresholds:
+              - priority: DEFAULT
+                max_connections: {{ .Values.envoy.sseCircuitBreaker.maxConnections }}
+                max_pending_requests: {{ .Values.envoy.sseCircuitBreaker.maxPendingRequests }}
+                max_requests: {{ .Values.envoy.sseCircuitBreaker.maxRequests }}
+          load_assignment:
+            cluster_name: api-sse
+            endpoints:
+              - lb_endpoints:
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: localhost
+                        port_value: 8000
+          dns_lookup_family: V4_ONLY
+          lb_policy: {{ .Values.envoy.lbPolicy }}
+          typed_extension_protocol_options:
+            envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+              '@type': type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+              explicit_http_config:
+                http2_protocol_options: {}
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              common_tls_context:
+                alpn_protocols: ["h2"]
+                tls_certificates:
+                  - certificate_chain:
+                      filename: /usr/local/certs/service/tls.crt
+                    private_key:
+                      filename: /usr/local/certs/service/tls.key
+          type: strict_dns
         - name: api-grpc-gateway
           connect_timeout: 5s
           ignore_health_on_host_removal: true
@@ -237,11 +274,11 @@ data:
                             route:
                               cluster: api
                               timeout: 60s
-                          # SSE: long-lived stream, no retry
+                          # SSE: long-lived stream, no retry, dedicated cluster for independent circuit breaking
                           - match:
                               prefix: /v1/gateway/stream_evaluations
                             route:
-                              cluster: api-rest-v1
+                              cluster: api-sse
                               timeout: 0s # hard deadline disabled
                               idle_timeout: 300s # dead connection cleanup; reset by heartbeat
                           # API REST v1 Gateway routes (Deprecated)

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -125,8 +125,7 @@ envoy:
   sseCircuitBreaker:
     maxRequests: 20000
     maxConnections: 20000
-    # Let clients access another server without pending
-    # because SSE is long-lived.
+    # Reject immediately so the LB routes to another pod
     maxPendingRequests: 0
 service:
   type: ClusterIP

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -122,6 +122,12 @@ envoy:
     maxPendingRequests: 3500
     maxRequests: 3500
     maxConnections: 3500
+  sseCircuitBreaker:
+    maxRequests: 20000
+    maxConnections: 20000
+    # Let clients access another server without pending
+    # because SSE is long-lived.
+    maxPendingRequests: 0
 service:
   type: ClusterIP
   externalPort: 9000


### PR DESCRIPTION
Part of #2152, Follows #2688

## What this PR does

Add a dedicated Envoy cluster (`api-sse`) with independent circuit breaker settings and route the SSE streaming endpoint through it, so SSE and regular API traffic have isolated connection limits.

## Background

PR #2688 introduced a separate Service/BackendConfig for SSE but still routed SSE through the shared `api-rest-v1` Envoy cluster. This means SSE connections share the same circuit breaker thresholds as short-lived API requests — a spike in long-lived SSE connections could trip the breaker and block normal API traffic, or vice versa.

## Points

- `maxPendingRequests: 0` forces clients to immediately connect to another pod rather than queuing, which suits long-lived SSE where pending is pointless
- The SSE route must appear before the generic `/v1/gateway` route for Envoy prefix matching to work correctly
- The new cluster points to port 8000 (same as `api-rest-v1`) since SSE is served by the rest server