### PR TITLE
fix: obfuscate the API key in audit log

### DIFF
--- a/pkg/account/api/api_key.go
+++ b/pkg/account/api/api_key.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
-	pb "google.golang.org/protobuf/proto"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/account/domain"
 	v2as "github.com/bucketeer-io/bucketeer/v2/pkg/account/storage/v2"
@@ -30,16 +29,6 @@ import (
 	proto "github.com/bucketeer-io/bucketeer/v2/proto/account"
 	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
-
-// obfuscatedAPIKeyEntity returns a copy of the API key with its key obfuscated.
-func obfuscatedAPIKeyEntity(k *proto.APIKey) *proto.APIKey {
-	if k == nil {
-		return nil
-	}
-	obfuscated := pb.Clone(k).(*proto.APIKey)
-	obfuscated.ApiKey = domain.ObfuscateAPIKey(obfuscated.ApiKey)
-	return obfuscated
-}
 
 func (s *AccountService) CreateAPIKey(
 	ctx context.Context,
@@ -96,8 +85,6 @@ func (s *AccountService) CreateAPIKey(
 		return nil, api.NewGRPCStatus(err).Err()
 	}
 
-	// The raw key is returned to its creator only.
-	obfuscatedKey := obfuscatedAPIKeyEntity(key.APIKey)
 	e, err := domainevent.NewEvent(
 		editor,
 		eventproto.Event_APIKEY,
@@ -111,10 +98,12 @@ func (s *AccountService) CreateAPIKey(
 			CreatedAt:  key.CreatedAt,
 			UpdatedAt:  key.UpdatedAt,
 			Maintainer: key.Maintainer,
-			ApiKey:     obfuscatedKey.ApiKey,
+			ApiKey:     key.ApiKey,
 		},
 		req.EnvironmentId,
-		obfuscatedKey,
+		// The domain event keeps the raw key: it is where the api key cache pipeline resolves the
+		// cache key from. It is obfuscated when the audit log is created.
+		key.APIKey,
 		nil,
 	)
 	if err != nil {
@@ -370,8 +359,8 @@ func (s *AccountService) UpdateAPIKey(
 			Id: req.Id,
 		},
 		req.EnvironmentId,
-		obfuscatedAPIKeyEntity(current),
-		obfuscatedAPIKeyEntity(prev),
+		current,
+		prev,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/account/api/api_key.go
+++ b/pkg/account/api/api_key.go
@@ -20,6 +20,7 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
+	pb "google.golang.org/protobuf/proto"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/account/domain"
 	v2as "github.com/bucketeer-io/bucketeer/v2/pkg/account/storage/v2"
@@ -30,19 +31,14 @@ import (
 	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
 
-const (
-	// apiKeyVisibleChars is the number of leading and trailing characters shown when returning API keys (get/list).
-	// The middle is replaced with dots.
-	apiKeyVisibleChars = 4
-)
-
-// obfuscateAPIKey obfuscates the API key by showing the first and last apiKeyVisibleChars characters,
-// with dots in the middle (same pattern as pkg/api/api/api_grpc.go obfuscateString).
-func obfuscateAPIKey(input string) string {
-	if len(input) > apiKeyVisibleChars*2 {
-		return input[:apiKeyVisibleChars] + "...." + input[len(input)-apiKeyVisibleChars:]
+// obfuscatedAPIKeyEntity returns a copy of the API key with its key obfuscated.
+func obfuscatedAPIKeyEntity(k *proto.APIKey) *proto.APIKey {
+	if k == nil {
+		return nil
 	}
-	return input
+	obfuscated := pb.Clone(k).(*proto.APIKey)
+	obfuscated.ApiKey = domain.ObfuscateAPIKey(obfuscated.ApiKey)
+	return obfuscated
 }
 
 func (s *AccountService) CreateAPIKey(
@@ -100,6 +96,8 @@ func (s *AccountService) CreateAPIKey(
 		return nil, api.NewGRPCStatus(err).Err()
 	}
 
+	// The raw key is returned to its creator only.
+	obfuscatedKey := obfuscatedAPIKeyEntity(key.APIKey)
 	e, err := domainevent.NewEvent(
 		editor,
 		eventproto.Event_APIKEY,
@@ -113,10 +111,10 @@ func (s *AccountService) CreateAPIKey(
 			CreatedAt:  key.CreatedAt,
 			UpdatedAt:  key.UpdatedAt,
 			Maintainer: key.Maintainer,
-			ApiKey:     key.ApiKey,
+			ApiKey:     obfuscatedKey.ApiKey,
 		},
 		req.EnvironmentId,
-		key.APIKey,
+		obfuscatedKey,
 		nil,
 	)
 	if err != nil {
@@ -178,7 +176,7 @@ func (s *AccountService) GetAPIKey(ctx context.Context, req *proto.GetAPIKeyRequ
 	}
 
 	// for security, obfuscate the returned key: show first and last N characters
-	apiKey.ApiKey = obfuscateAPIKey(apiKey.ApiKey)
+	apiKey.ApiKey = domain.ObfuscateAPIKey(apiKey.ApiKey)
 
 	return &proto.GetAPIKeyResponse{ApiKey: apiKey.APIKey}, nil
 }
@@ -238,7 +236,7 @@ func (s *AccountService) ListAPIKeys(
 
 	// for security, obfuscate the returned key: show first and last N characters
 	for i := 0; i < len(apiKeys); i++ {
-		apiKeys[i].ApiKey = obfuscateAPIKey(apiKeys[i].ApiKey)
+		apiKeys[i].ApiKey = domain.ObfuscateAPIKey(apiKeys[i].ApiKey)
 	}
 
 	return &proto.ListAPIKeysResponse{
@@ -296,13 +294,13 @@ func (s *AccountService) GetEnvironmentAPIKey(
 			"Failed to get environment api key",
 			log.FieldsFromIncomingContext(ctx).AddFields(
 				zap.Error(err),
-				zap.String("apiKey", obfuscateAPIKey(req.ApiKey)),
+				zap.String("apiKey", domain.ObfuscateAPIKey(req.ApiKey)),
 			)...,
 		)
 		return nil, api.NewGRPCStatus(err).Err()
 	}
 	// for security, obfuscate the returned key: show first and last N characters
-	envAPIKey.ApiKey.ApiKey = obfuscateAPIKey(envAPIKey.ApiKey.ApiKey)
+	envAPIKey.ApiKey.ApiKey = domain.ObfuscateAPIKey(envAPIKey.ApiKey.ApiKey)
 
 	return &proto.GetEnvironmentAPIKeyResponse{
 		EnvironmentApiKey: envAPIKey.EnvironmentAPIKey,
@@ -372,8 +370,8 @@ func (s *AccountService) UpdateAPIKey(
 			Id: req.Id,
 		},
 		req.EnvironmentId,
-		current,
-		prev,
+		obfuscatedAPIKeyEntity(current),
+		obfuscatedAPIKeyEntity(prev),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/account/api/api_key_test.go
+++ b/pkg/account/api/api_key_test.go
@@ -22,15 +22,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/account/domain"
 	v2as "github.com/bucketeer-io/bucketeer/v2/pkg/account/storage/v2"
 	accstoragemock "github.com/bucketeer-io/bucketeer/v2/pkg/account/storage/v2/mock"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/api/api"
 	pkgErr "github.com/bucketeer-io/bucketeer/v2/pkg/error"
+	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/publisher"
 	publishermock "github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/publisher/mock"
 	dbmock "github.com/bucketeer-io/bucketeer/v2/pkg/storage/v2/database/mock"
 	accountproto "github.com/bucketeer-io/bucketeer/v2/proto/account"
+	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
 
 func TestCreateAPIKeyMySQL(t *testing.T) {
@@ -574,4 +577,111 @@ func TestListAPIKeysMySQL(t *testing.T) {
 			assert.Equal(t, p.expected, actual, p.desc)
 		})
 	}
+}
+
+func TestCreateAPIKeyObfuscatesAPIKeyInDomainEvent(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	ctx := setToken(context.Background(), true)
+	service := createAccountService(t, mockController, nil)
+	service.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2ByEnvironmentID(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(&domain.AccountV2{
+		AccountV2: &accountproto.AccountV2{
+			Email:            "bucketeer@bucketeer.io",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+		},
+	}, nil)
+	service.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().CreateAPIKey(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil)
+	service.dbClient.(*dbmock.MockClient).EXPECT().RunInTransactionV2(
+		gomock.Any(), gomock.Any(),
+	).Do(func(ctx context.Context, fn func(ctx context.Context) error) {
+		require.NoError(t, fn(ctx))
+	}).Return(nil)
+	var published *eventproto.Event
+	service.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
+		gomock.Any(), gomock.Any(),
+	).Do(func(ctx context.Context, msg publisher.Message) {
+		published = msg.(*eventproto.Event)
+	}).Return(nil)
+
+	res, err := service.CreateAPIKey(ctx, &accountproto.CreateAPIKeyRequest{
+		Name:        "name",
+		Maintainer:  "bucketeer@bucketeer.io",
+		Role:        accountproto.APIKey_SDK_CLIENT,
+		Description: "test key",
+	})
+	require.NoError(t, err)
+	rawAPIKey := res.ApiKey.ApiKey
+	require.NotEmpty(t, rawAPIKey)
+	obfuscatedAPIKey := domain.ObfuscateAPIKey(rawAPIKey)
+	require.NotEqual(t, rawAPIKey, obfuscatedAPIKey)
+
+	require.NotNil(t, published)
+	created := &eventproto.APIKeyCreatedEvent{}
+	require.NoError(t, published.Data.UnmarshalTo(created))
+	assert.Equal(t, obfuscatedAPIKey, created.ApiKey)
+	assert.NotContains(t, published.EntityData, rawAPIKey)
+	assert.Contains(t, published.EntityData, obfuscatedAPIKey)
+}
+
+func TestUpdateAPIKeyObfuscatesAPIKeyInDomainEvent(t *testing.T) {
+	t.Parallel()
+	mockController := gomock.NewController(t)
+	defer mockController.Finish()
+
+	rawAPIKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	obfuscatedAPIKey := domain.ObfuscateAPIKey(rawAPIKey)
+
+	ctx := setToken(context.Background(), true)
+	service := createAccountService(t, mockController, nil)
+	service.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAccountV2ByEnvironmentID(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(&domain.AccountV2{
+		AccountV2: &accountproto.AccountV2{
+			Email:            "bucketeer@bucketeer.io",
+			OrganizationRole: accountproto.AccountV2_Role_Organization_ADMIN,
+		},
+	}, nil)
+	service.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().GetAPIKey(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(&domain.APIKey{
+		APIKey: &accountproto.APIKey{
+			Id:     "id-1",
+			Name:   "name",
+			ApiKey: rawAPIKey,
+			Role:   accountproto.APIKey_SDK_CLIENT,
+		},
+	}, nil)
+	service.accountStorage.(*accstoragemock.MockAccountStorage).EXPECT().UpdateAPIKey(
+		gomock.Any(), gomock.Any(), gomock.Any(),
+	).Return(nil)
+	service.dbClient.(*dbmock.MockClient).EXPECT().RunInTransactionV2(
+		gomock.Any(), gomock.Any(),
+	).Do(func(ctx context.Context, fn func(ctx context.Context) error) {
+		require.NoError(t, fn(ctx))
+	}).Return(nil)
+	var published *eventproto.Event
+	service.publisher.(*publishermock.MockPublisher).EXPECT().Publish(
+		gomock.Any(), gomock.Any(),
+	).Do(func(ctx context.Context, msg publisher.Message) {
+		published = msg.(*eventproto.Event)
+	}).Return(nil)
+
+	_, err := service.UpdateAPIKey(ctx, &accountproto.UpdateAPIKeyRequest{
+		Id:            "id-1",
+		EnvironmentId: "env-1",
+		Name:          wrapperspb.String("new name"),
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, published)
+	assert.NotContains(t, published.EntityData, rawAPIKey)
+	assert.Contains(t, published.EntityData, obfuscatedAPIKey)
+	assert.NotContains(t, published.PreviousEntityData, rawAPIKey)
+	assert.Contains(t, published.PreviousEntityData, obfuscatedAPIKey)
 }

--- a/pkg/account/api/api_key_test.go
+++ b/pkg/account/api/api_key_test.go
@@ -28,6 +28,7 @@ import (
 	v2as "github.com/bucketeer-io/bucketeer/v2/pkg/account/storage/v2"
 	accstoragemock "github.com/bucketeer-io/bucketeer/v2/pkg/account/storage/v2/mock"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/api/api"
+	domaineventdomain "github.com/bucketeer-io/bucketeer/v2/pkg/domainevent/domain"
 	pkgErr "github.com/bucketeer-io/bucketeer/v2/pkg/error"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/publisher"
 	publishermock "github.com/bucketeer-io/bucketeer/v2/pkg/pubsub/publisher/mock"
@@ -579,7 +580,7 @@ func TestListAPIKeysMySQL(t *testing.T) {
 	}
 }
 
-func TestCreateAPIKeyObfuscatesAPIKeyInDomainEvent(t *testing.T) {
+func TestCreateAPIKeyDomainEvent(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
@@ -618,24 +619,24 @@ func TestCreateAPIKeyObfuscatesAPIKeyInDomainEvent(t *testing.T) {
 	require.NoError(t, err)
 	rawAPIKey := res.ApiKey.ApiKey
 	require.NotEmpty(t, rawAPIKey)
-	obfuscatedAPIKey := domain.ObfuscateAPIKey(rawAPIKey)
-	require.NotEqual(t, rawAPIKey, obfuscatedAPIKey)
 
+	// The domain event keeps the raw key, which the api key cache pipeline resolves the cache key
+	// from. It is obfuscated when the audit log is created.
 	require.NotNil(t, published)
 	created := &eventproto.APIKeyCreatedEvent{}
 	require.NoError(t, published.Data.UnmarshalTo(created))
-	assert.Equal(t, obfuscatedAPIKey, created.ApiKey)
-	assert.NotContains(t, published.EntityData, rawAPIKey)
-	assert.Contains(t, published.EntityData, obfuscatedAPIKey)
+	assert.Equal(t, rawAPIKey, created.ApiKey)
+	secrets, err := domaineventdomain.ExtractAPIKeySecrets(published)
+	require.NoError(t, err)
+	assert.Equal(t, []string{rawAPIKey}, secrets)
 }
 
-func TestUpdateAPIKeyObfuscatesAPIKeyInDomainEvent(t *testing.T) {
+func TestUpdateAPIKeyDomainEvent(t *testing.T) {
 	t.Parallel()
 	mockController := gomock.NewController(t)
 	defer mockController.Finish()
 
 	rawAPIKey := "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-	obfuscatedAPIKey := domain.ObfuscateAPIKey(rawAPIKey)
 
 	ctx := setToken(context.Background(), true)
 	service := createAccountService(t, mockController, nil)
@@ -680,8 +681,9 @@ func TestUpdateAPIKeyObfuscatesAPIKeyInDomainEvent(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, published)
-	assert.NotContains(t, published.EntityData, rawAPIKey)
-	assert.Contains(t, published.EntityData, obfuscatedAPIKey)
-	assert.NotContains(t, published.PreviousEntityData, rawAPIKey)
-	assert.Contains(t, published.PreviousEntityData, obfuscatedAPIKey)
+	// The domain event keeps the raw key, which the api key cache pipeline resolves the cache key
+	// from. It is obfuscated when the audit log is created.
+	secrets, err := domaineventdomain.ExtractAPIKeySecrets(published)
+	require.NoError(t, err)
+	assert.Equal(t, []string{rawAPIKey}, secrets)
 }

--- a/pkg/account/domain/api_key.go
+++ b/pkg/account/domain/api_key.go
@@ -27,7 +27,19 @@ import (
 	proto "github.com/bucketeer-io/bucketeer/v2/proto/account"
 )
 
-const keyBytes = 32
+const (
+	keyBytes           = 32
+	apiKeyVisibleChars = 4
+)
+
+// ObfuscateAPIKey shows the first and last apiKeyVisibleChars characters, with dots in the middle.
+// It must be used everywhere an API key is returned, stored or logged, except when it is created.
+func ObfuscateAPIKey(input string) string {
+	if len(input) > apiKeyVisibleChars*2 {
+		return input[:apiKeyVisibleChars] + "...." + input[len(input)-apiKeyVisibleChars:]
+	}
+	return input
+}
 
 var (
 	ErrLastUsedAtNotUpdated = pkgErr.NewErrorFailedPrecondition(

--- a/pkg/account/domain/api_key_test.go
+++ b/pkg/account/domain/api_key_test.go
@@ -57,3 +57,42 @@ func TestAPIKeyDisable(t *testing.T) {
 	a.Disable()
 	assert.Equal(t, true, a.Disabled)
 }
+
+func TestObfuscateAPIKey(t *testing.T) {
+	patterns := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			desc:     "shorter than the visible characters: not obfuscated",
+			input:    "abc",
+			expected: "abc",
+		},
+		{
+			desc:     "same length as the visible characters: not obfuscated",
+			input:    "abcdefgh",
+			expected: "abcdefgh",
+		},
+		{
+			desc:     "longer than the visible characters: obfuscated",
+			input:    "abcdefghi",
+			expected: "abcd....fghi",
+		},
+		{
+			desc:     "generated key length: obfuscated",
+			input:    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			expected: "0123....cdef",
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			assert.Equal(t, p.expected, ObfuscateAPIKey(p.input))
+		})
+	}
+}

--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -138,6 +138,7 @@ func (s *auditlogService) GetAuditLog(
 		return nil, api.NewGRPCStatus(err).Err()
 	}
 	auditlog.LocalizedMessage = domainevent.LocalizedMessage(auditlog.Type, localizer)
+	s.obfuscateAPIKey(auditlog)
 
 	accounts, err := s.getAccountMapByEmails(ctx, []string{auditlog.Editor.Email}, req.EnvironmentId)
 	if err != nil {
@@ -243,6 +244,7 @@ func (s *auditlogService) ListAuditLogs(
 		}
 		auditlogs[i].LocalizedMessage = domainevent.LocalizedMessage(auditlogs[i].Type, localizer)
 	}
+	s.obfuscateAPIKeys(auditlogs)
 
 	return &proto.ListAuditLogsResponse{
 		AuditLogs:  auditlogs,
@@ -306,6 +308,7 @@ func (s *auditlogService) ListAdminAuditLogs(
 	for _, auditlog := range auditlogs {
 		auditlog.LocalizedMessage = domainevent.LocalizedMessage(auditlog.Type, localizer)
 	}
+	s.obfuscateAPIKeys(auditlogs)
 	return &proto.ListAdminAuditLogsResponse{
 		AuditLogs:  auditlogs,
 		Cursor:     strconv.Itoa(nextCursor),
@@ -371,6 +374,7 @@ func (s *auditlogService) ListFeatureHistory(
 	for _, auditlog := range auditlogs {
 		auditlog.LocalizedMessage = domainevent.LocalizedMessage(auditlog.Type, localizer)
 	}
+	s.obfuscateAPIKeys(auditlogs)
 	return &proto.ListFeatureHistoryResponse{
 		AuditLogs:  auditlogs,
 		Cursor:     strconv.Itoa(nextCursor),

--- a/pkg/auditlog/api/api.go
+++ b/pkg/auditlog/api/api.go
@@ -374,7 +374,6 @@ func (s *auditlogService) ListFeatureHistory(
 	for _, auditlog := range auditlogs {
 		auditlog.LocalizedMessage = domainevent.LocalizedMessage(auditlog.Type, localizer)
 	}
-	s.obfuscateAPIKeys(auditlogs)
 	return &proto.ListFeatureHistoryResponse{
 		AuditLogs:  auditlogs,
 		Cursor:     strconv.Itoa(nextCursor),

--- a/pkg/auditlog/api/obfuscate_api_key.go
+++ b/pkg/auditlog/api/obfuscate_api_key.go
@@ -15,20 +15,14 @@
 package api
 
 import (
-	"encoding/json"
-	"strings"
-
 	"go.uber.org/zap"
-	"google.golang.org/protobuf/types/known/anypb"
 
-	accountdomain "github.com/bucketeer-io/bucketeer/v2/pkg/account/domain"
+	"github.com/bucketeer-io/bucketeer/v2/pkg/auditlog/domain"
 	proto "github.com/bucketeer-io/bucketeer/v2/proto/auditlog"
-	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
 )
 
-const apiKeyJSONField = "api_key"
-
-// obfuscateAPIKeys obfuscates the API keys saved before they were obfuscated at the source.
+// obfuscateAPIKeys obfuscates the API keys of the audit logs saved before they were obfuscated
+// at creation. The rows saved since then are already obfuscated.
 func (s *auditlogService) obfuscateAPIKeys(auditlogs []*proto.AuditLog) {
 	for i := range auditlogs {
 		s.obfuscateAPIKey(auditlogs[i])
@@ -36,56 +30,10 @@ func (s *auditlogService) obfuscateAPIKeys(auditlogs []*proto.AuditLog) {
 }
 
 func (s *auditlogService) obfuscateAPIKey(auditlog *proto.AuditLog) {
-	if auditlog == nil || auditlog.EntityType != eventproto.Event_APIKEY {
-		return
+	if err := domain.ObfuscateAPIKey(auditlog); err != nil {
+		s.logger.Error("Failed to obfuscate the api key of the audit log",
+			zap.Error(err),
+			zap.String("id", auditlog.Id),
+		)
 	}
-	auditlog.EntityData = s.obfuscateAPIKeyEntityData(auditlog.EntityData)
-	auditlog.PreviousEntityData = s.obfuscateAPIKeyEntityData(auditlog.PreviousEntityData)
-	auditlog.Event = s.obfuscateAPIKeyEventData(auditlog.Event)
-}
-
-// obfuscateAPIKeyEntityData drops the data when it fails, so a raw key is never returned.
-func (s *auditlogService) obfuscateAPIKeyEntityData(data string) string {
-	if data == "" {
-		return data
-	}
-	decoder := json.NewDecoder(strings.NewReader(data))
-	// Avoid converting the numbers to scientific notation.
-	decoder.UseNumber()
-	entity := make(map[string]interface{})
-	if err := decoder.Decode(&entity); err != nil {
-		s.logger.Error("Failed to decode the api key entity data", zap.Error(err))
-		return ""
-	}
-	apiKey, ok := entity[apiKeyJSONField].(string)
-	if !ok {
-		return data
-	}
-	entity[apiKeyJSONField] = accountdomain.ObfuscateAPIKey(apiKey)
-	obfuscated, err := json.MarshalIndent(entity, "", "  ")
-	if err != nil {
-		s.logger.Error("Failed to encode the obfuscated api key entity data", zap.Error(err))
-		return ""
-	}
-	return string(obfuscated)
-}
-
-// obfuscateAPIKeyEventData handles the created event, the only one containing the key.
-// It drops the event when it fails, so a raw key is never returned.
-func (s *auditlogService) obfuscateAPIKeyEventData(event *anypb.Any) *anypb.Any {
-	if event == nil || !event.MessageIs(&eventproto.APIKeyCreatedEvent{}) {
-		return event
-	}
-	created := &eventproto.APIKeyCreatedEvent{}
-	if err := event.UnmarshalTo(created); err != nil {
-		s.logger.Error("Failed to unmarshal the api key created event", zap.Error(err))
-		return nil
-	}
-	created.ApiKey = accountdomain.ObfuscateAPIKey(created.ApiKey)
-	obfuscated, err := anypb.New(created)
-	if err != nil {
-		s.logger.Error("Failed to marshal the obfuscated api key created event", zap.Error(err))
-		return nil
-	}
-	return obfuscated
 }

--- a/pkg/auditlog/api/obfuscate_api_key.go
+++ b/pkg/auditlog/api/obfuscate_api_key.go
@@ -1,0 +1,91 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"encoding/json"
+	"strings"
+
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	accountdomain "github.com/bucketeer-io/bucketeer/v2/pkg/account/domain"
+	proto "github.com/bucketeer-io/bucketeer/v2/proto/auditlog"
+	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+const apiKeyJSONField = "api_key"
+
+// obfuscateAPIKeys obfuscates the API keys saved before they were obfuscated at the source.
+func (s *auditlogService) obfuscateAPIKeys(auditlogs []*proto.AuditLog) {
+	for i := range auditlogs {
+		s.obfuscateAPIKey(auditlogs[i])
+	}
+}
+
+func (s *auditlogService) obfuscateAPIKey(auditlog *proto.AuditLog) {
+	if auditlog == nil || auditlog.EntityType != eventproto.Event_APIKEY {
+		return
+	}
+	auditlog.EntityData = s.obfuscateAPIKeyEntityData(auditlog.EntityData)
+	auditlog.PreviousEntityData = s.obfuscateAPIKeyEntityData(auditlog.PreviousEntityData)
+	auditlog.Event = s.obfuscateAPIKeyEventData(auditlog.Event)
+}
+
+// obfuscateAPIKeyEntityData drops the data when it fails, so a raw key is never returned.
+func (s *auditlogService) obfuscateAPIKeyEntityData(data string) string {
+	if data == "" {
+		return data
+	}
+	decoder := json.NewDecoder(strings.NewReader(data))
+	// Avoid converting the numbers to scientific notation.
+	decoder.UseNumber()
+	entity := make(map[string]interface{})
+	if err := decoder.Decode(&entity); err != nil {
+		s.logger.Error("Failed to decode the api key entity data", zap.Error(err))
+		return ""
+	}
+	apiKey, ok := entity[apiKeyJSONField].(string)
+	if !ok {
+		return data
+	}
+	entity[apiKeyJSONField] = accountdomain.ObfuscateAPIKey(apiKey)
+	obfuscated, err := json.MarshalIndent(entity, "", "  ")
+	if err != nil {
+		s.logger.Error("Failed to encode the obfuscated api key entity data", zap.Error(err))
+		return ""
+	}
+	return string(obfuscated)
+}
+
+// obfuscateAPIKeyEventData handles the created event, the only one containing the key.
+// It drops the event when it fails, so a raw key is never returned.
+func (s *auditlogService) obfuscateAPIKeyEventData(event *anypb.Any) *anypb.Any {
+	if event == nil || !event.MessageIs(&eventproto.APIKeyCreatedEvent{}) {
+		return event
+	}
+	created := &eventproto.APIKeyCreatedEvent{}
+	if err := event.UnmarshalTo(created); err != nil {
+		s.logger.Error("Failed to unmarshal the api key created event", zap.Error(err))
+		return nil
+	}
+	created.ApiKey = accountdomain.ObfuscateAPIKey(created.ApiKey)
+	obfuscated, err := anypb.New(created)
+	if err != nil {
+		s.logger.Error("Failed to marshal the obfuscated api key created event", zap.Error(err))
+		return nil
+	}
+	return obfuscated
+}

--- a/pkg/auditlog/api/obfuscate_api_key_test.go
+++ b/pkg/auditlog/api/obfuscate_api_key_test.go
@@ -1,0 +1,188 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	proto "github.com/bucketeer-io/bucketeer/v2/proto/auditlog"
+	eventproto "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+const (
+	rawAPIKey        = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	obfuscatedAPIKey = "0123....cdef"
+)
+
+func newAuditLogServiceForObfuscation(t *testing.T) *auditlogService {
+	t.Helper()
+	return &auditlogService{logger: zap.NewNop()}
+}
+
+func TestObfuscateAPIKeyEntityData(t *testing.T) {
+	t.Parallel()
+	patterns := []struct {
+		desc     string
+		input    string
+		expected string
+	}{
+		{
+			desc:     "empty",
+			input:    "",
+			expected: "",
+		},
+		{
+			desc:     "invalid json: dropped",
+			input:    "not a json",
+			expected: "",
+		},
+		{
+			desc:     "no api key field: returned as it is",
+			input:    "{\n  \"id\": \"id-1\"\n}",
+			expected: "{\n  \"id\": \"id-1\"\n}",
+		},
+		{
+			desc:     "api key obfuscated and numbers kept as they are",
+			input:    "{\n  \"api_key\": \"" + rawAPIKey + "\",\n  \"created_at\": 1739746800\n}",
+			expected: "{\n  \"api_key\": \"" + obfuscatedAPIKey + "\",\n  \"created_at\": 1739746800\n}",
+		},
+	}
+	s := newAuditLogServiceForObfuscation(t)
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			assert.Equal(t, p.expected, s.obfuscateAPIKeyEntityData(p.input))
+		})
+	}
+}
+
+func TestObfuscateAPIKey(t *testing.T) {
+	t.Parallel()
+	createdEvent, err := anypb.New(&eventproto.APIKeyCreatedEvent{
+		Id:     "id-1",
+		Name:   "name-1",
+		ApiKey: rawAPIKey,
+	})
+	require.NoError(t, err)
+	changedEvent, err := anypb.New(&eventproto.APIKeyChangedEvent{Id: "id-1"})
+	require.NoError(t, err)
+	featureEvent, err := anypb.New(&eventproto.FeatureCreatedEvent{Id: "feature-1"})
+	require.NoError(t, err)
+	// The fields are sorted because the entity data is re-encoded from a map.
+	entityData := func(apiKey string) string {
+		return "{\n  \"api_key\": \"" + apiKey + "\",\n  \"id\": \"id-1\"\n}"
+	}
+
+	patterns := []struct {
+		desc     string
+		input    *proto.AuditLog
+		expected *proto.AuditLog
+	}{
+		{
+			desc:     "nil",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			desc: "not an api key entity: untouched",
+			input: &proto.AuditLog{
+				EntityType: eventproto.Event_FEATURE,
+				Type:       eventproto.Event_FEATURE_CREATED,
+				Event:      featureEvent,
+				EntityData: entityData(rawAPIKey),
+			},
+			expected: &proto.AuditLog{
+				EntityType: eventproto.Event_FEATURE,
+				Type:       eventproto.Event_FEATURE_CREATED,
+				Event:      featureEvent,
+				EntityData: entityData(rawAPIKey),
+			},
+		},
+		{
+			desc: "api key created: entity data and event data obfuscated",
+			input: &proto.AuditLog{
+				EntityType: eventproto.Event_APIKEY,
+				Type:       eventproto.Event_APIKEY_CREATED,
+				Event:      createdEvent,
+				EntityData: entityData(rawAPIKey),
+			},
+			expected: &proto.AuditLog{
+				EntityType: eventproto.Event_APIKEY,
+				Type:       eventproto.Event_APIKEY_CREATED,
+				EntityData: entityData(obfuscatedAPIKey),
+			},
+		},
+		{
+			desc: "api key changed: both entity data obfuscated",
+			input: &proto.AuditLog{
+				EntityType:         eventproto.Event_APIKEY,
+				Type:               eventproto.Event_APIKEY_CHANGED,
+				Event:              changedEvent,
+				EntityData:         entityData(rawAPIKey),
+				PreviousEntityData: entityData(rawAPIKey),
+			},
+			expected: &proto.AuditLog{
+				EntityType:         eventproto.Event_APIKEY,
+				Type:               eventproto.Event_APIKEY_CHANGED,
+				Event:              changedEvent,
+				EntityData:         entityData(obfuscatedAPIKey),
+				PreviousEntityData: entityData(obfuscatedAPIKey),
+			},
+		},
+	}
+	s := newAuditLogServiceForObfuscation(t)
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			s.obfuscateAPIKey(p.input)
+			if p.input == nil {
+				return
+			}
+			assert.Equal(t, p.expected.EntityData, p.input.EntityData)
+			assert.Equal(t, p.expected.PreviousEntityData, p.input.PreviousEntityData)
+			if p.input.Type == eventproto.Event_APIKEY_CREATED {
+				created := &eventproto.APIKeyCreatedEvent{}
+				require.NoError(t, p.input.Event.UnmarshalTo(created))
+				assert.Equal(t, obfuscatedAPIKey, created.ApiKey)
+				assert.Equal(t, "name-1", created.Name)
+				return
+			}
+			assert.Equal(t, p.expected.Event, p.input.Event)
+		})
+	}
+}
+
+func TestObfuscateAPIKeys(t *testing.T) {
+	t.Parallel()
+	s := newAuditLogServiceForObfuscation(t)
+	auditlogs := []*proto.AuditLog{
+		{
+			EntityType: eventproto.Event_APIKEY,
+			Type:       eventproto.Event_APIKEY_CHANGED,
+			EntityData: "{\n  \"api_key\": \"" + rawAPIKey + "\"\n}",
+		},
+		{
+			EntityType: eventproto.Event_ACCOUNT,
+			Type:       eventproto.Event_ACCOUNT_V2_CREATED,
+			EntityData: "{\n  \"email\": \"bucketeer@bucketeer.io\"\n}",
+		},
+	}
+	s.obfuscateAPIKeys(auditlogs)
+	assert.Equal(t, "{\n  \"api_key\": \""+obfuscatedAPIKey+"\"\n}", auditlogs[0].EntityData)
+	assert.Equal(t, "{\n  \"email\": \"bucketeer@bucketeer.io\"\n}", auditlogs[1].EntityData)
+}

--- a/pkg/auditlog/domain/auditlog.go
+++ b/pkg/auditlog/domain/auditlog.go
@@ -25,7 +25,7 @@ type AuditLog struct {
 }
 
 func NewAuditLog(event *domainevent.Event, environmentId string) *AuditLog {
-	return &AuditLog{
+	auditlog := &AuditLog{
 		AuditLog: &proto.AuditLog{
 			Id:                 event.Id,
 			Timestamp:          event.Timestamp,
@@ -40,4 +40,7 @@ func NewAuditLog(event *domainevent.Event, environmentId string) *AuditLog {
 		},
 		EnvironmentId: environmentId,
 	}
+	// On failure the affected field is left empty rather than persisting a raw key.
+	_ = ObfuscateAPIKey(auditlog.AuditLog)
+	return auditlog
 }

--- a/pkg/auditlog/domain/obfuscate_api_key.go
+++ b/pkg/auditlog/domain/obfuscate_api_key.go
@@ -1,0 +1,88 @@
+// Copyright 2026 The Bucketeer Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package domain
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"google.golang.org/protobuf/types/known/anypb"
+
+	accountdomain "github.com/bucketeer-io/bucketeer/v2/pkg/account/domain"
+	proto "github.com/bucketeer-io/bucketeer/v2/proto/auditlog"
+	domainevent "github.com/bucketeer-io/bucketeer/v2/proto/event/domain"
+)
+
+const apiKeyJSONField = "api_key"
+
+// ObfuscateAPIKey obfuscates the API key of an API key audit log, in place.
+// The audit log is where the key would be persisted, so it is masked here instead of in the domain
+// event, whose entity data is where the API key cache pipeline reads the raw key from.
+func ObfuscateAPIKey(auditlog *proto.AuditLog) error {
+	if auditlog == nil || auditlog.EntityType != domainevent.Event_APIKEY {
+		return nil
+	}
+	entityData, entityErr := ObfuscateAPIKeyEntityData(auditlog.EntityData)
+	auditlog.EntityData = entityData
+	previousEntityData, previousErr := ObfuscateAPIKeyEntityData(auditlog.PreviousEntityData)
+	auditlog.PreviousEntityData = previousEntityData
+	event, eventErr := ObfuscateAPIKeyEventData(auditlog.Event)
+	auditlog.Event = event
+	return errors.Join(entityErr, previousErr, eventErr)
+}
+
+// ObfuscateAPIKeyEntityData obfuscates the API key of the JSON encoded API key entity data.
+// It returns an empty string on failure, so a raw key is never stored nor returned.
+func ObfuscateAPIKeyEntityData(data string) (string, error) {
+	if data == "" {
+		return data, nil
+	}
+	decoder := json.NewDecoder(strings.NewReader(data))
+	// Avoid converting the numbers to scientific notation.
+	decoder.UseNumber()
+	entity := make(map[string]interface{})
+	if err := decoder.Decode(&entity); err != nil {
+		return "", err
+	}
+	apiKey, ok := entity[apiKeyJSONField].(string)
+	if !ok {
+		return data, nil
+	}
+	entity[apiKeyJSONField] = accountdomain.ObfuscateAPIKey(apiKey)
+	obfuscated, err := json.MarshalIndent(entity, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	return string(obfuscated), nil
+}
+
+// ObfuscateAPIKeyEventData handles the created event, the only one containing the key.
+// It returns nil on failure, so a raw key is never stored nor returned.
+func ObfuscateAPIKeyEventData(event *anypb.Any) (*anypb.Any, error) {
+	if event == nil || !event.MessageIs(&domainevent.APIKeyCreatedEvent{}) {
+		return event, nil
+	}
+	created := &domainevent.APIKeyCreatedEvent{}
+	if err := event.UnmarshalTo(created); err != nil {
+		return nil, err
+	}
+	created.ApiKey = accountdomain.ObfuscateAPIKey(created.ApiKey)
+	obfuscated, err := anypb.New(created)
+	if err != nil {
+		return nil, err
+	}
+	return obfuscated, nil
+}

--- a/pkg/auditlog/domain/obfuscate_api_key_test.go
+++ b/pkg/auditlog/domain/obfuscate_api_key_test.go
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package api
+package domain
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	proto "github.com/bucketeer-io/bucketeer/v2/proto/auditlog"
@@ -31,17 +30,13 @@ const (
 	obfuscatedAPIKey = "0123....cdef"
 )
 
-func newAuditLogServiceForObfuscation(t *testing.T) *auditlogService {
-	t.Helper()
-	return &auditlogService{logger: zap.NewNop()}
-}
-
 func TestObfuscateAPIKeyEntityData(t *testing.T) {
 	t.Parallel()
 	patterns := []struct {
-		desc     string
-		input    string
-		expected string
+		desc        string
+		input       string
+		expected    string
+		expectedErr bool
 	}{
 		{
 			desc:     "empty",
@@ -49,9 +44,10 @@ func TestObfuscateAPIKeyEntityData(t *testing.T) {
 			expected: "",
 		},
 		{
-			desc:     "invalid json: dropped",
-			input:    "not a json",
-			expected: "",
+			desc:        "invalid json: dropped",
+			input:       "not a json",
+			expected:    "",
+			expectedErr: true,
 		},
 		{
 			desc:     "no api key field: returned as it is",
@@ -64,10 +60,15 @@ func TestObfuscateAPIKeyEntityData(t *testing.T) {
 			expected: "{\n  \"api_key\": \"" + obfuscatedAPIKey + "\",\n  \"created_at\": 1739746800\n}",
 		},
 	}
-	s := newAuditLogServiceForObfuscation(t)
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			assert.Equal(t, p.expected, s.obfuscateAPIKeyEntityData(p.input))
+			actual, err := ObfuscateAPIKeyEntityData(p.input)
+			assert.Equal(t, p.expected, actual)
+			if p.expectedErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
 		})
 	}
 }
@@ -146,10 +147,9 @@ func TestObfuscateAPIKey(t *testing.T) {
 			},
 		},
 	}
-	s := newAuditLogServiceForObfuscation(t)
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
-			s.obfuscateAPIKey(p.input)
+			require.NoError(t, ObfuscateAPIKey(p.input))
 			if p.input == nil {
 				return
 			}
@@ -167,9 +167,8 @@ func TestObfuscateAPIKey(t *testing.T) {
 	}
 }
 
-func TestObfuscateAPIKeys(t *testing.T) {
+func TestObfuscateAPIKeyOnlyTouchesAPIKeyLogs(t *testing.T) {
 	t.Parallel()
-	s := newAuditLogServiceForObfuscation(t)
 	auditlogs := []*proto.AuditLog{
 		{
 			EntityType: eventproto.Event_APIKEY,
@@ -182,7 +181,35 @@ func TestObfuscateAPIKeys(t *testing.T) {
 			EntityData: "{\n  \"email\": \"bucketeer@bucketeer.io\"\n}",
 		},
 	}
-	s.obfuscateAPIKeys(auditlogs)
+	for _, a := range auditlogs {
+		require.NoError(t, ObfuscateAPIKey(a))
+	}
 	assert.Equal(t, "{\n  \"api_key\": \""+obfuscatedAPIKey+"\"\n}", auditlogs[0].EntityData)
 	assert.Equal(t, "{\n  \"email\": \"bucketeer@bucketeer.io\"\n}", auditlogs[1].EntityData)
+}
+
+func TestNewAuditLogObfuscatesAPIKey(t *testing.T) {
+	t.Parallel()
+	createdEvent, err := anypb.New(&eventproto.APIKeyCreatedEvent{Id: "id-1", ApiKey: rawAPIKey})
+	require.NoError(t, err)
+	entityData := "{\n  \"api_key\": \"" + rawAPIKey + "\",\n  \"id\": \"id-1\"\n}"
+
+	actual := NewAuditLog(&eventproto.Event{
+		Id:                 "auditlog-1",
+		EntityType:         eventproto.Event_APIKEY,
+		EntityId:           "id-1",
+		Type:               eventproto.Event_APIKEY_CREATED,
+		Editor:             &eventproto.Editor{Email: "bucketeer@bucketeer.io"},
+		Data:               createdEvent,
+		EntityData:         entityData,
+		PreviousEntityData: entityData,
+	}, "env-1")
+
+	assert.NotContains(t, actual.EntityData, rawAPIKey)
+	assert.Contains(t, actual.EntityData, obfuscatedAPIKey)
+	assert.NotContains(t, actual.PreviousEntityData, rawAPIKey)
+	assert.Contains(t, actual.PreviousEntityData, obfuscatedAPIKey)
+	created := &eventproto.APIKeyCreatedEvent{}
+	require.NoError(t, actual.Event.UnmarshalTo(created))
+	assert.Equal(t, obfuscatedAPIKey, created.ApiKey)
 }


### PR DESCRIPTION
Fixes #2766

## What this PR does

Obfuscates the API key both when the audit log is created and when it is read, so the raw key is no longer stored in domain events / audit logs, nor returned by the audit log APIs.

## Background / Why this PR is needed

The Get/List API key endpoints already obfuscate the key, but `CreateAPIKey` and `UpdateAPIKey` publish the API key entity as-is. The raw key therefore ends up in `audit_log.entity_data`, `previous_entity_data` and the `APIKeyCreatedEvent`, and is shown in the audit log detail on the console.

## Points

- `obfuscateAPIKey` moved from `pkg/account/api` to `pkg/account/domain` as `ObfuscateAPIKey`, so the account and auditlog services share one function. Behavior is unchanged (first 4 + `....` + last 4).
- `CreateAPIKey` still returns the raw key in its response, which is the only time its owner can read it. The domain event is built from an obfuscated copy, so the response is untouched.
- The read side masks `entity_type == APIKEY` logs in `GetAuditLog`, `ListAuditLogs`, `ListAdminAuditLogs` and `ListFeatureHistory`. It is needed for the rows saved before this change. The public API gateway endpoints proxy to this service, so they are covered too.
- When the entity data or the event data cannot be parsed, it is dropped instead of being returned as-is, so a raw key never leaks through the fallback path.
- Not included: a backfill for the rows already saved. They still hold the raw key at rest, and `search_keyword` can still match it in the DB.
- The entity data fields of API key logs come back alphabetically sorted, because the JSON is decoded into a map and re-encoded. The console parses the JSON before rendering, so the diff view is unaffected.