### PR TITLE
fix(flaky test): use proto.Equal for gRPC status comparison in TestUpdateFeature

### DIFF
--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -3213,8 +3213,15 @@ func TestUpdateFeature(t *testing.T) {
 				require.Error(t, err)
 				expectedSt, _ := status.FromError(p.expectedErr)
 				actualSt, _ := status.FromError(err)
-				assert.True(t, proto.Equal(expectedSt.Proto(), actualSt.Proto()),
-					"expected status %v, got %v", expectedSt.Proto(), actualSt.Proto())
+				assert.Equal(t, expectedSt.Code(), actualSt.Code())
+				assert.Equal(t, expectedSt.Message(), actualSt.Message())
+				expectedDetails := expectedSt.Details()
+				actualDetails := actualSt.Details()
+				require.Equal(t, len(expectedDetails), len(actualDetails))
+				for i := range expectedDetails {
+					assert.True(t, proto.Equal(expectedDetails[i].(proto.Message), actualDetails[i].(proto.Message)),
+						"detail[%d]: expected %v, got %v", i, expectedDetails[i], actualDetails[i])
+				}
 			}
 		})
 	}

--- a/pkg/feature/api/feature_test.go
+++ b/pkg/feature/api/feature_test.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/api/api"
@@ -3206,7 +3207,15 @@ func TestUpdateFeature(t *testing.T) {
 				p.setup(service)
 			}
 			_, err := service.UpdateFeature(p.ctx, p.input)
-			assert.Equal(t, p.expectedErr, err)
+			if p.expectedErr == nil {
+				assert.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				expectedSt, _ := status.FromError(p.expectedErr)
+				actualSt, _ := status.FromError(err)
+				assert.True(t, proto.Equal(expectedSt.Proto(), actualSt.Proto()),
+					"expected status %v, got %v", expectedSt.Proto(), actualSt.Proto())
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

Fix flaky `TestUpdateFeature/fail:_variation_value_schema_violation_returns_InvalidArgument` by replacing `assert.Equal` with `proto.Equal` for gRPC status error comparison.

## Background

The test added in #2765 compares gRPC status errors using `assert.Equal`, which compares serialized proto bytes. When `ErrorInfo.Metadata` contains multiple map entries (`messageKey` + `field`), Go's non-deterministic map iteration order causes the proto serialization order to vary between runs, leading to intermittent test failures. Using `proto.Equal` performs semantic comparison that is insensitive to map field ordering.