### PR TITLE
ci: enable govet for test files in golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 version: "2"
-run:
-  tests: false
 linters:
   default: none
   enable:
@@ -36,6 +34,15 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - path: '_test\.go'
+        linters:
+          - errcheck
+          - goheader
+          - ineffassign
+          - lll
+          - staticcheck
+          - unused
 formatters:
   enable:
     - gofmt

--- a/pkg/api/api/save_api_key_last_used_at_test.go
+++ b/pkg/api/api/save_api_key_last_used_at_test.go
@@ -31,8 +31,8 @@ func TestCacheAPIKeyLastUsedAt(t *testing.T) {
 		name          string
 		apikey        *account.EnvironmentAPIKey
 		lastUsedAt    int64
-		existingCache sync.Map
-		expectedCache sync.Map
+		setupCache    func(m *sync.Map)
+		expectedCache map[string]apikeyLastUsedAt
 	}{
 		{
 			name: "new entry",
@@ -45,19 +45,14 @@ func TestCacheAPIKeyLastUsedAt(t *testing.T) {
 				},
 			},
 			lastUsedAt: 1000,
-			existingCache: func() sync.Map {
-				var m sync.Map
-				return m
-			}(),
-			expectedCache: func() sync.Map {
-				var m sync.Map
-				m.Store("key1", apikeyLastUsedAt{
+			setupCache: func(m *sync.Map) {},
+			expectedCache: map[string]apikeyLastUsedAt{
+				"key1": {
 					apiKeyID:      "key1",
 					lastUsedAt:    1000,
 					environmentID: "env1",
-				})
-				return m
-			}(),
+				},
+			},
 		},
 		{
 			name: "update existing entry with higher lastUsedAt",
@@ -70,24 +65,20 @@ func TestCacheAPIKeyLastUsedAt(t *testing.T) {
 				},
 			},
 			lastUsedAt: 2000,
-			existingCache: func() sync.Map {
-				var m sync.Map
+			setupCache: func(m *sync.Map) {
 				m.Store("key1", apikeyLastUsedAt{
 					apiKeyID:      "key1",
 					lastUsedAt:    1500,
 					environmentID: "env1",
 				})
-				return m
-			}(),
-			expectedCache: func() sync.Map {
-				var m sync.Map
-				m.Store("key1", apikeyLastUsedAt{
+			},
+			expectedCache: map[string]apikeyLastUsedAt{
+				"key1": {
 					apiKeyID:      "key1",
 					lastUsedAt:    2000,
 					environmentID: "env1",
-				})
-				return m
-			}(),
+				},
+			},
 		},
 		{
 			name: "do not update existing entry with lower lastUsedAt",
@@ -100,38 +91,27 @@ func TestCacheAPIKeyLastUsedAt(t *testing.T) {
 				},
 			},
 			lastUsedAt: 1000,
-			existingCache: func() sync.Map {
-				var m sync.Map
+			setupCache: func(m *sync.Map) {
 				m.Store("key1", apikeyLastUsedAt{
 					apiKeyID:      "key1",
 					lastUsedAt:    1500,
 					environmentID: "env1",
 				})
-				return m
-			}(),
-			expectedCache: func() sync.Map {
-				var m sync.Map
-				m.Store("key1", apikeyLastUsedAt{
+			},
+			expectedCache: map[string]apikeyLastUsedAt{
+				"key1": {
 					apiKeyID:      "key1",
 					lastUsedAt:    1500,
 					environmentID: "env1",
-				})
-				return m
-			}(),
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			service := &grpcGatewayService{
-				apiKeyLastUsedInfoCacher: tt.existingCache,
-			}
+			service := &grpcGatewayService{}
+			tt.setupCache(&service.apiKeyLastUsedInfoCacher)
 			service.cacheAPIKeyLastUsedAt(tt.apikey, tt.lastUsedAt)
-
-			listExpected := make(map[string]apikeyLastUsedAt)
-			tt.expectedCache.Range(func(key, value interface{}) bool {
-				listExpected[key.(string)] = value.(apikeyLastUsedAt)
-				return true
-			})
 
 			listActual := make(map[string]apikeyLastUsedAt)
 			service.apiKeyLastUsedInfoCacher.Range(func(key, value interface{}) bool {
@@ -139,7 +119,7 @@ func TestCacheAPIKeyLastUsedAt(t *testing.T) {
 				return true
 			})
 
-			assert.Equal(t, listExpected, listActual)
+			assert.Equal(t, tt.expectedCache, listActual)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

Remove `run.tests: false` from `.golangci.yml` and replace with per-linter exclusion rules, so that `govet` runs on test files while other linters remain excluded. Fix existing `sync.Map` value copy violation detected by the `copylocks` analyzer.

## Background

`.golangci.yml` had `run.tests: false`, which excluded all test files from all linters including `govet`. `govet` has very low false-positive rates and catches real bugs — the `copylocks` analyzer, for example, has existed since at least Go 1.21 but its violations in test files were invisible in CI.

Other linters (`errcheck`, `goheader`, `lll`, etc.) can be noisy on test files, so enabling `tests: true` globally is not ideal. golangci-lint v2 supports per-linter exclusion via `linters.exclusions.rules`, which allows enabling `govet` for tests while keeping other linters excluded.

### Verification commands

```bash
# Confirm govet detects test file issues (before the test fix)
golangci-lint run --timeout 3m0s ./pkg/api/api/...
# → 5 copylocks violations in save_api_key_last_used_at_test.go

# Confirm 0 issues after the fix
golangci-lint run --timeout 3m0s ./cmd/... ./evaluation/go/... ./pkg/... ./hack/... ./test/...
# → 0 issues

# Confirm no other govet violations exist in test files
go vet ./cmd/... ./pkg/... ./evaluation/go/...
# → 0 errors
```

## Points

- The `copylocks` issue in `save_api_key_last_used_at_test.go` predates this PR — it was never detected because test files were excluded from linting
- The test struct fields `existingCache sync.Map` / `expectedCache sync.Map` are replaced with `setupCache func(*sync.Map)` / `expectedCache map[string]apikeyLastUsedAt` to avoid value copies of `sync.Map`