### PR TITLE
chore(devcontainer): add SSH server to devcontainer base image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -76,5 +76,8 @@
     "memory": "8gb",
     "storage": "32gb"
   },
+  // Start sshd at every container start so `gh codespace ssh` works without an editor attach
+  // (postAttachCommand only fires when an editor client attaches)
+  "postStartCommand": "bash .devcontainer/start-sshd.sh",
   "postAttachCommand": "bash .devcontainer/setup.sh"
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -526,6 +526,8 @@ if ! pgrep -x sshd > /dev/null 2>&1; then
     echo "🔑 Starting SSH daemon..."
     # Regenerate host keys if missing (never baked into the shared image)
     sudo ssh-keygen -A > /dev/null 2>&1
+    # Privilege-separation dir; /run can be tmpfs, wiping the build-time mkdir
+    sudo mkdir -p /run/sshd
     sudo /usr/sbin/sshd
     echo "✅ SSH daemon started successfully"
 else

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -518,18 +518,6 @@ else
     echo "✅ Docker daemon already running"
 fi
 
-# Start SSH daemon automatically after main setup is complete.
-# The Dockerfile's own ENTRYPOINT (docker-init.sh) also does this, but Codespaces/devcontainer
-# tooling overrides the container's entrypoint at container-start time, so that logic never
-# actually runs there. This mirrors the Docker daemon fallback above for the same reason.
-if ! pgrep -x sshd > /dev/null 2>&1; then
-    echo "🔑 Starting SSH daemon..."
-    # Regenerate host keys if missing (never baked into the shared image)
-    sudo ssh-keygen -A > /dev/null 2>&1
-    # Privilege-separation dir; /run can be tmpfs, wiping the build-time mkdir
-    sudo mkdir -p /run/sshd
-    sudo /usr/sbin/sshd
-    echo "✅ SSH daemon started successfully"
-else
-    echo "✅ SSH daemon already running"
-fi
+# Start SSH daemon if needed. postStartCommand (start-sshd.sh) already does this at every
+# container start; this attach-time call is a safety net in case sshd died mid-session.
+bash "$(dirname "$0")/start-sshd.sh"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -517,7 +517,3 @@ if ! docker info > /dev/null 2>&1; then
 else
     echo "✅ Docker daemon already running"
 fi
-
-# Start SSH daemon if needed. postStartCommand (start-sshd.sh) already does this at every
-# container start; this attach-time call is a safety net in case sshd died mid-session.
-bash "$(dirname "$0")/start-sshd.sh"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -517,3 +517,17 @@ if ! docker info > /dev/null 2>&1; then
 else
     echo "✅ Docker daemon already running"
 fi
+
+# Start SSH daemon automatically after main setup is complete.
+# The Dockerfile's own ENTRYPOINT (docker-init.sh) also does this, but Codespaces/devcontainer
+# tooling overrides the container's entrypoint at container-start time, so that logic never
+# actually runs there. This mirrors the Docker daemon fallback above for the same reason.
+if ! pgrep -x sshd > /dev/null 2>&1; then
+    echo "🔑 Starting SSH daemon..."
+    # Regenerate host keys if missing (never baked into the shared image)
+    sudo ssh-keygen -A > /dev/null 2>&1
+    sudo /usr/sbin/sshd
+    echo "✅ SSH daemon started successfully"
+else
+    echo "✅ SSH daemon already running"
+fi

--- a/.devcontainer/start-sshd.sh
+++ b/.devcontainer/start-sshd.sh
@@ -7,14 +7,14 @@
 # comes up at every container start — with or without an editor attach.
 set -e
 
-if pgrep -x sshd > /dev/null 2>&1; then
+if pgrep -x sshd > /dev/null; then
     echo "✅ SSH daemon already running"
     exit 0
 fi
 
 echo "🔑 Starting SSH daemon..."
 # Regenerate host keys if missing (never baked into the shared image)
-sudo ssh-keygen -A > /dev/null 2>&1
+sudo ssh-keygen -A > /dev/null
 # Privilege-separation dir; /run can be tmpfs, wiping the build-time mkdir
 sudo mkdir -p /run/sshd
 sudo /usr/sbin/sshd

