### PR TITLE
feat(notification): implement MarkAllNotificationsAsRead API

### DIFF
--- a/pkg/notification/api/api.go
+++ b/pkg/notification/api/api.go
@@ -302,7 +302,21 @@ func (s *NotificationService) MarkAllNotificationsAsRead(
 	ctx context.Context,
 	req *proto.MarkAllNotificationsAsReadRequest,
 ) (*proto.MarkAllNotificationsAsReadResponse, error) {
-	return nil, statusNotImplemented
+	t, err := s.checkAuthenticated(ctx)
+	if err != nil {
+		return nil, err
+	}
+	err = s.dbClient.RunInTransactionV2(ctx, func(ctxWithTx context.Context) error {
+		return s.notificationStorage.MarkAllNotificationsAsRead(ctxWithTx, t.Email, time.Now().Unix())
+	})
+	if err != nil {
+		s.logger.Error(
+			"Failed to mark all notifications as read",
+			log.FieldsFromIncomingContext(ctx).AddFields(zap.Error(err))...,
+		)
+		return nil, api.NewGRPCStatus(err).Err()
+	}
+	return &proto.MarkAllNotificationsAsReadResponse{}, nil
 }
 
 func (s *NotificationService) ListDraftAdminNotifications(

--- a/pkg/notification/api/api_test.go
+++ b/pkg/notification/api/api_test.go
@@ -1329,3 +1329,65 @@ func TestNotificationService_GetNotificationUnreadCount(t *testing.T) {
 		})
 	}
 }
+
+func TestNotificationService_MarkAllNotificationsAsRead(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	viewerCtx := metadata.NewIncomingContext(
+		createContextWithToken(t, false),
+		metadata.MD{"accept-language": []string{"en"}},
+	)
+
+	patterns := []struct {
+		desc        string
+		ctx         context.Context
+		setup       func(*NotificationService)
+		expectedErr error
+	}{
+		{
+			desc:        "err: unauthenticated",
+			ctx:         context.TODO(),
+			expectedErr: statusUnauthenticated.Err(),
+		},
+		{
+			desc: "err: internal",
+			ctx:  viewerCtx,
+			setup: func(s *NotificationService) {
+				s.dbClient.(*databasemock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
+				).Return(errors.New("error"))
+			},
+			expectedErr: api.NewGRPCStatus(errors.New("error")).Err(),
+		},
+		{
+			desc: "success",
+			ctx:  viewerCtx,
+			setup: func(s *NotificationService) {
+				s.dbClient.(*databasemock.MockClient).EXPECT().RunInTransactionV2(
+					gomock.Any(), gomock.Any(),
+				).DoAndReturn(func(ctx context.Context, fn func(ctx context.Context) error) error {
+					return fn(ctx)
+				})
+				s.notificationStorage.(*notificationstoragemock.MockNotificationStorage).EXPECT().MarkAllNotificationsAsRead(
+					gomock.Any(), "email", gomock.Any(),
+				).Return(nil)
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s := createNotificationService(mockController)
+			if p.setup != nil {
+				p.setup(s)
+			}
+			resp, err := s.MarkAllNotificationsAsRead(p.ctx, &proto.MarkAllNotificationsAsReadRequest{})
+			assert.Equal(t, p.expectedErr, err)
+			if p.expectedErr == nil {
+				assert.NotNil(t, resp)
+			}
+		})
+	}
+}

--- a/pkg/notification/api/error.go
+++ b/pkg/notification/api/error.go
@@ -15,14 +15,9 @@
 package api
 
 import (
-	"google.golang.org/grpc/codes"
-	gstatus "google.golang.org/grpc/status"
-
 	"github.com/bucketeer-io/bucketeer/v2/pkg/api/api"
 	bkterr "github.com/bucketeer-io/bucketeer/v2/pkg/error"
 )
