### PR TITLE
fix(subscriber): discard goal events older than the user's latest evaluation

### DIFF
--- a/pkg/subscriber/processor/errors.go
+++ b/pkg/subscriber/processor/errors.go
@@ -30,11 +30,18 @@ var (
 	ErrReasonNil                                 = errors.New("eventpersister: reason is nil")
 	ErrEvaluationsAreEmpty                       = errors.New("eventpersister: evaluations are empty")
 	ErrEvaluationEventIssuedAfterExperimentEnded = errors.New("eventpersister: evaluation event issued after experiment ended") //nolint:lll
-	ErrFailedToEvaluateUser                      = errors.New("eventpersister: failed to evaluate user")
-	ErrAutoOpsRuleNotFound                       = errors.New("eventpersister: auto ops rule not found")
-	ErrFeatureEmptyList                          = errors.New("eventpersister: list feature returned empty")
-	ErrFeatureVersionNotFound                    = errors.New("eventpersister: feature version not found")
-	ErrUnknownEvent                              = errors.New("metricsevent persister: unknown metrics event")
-	ErrInvalidDuration                           = errors.New("metricsevent persister: invalid duration")
-	ErrUnknownApiId                              = errors.New("metricsevent persister: unknown api id")
+	// ErrGoalEventOlderThanEvaluation is returned when the goal event timestamp is older
+	// than the user's latest evaluation timestamp. Because the client SDK sets both
+	// timestamps when the events are generated, this means the goal event was created
+	// before the user was evaluated (incorrect SDK implementation), so the event is
+	// discarded instead of retried.
+	ErrGoalEventOlderThanEvaluation = errors.New(
+		"eventpersister: goal event timestamp is older than the user's latest evaluation timestamp")
+	ErrFailedToEvaluateUser   = errors.New("eventpersister: failed to evaluate user")
+	ErrAutoOpsRuleNotFound    = errors.New("eventpersister: auto ops rule not found")
+	ErrFeatureEmptyList       = errors.New("eventpersister: list feature returned empty")
+	ErrFeatureVersionNotFound = errors.New("eventpersister: feature version not found")
+	ErrUnknownEvent           = errors.New("metricsevent persister: unknown metrics event")
+	ErrInvalidDuration        = errors.New("metricsevent persister: invalid duration")
+	ErrUnknownApiId           = errors.New("metricsevent persister: unknown api id")
 )

--- a/pkg/subscriber/processor/goal_events_dwh.go
+++ b/pkg/subscriber/processor/goal_events_dwh.go
@@ -141,6 +141,12 @@ func (w *goalEvtWriter) Write(
 						subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeExperimentNotFound).Inc()
 						continue
 					}
+					if errors.Is(err, ErrGoalEventOlderThanEvaluation) {
+						// The goal event was created before the user was evaluated
+						// (the client SDK sets the timestamps), so it can never be
+						// linked. Discard it by acking the message.
+						continue
+					}
 					if !retriable {
 						w.logger.Error(
 							"Failed to convert to goal event",
@@ -264,19 +270,23 @@ func (w *goalEvtWriter) linkGoalEvent(
 	id, environmentID, tag string,
 	experiments []*exproto.Experiment,
 ) ([]*ecdwh.UserEvaluation, bool, error) {
-	evalExp, retriable, err := w.linkGoalEventByExperiment(ctx, event, id, environmentID, tag, experiments)
+	evalExp, retriable, err := w.linkGoalEventByExperiment(ctx, event, id, environmentID, tag, experiments, true)
 	if err != nil {
 		return nil, retriable, err
 	}
 	return evalExp, false, nil
 }
 
-// Link one or more experiments by goal ID
+// Link one or more experiments by goal ID.
+// When storeRetryOnMiss is true (fresh events from Pub/Sub), goal events that can't be
+// linked yet are stored in Redis so the retry processor can link them later.
+// The retry processor itself passes false because it manages its own retry message.
 func (w *goalEvtWriter) linkGoalEventByExperiment(
 	ctx context.Context,
 	event *eventproto.GoalEvent,
 	id, environmentID, tag string,
 	experiments []*exproto.Experiment,
+	storeRetryOnMiss bool,
 ) ([]*ecdwh.UserEvaluation, bool, error) {
 	// Find the experiment by goal ID
 	// TODO: we must change the console UI not to allow creating
@@ -324,19 +334,21 @@ func (w *goalEvtWriter) linkGoalEventByExperiment(
 					zap.Any("goalEvent", event),
 				)
 				subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeUserEvaluationNotFound).Inc()
-				if err := w.storeRetryMessage(&retryMessage{
-					GoalEvent:     event,
-					EnvironmentID: environmentID,
-					RetryCount:    0,
-					ID:            id,
-				}); err != nil {
-					subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeFailedToStoreRetryMessage).Inc()
-					w.logger.Error("Failed to store retry message",
-						zap.Error(err),
-						zap.String("environmentId", environmentID),
-						zap.Any("goalEvent", event),
-					)
-					return nil, true, err
+				if storeRetryOnMiss {
+					if err := w.storeRetryMessage(&retryMessage{
+						GoalEvent:     event,
+						EnvironmentID: environmentID,
+						RetryCount:    0,
+						ID:            id,
+					}); err != nil {
+						subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeFailedToStoreRetryMessage).Inc()
+						w.logger.Error("Failed to store retry message",
+							zap.Error(err),
+							zap.String("environmentId", environmentID),
+							zap.Any("goalEvent", event),
+						)
+						return nil, true, err
+					}
 				}
 				return nil, false, err
 			}
