### PR TITLE
test: fix flaky e2e tests

### DIFF
--- a/manifests/bucketeer/charts/subscriber/templates/subscribers-configmap.yaml
+++ b/manifests/bucketeer/charts/subscriber/templates/subscribers-configmap.yaml
@@ -21,7 +21,8 @@ data:
     {{- $_ := set $config "redisAddr" $.Values.global.pubsub.redis.addr }}
     {{- $_ := set $config "redisPoolSize" $.Values.global.pubsub.redis.poolSize }}
     {{- $_ := set $config "redisMinIdle" $.Values.global.pubsub.redis.minIdle }}
-    {{- $_ := set $config "redisIdleTime" $.Values.global.pubsub.redis.idleTime }}
+    {{- /* Allow a per-subscriber redisIdleTime override; fall back to the global value */}}
+    {{- $_ := set $config "redisIdleTime" (default $.Values.global.pubsub.redis.idleTime $config.redisIdleTime) }}
     {{- $_ := set $config "redisMode" $.Values.global.pubsub.redis.mode }}
     {{- $_ := set $config "project" $.Values.global.pubsub.project }}
     {{- $_ := set $config "redisPartitionCount" $.Values.global.pubsub.redis.partitionCount }}

--- a/manifests/bucketeer/values.dev.yaml
+++ b/manifests/bucketeer/values.dev.yaml
@@ -551,6 +551,10 @@ subscriber:
       redisMinIdle: ${global.pubsub.redis.minIdle}
       redisMode: ${global.pubsub.redis.mode}
       project: ${global.pubsub.project}
