### PR TITLE
ci: fix satisfy npm trusted publishing requirements for evaluation ts

### DIFF
--- a/.github/workflows/publish-evaluation-ts.yaml
+++ b/.github/workflows/publish-evaluation-ts.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
 
 env:
-  NODE_VERSION: 20
+  NODE_VERSION: 24
   EVALUATION_DIRECTORY: "evaluation/typescript"
 
 permissions:

--- a/evaluation/typescript/package.json
+++ b/evaluation/typescript/package.json
@@ -6,6 +6,11 @@
   "types": "lib/index.d.ts",
   "author": "",
   "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/bucketeer-io/bucketeer.git",
+    "directory": "evaluation/typescript"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- upgrade the evaluation publishing workflow from Node.js 20 to 24
- add the package repository metadata required by npm trusted publishing
- fix the OIDC authorization failure that produced an npm E404

## Test plan
- [x] Validate `package.json` repository metadata
- [x] Check workflow and package files for lint errors
- [ ] Merge and retry publishing `@bucketeer/evaluation@0.0.9`