### PR TITLE
fix(subscriber): retain in-memory buffers when periodic writes fail

### DIFF
--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -696,17 +696,23 @@ func (p *evaluationCountEventPersister) writeEnvLastUsedInfo() {
 			info = append(info, v)
 		}
 		if err := p.upsertMultiFeatureLastUsedInfo(context.Background(), info, environmentId); err != nil {
-			p.logger.Error("Failed to write feature last-used info", zap.Error(err),
+			// Keep the entries so they are retried on the next cycle.
+			// The Pub/Sub messages were already acked when the evaluation counts
+			// were written to Redis, so dropping the entries here would lose the
+			// last-used info until the next evaluation event arrives for the flag.
+			p.logger.Error("Failed to write feature last-used info, will retry next cycle",
+				zap.Error(err),
 				zap.String("environmentId", environmentId))
 			continue
 		}
+		// Remove only the environments that were successfully written.
+		// The failed ones will remain for the next attempt.
+		delete(p.envLastUsedCache, environmentId)
 		p.logger.Debug("Cache has been written",
 			zap.String("environmentId", environmentId),
 			zap.Int("cacheSize", len(info)),
 		)
 	}
-	// Reset the cache
-	p.envLastUsedCache = make(environmentLastUsedInfoCache)
 }
 
 func (p *evaluationCountEventPersister) upsertMultiFeatureLastUsedInfo(

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister.go
@@ -607,10 +607,31 @@ func (p *evaluationCountEventPersister) writeDAU() {
 	}
 	if err := p.dauCache.RecordDAUBatch(records); err != nil {
 		if !strings.Contains(err.Error(), "client is closed") {
-			p.logger.Warn("Failed to record DAU batch",
+			p.logger.Warn("Failed to record DAU batch, will retry next cycle",
 				zap.Error(err),
 				zap.Int("recordCount", len(records)),
 			)
+		}
+		// Merge the buffer back so the entries are retried on the next cycle.
+		// The Pub/Sub messages were already acked, so dropping the buffer here
+		// would lose the DAU data. Re-sending already-recorded user IDs is safe
+		// because PFADD (HyperLogLog) is idempotent.
+		p.restoreDAUBuffer(buf)
+	}
+}
+
+// restoreDAUBuffer merges a previously swapped-out DAU buffer back into the
+// current one, preserving any entries buffered in the meantime.
+func (p *evaluationCountEventPersister) restoreDAUBuffer(buf dauBuffer) {
+	p.dauBufferMutex.Lock()
+	defer p.dauBufferMutex.Unlock()
+	for key, userIDSet := range buf {
+		if p.dauBuf[key] == nil {
+			p.dauBuf[key] = userIDSet
+			continue
+		}
+		for userID := range userIDSet {
+			p.dauBuf[key][userID] = struct{}{}
 		}
 	}
 }

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister_test.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister_test.go
@@ -17,6 +17,8 @@ import (
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 
+	cachev3 "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3"
+	cachemock "github.com/bucketeer-io/bucketeer/v2/pkg/cache/v3/mock"
 	ftdomain "github.com/bucketeer-io/bucketeer/v2/pkg/feature/domain"
 	ftstoragemock "github.com/bucketeer-io/bucketeer/v2/pkg/feature/storage/v2/mock"
 	redisv3 "github.com/bucketeer-io/bucketeer/v2/pkg/redis/v3"
@@ -1981,4 +1983,43 @@ func TestWriteEnvLastUsedInfoRemovesOnlySuccessfulEnvironments(t *testing.T) {
 	p.writeEnvLastUsedInfo()
 	assert.Len(t, p.envLastUsedCache, 1)
 	assert.Contains(t, p.envLastUsedCache, "env-ng")
+}
+
+func TestWriteDAURestoresBufferOnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	dauCacheMock := cachemock.NewMockDAUCache(ctrl)
+	p := &evaluationCountEventPersister{
+		dauCache: dauCacheMock,
+		dauBuf:   make(dauBuffer),
+		logger:   zap.NewNop(),
+	}
+	key := dauBufferKey{dateStr: "20260730", envID: "env-1", sourceID: "ANDROID"}
+	p.dauBuf[key] = map[string]struct{}{"user-1": {}}
+
+	// First cycle: Redis fails. The buffer must be restored so the entries
+	// are retried on the next cycle, because the Pub/Sub messages were
+	// already acked.
+	dauCacheMock.EXPECT().RecordDAUBatch(gomock.Any()).
+		Return(errors.New("redis: connection refused"))
+	p.writeDAU()
+	assert.Len(t, p.dauBuf, 1)
+	assert.Contains(t, p.dauBuf[key], "user-1")
+
+	// A new user arrives before the next cycle; it must be merged with the
+	// restored entries.
+	p.dauBuf[key]["user-2"] = struct{}{}
+
+	// Second cycle: Redis recovers. Both users must be flushed together
+	// and the buffer left empty.
+	dauCacheMock.EXPECT().RecordDAUBatch(gomock.Any()).DoAndReturn(
+		func(records []cachev3.DAURecord) error {
+			assert.Len(t, records, 1)
+			assert.ElementsMatch(t, []string{"user-1", "user-2"}, records[0].UserIDs)
+			return nil
+		},
+	)
+	p.writeDAU()
+	assert.Empty(t, p.dauBuf)
 }

--- a/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister_test.go
+++ b/pkg/subscriber/processor/evaluation_events_evaluation_count_event_persister_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strings"
 	"sync"
@@ -13,8 +14,11 @@ import (
 	goredis "github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 	"go.uber.org/zap"
 
+	ftdomain "github.com/bucketeer-io/bucketeer/v2/pkg/feature/domain"
+	ftstoragemock "github.com/bucketeer-io/bucketeer/v2/pkg/feature/storage/v2/mock"
 	redisv3 "github.com/bucketeer-io/bucketeer/v2/pkg/redis/v3"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/storage"
 	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/client"
@@ -1920,4 +1924,61 @@ func (m *mockPipeClient) Get(key string) *goredis.StringCmd {
 }
 func (m *mockPipeClient) Del(keys string) *goredis.IntCmd {
 	return goredis.NewIntCmd(context.Background())
+}
+
+func TestWriteEnvLastUsedInfoRetainsCacheOnFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	storageMock := ftstoragemock.NewMockFeatureLastUsedInfoStorage(ctrl)
+	p := &evaluationCountEventPersister{
+		fluiStorage:      storageMock,
+		envLastUsedCache: make(environmentLastUsedInfoCache),
+		logger:           zap.NewNop(),
+	}
+	info := ftdomain.NewFeatureLastUsedInfo("feature-1", 1, time.Now().Unix(), "1.0.0")
+	p.envLastUsedCache["env-1"] = lastUsedInfoCache{info.ID(): info}
+
+	// First cycle: the storage fails (e.g. MySQL deadlock).
+	// The cache must be kept so the info is retried on the next cycle,
+	// because the Pub/Sub messages were already acked.
+	storageMock.EXPECT().GetFeatureLastUsedInfos(gomock.Any(), gomock.Any(), "env-1").
+		Return(nil, errors.New("mysql: deadlock"))
+	p.writeEnvLastUsedInfo()
+	assert.Len(t, p.envLastUsedCache, 1)
+	assert.Contains(t, p.envLastUsedCache, "env-1")
+
+	// Second cycle: the storage recovers. The info must be written
+	// and the environment removed from the cache.
+	storageMock.EXPECT().GetFeatureLastUsedInfos(gomock.Any(), gomock.Any(), "env-1").
+		Return(nil, nil)
+	storageMock.EXPECT().UpsertFeatureLastUsedInfo(gomock.Any(), info, "env-1").Return(nil)
+	p.writeEnvLastUsedInfo()
+	assert.Empty(t, p.envLastUsedCache)
+}
+
+func TestWriteEnvLastUsedInfoRemovesOnlySuccessfulEnvironments(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	storageMock := ftstoragemock.NewMockFeatureLastUsedInfoStorage(ctrl)
+	p := &evaluationCountEventPersister{
+		fluiStorage:      storageMock,
+		envLastUsedCache: make(environmentLastUsedInfoCache),
+		logger:           zap.NewNop(),
+	}
+	infoOK := ftdomain.NewFeatureLastUsedInfo("feature-ok", 1, time.Now().Unix(), "1.0.0")
+	infoNG := ftdomain.NewFeatureLastUsedInfo("feature-ng", 1, time.Now().Unix(), "1.0.0")
+	p.envLastUsedCache["env-ok"] = lastUsedInfoCache{infoOK.ID(): infoOK}
+	p.envLastUsedCache["env-ng"] = lastUsedInfoCache{infoNG.ID(): infoNG}
+
+	storageMock.EXPECT().GetFeatureLastUsedInfos(gomock.Any(), gomock.Any(), "env-ok").
+		Return(nil, nil)
+	storageMock.EXPECT().UpsertFeatureLastUsedInfo(gomock.Any(), infoOK, "env-ok").Return(nil)
+	storageMock.EXPECT().GetFeatureLastUsedInfos(gomock.Any(), gomock.Any(), "env-ng").
+		Return(nil, errors.New("mysql: deadlock"))
+
+	p.writeEnvLastUsedInfo()
+	assert.Len(t, p.envLastUsedCache, 1)
+	assert.Contains(t, p.envLastUsedCache, "env-ng")
 }


### PR DESCRIPTION
## Why

`TestFeatureAutoArchiver_RecentlyUsedNotArchived` (and the other
`TestFeatureAutoArchiver` tests) fail intermittently in the dev cluster with:

    LastUsedInfo not recorded for feature ... after 60 retries

The test registers a single evaluation event and polls `GetFeature` for
120 seconds waiting for `LastUsedInfo`. Normally the data lands within
~20 seconds (`flushInterval` + `writeCacheInterval: 10`), so this is not a
timing problem — the data was being lost.

Investigating the `evaluationCountEventPersister` subscriber revealed the
same data-loss pattern in two of its three periodic writers. The subscriber
acks the Pub/Sub messages as soon as the evaluation counts are written to
Redis, so the in-memory buffers are the **only copy** of the remaining data.
If a periodic flush fails and the buffer is discarded, that data is lost
permanently — there is no redelivery.

## Fix 1: Feature last-used info (MySQL)

`writeEnvLastUsedInfo` flushes the in-memory last-used info buffer to MySQL
every `writeCacheInterval` seconds. When the upsert failed for an
environment (e.g. a transient MySQL deadlock, common in the dev cluster
while parallel e2e suites write to `feature_last_used_info`), the error was
logged and the environment skipped — but the entire buffer was
unconditionally reset right after the loop, discarding the failed
environment's entries too:

    if err := p.upsertMultiFeatureLastUsedInfo(...); err != nil {
        p.logger.Error(...)
        continue
    }
    ...
    // Reset the cache
    p.envLastUsedCache = make(environmentLastUsedInfoCache)

One failed flush permanently lost the last-used info until the next
evaluation event arrived for the same flag. Since the e2e test sends exactly
one event, `LastUsedInfo` never appeared and the test timed out.

Beyond the flaky test, this affects production: silently lost last-used
info skews `UnusedDays`, which feeds auto-archive and stale-flag detection.

**Fix:** remove an environment from the buffer only after a successful
write. Failed environments are kept and retried on the next cycle — the
same pattern `writeUserAttributes` already uses. Retrying is safe because
the upsert merges with the existing DB row and only updates when
`LastUsedAt` is newer.

## Fix 2: DAU buffer (Redis HyperLogLog)

`writeDAU` had the same pattern: the in-memory DAU buffer was swapped out
*before* the Redis write, and on failure the error was only logged — the
swapped-out buffer was discarded, permanently losing those users' DAU
records. `RecordDAUBatch` also fails fast on the first Redis error, so all
records after the failing key in the batch were dropped as well.

**Fix:** merge the buffer back on failure and retry on the next cycle.
Re-sending already-recorded user IDs is safe because `PFADD` (HyperLogLog)
is idempotent, so there is no double counting.

## Audited but not changed

- `writeUserAttributes` already handles failures correctly: it removes
  entries from its cache only after a successful write.
- The evaluation counts themselves are flushed synchronously with proper
  ack/nack handling, so failures there are redelivered by Pub/Sub.

## Tests

Added unit tests covering:

- A failed last-used info flush keeps the buffer; the next cycle writes it
  and clears it.
- With one failing and one succeeding environment, only the successful one
  is removed from the buffer.
- A failed DAU flush restores the buffer; entries buffered in the meantime
  are merged, and the next cycle flushes both together.

## Impact on the e2e tests

Worst case for `TestFeatureAutoArchiver_*` is now one extra flush cycle
(~10s), well within the 120s polling budget, so no test-side changes are
needed.