+      # Reclaim nacked bulk-upload messages quickly (default is 60s idle +
+      # a 30s recovery tick, which exceeds the e2e test wait budget).
+      # Safe for this subscriber because persisting segment users is idempotent.
+      redisIdleTime: 20
       topic: bulk-segment-users-received
       subscription: bulk-segment-users-received-subscription
       pullerNumGoroutines: 5

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -2357,11 +2357,18 @@ func waitAndCheckExperimentResult(
 		resp, err := getExperimentResult(t, ecClient, experiment.Id)
 		if err != nil {
 			st, _ := status.FromError(err)
-			if st.Code() != codes.NotFound {
+			switch st.Code() {
+			case codes.NotFound:
+				t.Logf("Retry %d/%d: ExperimentResult not found yet (NotFound error)", i+1, retryTimes)
+				continue
+			case codes.Unavailable, codes.DeadlineExceeded:
+				// Transient errors happen under parallel test load;
+				// the outer loop already bounds the total wait time.
+				t.Logf("Retry %d/%d: transient error getting ExperimentResult: %v", i+1, retryTimes, err)
+				continue
+			default:
 				t.Fatalf("Failed to get the experiment result. Error code: %d. Error: %v\n", st.Code(), err)
 			}
-			t.Logf("Retry %d/%d: ExperimentResult not found yet (NotFound error)", i+1, retryTimes)
-			continue
 		}
 		if resp == nil {
 			continue
@@ -2644,8 +2651,6 @@ func getEvaluation(t *testing.T, tag string, userID string) (*gatewayproto.GetEv
 	t.Helper()
 	c := newGatewayClient(t)
 	defer c.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	req := &gatewayproto.GetEvaluationsRequest{
 		Tag:  tag,
 		User: &userproto.User{Id: userID},
@@ -2654,12 +2659,15 @@ func getEvaluation(t *testing.T, tag string, userID string) (*gatewayproto.GetEv
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = c.GetEvaluations(ctx, req)
+		cancel()
 		if err == nil {
 			break
 		}
 		st, _ := status.FromError(err)
-		if st.Code() != codes.Unavailable {
+		if st.Code() != codes.Unavailable && st.Code() != codes.DeadlineExceeded {
 			return nil, err
 		}
 		fmt.Printf("Failed to get evaluations. Error code: %d. Retrying in 5 seconds.\n", st.Code())
@@ -2673,8 +2681,6 @@ func getEvaluation(t *testing.T, tag string, userID string) (*gatewayproto.GetEv
 
 func getExperiment(t *testing.T, c experimentclient.Client, id string) (*experimentproto.GetExperimentResponse, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	req := &experimentproto.GetExperimentRequest{
 		EnvironmentId: *environmentID,
 		Id:            id,
@@ -2683,12 +2689,15 @@ func getExperiment(t *testing.T, c experimentclient.Client, id string) (*experim
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = c.GetExperiment(ctx, req)
+		cancel()
 		if err == nil {
 			break
 		}
 		st, _ := status.FromError(err)
-		if st.Code() != codes.Unavailable {
+		if st.Code() != codes.Unavailable && st.Code() != codes.DeadlineExceeded {
 			return nil, err
 		}
 		fmt.Printf("Failed to get experiment. Experiment ID: %s. Error code: %d. Retrying in 5 seconds.\n", id, st.Code())
@@ -2702,8 +2711,6 @@ func getExperiment(t *testing.T, c experimentclient.Client, id string) (*experim
 
 func getExperimentResult(t *testing.T, c ecclient.Client, experimentID string) (*ecproto.GetExperimentResultResponse, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	req := &ecproto.GetExperimentResultRequest{
 		ExperimentId:  experimentID,
 		EnvironmentId: *environmentID,
@@ -2712,7 +2719,10 @@ func getExperimentResult(t *testing.T, c ecclient.Client, experimentID string) (
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = c.GetExperimentResult(ctx, req)
+		cancel()
 		if err == nil {
 			break
 		}
@@ -2720,7 +2730,7 @@ func getExperimentResult(t *testing.T, c ecclient.Client, experimentID string) (
 		// Retry on transient BigQuery emulator errors:
 		// - "database table is locked": SQLite backend used by the emulator can't handle concurrent writes
 		// - "job is not found": job may not be registered yet in the emulator
-		if st.Code() == codes.Unavailable || st.Code() == codes.Internal ||
+		if st.Code() == codes.Unavailable || st.Code() == codes.Internal || st.Code() == codes.DeadlineExceeded ||
 			(st.Code() == codes.Unknown && (strings.Contains(err.Error(), "database table is locked") ||
 				strings.Contains(err.Error(), "job") && strings.Contains(err.Error(), "is not found"))) {
 			fmt.Printf("Failed to get experiment result. Experiment ID: %s. Error code: %d. Retrying in 5 seconds.\n", experimentID, st.Code())
@@ -2739,8 +2749,6 @@ func getExperimentEvaluationCount(
 	t *testing.T, c ecclient.Client, featureID string, featureVersion int32, variationIDs []string,
 ) (*ecproto.GetExperimentEvaluationCountResponse, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	now := time.Now()
 	req := &ecproto.GetExperimentEvaluationCountRequest{
 		EnvironmentId:  *environmentID,
@@ -2754,7 +2762,10 @@ func getExperimentEvaluationCount(
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = c.GetExperimentEvaluationCount(ctx, req)
+		cancel()
 		if err == nil {
 			break
 		}
@@ -2762,7 +2773,7 @@ func getExperimentEvaluationCount(
 		// Retry on transient BigQuery emulator errors:
 		// - "database table is locked": SQLite backend used by the emulator can't handle concurrent writes
 		// - "job is not found": job may not be registered yet in the emulator
-		if st.Code() == codes.Unavailable || st.Code() == codes.Internal ||
+		if st.Code() == codes.Unavailable || st.Code() == codes.Internal || st.Code() == codes.DeadlineExceeded ||
 			(st.Code() == codes.Unknown && (strings.Contains(err.Error(), "database table is locked") ||
 				strings.Contains(err.Error(), "job") && strings.Contains(err.Error(), "is not found"))) {
 			fmt.Printf("Failed to get experiment evaluation count. Error code: %d. Retrying in 5 seconds.\n", st.Code())
@@ -2781,8 +2792,6 @@ func getExperimentGoalCount(
 	t *testing.T, c ecclient.Client, goalID, featureID string, featureVersion int32, variationIDs []string,
 ) (*ecproto.GetExperimentGoalCountResponse, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	now := time.Now()
 	req := &ecproto.GetExperimentGoalCountRequest{
 		EnvironmentId:  *environmentID,
@@ -2797,7 +2806,10 @@ func getExperimentGoalCount(
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = c.GetExperimentGoalCount(ctx, req)
+		cancel()
 		if err == nil {
 			break
 		}
@@ -2805,7 +2817,7 @@ func getExperimentGoalCount(
 		// Retry on transient BigQuery emulator errors:
 		// - "database table is locked": SQLite backend used by the emulator can't handle concurrent writes
 		// - "job is not found": job may not be registered yet in the emulator
-		if st.Code() == codes.Unavailable || st.Code() == codes.Internal ||
+		if st.Code() == codes.Unavailable || st.Code() == codes.Internal || st.Code() == codes.DeadlineExceeded ||
 			(st.Code() == codes.Unknown && (strings.Contains(err.Error(), "database table is locked") ||
 				strings.Contains(err.Error(), "job") && strings.Contains(err.Error(), "is not found"))) {
 			fmt.Printf("Failed to get experiment goal count. Error code: %d. Retrying in 5 seconds.\n", st.Code())
@@ -2826,24 +2838,28 @@ func getFeature(t *testing.T, client featureclient.Client, featureID string) (*f
 		Id:            featureID,
 		EnvironmentId: *environmentID,
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	var response *featureproto.GetFeatureResponse
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = client.GetFeature(ctx, getReq)
+		cancel()
 		if err == nil {
 			break
 		}
 		st, _ := status.FromError(err)
-		if st.Code() != codes.Unavailable {
+		if st.Code() != codes.Unavailable && st.Code() != codes.DeadlineExceeded {
 			return nil, err
 		}
 		fmt.Printf("Failed to get feature. ID: %s. Error code: %d. Retrying in 5 seconds.\n", featureID, st.Code())
 		time.Sleep(5 * time.Second)
 	}
-	return response.Feature, err
+	if err != nil {
+		return nil, err
+	}
+	return response.Feature, nil
 }
 
 func getEvaluationTimeseriesCount(
@@ -2853,8 +2869,6 @@ func getEvaluationTimeseriesCount(
 	timeRange ecproto.GetEvaluationTimeseriesCountRequest_TimeRange,
 ) (*ecproto.GetEvaluationTimeseriesCountResponse, error) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
-	defer cancel()
 	req := &ecproto.GetEvaluationTimeseriesCountRequest{
 		EnvironmentId: *environmentID,
 		FeatureId:     featureID,
@@ -2864,10 +2878,13 @@ func getEvaluationTimeseriesCount(
 	var err error
 	numRetries := 3
 	for i := 0; i < numRetries; i++ {
+		// Use a fresh context per attempt so retries don't run on an expired deadline
+		ctx, cancel := context.WithTimeout(context.Background(), grpcTimeout)
 		response, err = c.GetEvaluationTimeseriesCount(
 			ctx,
 			req,
 		)
+		cancel()
 		if err == nil {
 			break
 		}
@@ -2875,7 +2892,7 @@ func getEvaluationTimeseriesCount(
 		// Retry on transient BigQuery emulator errors:
 		// - "database table is locked": SQLite backend used by the emulator can't handle concurrent writes
 		// - "job is not found": job may not be registered yet in the emulator
-		if st.Code() == codes.Unavailable || st.Code() == codes.Internal ||
+		if st.Code() == codes.Unavailable || st.Code() == codes.Internal || st.Code() == codes.DeadlineExceeded ||
 			(st.Code() == codes.Unknown && (strings.Contains(err.Error(), "database table is locked") ||
 				strings.Contains(err.Error(), "job") && strings.Contains(err.Error(), "is not found"))) {
 			fmt.Printf("Failed to get evaluation timeseries count. ID: %s. Error code: %d. Retrying in 5 seconds.\n", featureID, st.Code())

--- a/test/e2e/feature/segment_user_test.go
+++ b/test/e2e/feature/segment_user_test.go
@@ -32,12 +32,18 @@ import (
 )
 
 const (
-	segmentUserRetryTimes = 25
+	// The wait must cover a full redelivery cycle of the redis-stream pubsub used
+	// in the dev container: a nacked message is only reclaimed by the puller's
+	// recovery loop (30s ticker) after it has been idle for redisIdleTime, plus
+	// the persister's flush interval. 60 retries x 2s = 120s of polling.
+	segmentUserRetryTimes = 60
+	// The default 60s package timeout is too short to cover the polling budget above.
+	segmentUserTimeout = 3 * time.Minute
 )
 
 func TestListSegmentUsersPageSize(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), segmentUserTimeout)
 	defer cancel()
 	client := newFeatureClient(t)
 	segmentID := createSegment(ctx, t, client).Id
@@ -57,7 +63,7 @@ func TestListSegmentUsersPageSize(t *testing.T) {
 
 func TestListSegmentUsersCursor(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), segmentUserTimeout)
 	defer cancel()
 	client := newFeatureClient(t)
 	segmentID := createSegment(ctx, t, client).Id
@@ -99,7 +105,7 @@ func TestListSegmentUsersCursor(t *testing.T) {
 
 func TestListSegmentUsersWithoutState(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), segmentUserTimeout)
 	defer cancel()
 	client := newFeatureClient(t)
 	segmentID := createSegment(ctx, t, client).Id
@@ -115,7 +121,7 @@ func TestListSegmentUsersWithoutState(t *testing.T) {
 
 func TestBulkUploadAndDownloadSegmentUsers(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), segmentUserTimeout)
 	defer cancel()
 	client := newFeatureClient(t)
 	segmentID := createSegment(ctx, t, client).Id
@@ -221,17 +227,25 @@ func waitForSegmentUsers(
 		State:         state,
 		EnvironmentId: *environmentID,
 	}
+	var lastCount int
+	var lastErr error
 	for i := 0; i < segmentUserRetryTimes; i++ {
 		if err := ctx.Err(); err != nil {
-			t.Fatalf("waitForSegmentUsers: context done: %v", err)
+			t.Fatalf("waitForSegmentUsers: context done: %v (last count: %d/%d, last error: %v)",
+				err, lastCount, expectedSize, lastErr)
 		}
 		res, err := client.ListSegmentUsers(ctx, req)
-		if err == nil && res != nil && len(res.Users) >= expectedSize {
-			return
+		lastErr = err
+		if err == nil && res != nil {
+			lastCount = len(res.Users)
+			if lastCount >= expectedSize {
+				return
+			}
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Fatalf("segment users not ready")
+	t.Fatalf("segment users not ready after %d attempts: segmentID: %s, last count: %d/%d, last error: %v",
+		segmentUserRetryTimes, segmentID, lastCount, expectedSize, lastErr)
 }
 
 func waitForSegmentStatus(
@@ -246,17 +260,25 @@ func waitForSegmentStatus(
 		Id:            segmentID,
 		EnvironmentId: *environmentID,
 	}
+	var lastStatus featureproto.Segment_Status
+	var lastErr error
 	for i := 0; i < segmentUserRetryTimes; i++ {
 		if err := ctx.Err(); err != nil {
-			t.Fatalf("waitForSegmentStatus: context done: %v", err)
+			t.Fatalf("waitForSegmentStatus: context done: %v (last status: %v, last error: %v)",
+				err, lastStatus, lastErr)
 		}
 		res, err := client.GetSegment(ctx, req)
-		if err == nil && res.Segment != nil && res.Segment.Status == status {
-			return
+		lastErr = err
+		if err == nil && res.Segment != nil {
+			lastStatus = res.Segment.Status
+			if lastStatus == status {
+				return
+			}
 		}
 		time.Sleep(2 * time.Second)
 	}
-	t.Fatalf("segment status did not become %v", status)
+	t.Fatalf("segment status did not become %v after %d attempts: segmentID: %s, last status: %v, last error: %v",
+		status, segmentUserRetryTimes, segmentID, lastStatus, lastErr)
 }
 
 func newUserID(t *testing.T) string {

--- a/test/e2e/gateway/api_grpc_test.go
+++ b/test/e2e/gateway/api_grpc_test.go
@@ -57,6 +57,12 @@ const (
 	// manifests/bucketeer/charts/api/values.yaml). If the server default
 	// changes, update this constant so the e2e tests stay aligned.
 	evaluatedAtGracePeriodSeconds int64 = 600
+	// GetEvaluations can transiently fail with codes.Internal when the
+	// feature-flag cache snapshot is inconsistent (see
+	// grpcGetEvaluationsWithRetry). The retry window must outlast the
+	// gateway's in-memory features cache TTL (1 minute by default).
+	getEvaluationsRetryAttempts = 10
+	getEvaluationsRetryInterval = 10 * time.Second
 )
 
 var (
@@ -2032,40 +2038,67 @@ func archiveFeature(t *testing.T, featureID string, client featureclient.Client)
 	}
 }
 
-func grpcGetEvaluations(t *testing.T, tag, userID string) *gatewayproto.GetEvaluationsResponse {
+// grpcGetEvaluationsWithRetry sends a GetEvaluations request, retrying on
+// transient Internal errors.
+//
+// GetEvaluations may evaluate every flag in the shared e2e environment (a
+// full re-evaluation happens when evaluatedAt is more than 30 days old, the
+// UserEvaluationsID is empty, or no tag is set), so it is sensitive to flags
+// owned by other test suites running in parallel. Those suites create
+// parent/child prerequisite flags and constantly re-run the FeatureFlagCacher
+// batch job; a cache snapshot taken mid-write can contain a flag whose
+// prerequisite is missing from the same snapshot. Evaluating such a snapshot
+// fails with ErrFeatureNotFound, which the gateway returns as
+// "gateway: internal" to every caller until the next snapshot is taken AND
+// the gateway's in-memory L1 cache (1 minute TTL by default) expires.
+// Retrying long enough to outlast both keeps these tests stable.
+func grpcGetEvaluationsWithRetry(
+	t *testing.T,
+	req *gatewayproto.GetEvaluationsRequest,
+) *gatewayproto.GetEvaluationsResponse {
 	t.Helper()
 	c := newGatewayClient(t, *apiKeyPath)
 	defer c.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	var lastErr error
+	for i := 0; i < getEvaluationsRetryAttempts; i++ {
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		response, err := c.GetEvaluations(ctx, req)
+		cancel()
+		if err == nil {
+			return response
+		}
+		lastErr = err
+		if status.Code(err) != codes.Internal {
+			break
+		}
+		if i < getEvaluationsRetryAttempts-1 {
+			t.Logf("GetEvaluations returned Internal (attempt %d/%d). Retrying in %v: %v",
+				i+1, getEvaluationsRetryAttempts, getEvaluationsRetryInterval, err)
+			time.Sleep(getEvaluationsRetryInterval)
+		}
+	}
+	t.Fatal(lastErr)
+	return nil
+}
+
+func grpcGetEvaluations(t *testing.T, tag, userID string) *gatewayproto.GetEvaluationsResponse {
+	t.Helper()
 	req := &gatewayproto.GetEvaluationsRequest{
 		Tag:  tag,
 		User: &userproto.User{Id: userID},
 	}
-	response, err := c.GetEvaluations(ctx, req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return response
+	return grpcGetEvaluationsWithRetry(t, req)
 }
 
 // grpcGetEvaluationsWithUser is like grpcGetEvaluations but accepts a full
 // user object so tests can pass user attributes.
 func grpcGetEvaluationsWithUser(t *testing.T, tag string, user *userproto.User) *gatewayproto.GetEvaluationsResponse {
 	t.Helper()
-	c := newGatewayClient(t, *apiKeyPath)
-	defer c.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 	req := &gatewayproto.GetEvaluationsRequest{
 		Tag:  tag,
 		User: user,
 	}
-	response, err := c.GetEvaluations(ctx, req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return response
+	return grpcGetEvaluationsWithRetry(t, req)
 }
 
 func grpcGetFeatureFlags(t *testing.T, tag, featuresID string, requestedAt int64) *gatewayproto.GetFeatureFlagsResponse {
@@ -2123,10 +2156,6 @@ func grpcGetEvaluationsByEvaluatedAt(
 	userAttributesUpdated bool,
 ) *gatewayproto.GetEvaluationsResponse {
 	t.Helper()
-	c := newGatewayClient(t, *apiKeyPath)
-	defer c.Close()
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
 	req := &gatewayproto.GetEvaluationsRequest{
 		UserEvaluationsId: userEvaluationsID,
 		User:              &userproto.User{Id: userID},
@@ -2136,11 +2165,7 @@ func grpcGetEvaluationsByEvaluatedAt(
 		},
 		Tag: tag,
 	}
-	response, err := c.GetEvaluations(ctx, req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return response
+	return grpcGetEvaluationsWithRetry(t, req)
 }
 
 func grpcGetEvaluation(t *testing.T, tag, featureID, userID string) *gatewayproto.GetEvaluationResponse {


### PR DESCRIPTION
## Why

Several e2e tests fail intermittently, especially when the suites run in
parallel and in the dev container:

- `TestExperimentResult` / `TestGrpcExperimentResult` failed with
  `DeadlineExceeded` even when the experiment results were correct.
- `TestBulkUploadAndDownloadSegmentUsers` failed with "segment users not
  ready" in the dev container (Helm-based), but rarely in the GCP dev cluster.
- Gateway tests calling `GetEvaluations` occasionally failed with
  `gateway: internal`.

None of these are product bugs; they are timing issues between the tests and
the async pipeline (Pub/Sub delivery, subscriber retries, cache refresh
batch jobs).

## Root causes and fixes

### 1. Expired context reused across retries (`eventcounter_test.go`)

The read helpers (`getEvaluation`, `getExperiment`, `getExperimentResult`,
etc.) created a single 10-second context *outside* their retry loop. After a
transient `Unavailable` error plus a 5-second sleep, the next attempt ran on
an almost-expired context and failed with `DeadlineExceeded`, which was not
treated as retriable — so the test failed even though the data was fine.

**Fix:** create a fresh context per attempt, treat `DeadlineExceeded` as
transient in the helpers and in `waitAndCheckExperimentResult`, and return
the error instead of dereferencing a nil response in `getFeature`.

### 2. Test budget shorter than Redis Streams redelivery (`segment_user_test.go`, Helm values)

In the dev container, Pub/Sub is backed by Redis Streams. A message that
fails processing once (e.g. a MySQL deadlock during segment user upsert) is
not nacked; it is only reclaimed by the recovery loop after being idle for
`redisIdleTime` (60s by default), checked every 30s — so redelivery can take
60–90s. The test's polling budget was 25 × 2s = 50s inside a 60s context,
which any single redelivery cycle exceeded.

**Fix (test):** dedicated 3-minute context for the segment user tests and a
120s polling budget, plus diagnostic failure messages (last count/status and
last error instead of "segment users not ready").

**Fix (Helm):** `subscribers-configmap.yaml` now supports a per-subscriber
`redisIdleTime` override, and `values.dev.yaml` sets `redisIdleTime: 20` for
`segmentUserPersister` so failed messages are reclaimed in ~20–50s instead
of 60–90s. Only the dev environment is affected; the GCP clusters use
Google Pub/Sub and ignore this setting.

### 3. Transient `Internal` from inconsistent flag-cache snapshots (`api_grpc_test.go`)

`GetEvaluations` may evaluate every flag in the shared e2e environment.
Other suites running in parallel create parent/child prerequisite flags
while the `FeatureFlagCacher` batch job rebuilds the cache; a snapshot taken
mid-write can contain a flag whose prerequisite is missing from the same
snapshot. Evaluating that snapshot fails with `ErrFeatureNotFound`, which
the gateway returns as `gateway: internal` to every caller until the next
snapshot lands *and* the gateway's in-memory L1 cache (1-minute TTL)
expires.

**Fix:** `grpcGetEvaluationsWithRetry` retries `Internal` errors for up to
10 × 10s, long enough to outlast both the snapshot rebuild and the L1 cache
TTL. Non-`Internal` errors still fail immediately.

## Notes

- Tests keep running in parallel; no `t.Parallel()` was removed.
- No production code paths are changed; the Helm change affects the dev
  environment only.

## Related

- The investigation also uncovered a real bug in the goal event DWH
  subscriber (silent drop / endless retry of goal events older than the
  user's latest evaluation), fixed separately in #<goal-event PR number>.