@@ -353,11 +365,14 @@ func (w *goalEvtWriter) linkGoalEventByExperiment(
 			zap.Any("goalEvent", event),
 			zap.Any("evaluation", eval),
 		)
-		// Skip goal events that occurred before the evaluation timestamp.
-		// This is intentional to trigger retry logic for proper event linking.
+		// Skip goal events older than the evaluation timestamp.
+		// Because the client SDK sets the timestamps when the events are generated,
+		// a goal event older than the user's latest evaluation means the client
+		// sent the goal event before evaluating the user (incorrect implementation),
+		// so it must be discarded instead of retried.
 		if event.Timestamp < eval.Timestamp {
 			subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeGoalEventIssuedBeforeEvaluation).Inc()
-			w.logger.Error("Goal event issued before evaluation",
+			w.logger.Warn("Goal event is older than the user's latest evaluation, discarding it",
 				zap.String("environmentId", environmentID),
 				zap.Any("goalEvent", event),
 				zap.Any("evaluation", eval),
@@ -365,6 +380,11 @@ func (w *goalEvtWriter) linkGoalEventByExperiment(
 			continue
 		}
 		evals = append(evals, eval)
+	}
+	if len(evals) == 0 {
+		// Every matching evaluation is newer than the goal event,
+		// so the goal event can never be linked. The callers must discard it.
+		return nil, false, ErrGoalEventOlderThanEvaluation
 	}
 	return evals, false, nil
 }

--- a/pkg/subscriber/processor/goal_events_dwh_retry.go
+++ b/pkg/subscriber/processor/goal_events_dwh_retry.go
@@ -188,6 +188,9 @@ func (w *goalEvtWriter) handleNewRetry(ctx context.Context, msg *retryMessage, k
 		return
 	}
 
+	// Pass storeRetryOnMiss=false: this path owns the retry message and
+	// re-stores it below with the incremented retry count, so the linker must
+	// not overwrite it with a fresh message (which would reset the backoff).
 	evals, _, err := w.linkGoalEventByExperiment(
 		ctx,
 		msg.GoalEvent,
@@ -195,11 +198,18 @@ func (w *goalEvtWriter) handleNewRetry(ctx context.Context, msg *retryMessage, k
 		msg.EnvironmentID,
 		msg.GoalEvent.Tag,
 		experiments,
+		false,
 	)
 	if err != nil {
 		if errors.Is(err, ErrExperimentNotFound) {
 			subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeExperimentNotFound).Inc()
 			lg.Error("Experiment not found, deleting retry message")
+			w.deleteKey(ctx, key)
+		} else if errors.Is(err, ErrGoalEventOlderThanEvaluation) {
+			// The goal event was created before the user was evaluated
+			// (the client SDK sets the timestamps), so retrying can never
+			// link it. Discard the retry message.
+			lg.Warn("Goal event is older than the user's latest evaluation, deleting retry message")
 			w.deleteKey(ctx, key)
 		} else {
 			lg.Error("Linking failed", zap.Error(err))
@@ -208,15 +218,6 @@ func (w *goalEvtWriter) handleNewRetry(ctx context.Context, msg *retryMessage, k
 				subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeFailedToStoreRetryMessage).Inc()
 				lg.Error("Failed to store retry message", zap.Error(err))
 			}
-		}
-		return
-	}
-	if len(evals) == 0 {
-		subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeRetryMessageNoEvaluations).Inc()
-		msg.RetryCount++
-		if err := w.storeRetryMessage(msg); err != nil {
-			subscriberHandledCounter.WithLabelValues(subscriberGoalEventDWH, codeFailedToStoreRetryMessage).Inc()
-			lg.Error("Failed to store retry message", zap.Error(err))
 		}
 		return
 	}