--- a/.devcontainer/start-sshd.sh
+++ b/.devcontainer/start-sshd.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Starts the SSH daemon so `gh codespace ssh` (and other SSH clients) can connect.
+#
+# The Dockerfile's own ENTRYPOINT (docker-init.sh) also starts sshd, but Codespaces/
+# devcontainer tooling overrides the container's entrypoint at container-start time,
+# so that logic never runs there. This script is wired to postStartCommand so sshd
+# comes up at every container start — with or without an editor attach — and is called
+# again from setup.sh (postAttachCommand) as a safety net in case sshd died mid-session.
+set -e
+
+if pgrep -x sshd > /dev/null 2>&1; then
+    echo "✅ SSH daemon already running"
+    exit 0
+fi
+
+echo "🔑 Starting SSH daemon..."
+# Regenerate host keys if missing (never baked into the shared image)
+sudo ssh-keygen -A > /dev/null 2>&1
+# Privilege-separation dir; /run can be tmpfs, wiping the build-time mkdir
+sudo mkdir -p /run/sshd
+sudo /usr/sbin/sshd
+echo "✅ SSH daemon started successfully"

--- a/.devcontainer/start-sshd.sh
+++ b/.devcontainer/start-sshd.sh
@@ -4,8 +4,7 @@
 # The Dockerfile's own ENTRYPOINT (docker-init.sh) also starts sshd, but Codespaces/
 # devcontainer tooling overrides the container's entrypoint at container-start time,
 # so that logic never runs there. This script is wired to postStartCommand so sshd
-# comes up at every container start — with or without an editor attach — and is called
-# again from setup.sh (postAttachCommand) as a safety net in case sshd died mid-session.
+# comes up at every container start — with or without an editor attach.
 set -e
 
 if pgrep -x sshd > /dev/null 2>&1; then

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -197,7 +197,7 @@ RUN apt-get update \
 # .devcontainer/setup.sh (postAttachCommand) instead. Keep these in sync.
 RUN echo '#!/bin/bash\n\
 # Regenerate SSH host keys if missing (never baked into the shared image)\n\
-sudo ssh-keygen -A > /dev/null 2>&1\n\
+sudo ssh-keygen -A > /dev/null\n\
 # Privilege-separation dir; /run can be tmpfs, wiping the build-time mkdir\n\
 sudo mkdir -p /run/sshd\n\
 # Start the SSH daemon (self-daemonizes; do not add -D here)\n\

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -171,8 +171,30 @@ RUN ARCH=$(dpkg --print-architecture) \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+# Install and configure OpenSSH server (replaces the ghcr.io/devcontainers/features/sshd feature).
+# Host keys must never be baked into this shared base image (every container/Codespace built
+# from it would otherwise share one static key pair), so they are stripped here and regenerated
+# fresh at container startup instead, by docker-init.sh via `ssh-keygen -A`.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssh-server openssh-sftp-server \
+    && mkdir -p /run/sshd \
+    && sed -i -E \
+        -e 's/^#?Port .*/Port 2222/' \
+        -e 's/^#?PasswordAuthentication .*/PasswordAuthentication no/' \
+        -e 's/^#?PubkeyAuthentication .*/PubkeyAuthentication yes/' \
+        -e 's/^#?UsePAM .*/UsePAM yes/' \
+        /etc/ssh/sshd_config \
+    && /usr/sbin/sshd -t \
+    && rm -f /etc/ssh/ssh_host_* \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Create docker startup script
 RUN echo '#!/bin/bash\n\
+# Regenerate SSH host keys if missing (never baked into the shared image)\n\
+sudo ssh-keygen -A > /dev/null 2>&1\n\
+# Start the SSH daemon (self-daemonizes; do not add -D here)\n\
+sudo /usr/sbin/sshd\n\
 # Start docker daemon in background\n\
 sudo dockerd > /dev/null 2>&1 &\n\
 # Wait for docker to be ready\n\

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -192,8 +192,9 @@ RUN apt-get update \
 # Create docker startup script.
 # NOTE: This script is the image's ENTRYPOINT, but Codespaces/devcontainer tooling
 # overrides the entrypoint at container start, so it never runs there — it only
-# runs under plain `docker run`. On Codespaces these daemons are started from
-# .devcontainer/setup.sh (postAttachCommand) instead. Keep both in sync.
+# runs under plain `docker run`. On Codespaces sshd is started by
+# .devcontainer/start-sshd.sh (postStartCommand) and dockerd by
+# .devcontainer/setup.sh (postAttachCommand) instead. Keep these in sync.
 RUN echo '#!/bin/bash\n\
 # Regenerate SSH host keys if missing (never baked into the shared image)\n\
 sudo ssh-keygen -A > /dev/null 2>&1\n\

