### PR TITLE
feat(ui/dashboard): show selected user segments in a popover

### DIFF
--- a/ui/dashboard/src/@locales/en/common.json
+++ b/ui/dashboard/src/@locales/en/common.json
@@ -219,6 +219,8 @@
   "and": "AND",
   "or": "OR",
   "see-more": "See more",
+  "show-count-user-segments_one": "{{count}} user segment selected",
+  "show-count-user-segments_other": "{{count}} user segments selected",
   "default": "Default",
   "sort-by": "Sort by: {{sortBy}}",
   "sort-asc": "Ascending",

--- a/ui/dashboard/src/@locales/ja/common.json
+++ b/ui/dashboard/src/@locales/ja/common.json
@@ -219,6 +219,8 @@
   "and": "AND",
   "or": "OR",
   "see-more": "もっと見る",
+  "show-count-user-segments_one": "ユーザーセグメントを{{count}}件選択中",
+  "show-count-user-segments_other": "ユーザーセグメントを{{count}}件選択中",
   "default": "デフォルト",
   "sort-by": "並び替え: {{sortBy}}",
   "sort-asc": "昇順",

--- a/ui/dashboard/src/elements/rule-clauses-form/index.tsx
+++ b/ui/dashboard/src/elements/rule-clauses-form/index.tsx
@@ -26,6 +26,7 @@ import Dropdown from 'components/dropdown';
 import Form from 'components/form';
 import Icon from 'components/icon';
 import Input from 'components/input';
+import { Popover } from 'components/popover';
 import { Tooltip } from 'components/tooltip';
 import DropdownMenuWithSearch from 'elements/dropdown-with-search';
 import FeatureFlagStatus from 'elements/feature-flag-status';
@@ -494,51 +495,34 @@ const RuleClausesForm = ({
                                     }}
                                   />
                                 ) : isUserSegment ? (
-                                  <>
-                                    <Dropdown
-                                      options={segmentOptions}
-                                      multiselect
-                                      value={(value as string[]) || []}
-                                      labelCustom={
-                                        selectedSegments.length
-                                          ? truncateBySide(
-                                              selectedSegments
-                                                .map(item => item.name)
-                                                .join(', '),
-                                              50
-                                            )
-                                          : ''
-                                      }
-                                      onChange={val => {
-                                        const current =
-                                          (value as string[]) || [];
-                                        const next = current.includes(
-                                          val as string
-                                        )
-                                          ? current.filter(v => v !== val)
-                                          : [...current, val as string];
-                                        field.onChange(next);
-                                      }}
-                                      onClear={() => field.onChange([])}
-                                      placeholder={t('common:select-value')}
-                                      disabled={!segmentOptions?.length}
-                                      className="w-full [&>div>p]:truncate [&>div]:max-w-[calc(100%-36px)]"
-                                    />
-                                    {selectedSegments.length > 0 && (
-                                      <div className="flex flex-col w-full gap-y-1 mt-2">
-                                        {selectedSegments.map(item => (
-                                          <Link
-                                            key={item.id}
-                                            target="_blank"
-                                            to={`/${currentEnvironment.urlCode}${PAGE_PATH_USER_SEGMENTS}/${item.id}`}
-                                            className="typo-para-small text-primary-500 hover:underline truncate w-fit max-w-full"
-                                          >
-                                            {`${item.name} (${getSegmentSummary(item, t)})`}
-                                          </Link>
-                                        ))}
-                                      </div>
-                                    )}
-                                  </>
+                                  <Dropdown
+                                    options={segmentOptions}
+                                    multiselect
+                                    value={(value as string[]) || []}
+                                    labelCustom={
+                                      selectedSegments.length
+                                        ? truncateBySide(
+                                            selectedSegments
+                                              .map(item => item.name)
+                                              .join(', '),
+                                            50
+                                          )
+                                        : ''
+                                    }
+                                    onChange={val => {
+                                      const current = (value as string[]) || [];
+                                      const next = current.includes(
+                                        val as string
+                                      )
+                                        ? current.filter(v => v !== val)
+                                        : [...current, val as string];
+                                      field.onChange(next);
+                                    }}
+                                    onClear={() => field.onChange([])}
+                                    placeholder={t('common:select-value')}
+                                    disabled={!segmentOptions?.length}
+                                    className="w-full [&>div>p]:truncate [&>div]:max-w-[calc(100%-36px)]"
+                                  />
                                 ) : isFlag ? (
                                   <Dropdown
                                     options={variationOptions}
@@ -575,6 +559,44 @@ const RuleClausesForm = ({
                                   />
                                 )}
                               </Form.Control>
+                              {isUserSegment && selectedSegments.length > 0 && (
+                                <div className="mt-0.5">
+                                  <Popover
+                                    align="start"
+                                    trigger={
+                                      <div>
+                                        <span className="typo-para-small font-medium text-primary-500">
+                                          {t(
+                                            'common:show-count-user-segments',
+                                            {
+                                              count: selectedSegments.length
+                                            }
+                                          )}
+                                        </span>
+                                      </div>
+                                    }
+                                    triggerCls="w-fit justify-start"
+                                    className="flex flex-col w-[300px] gap-y-0.5 p-0 overflow-hidden"
+                                  >
+                                    <div className="flex flex-col gap-y-0.5 max-h-[220px] overflow-y-auto small-scroll p-2">
+                                      {selectedSegments.map(item => (
+                                        <div
+                                          key={item.id}
+                                          className="flex items-center w-full gap-x-1 rounded hover:bg-primary-50"
+                                        >
+                                          <Link
+                                            target="_blank"
+                                            to={`/${currentEnvironment.urlCode}${PAGE_PATH_USER_SEGMENTS}/${item.id}`}
+                                            className="typo-para-small text-primary-500 hover:underline truncate flex-1 min-w-0 px-1 py-1"
+                                          >
+                                            {`${item.name} (${getSegmentSummary(item, t)})`}
+                                          </Link>
+                                        </div>
+                                      ))}
+                                    </div>
+                                  </Popover>
+                                </div>
+                              )}
                               <Form.Message />
                             </Form.Item>
                           );


### PR DESCRIPTION
## Summary
RuleClausesForm (shared by Feature Flag Details → Targeting rules) showed every selected user segment as an always-expanded list of links under the segment dropdown, which took up a lot of vertical space when many segments were selected.

Replaced the inline list with a compact "N user segments selected" trigger that opens a popover listing the segments

<img width="1568" height="436" alt="image" src="https://github.com/user-attachments/assets/7cbb0b1a-322e-4f6b-ad81-31b051c45505" />
->
<img width="1014" height="351" alt="image" src="https://github.com/user-attachments/assets/fdbf5fbe-cf2a-406f-a53a-a91f93dbe0b7" />

 