### PR TITLE
fix(eventcounter): deduplicate events by ID in BigQuery count queries

### DIFF
--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/evaluation_count.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/evaluation_count.sql
@@ -1,7 +1,11 @@
 SELECT
     variation_id as variationID,
     COUNT(DISTINCT user_id) as evaluationUser,
-    COUNT(id) as evaluationTotal
+    -- DISTINCT by event ID: BigQuery has no primary keys, so an at-least-once
+    -- Pub/Sub redelivery can append the same event twice. Each legitimate
+    -- event has its own unique ID, so this still counts repeat evaluations
+    -- by the same user.
+    COUNT(DISTINCT id) as evaluationTotal
 FROM
     `%s`
 WHERE

--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
@@ -1,9 +1,14 @@
-WITH grouped_by_user_evaluation AS (
-    SELECT
+WITH deduped_events AS (
+    -- BigQuery has no primary keys, so an at-least-once Pub/Sub redelivery
+    -- can append the same event twice. Deduplicate by event ID before any
+    -- aggregation, otherwise duplicates inflate event_count and value_sum.
+    -- Duplicates are identical rows, so DISTINCT over the used columns is
+    -- equivalent to picking one row per ID.
+    SELECT DISTINCT
+        id,
         user_id,
         variation_id,
-        COUNT(id) as event_count,
-        IFNULL(SUM(value), 0) as value_sum
+        value
     FROM
         `%s`
     WHERE
@@ -12,9 +17,18 @@ WITH grouped_by_user_evaluation AS (
     AND goal_id = @goalID
     AND feature_id = @featureID
     AND feature_version = @featureVersion
-GROUP BY
-    user_id,
-    variation_id
+),
+grouped_by_user_evaluation AS (
+    SELECT
+        user_id,
+        variation_id,
+        COUNT(id) as event_count,
+        IFNULL(SUM(value), 0) as value_sum
+    FROM
+        deduped_events
+    GROUP BY
+        user_id,
+        variation_id
 ),
 cap_level AS (
     -- Winsorization threshold: the configurable percentile

--- a/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
+++ b/pkg/eventcounter/storage/v2/dwh_database/bigquery/sql/goal_count.sql
@@ -2,8 +2,9 @@ WITH deduped_events AS (
     -- BigQuery has no primary keys, so an at-least-once Pub/Sub redelivery
     -- can append the same event twice. Deduplicate by event ID before any
     -- aggregation, otherwise duplicates inflate event_count and value_sum.
-    -- Duplicates are identical rows, so DISTINCT over the used columns is
-    -- equivalent to picking one row per ID.
+    -- Duplicates are expected to be identical rows; DISTINCT collapses exact
+    -- duplicates for the columns used downstream without changing the
+    -- aggregation semantics.
     SELECT DISTINCT
         id,
         user_id,


### PR DESCRIPTION
## Why

BigQuery has no primary keys, so an at-least-once Pub/Sub redelivery after a
successful append stores the same event twice. The MySQL and Postgres event
tables reject duplicates via `PRIMARY KEY (id)`, but the BigQuery count
queries silently trusted row uniqueness — a guarantee BigQuery doesn't
provide:

- `evaluation_count.sql` used `COUNT(id)` for the event total, so one
  duplicated evaluation event inflated `evaluationTotal` forever.
- `goal_count.sql` aggregated `COUNT(id)` and `SUM(value)` per user directly
  over the raw table, so duplicates inflated `goalTotal` and the per-user
  value sums that feed the Bayesian value-metric analysis
  (`goalValueTotal` / mean / variance).

User counts already used `COUNT(DISTINCT user_id)`, so unique-user metrics
and the CVR analysis were unaffected.

This is also the likely cause of `TestGrpcExperimentResult` hanging in the
dev cluster: the test waits for exact event counts, and a single duplicated
event keeps the count above the expected total forever (user counts show
50/50 while an event count is stuck at 51).

## What

- `evaluation_count.sql`: `COUNT(id)` → `COUNT(DISTINCT id)`.
- `goal_count.sql`: added a `deduped_events` CTE (`SELECT DISTINCT id, ...`)
  before any aggregation; the winsorization and final aggregation stages are
  unchanged.

The metric semantics are preserved: each legitimate event has its own unique
ID, so repeat evaluations/goals by the same user still count toward the
totals. Only physically duplicated rows are collapsed. Because the dedup is
at read time, it also retroactively corrects duplicates already sitting in
the tables.

## Performance

- Bytes scanned (billing) are unchanged — both queries already read `id`
  and the filters are identical.
- Compute increases slightly (one exact-distinct / dedup pass over the
  filtered rows), but the filter is already narrow (one feature/goal +
  version + experiment window) and the queries run in the batch calculator,
  not on a user-facing path. The queries already pay for an exact
  `COUNT(DISTINCT user_id)`, so this adds no new class of operation.

## Notes

- MySQL and Postgres queries are untouched: their primary keys make
  duplicate rows impossible at write time.
- Complements the diagnostic branch `test/eventcounter-diagnose-stuck-counts`,
  which makes the e2e wait loop print all eight counters and fail fast on
  over-counts.