### PR TITLE
fix(stream): set SSE circuit breaker maxPendingRequests to 100

### DIFF
--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -129,8 +129,10 @@ envoy:
   sseCircuitBreaker:
     maxRequests: 20000
     maxConnections: 20000
-    # Reject immediately so the LB routes to another pod
-    maxPendingRequests: 0
+    # Allow pending requests during H2 connection establishment.
+    # 0 rejects the very first request burst before the upstream
+    # connection is ready, causing 503 overflow on every fresh pod.
+    maxPendingRequests: 100
 service:
   type: ClusterIP
   externalPort: 9000


### PR DESCRIPTION
Part of #2152

## What this PR does

Change the default `sseCircuitBreaker.maxPendingRequests` from `0` to `100` in the api Helm chart.

## Background

The `maxPendingRequests: 0` setting was introduced in #2698 with the intent to reject requests immediately so the load balancer routes to another pod. However, `0` also rejects the very first burst of requests that arrive while the H2 upstream connection to the REST backend (port 8000) is being established. This causes `503 upstream connect error or disconnect/reset before headers. reset reason: overflow` on every fresh pod start.

The chart default remains `0`, so `make deploy-bucketeer` for localenv deploys without a safe value and E2E tests fail with overflow when multiple parallel tests hit the SSE endpoint simultaneously.

## Points

- Connection capacity is still bounded by `maxConnections` (20000) and `maxRequests` (20000); `maxPendingRequests: 100` only allows a small queue during H2 connection establishment