--- a/.github/.devcontainer/Dockerfile
+++ b/.github/.devcontainer/Dockerfile
@@ -189,10 +189,16 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Create docker startup script
+# Create docker startup script.
+# NOTE: This script is the image's ENTRYPOINT, but Codespaces/devcontainer tooling
+# overrides the entrypoint at container start, so it never runs there — it only
+# runs under plain `docker run`. On Codespaces these daemons are started from
+# .devcontainer/setup.sh (postAttachCommand) instead. Keep both in sync.
 RUN echo '#!/bin/bash\n\
 # Regenerate SSH host keys if missing (never baked into the shared image)\n\
 sudo ssh-keygen -A > /dev/null 2>&1\n\
+# Privilege-separation dir; /run can be tmpfs, wiping the build-time mkdir\n\
+sudo mkdir -p /run/sshd\n\
 # Start the SSH daemon (self-daemonizes; do not add -D here)\n\
 sudo /usr/sbin/sshd\n\
 # Start docker daemon in background\n\


### PR DESCRIPTION
<!-- 
sshを入れるために、本当はdevcontainer.jsonを使ってfeatureとして入れたかった、けど、これはCIによる開発環境コンテナのpre buildに影響を与えられるようになっていなかった
devcontainer.jsonのfeatureを追加して、CIに手を入れるより、dockerfileにsshの機能を入れる方が今までの流れ的に妥当だと判断し、dockerfileによるpre buildを作った

もしもやっていいなら、開発環境構築系一切使われていないファイルを見つけたのでついでにクリーンアップをしておきたい

動作確認としてはまず、devcontainer cliによるビルドとローカル接続確認

次にブランチを分けてCIで自分のghcr.ioに開発環境用コンテナがプッシュできるかを確認
最後にgh cs sshでプッシュされたコンテナを使って開発環境に辿り着くことができるのかを確認
-->

## What this PR does
Reinstates the SSH server in the devcontainer base image so `gh codespace ssh` works again.

## Background

