### PR TITLE
ci: fix evaluation ts publish with Node.js 22

### DIFF
--- a/.github/workflows/publish-evaluation-ts.yaml
+++ b/.github/workflows/publish-evaluation-ts.yaml
@@ -10,7 +10,7 @@ on:
         type: boolean
 
 env:
-  NODE_VERSION: 24
+  NODE_VERSION: 22
   EVALUATION_DIRECTORY: "evaluation/typescript"
 
 permissions:

--- a/.github/workflows/publish-evaluation-ts.yaml
+++ b/.github/workflows/publish-evaluation-ts.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   dry-run:
-    if: github.ref == 'refs/heads/main' && inputs.dry_run
+    if: inputs.dry_run
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/publish-evaluation-ts.yaml
+++ b/.github/workflows/publish-evaluation-ts.yaml
@@ -8,6 +8,10 @@ on:
         required: false
         default: false
         type: boolean
+      checkout_ref:
+        description: "Branch, tag, or SHA to test (dry runs only)"
+        required: false
+        type: string
 
 env:
   NODE_VERSION: 22
@@ -15,12 +19,53 @@ env:
 
 permissions:
   contents: read
-  id-token: write # required for npm OIDC trusted publishing
 
 jobs:
-  publish:
-    if: github.ref == 'refs/heads/main'
+  dry-run:
+    if: github.ref == 'refs/heads/main' && inputs.dry_run
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.EVALUATION_DIRECTORY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          ref: ${{ inputs.checkout_ref || github.ref }}
+
+      - name: Setup node env
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Protoc
+        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
+
+      - name: Use publishing npm version
+        run: npm install -g npm@11.10.0
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate protobuf code
+        run: make gen_proto
+
+      - name: Build evaluation package
+        run: make build
+
+      - name: Verify npm package
+        run: |
+          make copy-genfiles
+          npm publish --dry-run --access public
+
+  publish:
+    if: github.ref == 'refs/heads/main' && !inputs.dry_run
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # required for npm OIDC trusted publishing
     defaults:
       run:
         working-directory: ${{ env.EVALUATION_DIRECTORY }}
@@ -57,5 +102,4 @@ jobs:
           make copy-genfiles
           npm publish \
             --provenance \
-            --access public \
-            ${{ inputs.dry_run && '--dry-run' || '' }}
+            --access public

--- a/.github/workflows/publish-evaluation-ts.yaml
+++ b/.github/workflows/publish-evaluation-ts.yaml
@@ -8,10 +8,6 @@ on:
         required: false
         default: false
         type: boolean
-      checkout_ref:
-        description: "Branch, tag, or SHA to test (dry runs only)"
-        required: false
-        type: string
 
 env:
   NODE_VERSION: 22
@@ -19,53 +15,12 @@ env:
 
 permissions:
   contents: read
+  id-token: write # required for npm OIDC trusted publishing
 
 jobs:
-  dry-run:
-    if: inputs.dry_run
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ env.EVALUATION_DIRECTORY }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
-        with:
-          ref: ${{ inputs.checkout_ref || github.ref }}
-
-      - name: Setup node env
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-
-      - name: Install Protoc
-        uses: arduino/setup-protoc@c65c819552d16ad3c9b72d9dfd5ba5237b9c906b # v3.0.0
-
-      - name: Use publishing npm version
-        run: npm install -g npm@11.10.0
-
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
-
-      - name: Generate protobuf code
-        run: make gen_proto
-
-      - name: Build evaluation package
-        run: make build
-
-      - name: Verify npm package
-        run: |
-          make copy-genfiles
-          npm publish --dry-run --access public
-
   publish:
-    if: github.ref == 'refs/heads/main' && !inputs.dry_run
+    if: github.ref == 'refs/heads/main' || inputs.dry_run
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # required for npm OIDC trusted publishing
     defaults:
       run:
         working-directory: ${{ env.EVALUATION_DIRECTORY }}
@@ -102,4 +57,5 @@ jobs:
           make copy-genfiles
           npm publish \
             --provenance \
-            --access public
+            --access public \
+            ${{ inputs.dry_run && '--dry-run' || '' }}

--- a/evaluation/typescript/README.md
+++ b/evaluation/typescript/README.md
@@ -44,12 +44,8 @@ To release a new version:
 
 1. Update the version in `package.json`.
 2. Merge the change into `main`.
-3. Run the workflow from the `main` branch. Enable `dry_run` to verify the
-   package without publishing it.
-
-To verify another branch, select that branch when starting the workflow and
-enable `dry_run`. Alternatively, run it from `main` and set `checkout_ref` to
-the branch, tag, or commit SHA to test.
+3. Run the workflow from the `main` branch to publish. Enable `dry_run` to
+   verify the package from another branch without publishing it.
 
 The workflow builds and publishes the package with npm trusted publishing
 (OIDC), so an npm token is not required.

--- a/evaluation/typescript/README.md
+++ b/evaluation/typescript/README.md
@@ -47,5 +47,8 @@ To release a new version:
 3. Run the workflow from the `main` branch. Enable `dry_run` to verify the
    package without publishing it.
 
+To verify another branch, run the workflow from `main`, enable `dry_run`, and
+set `checkout_ref` to the branch, tag, or commit SHA to test.
+
 The workflow builds and publishes the package with npm trusted publishing
 (OIDC), so an npm token is not required.

--- a/evaluation/typescript/README.md
+++ b/evaluation/typescript/README.md
@@ -47,8 +47,9 @@ To release a new version:
 3. Run the workflow from the `main` branch. Enable `dry_run` to verify the
    package without publishing it.
 
-To verify another branch, run the workflow from `main`, enable `dry_run`, and
-set `checkout_ref` to the branch, tag, or commit SHA to test.
+To verify another branch, select that branch when starting the workflow and
+enable `dry_run`. Alternatively, run it from `main` and set `checkout_ref` to
+the branch, tag, or commit SHA to test.
 
 The workflow builds and publishes the package with npm trusted publishing
 (OIDC), so an npm token is not required.


### PR DESCRIPTION
## Summary
- use Node.js 22 for package compatibility
- allow non-main runs when `dry_run` is enabled
- keep the publishing workflow simple with one job

## Test plan
- [x] Validate workflow syntax and formatting
- [x] Run from `main` with `dry_run` enabled and a branch in `checkout_ref`
- [ ] Merge and publish `@bucketeer/evaluation@0.0.9`