### PR TITLE
ci: replace classic pat for github app token

### DIFF
--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -214,7 +214,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+          client-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
           private-key: ${{ secrets.DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}
           owner: ${{ secrets.CONFIG_REPO_OWNER }}
           repositories: ${{ secrets.CONFIG_REPO_NAME }}

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -222,7 +222,7 @@ jobs:
       - name: Workflow Dispatch
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
-          repo: ${{ secrets.CONFIG_REPO }}
+          repo: ${{ secrets.CONFIG_REPO_OWNER }}/${{ secrets.CONFIG_REPO_NAME }}
           token: ${{ steps.app-token.outputs.token }}
           workflow: dev-deploy.yaml
           ref: master

--- a/.github/workflows/push-image.yaml
+++ b/.github/workflows/push-image.yaml
@@ -211,11 +211,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.DEPLOY_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.DEPLOY_DISPATCHER_APP_PRIVATE_KEY }}
+          owner: ${{ secrets.CONFIG_REPO_OWNER }}
+          repositories: ${{ secrets.CONFIG_REPO_NAME }}
+          permission-actions: write
       - name: Workflow Dispatch
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           repo: ${{ secrets.CONFIG_REPO }}
-          token: ${{ secrets.REPO_ACCESS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           workflow: dev-deploy.yaml
           ref: master
           inputs: '{"ref": "${{ needs.setup.outputs.REF }}", "image_tag": "${{ needs.setup.outputs.IMAGE_TAG }}", "committer": "${{ github.event.head_commit.author.name }}", "commit_message": "${{ needs.setup.outputs.COMMIT_MESSAGE }}", "commit_url": "${{ github.event.head_commit.url }}", "skip_e2e": "${{ github.event.inputs.skip_e2e }}", "skip_sdk_e2e": "${{ github.event.inputs.skip_sdk_e2e }}", "skip_prd_pr": "${{ github.event.inputs.skip_prd_pr }}", "migration_required": "${{ needs.setup.outputs.MIGRATION_REQUIRED }}"}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,10 +10,17 @@ jobs:
   release_please:
     name: Release Please
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
+    permissions: {} # release-please uses the app token, not GITHUB_TOKEN
     steps:
+      # The app token is used instead of GITHUB_TOKEN so the tag/release
+      # created by release-please can trigger the publishing workflows
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
-          token: ${{ secrets.REPO_ACCESS_PAT }} # We need to set the PAT so the publishing workflow can be triggered
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/trigger-ai-docs-update.yaml
+++ b/.github/workflows/trigger-ai-docs-update.yaml
@@ -72,7 +72,7 @@ jobs:
         if: steps.find-prs.outputs.pr_numbers != ''
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: bucketeer-io
           repositories: bucketeer-docs

--- a/.github/workflows/trigger-ai-docs-update.yaml
+++ b/.github/workflows/trigger-ai-docs-update.yaml
@@ -19,6 +19,7 @@ jobs:
     permissions:
       contents: read
       issues: read
+      pull-requests: read
     # Only trigger for issues closed as completed (not "not planned")
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -27,7 +28,7 @@ jobs:
       - name: Find linked merged PRs
         id: find-prs
         env:
-          GH_TOKEN: ${{ secrets.REPO_ACCESS_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_ISSUE_NUMBER: ${{ github.event.issue.number || inputs.issue_number }}
           REPO: ${{ github.repository }}
         run: |
@@ -67,12 +68,22 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         if: steps.find-prs.outputs.pr_numbers != ''
 
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: steps.find-prs.outputs.pr_numbers != ''
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: bucketeer-io
+          repositories: bucketeer-docs
+          permission-actions: write
+
       - name: Trigger AI docs update in bucketeer-docs
         if: steps.find-prs.outputs.pr_numbers != ''
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         with:
           repo: bucketeer-io/bucketeer-docs
-          token: ${{ secrets.REPO_ACCESS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           workflow: ai-docs-update.yaml
           ref: main
           inputs: '{"issue_number": "${{ steps.find-prs.outputs.issue_number }}", "pr_numbers": "${{ steps.find-prs.outputs.pr_numbers }}"}'

--- a/.github/workflows/update-changelog-docs-page.yml
+++ b/.github/workflows/update-changelog-docs-page.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          client-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           owner: bucketeer-io
           repositories: bucketeer-docs

--- a/.github/workflows/update-changelog-docs-page.yml
+++ b/.github/workflows/update-changelog-docs-page.yml
@@ -29,6 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          owner: bucketeer-io
+          repositories: bucketeer-docs
+          permission-actions: write
       - name: Workflow Dispatch
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26 # v1.3.2
         env:
@@ -42,7 +50,7 @@ jobs:
           FROM_REPOSITORY_URL: https://github.com/bucketeer-io/bucketeer
         with:
           repo: ${{ env.DOC_REPO }}
-          token: ${{ secrets.REPO_ACCESS_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           workflow: update-changelog.yaml
           ref: main
           inputs: '{"doc_filename": "${{ env.DOC_FILENAME }}", "doc_filepath": "${{ env.DOC_FILEPATH }}", "doc_title": "${{ env.DOC_TITLE }}", "doc_slug": "${{ env.DOC_SLUG }}", "changelog_url": "${{ env.CHANGELOG_URL }}", "from_repository_name": "${{ env.FROM_REPOSITORY_NAME }}", "from_repository_url": "${{ env.FROM_REPOSITORY_URL }}", "commit_url": "${{ needs.setup.outputs.COMMIT_URL }}", "release_tag": "${{ needs.setup.outputs.RELEASE_TAG }}"}'


### PR DESCRIPTION
Fix of https://github.com/bucketeer-io/bucketeer/issues/2703

## Summary

Classic personal access tokens are being removed from our CI for security reasons.
This PR replaces the classic PAT (`REPO_ACCESS_PAT`) with short-lived GitHub App installation tokens minted at runtime via `actions/create-github-app-token`.

Benefits over a PAT:

- **Short-lived credentials**: tokens expire after 1 hour and are revoked when the job completes; nothing long-lived is exposed to workflow runs
- **Least privilege**: each job requests only the permissions and repositories it needs (e.g. `actions: write` scoped to a single target repo)
- **Not tied to a user account**: the apps are owned by the organization, so CI no longer depends on a machine user and its token rotation
- **Better auditability**: actions show up as the app's bot identity instead of a shared user

## What changed

| Workflow | Before | After |
|---|---|---|
| `release.yaml` | PAT for release-please | App token with `contents: write` + `pull-requests: write`; job `GITHUB_TOKEN` permissions set to `{}`. The app token still allows the tag/release created by release-please to trigger the publishing workflows |
| `push-image.yaml` | PAT to dispatch the deploy workflow in the config repo | Token from a deploy-dispatcher app scoped to `actions: write` on the config repo only |
| `update-changelog-docs-page.yml` | PAT to dispatch the changelog update in bucketeer-docs | App token scoped to `actions: write` on `bucketeer-docs` only |
| `trigger-ai-docs-update.yaml` | PAT for `gh` API reads + docs dispatch | Built-in `GITHUB_TOKEN` (with `pull-requests: read` added) for same-repo reads; app token for the `bucketeer-docs` dispatch |

Also uses the `client-id` input instead of the deprecated `app-id` input.

## Notes

- `actions/create-github-app-token` is pinned to v3.2.0 by commit SHA, consistent with the other actions in this repo
- The checkout of this (public) repo needs no token, so none is passed
- Cross-org dispatch (`push-image.yaml`) and same-org dispatches (docs workflows) intentionally use **separate apps**, so each private key's blast radius stays limited to one direction

## Test plan

- [x] `push-image.yaml`: image push → deploy dispatch → dev deploy → e2e (including SDK e2e dispatches) verified end to end
- [ ] `release.yaml`: verify on the next release that the release PR is created and the tag triggers the publishing workflows
- [ ] `update-changelog-docs-page.yml` / `trigger-ai-docs-update.yaml`: verify via manual `workflow_dispatch`
- [x] Remove `REPO_ACCESS_PAT` from this repo's secrets once all of the above pass