### PR TITLE
feat(web): support reading OAuth client secret from K8s Secret

### DIFF
--- a/manifests/bucketeer/charts/web/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/web/templates/deployment.yaml
@@ -242,6 +242,13 @@ spec:
               value: "{{ .Values.env.accessTokenTTL }}"
             - name: BUCKETEER_WEB_REFRESH_TOKEN_TTL
               value: "{{ .Values.env.refreshTokenTTL }}"
+            {{- if .Values.oauth.google.clientSecretRef.name }}
+            - name: BUCKETEER_WEB_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.oauth.google.clientSecretRef.name }}"
+                  key: "{{ .Values.oauth.google.clientSecretRef.key }}"
+            {{- end }}
             {{- if .Values.env.aichat.openaiApiKeySecret.name }}
             - name: BUCKETEER_WEB_OPENAI_API_KEY
               valueFrom:

--- a/manifests/bucketeer/charts/web/values.yaml
+++ b/manifests/bucketeer/charts/web/values.yaml
@@ -131,6 +131,9 @@ oauth:
     issuer:
     clientId:
     clientSecret:
+    clientSecretRef:
+      name: ""
+      key: client-secret
     redirectUrls:
   demoSignIn:
     enabled:

--- a/pkg/web/cmd/server/server.go
+++ b/pkg/web/cmd/server/server.go
@@ -1467,9 +1467,6 @@ func (s *server) readOAuthConfig(
 		)
 		return nil, err
 	}
-	// Allow overriding the client secret from a K8s Secret via env var.
-	// This enables sourcing the secret from Secret Manager (via ESO)
-	// instead of embedding it in the oauth-config ConfigMap.
 	if secret := os.Getenv("BUCKETEER_WEB_OAUTH_CLIENT_SECRET"); secret != "" {
 		config.GoogleConfig.ClientSecret = secret
 	}

--- a/pkg/web/cmd/server/server.go
+++ b/pkg/web/cmd/server/server.go
@@ -1467,6 +1467,12 @@ func (s *server) readOAuthConfig(
 		)
 		return nil, err
 	}
+	// Allow overriding the client secret from a K8s Secret via env var.
+	// This enables sourcing the secret from Secret Manager (via ESO)
+	// instead of embedding it in the oauth-config ConfigMap.
+	if secret := os.Getenv("BUCKETEER_WEB_OAUTH_CLIENT_SECRET"); secret != "" {
+		config.GoogleConfig.ClientSecret = secret
+	}
 	return &config, nil
 }
 


### PR DESCRIPTION
## What this PR does

Add `BUCKETEER_WEB_OAUTH_CLIENT_SECRET` env var support so the Google OAuth client secret can be sourced from a K8s Secret (via External Secrets Operator) instead of being embedded in the oauth-config ConfigMap.

## Background

The web console's Google OAuth client secret is currently baked into the `web-oauth-config` ConfigMap via Helm values. To remove it from git and manage it through Secret Manager, the web server needs to accept the secret from an alternative source.

This adds:
1. An env var override in `readOAuthConfig()` — if `BUCKETEER_WEB_OAUTH_CLIENT_SECRET` is set, it overrides the value from the JSON config
2. A `clientSecretRef` option in the Helm chart values that mounts the env var from a K8s Secret via `secretKeyRef`
3. The change is backward compatible — when `clientSecretRef.name` is empty (default), behavior is unchanged

## Points

- Follows the same pattern as `openaiApiKeySecret` (existing `secretKeyRef` usage in the same Deployment template)
- No change needed to the `oauth-configmap.yaml` template — non-secret fields (clientId, redirectUrls, emailFilter) remain in the ConfigMap