--- a/pkg/subscriber/processor/goal_events_dwh_test.go
+++ b/pkg/subscriber/processor/goal_events_dwh_test.go
@@ -1,0 +1,298 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package processor
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+	"go.uber.org/zap"
+
+	cachemock "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3/mock"
+	ecdwh "github.com/bucketeer-io/bucketeer/v2/pkg/eventcounter/storage/v2/dwh_database"
+	ecdwhmock "github.com/bucketeer-io/bucketeer/v2/pkg/eventcounter/storage/v2/dwh_database/mock"
+	redismock "github.com/bucketeer-io/bucketeer/v2/pkg/redis/v3/mock"
+	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/client"
+	exproto "github.com/bucketeer-io/bucketeer/v2/proto/experiment"
+)
+
+const (
+	testEnvironmentID = "env-1"
+	testGoalID        = "goal-1"
+	testUserID        = "user-1"
+	testFeatureID     = "feature-1"
+	testEventID       = "event-1"
+)
+
+func newTestGoalEvtWriter(
+	eventStorage *ecdwhmock.MockEventStorage,
+	redisClient *redismock.MockClient,
+	cache *cachemock.MockExperimentsCache,
+) *goalEvtWriter {
+	return &goalEvtWriter{
+		eventStorage:            eventStorage,
+		redisClient:             redisClient,
+		cache:                   cache,
+		location:                time.UTC,
+		logger:                  zap.NewNop(),
+		maxRetryGoalEventPeriod: time.Hour,
+		retryGoalEventInterval:  time.Minute,
+	}
+}
+
+func newTestExperiment(now int64) *exproto.Experiment {
+	return &exproto.Experiment{
+		Id:             "experiment-1",
+		GoalIds:        []string{testGoalID},
+		FeatureId:      testFeatureID,
+		FeatureVersion: 1,
+		StartAt:        now - 3600,
+		StopAt:         now + 3600,
+	}
+}
+
+func newTestGoalEvent(timestamp int64) *eventproto.GoalEvent {
+	return &eventproto.GoalEvent{
+		GoalId:    testGoalID,
+		UserId:    testUserID,
+		Timestamp: timestamp,
+		Tag:       "tag",
+		Value:     1.0,
+	}
+}
+
+func TestLinkGoalEventByExperimentLinksWhenEvaluationIsOlder(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now().Unix()
+	eventStorage := ecdwhmock.NewMockEventStorage(ctrl)
+	redisClient := redismock.NewMockClient(ctrl)
+	w := newTestGoalEvtWriter(eventStorage, redisClient, nil)
+
+	// The user was evaluated before the goal event was created: the event must link.
+	eventStorage.EXPECT().QueryUserEvaluation(
+		gomock.Any(), testEnvironmentID, testUserID, testFeatureID, int32(1), gomock.Any(), gomock.Any(),
+	).Return(&ecdwh.UserEvaluation{
+		UserID:         testUserID,
+		FeatureID:      testFeatureID,
+		FeatureVersion: 1,
+		VariationID:    "variation-a",
+		Reason:         "TARGET",
+		Timestamp:      now - 60,
+	}, nil)
+
+	evals, retriable, err := w.linkGoalEventByExperiment(
+		context.Background(),
+		newTestGoalEvent(now),
+		testEventID,
+		testEnvironmentID,
+		"tag",
+		[]*exproto.Experiment{newTestExperiment(now)},
+		true,
+	)
+	assert.NoError(t, err)
+	assert.False(t, retriable)
+	assert.Len(t, evals, 1)
+	assert.Equal(t, "variation-a", evals[0].VariationID)
+}
+
+func TestLinkGoalEventByExperimentDiscardsGoalEventOlderThanEvaluation(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now().Unix()
+	eventStorage := ecdwhmock.NewMockEventStorage(ctrl)
+	// No expectations are set on the Redis client: storing a retry message
+	// for this case would fail the test.
+	redisClient := redismock.NewMockClient(ctrl)
+	w := newTestGoalEvtWriter(eventStorage, redisClient, nil)
+
+	// The latest evaluation is newer than the goal event: the client SDK sent
+	// the goal event before evaluating the user, so it must be discarded.
+	eventStorage.EXPECT().QueryUserEvaluation(
+		gomock.Any(), testEnvironmentID, testUserID, testFeatureID, int32(1), gomock.Any(), gomock.Any(),
+	).Return(&ecdwh.UserEvaluation{
+		UserID:         testUserID,
+		FeatureID:      testFeatureID,
+		FeatureVersion: 1,
+		VariationID:    "variation-a",
+		Reason:         "TARGET",
+		Timestamp:      now + 60,
+	}, nil)
+
+	evals, retriable, err := w.linkGoalEventByExperiment(
+		context.Background(),
+		newTestGoalEvent(now),
+		testEventID,
+		testEnvironmentID,
+		"tag",
+		[]*exproto.Experiment{newTestExperiment(now)},
+		true,
+	)
+	assert.ErrorIs(t, err, ErrGoalEventOlderThanEvaluation)
+	assert.False(t, retriable)
+	assert.Nil(t, evals)
+}
+
+func TestLinkGoalEventByExperimentStoresRetryMessageWhenEvaluationNotFound(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now().Unix()
+	eventStorage := ecdwhmock.NewMockEventStorage(ctrl)
+	redisClient := redismock.NewMockClient(ctrl)
+	w := newTestGoalEvtWriter(eventStorage, redisClient, nil)
+
+	// The evaluation hasn't landed in the DWH yet (e.g. pub/sub delivered the
+	// goal event first): a retry message must be stored.
+	eventStorage.EXPECT().QueryUserEvaluation(
+		gomock.Any(), testEnvironmentID, testUserID, testFeatureID, int32(1), gomock.Any(), gomock.Any(),
+	).Return(nil, ecdwh.ErrBQNoResultsFound)
+	redisClient.EXPECT().Set(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+
+	evals, retriable, err := w.linkGoalEventByExperiment(
+		context.Background(),
+		newTestGoalEvent(now),
+		testEventID,
+		testEnvironmentID,
+		"tag",
+		[]*exproto.Experiment{newTestExperiment(now)},
+		true,
+	)
+	assert.True(t, ecdwh.IsNoResultsFound(err))
+	assert.False(t, retriable)
+	assert.Nil(t, evals)
+}
+
+func TestLinkGoalEventByExperimentDoesNotStoreRetryMessageForRetryProcessor(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now().Unix()
+	eventStorage := ecdwhmock.NewMockEventStorage(ctrl)
+	// No expectations are set on the Redis client: the retry processor owns its
+	// retry message, so the linker must not overwrite it (that would reset the
+	// backoff counter).
+	redisClient := redismock.NewMockClient(ctrl)
+	w := newTestGoalEvtWriter(eventStorage, redisClient, nil)
+
+	eventStorage.EXPECT().QueryUserEvaluation(
+		gomock.Any(), testEnvironmentID, testUserID, testFeatureID, int32(1), gomock.Any(), gomock.Any(),
+	).Return(nil, ecdwh.ErrBQNoResultsFound)
+
+	evals, retriable, err := w.linkGoalEventByExperiment(
+		context.Background(),
+		newTestGoalEvent(now),
+		testEventID,
+		testEnvironmentID,
+		"tag",
+		[]*exproto.Experiment{newTestExperiment(now)},
+		false,
+	)
+	assert.True(t, ecdwh.IsNoResultsFound(err))
+	assert.False(t, retriable)
+	assert.Nil(t, evals)
+}
+
+func TestHandleNewRetryDiscardsGoalEventOlderThanEvaluation(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now().Unix()
+	eventStorage := ecdwhmock.NewMockEventStorage(ctrl)
+	redisClient := redismock.NewMockClient(ctrl)
+	cache := cachemock.NewMockExperimentsCache(ctrl)
+	w := newTestGoalEvtWriter(eventStorage, redisClient, cache)
+
+	cache.EXPECT().Get(testEnvironmentID).Return(&exproto.Experiments{
+		Experiments: []*exproto.Experiment{newTestExperiment(now)},
+	}, nil)
+	eventStorage.EXPECT().QueryUserEvaluation(
+		gomock.Any(), testEnvironmentID, testUserID, testFeatureID, int32(1), gomock.Any(), gomock.Any(),
+	).Return(&ecdwh.UserEvaluation{
+		UserID:         testUserID,
+		FeatureID:      testFeatureID,
+		FeatureVersion: 1,
+		VariationID:    "variation-a",
+		Reason:         "TARGET",
+		Timestamp:      now + 60,
+	}, nil)
+	// The retry message must be deleted instead of re-stored:
+	// retrying can never link a goal event older than the latest evaluation.
+	key := testEnvironmentID + ":" + retryGoalEventKeyKind + ":" + testEventID
+	redisClient.EXPECT().Del(key).Return(nil).Times(1)
+
+	msg := &retryMessage{
+		GoalEvent:     newTestGoalEvent(now),
+		EnvironmentID: testEnvironmentID,
+		RetryCount:    1,
+		ID:            testEventID,
+		FirstRetryAt:  now - 60,
+		RetryAt:       now - 30,
+	}
+	w.handleNewRetry(context.Background(), msg, key, w.logger)
+}
+
+func TestHandleNewRetryRequeuesWhenEvaluationNotFound(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	now := time.Now().Unix()
+	eventStorage := ecdwhmock.NewMockEventStorage(ctrl)
+	redisClient := redismock.NewMockClient(ctrl)
+	cache := cachemock.NewMockExperimentsCache(ctrl)
+	w := newTestGoalEvtWriter(eventStorage, redisClient, cache)
+
+	cache.EXPECT().Get(testEnvironmentID).Return(&exproto.Experiments{
+		Experiments: []*exproto.Experiment{newTestExperiment(now)},
+	}, nil)
+	eventStorage.EXPECT().QueryUserEvaluation(
+		gomock.Any(), testEnvironmentID, testUserID, testFeatureID, int32(1), gomock.Any(), gomock.Any(),
+	).Return(nil, ecdwh.ErrBQNoResultsFound)
+	// The evaluation may still land later, so the retry message must be
+	// re-stored exactly once with the incremented retry count.
+	key := testEnvironmentID + ":" + retryGoalEventKeyKind + ":" + testEventID
+	redisClient.EXPECT().Set(key, gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ string, value interface{}, _ time.Duration) error {
+			data, ok := value.([]byte)
+			if !ok {
+				return errors.New("unexpected value type")
+			}
+			assert.Contains(t, string(data), `"retryCount":2`)
+			return nil
+		},
+	).Times(1)
+
+	msg := &retryMessage{
+		GoalEvent:     newTestGoalEvent(now),
+		EnvironmentID: testEnvironmentID,
+		RetryCount:    1,
+		ID:            testEventID,
+		FirstRetryAt:  now - 60,
+		RetryAt:       now - 30,
+	}
+	w.handleNewRetry(context.Background(), msg, key, w.logger)
+}

