### PR TITLE
test: raise e2e suite timeout and log progress in goal count waits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ LDFLAGS_BUILDDATE := $(LDFLAGS_PACKAGE).BuildDate
 # $(CERT_DIR); the e2e tests then authenticate with them instead of a service
 # token. All paths can be overridden by the caller (e.g. CI).
 CERT_DIR ?= tools/dev/cert
+# Go test binary timeout for the e2e suites. Go's default of 10m is too tight
+# when parallel suites slow down the async event pipeline: it panics the whole
+# binary while slow-but-healthy waits are still within their own retry budgets,
+# killing tests that would otherwise pass.
+E2E_TIMEOUT ?= 30m
 SYS_ADMIN_EMAIL ?= sysadmin@bucketeer.io
 ORG_OWNER_EMAIL ?= orgowner@bucketeer.io
 ENV_WRITE_EMAIL ?= envwrite@bucketeer.io
@@ -368,7 +373,7 @@ create-api-key:
 e2e-l4:
 	TZ=UTC CGO_ENABLED=0 go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) \
 		--format pkgname \
-		-- -v ./test/e2e/... -args \
+		-- -v -timeout $(E2E_TIMEOUT) ./test/e2e/... -args \
 		-web-gateway-addr=${WEB_GATEWAY_URL} \
 		-web-gateway-port=443 \
 		-web-gateway-cert=${WEB_GATEWAY_CERT_PATH} \
@@ -388,7 +393,7 @@ e2e-l4:
 e2e:
 	TZ=UTC CGO_ENABLED=0 go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION) \
 		--format pkgname \
-		-- -v ./test/e2e/... -args \
+		-- -v -timeout $(E2E_TIMEOUT) ./test/e2e/... -args \
 		-web-gateway-addr=${WEB_GATEWAY_URL} \
 		-web-gateway-port=443 \
 		-web-gateway-cert=${WEB_GATEWAY_CERT_PATH} \