-
-var statusNotImplemented = gstatus.Error(codes.Unimplemented, "notification: not implemented")
 
 var (
 	statusUnauthenticated = api.NewGRPCStatus(

--- a/pkg/notification/storage/mock/notification.go
+++ b/pkg/notification/storage/mock/notification.go
@@ -150,6 +150,20 @@ func (mr *MockNotificationStorageMockRecorder) ListNotifications(ctx, params any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNotifications", reflect.TypeOf((*MockNotificationStorage)(nil).ListNotifications), ctx, params)
 }
 
+// MarkAllNotificationsAsRead mocks base method.
+func (m *MockNotificationStorage) MarkAllNotificationsAsRead(ctx context.Context, email string, readAt int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MarkAllNotificationsAsRead", ctx, email, readAt)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MarkAllNotificationsAsRead indicates an expected call of MarkAllNotificationsAsRead.
+func (mr *MockNotificationStorageMockRecorder) MarkAllNotificationsAsRead(ctx, email, readAt any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MarkAllNotificationsAsRead", reflect.TypeOf((*MockNotificationStorage)(nil).MarkAllNotificationsAsRead), ctx, email, readAt)
+}
+
 // MarkNotificationsAsRead mocks base method.
 func (m *MockNotificationStorage) MarkNotificationsAsRead(ctx context.Context, ids []string, email string, readAt int64) error {
 	m.ctrl.T.Helper()

--- a/pkg/notification/storage/mysql/notification.go
+++ b/pkg/notification/storage/mysql/notification.go
@@ -59,6 +59,8 @@ var (
 	insertNotificationReadSQL string
 	//go:embed sql/count_unread_notifications.sql
 	countUnreadNotificationsSQL string
+	//go:embed sql/insert_all_notification_reads.sql
+	insertAllNotificationReadsSQL string
 )
 
 // readNotificationExistsSubquery correlates a viewer's read marker with the
@@ -558,6 +560,23 @@ func (s *notificationStorage) MarkNotificationsAsRead(
 		}
 	}
 	return nil
+}
+
+// MarkAllNotificationsAsRead upserts read markers for every published
+// notification for the viewer.
+func (s *notificationStorage) MarkAllNotificationsAsRead(
+	ctx context.Context,
+	email string,
+	readAt int64,
+) error {
+	_, err := s.qe.ExecContext(
+		ctx,
+		insertAllNotificationReadsSQL,
+		email,
+		readAt,
+		int32(proto.Notification_PUBLISHED),
+	)
+	return err
 }
 
 // GetNotificationUnreadCount counts the published notifications the viewer

--- a/pkg/notification/storage/mysql/notification_test.go
+++ b/pkg/notification/storage/mysql/notification_test.go
@@ -1144,3 +1144,48 @@ func TestGetNotificationUnreadCount(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkAllNotificationsAsRead(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc        string
+		setup       func(*notificationStorage)
+		expectedErr error
+	}{
+		{
+			desc: "Error",
+			setup: func(s *notificationStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *notificationStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					insertAllNotificationReadsSQL,
+					"viewer@example.com",
+					int64(5),
+					int32(proto.Notification_PUBLISHED),
+				).Return(nil, nil)
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := &notificationStorage{qe: mock.NewMockQueryExecer(mockController)}
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.MarkAllNotificationsAsRead(context.Background(), "viewer@example.com", 5)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}

--- a/pkg/notification/storage/mysql/sql/insert_all_notification_reads.sql
+++ b/pkg/notification/storage/mysql/sql/insert_all_notification_reads.sql
@@ -1,0 +1,14 @@
+INSERT IGNORE INTO notification_read (
+    notification_id,
+    email,
+    read_at
+)
+SELECT
+    id,
+    ?,
+    ?
+FROM
+    notification
+WHERE
+    status = ? AND
+    deleted = false

--- a/pkg/notification/storage/notification.go
+++ b/pkg/notification/storage/notification.go
@@ -83,6 +83,10 @@ type NotificationStorage interface {
 	// viewer has not read, limited to notifications published after the
 	// viewer's account was created.
 	GetNotificationUnreadCount(ctx context.Context, email string) (int64, error)
+	// MarkAllNotificationsAsRead upserts read markers for every published
+	// notification for the viewer. Idempotent: already-read notifications
+	// keep their original read_at.
+	MarkAllNotificationsAsRead(ctx context.Context, email string, readAt int64) error
 }
 
 type ListDraftAdminNotificationsParams struct {

--- a/pkg/notification/storage/postgres/notification.go
+++ b/pkg/notification/storage/postgres/notification.go
@@ -60,6 +60,8 @@ var (
 	insertNotificationReadSQL string
 	//go:embed sql/count_unread_notifications.sql
 	countUnreadNotificationsSQL string
+	//go:embed sql/insert_all_notification_reads.sql
+	insertAllNotificationReadsSQL string
 )
 
 // readNotificationExistsSubquery correlates a viewer's read marker with the
@@ -563,6 +565,23 @@ func (s *notificationStorage) MarkNotificationsAsRead(
 		}
 	}
 	return nil
+}
+
+// MarkAllNotificationsAsRead upserts read markers for every published
+// notification for the viewer.
+func (s *notificationStorage) MarkAllNotificationsAsRead(
+	ctx context.Context,
+	email string,
+	readAt int64,
+) error {
+	_, err := s.qe.ExecContext(
+		ctx,
+		insertAllNotificationReadsSQL,
+		email,
+		readAt,
+		int32(proto.Notification_PUBLISHED),
+	)
+	return err
 }
 
 // GetNotificationUnreadCount counts the published notifications the viewer

--- a/pkg/notification/storage/postgres/notification_test.go
+++ b/pkg/notification/storage/postgres/notification_test.go
@@ -1174,3 +1174,48 @@ func TestGetNotificationUnreadCount(t *testing.T) {
 		})
 	}
 }