--- a/pkg/subscriber/processor/metrics.go
+++ b/pkg/subscriber/processor/metrics.go
@@ -46,7 +46,6 @@ const (
 	codeFailedToGetUserEvaluation           = "FailedToGetUserEvaluation"
 	codeFailedToStoreRetryMessage           = "FailedToStoreRetryMessage"
 	codeRetryMessageAppendSuccess           = "RetryMessageAppendSuccess"
-	codeRetryMessageNoEvaluations           = "RetryMessageNoEvaluations"
 	codeRetryMessageNoGoalEvents            = "RetryMessageNoGoalEvents"
 	codeRetryMessageNoExperiments           = "RetryMessageNoExperiments"
 	codeGetFeaturesReturnedEmpty            = "GetFeaturesReturnedEmpty"


### PR DESCRIPTION
## Summary

The client SDK sets the event timestamps when evaluation and goal events are generated. If a goal event's timestamp is older than the user's latest evaluation timestamp, the app tracked the goal before evaluating the user (incorrect SDK usage), so the event can never be linked. Pub/Sub reordering cannot cause this case: reordering only delays delivery, it doesn't change the timestamps inside the payloads.

The goal event DWH subscriber handled this condition inconsistently:

- **Fresh delivery**: the event was acked and dropped silently, while being
  counted in the `Linked` metric — it looked like a successful link but
  nothing was written to the DWH.
- **Retry path**: the message was re-queued with backoff and retried until it
  expired (12–24h), even though retrying can never succeed because the query
  always returns the user's latest evaluation and timestamps only grow.

## What

- Both paths now discard the event explicitly: the fresh path acks it, the
  retry path deletes the Redis key, each with a warning log and the
  `GoalEventIssuedBeforeEvaluation` metric.
- Renamed the sentinel error to `ErrGoalEventOlderThanEvaluation`.
- The linker no longer stores a retry message when called from the retry
  processor, which previously reset the backoff retry count.
- The legitimate out-of-order Pub/Sub case (evaluation row not yet in the
  DWH) is **unchanged**: it still goes to the Redis retry queue and links on
  a later pass.
- Added unit tests (`goal_events_dwh_test.go`) covering the link, discard,
  and retry/re-queue paths.