--- a/test/e2e/eventcounter/eventcounter_test.go
+++ b/test/e2e/eventcounter/eventcounter_test.go
@@ -166,69 +166,8 @@ func TestGrpcExperimentGoalCount(t *testing.T) {
 	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
 	grpcRegisterGoalEvent(t, goalIDs[0], userID, tag, float64(0.3), time.Now().Add(-2*time.Hour).Unix())
 
-	for i := 0; i < retryTimes; i++ {
-		if i == retryTimes-1 {
-			t.Fatalf("retry timeout")
-		}
-		time.Sleep(10 * time.Second)
-
-		resp, err := getExperimentGoalCount(t, ecClient, goalIDs[0], featureID, f.Version, variationIDs)
-		if err != nil {
-			st, _ := status.FromError(err)
-			if st.Code() != codes.NotFound {
-				t.Fatalf("Failed to get the experiment goal count. Error code: %d. Error: %v\n", st.Code(), err)
-			} else {
-				continue
-			}
-		}
-
-		if len(resp.VariationCounts) == 0 {
-			t.Fatalf("no count returned")
-		}
-		if resp.GoalId != goalIDs[0] {
-			t.Fatalf("goal ID is not correct: %s", resp.GoalId)
-		}
-
-		vcA := getVariationCount(resp.VariationCounts, variations[variationVarA].Id)
-		if vcA == nil {
-			t.Fatalf("variation a is missing")
-		}
-		if vcA.UserCount != 1 {
-			continue
-		}
-		if vcA.EventCount != 2 {
-			continue
-		}
-		if diff := cmp.Diff(vcA.ValueSum, 0.5, compareFloatOpt); diff != "" {
-			continue
-		}
-		if diff := cmp.Diff(vcA.ValueSumPerUserMean, 0.5, compareFloatOpt); diff != "" {
-			continue
-		}
-		if diff := cmp.Diff(vcA.ValueSumPerUserVariance, float64(0), compareFloatOpt); diff != "" {
-			continue
-		}
-		vcB := getVariationCount(resp.VariationCounts, variations[variationVarB].Id)
-		if vcB == nil {
-			t.Fatalf("variation b is missing")
-		}
-		if vcB.UserCount != 0 {
-			continue
-		}
-		if vcB.EventCount != 0 {
-			continue
-		}
-		if vcB.ValueSum != float64(0) {
-			continue
-		}
-		if vcB.ValueSumPerUserMean != float64(0.0) {
-			continue
-		}
-		if vcB.ValueSumPerUserVariance != float64(0.0) {
-			continue
-		}
-		break
-	}
+	waitForSingleUserGoalCount(t, ecClient, goalIDs[0], featureID, f.Version, variationIDs,
+		variations[variationVarA].Id, variations[variationVarB].Id)
 }
 
 func TestExperimentGoalCount(t *testing.T) {
@@ -306,70 +245,85 @@ func TestExperimentGoalCount(t *testing.T) {
 	// This event will be ignored because the timestamp is older than the experiment startAt time stamp
 	registerGoalEvent(t, goalIDs[0], userID, tag, float64(0.3), time.Now().Add(-2*time.Hour).Unix())
 
+	waitForSingleUserGoalCount(t, ecClient, goalIDs[0], featureID, f.Version, variationIDs,
+		variations[variationVarA].Id, variations[variationVarB].Id)
+}
+
+// waitForSingleUserGoalCount polls the experiment goal count until it matches
+// the shared fixture of TestGrpcExperimentGoalCount / TestExperimentGoalCount:
+// one user with two goal events (values 0.2 + 0.3) on variation A and nothing
+// on variation B. It logs progress on every retry so a slow run shows where it
+// is stuck, and fails fast when an event count exceeds the expected total,
+// because DWH rows are append-only and an over-count can never converge back.
+func waitForSingleUserGoalCount(
+	t *testing.T,
+	ecClient ecclient.Client,
+	goalID, featureID string,
+	featureVersion int32,
+	variationIDs []string,
+	variationAID, variationBID string,
+) {
+	t.Helper()
 	for i := 0; i < retryTimes; i++ {
 		if i == retryTimes-1 {
-			t.Fatalf("retry timeout")
+			t.Fatalf("retry timeout after %d attempts", retryTimes)
 		}
 		time.Sleep(10 * time.Second)
 
-		resp, err := getExperimentGoalCount(t, ecClient, goalIDs[0], featureID, f.Version, variationIDs)
+		resp, err := getExperimentGoalCount(t, ecClient, goalID, featureID, featureVersion, variationIDs)
 		if err != nil {
 			st, _ := status.FromError(err)
 			if st.Code() != codes.NotFound {
 				t.Fatalf("Failed to get the experiment goal count. Error code: %d. Error: %v\n", st.Code(), err)
-			} else {
-				continue
 			}
+			t.Logf("Retry %d/%d: experiment goal count not found yet (NotFound error)", i+1, retryTimes)
+			continue
 		}
 
 		if len(resp.VariationCounts) == 0 {
 			t.Fatalf("no count returned")
 		}
-		if resp.GoalId != goalIDs[0] {
+		if resp.GoalId != goalID {
 			t.Fatalf("goal ID is not correct: %s", resp.GoalId)
 		}
 
-		vcA := getVariationCount(resp.VariationCounts, variations[variationVarA].Id)
+		vcA := getVariationCount(resp.VariationCounts, variationAID)
 		if vcA == nil {
 			t.Fatalf("variation a is missing")
 		}
-		if vcA.UserCount != 1 {
-			continue
-		}
-		if vcA.EventCount != 2 {
-			continue
-		}
-		if diff := cmp.Diff(vcA.ValueSum, 0.5, compareFloatOpt); diff != "" {
-			continue
-		}
-		if diff := cmp.Diff(vcA.ValueSumPerUserMean, 0.5, compareFloatOpt); diff != "" {
-			continue
-		}
-		if diff := cmp.Diff(vcA.ValueSumPerUserVariance, float64(0), compareFloatOpt); diff != "" {
-			continue
-		}
-
-		vcB := getVariationCount(resp.VariationCounts, variations[variationVarB].Id)
+		vcB := getVariationCount(resp.VariationCounts, variationBID)
 		if vcB == nil {
 			t.Fatalf("variation b is missing")
 		}
-		if vcB.UserCount != 0 {
+		if vcA.EventCount > 2 || vcB.EventCount > 0 {
+			t.Fatalf("goal event count exceeds the expected total (A=%d/2 B=%d/0): "+
+				"events were likely persisted or linked more than once; "+
+				"this can never recover, failing fast",
+				vcA.EventCount, vcB.EventCount)
+		}
+		if !singleUserGoalCountReady(vcA, vcB) {
+			t.Logf("Retry %d/%d: waiting for goal counts: "+
+				"A{users=%d/1 events=%d/2 valueSum=%.2f/0.50} B{users=%d/0 events=%d/0 valueSum=%.2f/0.00}",
+				i+1, retryTimes,
+				vcA.UserCount, vcA.EventCount, vcA.ValueSum,
+				vcB.UserCount, vcB.EventCount, vcB.ValueSum)
 			continue
 		}
-		if vcB.EventCount != 0 {
-			continue
-		}
-		if diff := cmp.Diff(vcB.ValueSum, float64(0), compareFloatOpt); diff != "" {
-			continue
-		}
-		if diff := cmp.Diff(vcB.ValueSumPerUserMean, float64(0), compareFloatOpt); diff != "" {
-			continue
-		}
-		if diff := cmp.Diff(vcB.ValueSumPerUserVariance, float64(0), compareFloatOpt); diff != "" {
-			continue
-		}
-		break
+		return
 	}
+}
+
+func singleUserGoalCountReady(vcA, vcB *ecproto.VariationCount) bool {
+	return vcA.UserCount == 1 &&
+		vcA.EventCount == 2 &&
+		cmp.Diff(vcA.ValueSum, 0.5, compareFloatOpt) == "" &&
+		cmp.Diff(vcA.ValueSumPerUserMean, 0.5, compareFloatOpt) == "" &&
+		cmp.Diff(vcA.ValueSumPerUserVariance, float64(0), compareFloatOpt) == "" &&
+		vcB.UserCount == 0 &&
+		vcB.EventCount == 0 &&
+		cmp.Diff(vcB.ValueSum, float64(0), compareFloatOpt) == "" &&
+		cmp.Diff(vcB.ValueSumPerUserMean, float64(0), compareFloatOpt) == "" &&
+		cmp.Diff(vcB.ValueSumPerUserVariance, float64(0), compareFloatOpt) == ""
 }
 
 func TestGrpcExperimentResult(t *testing.T) {


### PR DESCRIPTION
## Why

A dev cluster e2e run panicked with `test timed out after 10m0s` while
`TestExperimentGoalCount` was still healthily waiting. No test assertion
failed: the goal-event retry queue drains with exponential backoff (5s base
in the dev cluster, doubling to ~40–160s per message after a few misses
while evaluations become queryable in BigQuery), so under parallel suite
load a test that starts late behind a parallel slot can legitimately need
several minutes. `TestGrpcExperimentResult` passed in 247s in the same run;
the 10m Go default simply doesn't fit the worst case, and the panic kills
every test still in flight.

`TestExperimentGoalCount` was also invisible in the logs: its wait loop had
no progress output at all.

## What

- Add `-timeout $(E2E_TIMEOUT)` (default `30m`, overridable) to the `e2e`
  and `e2e-l4` Makefile targets. Individual tests still fail on their own
  retry budgets, so genuine hangs remain bounded — this only prevents the
  suite-wide panic from killing healthy tests.
- Extract the duplicated silent wait loops of `TestGrpcExperimentGoalCount`
  and `TestExperimentGoalCount` into `waitForSingleUserGoalCount`, which
  logs the current counts against expectations on every retry and fails
  fast when an event count exceeds the expected total (DWH rows are
  append-only, so an over-count can never converge back down).

## Notes

- Complements #2737 (full-counter logging in the experiment result waits).
- The run that motivated this showed all counters converging exactly — no
  duplicates — so the BigQuery dedup change remains separate hardening.