SSH used to be provided by the ghcr.io/devcontainers/features/sshd feature, which was dropped along with every other feature in a616dae2 (#2063) when the devcontainer build moved to plain Dockerfile RUN steps. This reimplements it as a plain openssh-server install, consistent with how everything else in this image is installed.

## Points

- Host keys are stripped at build time and regenerated per container at startup (`ssh-keygen -A`), so containers/Codespaces built from the shared image never share a static host key pair.

- No authorized_keys setup is needed: `gh codespace ssh` provisions per-connection keys automatically, as long as sshd is running and accepts pubkey auth.

- Also fixes real gaps found during verification: Codespaces overrides the container entrypoint (so docker-init.sh never runs there), and `postAttachCommand` only fires when an editor attaches (so a codespace accessed purely via `gh codespace ssh` never got sshd started). sshd is therefore started from `postStartCommand` (`.devcontainer/start-sshd.sh`), which runs at every container start — with or without an editor attach.

## Test plan
- [x] Local image build: `make build-devcontainer` (→ evidence 1)
- [x] Local container: sshd config, negative/positive auth, host key uniqueness across containers (→ evidence 1)
- [x] CI dry-run: full image build pipeline against a personal GHCR namespace (→ evidence 2)
- [x] End-to-end: real Codespace, connected via `gh codespace ssh` without ever attaching an editor (→ evidence 3)

## Verification evidence

### 1. Local build + container verification (`make build-devcontainer` + `docker run`)

<details>
<summary>Setup: image build + container startup (all checks below run against this)</summary>

Image build:

```bash
$ make build-devcontainer
```

This expands to `devcontainer build --workspace-folder=.github --push=false --image-name="ghcr.io/bucketeer-io/bucketeer-devcontainer:latest"`. The build itself includes an `sshd -t` self-test, so invalid `sshd_config` edits fail the build.

Container startup (the entrypoint starts sshd, so waiting for the process doubles as verifying the entrypoint wiring):

```bash
$ docker run -d --name sshtest -p 2222:2222 ghcr.io/bucketeer-io/bucketeer-devcontainer:latest
$ until docker exec sshtest pgrep -x sshd > /dev/null; do sleep 0.5; done
```

</details>

<details>
<summary>sshd config/process check</summary>

```bash
$ docker exec sshtest sudo sshd -T | grep -Ei '^(port|passwordauthentication|pubkeyauthentication|usepam) '
port 2222
usepam yes
pubkeyauthentication yes
passwordauthentication no
```

```bash
$ docker exec sshtest pgrep -a sshd
11 sshd: /usr/sbin/sshd [listener] 0 of 10-100 startups
```
</details>

<details>
<summary>Negative auth check (no key → rejected, not connection-refused)</summary>

```bash
$ ssh -p 2222 -o StrictHostKeyChecking=no -o BatchMode=yes codespace@localhost
Warning: Permanently added '[localhost]:2222' (ED25519) to the list of known hosts.
codespace@localhost: Permission denied (publickey).
```

</details>

<details>
<summary>Positive auth check (test key placed in authorized_keys → full login)</summary>

```bash
$ ssh-keygen -t ed25519 -f /tmp/test_key -N ''
$ docker exec -i sshtest bash -c \
    'mkdir -p ~/.ssh && chmod 700 ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys' \
    < /tmp/test_key.pub
$ ssh -p 2222 -i /tmp/test_key -o StrictHostKeyChecking=no codespace@localhost echo ok
ok
```

</details>

<details>
<summary>Host key uniqueness across two separately started containers</summary>

```bash
$ docker run -d --name sshtest2 ghcr.io/bucketeer-io/bucketeer-devcontainer:latest
$ until docker exec sshtest2 test -f /etc/ssh/ssh_host_ed25519_key.pub; do sleep 0.5; done
$ docker exec sshtest  ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
$ docker exec sshtest2 ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub
```

```bash
--- container 1 ---
256 SHA256:euoeWvAKZbGgsUCzFmFTplpNiZJiKgfCJLK+sB2B9Q4 root@b9d8991aadbc (ED25519)
--- container 2 ---
256 SHA256:eKXhEj3X2e/pJSVPhh0XYaXXGQVCwYo4zt+aFk95/1M root@04b5cf666305 (ED25519)
Fingerprints differ, confirming host keys are not baked into the shared image.
```

</details>

### 2. Full CI dry-run against a personal GHCR namespace

Ran the unmodified `devcontainer-image-build.yaml` pipeline (both `build-amd64` and `build-arm64` jobs, multi-arch manifest creation/push) with only the registry namespace swapped to a personal one, to confirm the real `docker/build-push-action` pipeline builds cleanly (this repo's fork has no write access to `ghcr.io/bucketeer-io/...`, so this was the only way to validate the actual CI path pre-merge):

https://github.com/Rtosshy/bucketeer/actions/runs/29625663302 — `success` (all three jobs: `build-amd64`, `build-arm64`, `create-manifest`)

### 3. Real Codespace + `gh codespace ssh`

Created an actual Codespace from a test branch whose `.devcontainer/devcontainer.json` points at the dry-run image from (2), and connected with `gh codespace ssh` directly — **without ever attaching an editor**, so this exercises the `postStartCommand` path end-to-end:

```bash
$ gh codespace create -R Rtosshy/bucketeer -b test/ssh-codespace-check
fictional-waffle-pxj76qg5g5hrgg4
$ gh cs ssh
? Choose codespace: Rtosshy/bucketeer [test/ssh-codespace-check]: fictional waffle
Welcome to Ubuntu 22.04.5 LTS (GNU/Linux 6.8.0-1052-azure x86_64)
...
$
```

This step surfaced two real bugs not caught by (1) or (2):

- Codespaces/devcontainer tooling overrides the container's entrypoint at container-start time, so the Dockerfile's own `ENTRYPOINT` (`docker-init.sh`) never actually runs there — sshd has to be started from the repo-side lifecycle commands instead, mirroring the existing `dockerd` fallback in `setup.sh` that exists for the identical reason (12fc8c19).
- `postAttachCommand` only fires when an editor client attaches, so `gh codespace create` followed directly by `gh codespace ssh` — no editor involved — still found no running sshd and failed with `error getting ssh server details`. The startup was moved to `postStartCommand` (`.devcontainer/start-sshd.sh`), which runs at every container start (6780cf4c).

## Question for maintainers

While tracing the a616dae2 migration for this PR, I noticed two leftovers from the features era: a616dae2 removed the `features` block from devcontainer.json but left these behind, and nothing references them today.

- `.github/.devcontainer/local-features/setup-user/` — added in #711 and wired into the `features` block back then; now referenced by neither devcontainer.json, the Dockerfile, nor the image build workflow.
- `.github/.devcontainer/devcontainer-lock.json` — pins versions for features that devcontainer.json no longer declares.

Would you be OK with removing them? Happy to do that in this PR or as a separate follow-up, whichever you prefer.