+
+func TestMarkAllNotificationsAsRead(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	patterns := []struct {
+		desc        string
+		setup       func(*notificationStorage)
+		expectedErr error
+	}{
+		{
+			desc: "Error",
+			setup: func(s *notificationStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(), gomock.Any(), gomock.Any(),
+				).Return(nil, errors.New("error"))
+			},
+			expectedErr: errors.New("error"),
+		},
+		{
+			desc: "Success",
+			setup: func(s *notificationStorage) {
+				s.qe.(*mock.MockQueryExecer).EXPECT().ExecContext(
+					gomock.Any(),
+					insertAllNotificationReadsSQL,
+					"viewer@example.com",
+					int64(5),
+					int32(proto.Notification_PUBLISHED),
+				).Return(nil, nil)
+			},
+			expectedErr: nil,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			storage := &notificationStorage{qe: mock.NewMockQueryExecer(mockController)}
+			if p.setup != nil {
+				p.setup(storage)
+			}
+			err := storage.MarkAllNotificationsAsRead(context.Background(), "viewer@example.com", 5)
+			assert.Equal(t, p.expectedErr, err)
+		})
+	}
+}

--- a/pkg/notification/storage/postgres/sql/insert_all_notification_reads.sql
+++ b/pkg/notification/storage/postgres/sql/insert_all_notification_reads.sql
@@ -1,0 +1,15 @@
+INSERT INTO notification_read (
+    notification_id,
+    email,
+    read_at
+)
+SELECT
+    id,
+    $1,
+    $2
+FROM
+    notification
+WHERE
+    status = $3 AND
+    deleted = false
+ON CONFLICT (notification_id, email) DO NOTHING

--- a/proto/notification/service.proto
+++ b/proto/notification/service.proto
@@ -23,9 +23,6 @@ import "protoc-gen-openapiv2/options/annotations.proto";
 
 import "proto/notification/notification.proto";
 
-// NOTE: request/response bodies are intentionally left empty for now; fields
-// will be filled in once the notification center design is finalized.
-
 message ListNotificationsRequest {
   enum OrderBy {
     DEFAULT = 0;


### PR DESCRIPTION
Follows #2751

## What this PR does

Implements the `MarkAllNotificationsAsRead` RPC, the last remaining stub of the notification center backend: any authenticated console user can mark every published notification as read in one call.

## Background / Why this PR is needed

The inbox's "mark all as read" action needs a bulk endpoint; looping mark_as_read from the client would be racy and slow. With this, all RFC 0047 backend APIs are implemented.

## Points

- The whole operation is a single idempotent `INSERT ... SELECT` upserting read markers for every `status = PUBLISHED AND deleted = false` notification (`INSERT IGNORE` on MySQL, `ON CONFLICT DO NOTHING` on Postgres) — no per-row loop, and existing markers keep their original `read_at`.
- The account-created bound is intentionally NOT applied here: marking literally all published notifications keeps the `read` flag consistent across every tab, while the unread count/tab remain bounded as before.
- With no stubs left, the unused `statusNotImplemented` sentinel and the proto's "intentionally left empty" NOTE are removed; no generated files change (the comment never reached them).