### PR TITLE
feat(api): add connection-aware readiness probe for SSE

### DIFF
--- a/manifests/bucketeer/charts/api/templates/deployment.yaml
+++ b/manifests/bucketeer/charts/api/templates/deployment.yaml
@@ -200,6 +200,10 @@ spec:
             - name: BUCKETEER_API_SSE_MAX_CONNECTIONS
               value: "{{ .Values.env.sseMaxConnections }}"
             {{- end }}
+            {{- if .Values.env.sseReadinessThreshold }}
+            - name: BUCKETEER_API_SSE_READINESS_THRESHOLD
+              value: "{{ .Values.env.sseReadinessThreshold }}"
+            {{- end }}
             - name: BUCKETEER_API_SERVICE_TOKEN
               value: /usr/local/service-token/token
             - name: BUCKETEER_API_CERT

--- a/manifests/bucketeer/charts/api/values.yaml
+++ b/manifests/bucketeer/charts/api/values.yaml
@@ -71,6 +71,7 @@ env:
   cacheInvalidationTopic:
   sseHeartbeatInterval: 25s
   sseMaxConnections: 10000
+  sseReadinessThreshold: 0.95
   logLevel: info
   grpcGatewayPort: 9089
   port: 9090

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -144,7 +144,7 @@ type server struct {
 	cacheInvalidationTopic    *string
 	sseHeartbeatInterval      *time.Duration
 	sseMaxConnections         *int
-	sseReadinessThreshold    *float64
+	sseReadinessThreshold     *float64
 }
 
 func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"math"
 	"os"
 	"sync"
 	"time"
@@ -683,7 +684,11 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	healthCheckCtx, healthCheckCancel := context.WithCancel(context.Background())
 	defer healthCheckCancel()
 
-	sseReadinessLimit := int(float64(*s.sseMaxConnections) * *s.sseReadinessThreshold)
+	threshold := *s.sseReadinessThreshold
+	if threshold < 0 || threshold > 1 || math.IsNaN(threshold) {
+		return fmt.Errorf("sse-readiness-threshold must be between 0.0 and 1.0, got %v", threshold)
+	}
+	sseReadinessLimit := int(math.Ceil(float64(*s.sseMaxConnections) * threshold))
 	sseReadinessCheck := func() bool {
 		current, _ := streamDispatcher.ConnectionStatus()
 		return current < sseReadinessLimit

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -143,6 +143,7 @@ type server struct {
 	cacheInvalidationTopic    *string
 	sseHeartbeatInterval      *time.Duration
 	sseMaxConnections         *int
+	sseReadinessThreshold    *float64
 }
 
 func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
@@ -339,6 +340,9 @@ func RegisterCommand(r cli.CommandRegistry, p cli.ParentCommand) cli.Command {
 		sseMaxConnections: cmd.Flag("sse-max-connections",
 			"Maximum number of concurrent SSE connections per pod.",
 		).Default("10000").Int(),
+		sseReadinessThreshold: cmd.Flag("sse-readiness-threshold",
+			"Fraction of sse-max-connections at which the readiness probe starts failing (0.0-1.0).",
+		).Default("0.95").Float64(),
 	}
 	r.RegisterCommand(server)
 	return server
@@ -679,9 +683,15 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	healthCheckCtx, healthCheckCancel := context.WithCancel(context.Background())
 	defer healthCheckCancel()
 
+	sseReadinessLimit := int(float64(*s.sseMaxConnections) * *s.sseReadinessThreshold)
+	sseReadinessCheck := func() bool {
+		current, _ := streamDispatcher.ConnectionStatus()
+		return current < sseReadinessLimit
+	}
 	healthChecker := health.NewGrpcChecker(
 		health.WithTimeout(5*time.Second),
 		health.WithCheck("metrics", metrics.Check),
+		health.WithReadinessCheck("sse-connections", sseReadinessCheck),
 	)
 	go healthChecker.Run(healthCheckCtx)
 
@@ -729,6 +739,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 		api.Version, api.Service,
 		health.WithTimeout(5*time.Second),
 		health.WithCheck("metrics", metrics.Check),
+		health.WithReadinessCheck("sse-connections", sseReadinessCheck),
 	)
 	go restHealthChecker.Run(healthCheckCtx)
 

--- a/pkg/api/cmd/server.go
+++ b/pkg/api/cmd/server.go
@@ -690,7 +690,7 @@ func (s *server) Run(ctx context.Context, metrics metrics.Metrics, logger *zap.L
 	}
 	sseReadinessLimit := int(math.Ceil(float64(*s.sseMaxConnections) * threshold))
 	sseReadinessCheck := func() bool {
-		current, _ := streamDispatcher.ConnectionStatus()
+		current := streamDispatcher.ActiveConns()
 		return current < sseReadinessLimit
 	}
 	healthChecker := health.NewGrpcChecker(

--- a/pkg/api/stream/dispatcher.go
+++ b/pkg/api/stream/dispatcher.go
@@ -69,11 +69,11 @@ func NewDispatcher(maxConns int, fetchFeatures FeaturesFetcher, logger *zap.Logg
 	}
 }
 
-// ConnectionStatus returns the current and maximum number of SSE connections.
-func (d *Dispatcher) ConnectionStatus() (current, max int) {
+// ActiveConns returns the current number of SSE connections.
+func (d *Dispatcher) ActiveConns() int {
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	return d.totalConns, d.maxConns
+	return d.totalConns
 }
 
 // Shutdown signals all active SSE handlers to exit immediately.

--- a/pkg/api/stream/dispatcher.go
+++ b/pkg/api/stream/dispatcher.go
@@ -69,6 +69,13 @@ func NewDispatcher(maxConns int, fetchFeatures FeaturesFetcher, logger *zap.Logg
 	}
 }
 
+// ConnectionStatus returns the current and maximum number of SSE connections.
+func (d *Dispatcher) ConnectionStatus() (current, max int) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.totalConns, d.maxConns
+}
+
 // Shutdown signals all active SSE handlers to exit immediately.
 func (d *Dispatcher) Shutdown() {
 	d.shutdownOnce.Do(func() { close(d.shutdownCh) })

--- a/pkg/api/stream/dispatcher_test.go
+++ b/pkg/api/stream/dispatcher_test.go
@@ -135,30 +135,22 @@ func TestDispatcherRegisterMaxConns(t *testing.T) {
 	}
 }
 
-func TestDispatcherConnectionStatus(t *testing.T) {
+func TestDispatcherActiveConns(t *testing.T) {
 	t.Parallel()
 	d := NewDispatcher(100, nil, zap.NewNop())
-
-	cur, max := d.ConnectionStatus()
-	assert.Equal(t, 0, cur)
-	assert.Equal(t, 100, max)
+	assert.Equal(t, 0, d.ActiveConns())
 
 	_, dereg1, err := d.register("env-1", "tag-A", "src")
 	require.NoError(t, err)
 	_, dereg2, err := d.register("env-1", "tag-B", "src")
 	require.NoError(t, err)
-
-	cur, max = d.ConnectionStatus()
-	assert.Equal(t, 2, cur)
-	assert.Equal(t, 100, max)
+	assert.Equal(t, 2, d.ActiveConns())
 
 	dereg1()
-	cur, _ = d.ConnectionStatus()
-	assert.Equal(t, 1, cur)
+	assert.Equal(t, 1, d.ActiveConns())
 
 	dereg2()
-	cur, _ = d.ConnectionStatus()
-	assert.Equal(t, 0, cur)
+	assert.Equal(t, 0, d.ActiveConns())
 }
 
 func TestDispatcherRegisterSlotFreedByDeregister(t *testing.T) {

--- a/pkg/api/stream/dispatcher_test.go
+++ b/pkg/api/stream/dispatcher_test.go
@@ -135,6 +135,32 @@ func TestDispatcherRegisterMaxConns(t *testing.T) {
 	}
 }
 
+func TestDispatcherConnectionStatus(t *testing.T) {
+	t.Parallel()
+	d := NewDispatcher(100, nil, zap.NewNop())
+
+	cur, max := d.ConnectionStatus()
+	assert.Equal(t, 0, cur)
+	assert.Equal(t, 100, max)
+
+	_, dereg1, err := d.register("env-1", "tag-A", "src")
+	require.NoError(t, err)
+	_, dereg2, err := d.register("env-1", "tag-B", "src")
+	require.NoError(t, err)
+
+	cur, max = d.ConnectionStatus()
+	assert.Equal(t, 2, cur)
+	assert.Equal(t, 100, max)
+
+	dereg1()
+	cur, _ = d.ConnectionStatus()
+	assert.Equal(t, 1, cur)
+
+	dereg2()
+	cur, _ = d.ConnectionStatus()
+	assert.Equal(t, 0, cur)
+}
+
 func TestDispatcherRegisterSlotFreedByDeregister(t *testing.T) {
 	t.Parallel()
 	maxConns := 1

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -84,6 +84,9 @@ func WithTimeout(timeout time.Duration) option {
 
 func WithReadinessCheck(name string, rc ReadinessCheck) option {
 	return func(c *checker) {
+		if _, ok := c.readinessChecks[name]; ok {
+			panic(fmt.Sprintf("health: readiness check %s already registered", name))
+		}
 		c.readinessChecks[name] = rc
 	}
 }

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -45,13 +45,18 @@ func (s Status) String() string {
 
 type check func(context.Context) Status
 
+// ReadinessCheck is called synchronously on each readiness probe.
+// It returns true when the pod should accept new traffic.
+type ReadinessCheck func() bool
+
 type checker struct {
 	status  uint32
 	stopped uint32 // 0 = running, 1 = stopped
 
-	interval time.Duration
-	timeout  time.Duration
-	checks   map[string]check
+	interval        time.Duration
+	timeout         time.Duration
+	checks          map[string]check
+	readinessChecks map[string]ReadinessCheck
 }
 
 type option func(*checker)
@@ -77,12 +82,19 @@ func WithTimeout(timeout time.Duration) option {
 	}
 }
 
+func WithReadinessCheck(name string, rc ReadinessCheck) option {
+	return func(c *checker) {
+		c.readinessChecks[name] = rc
+	}
+}
+
 func newChecker(opts ...option) *checker {
 	checker := &checker{
-		status:   uint32(Unhealthy),
-		interval: 10 * time.Second,
-		timeout:  5 * time.Second,
-		checks:   make(map[string]check),
+		status:          uint32(Unhealthy),
+		interval:        10 * time.Second,
+		timeout:         5 * time.Second,
+		checks:          make(map[string]check),
+		readinessChecks: make(map[string]ReadinessCheck),
 	}
 	for _, o := range opts {
 		o(checker)
@@ -135,10 +147,15 @@ func (hc *checker) check(ctx context.Context) {
 }
 
 func (hc *checker) ServeReadyHTTP(resp http.ResponseWriter, req *http.Request) {
-	// Readiness check: return 503 if health checks fail
 	if hc.getStatus() == Unhealthy {
 		resp.WriteHeader(http.StatusServiceUnavailable)
 		return
+	}
+	for _, rc := range hc.readinessChecks {
+		if !rc() {
+			resp.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 	}
 	resp.WriteHeader(http.StatusOK)
 }

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -145,6 +145,7 @@ func TestReadinessCheckBlocksReady(t *testing.T) {
 	)
 	checker.check(context.Background())
 
+	// Success: readiness check passes -> 200
 	req := httptest.NewRequest("GET", fmt.Sprintf("%s%s%s", version, service, readyPath), nil)
 	resp := httptest.NewRecorder()
 	checker.ServeReadyHTTP(resp, req)
@@ -152,6 +153,7 @@ func TestReadinessCheckBlocksReady(t *testing.T) {
 		t.Errorf("Expected 200 when readiness check passes, got %d", resp.Code)
 	}
 
+	// Error: readiness check fails -> 503
 	ready = false
 	resp = httptest.NewRecorder()
 	checker.ServeReadyHTTP(resp, req)
@@ -183,6 +185,7 @@ func TestGRPCReadinessCheckBlocksReady(t *testing.T) {
 	)
 	checker.check(context.Background())
 
+	// Success: readiness check passes -> 200
 	req := httptest.NewRequest("GET", readyPath, nil)
 	resp := httptest.NewRecorder()
 	checker.ServeHTTP(resp, req)
@@ -190,6 +193,7 @@ func TestGRPCReadinessCheckBlocksReady(t *testing.T) {
 		t.Errorf("Expected 200 when readiness check passes, got %d", resp.Code)
 	}
 
+	// Error: readiness check fails -> 503
 	ready = false
 	resp = httptest.NewRecorder()
 	checker.ServeHTTP(resp, req)

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -137,6 +137,67 @@ func TestHTTPReadyUnhealthy(t *testing.T) {
 	}
 }
 
+func TestReadinessCheckBlocksReady(t *testing.T) {
+	t.Parallel()
+	ready := true
+	checker := NewRestChecker(version, service,
+		WithReadinessCheck("capacity", func() bool { return ready }),
+	)
+	checker.check(context.Background())
+
+	req := httptest.NewRequest("GET", fmt.Sprintf("%s%s%s", version, service, readyPath), nil)
+	resp := httptest.NewRecorder()
+	checker.ServeReadyHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected 200 when readiness check passes, got %d", resp.Code)
+	}
+
+	ready = false
+	resp = httptest.NewRecorder()
+	checker.ServeReadyHTTP(resp, req)
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected 503 when readiness check fails, got %d", resp.Code)
+	}
+}
+
+func TestReadinessCheckDoesNotAffectLiveness(t *testing.T) {
+	t.Parallel()
+	checker := NewRestChecker(version, service,
+		WithReadinessCheck("capacity", func() bool { return false }),
+	)
+	checker.check(context.Background())
+
+	req := httptest.NewRequest("GET", getTargetPath(t), nil)
+	resp := httptest.NewRecorder()
+	checker.ServeLiveHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Errorf("Liveness should not be affected by readiness check, got %d", resp.Code)
+	}
+}
+
+func TestGRPCReadinessCheckBlocksReady(t *testing.T) {
+	t.Parallel()
+	ready := true
+	checker := NewGrpcChecker(
+		WithReadinessCheck("capacity", func() bool { return ready }),
+	)
+	checker.check(context.Background())
+
+	req := httptest.NewRequest("GET", readyPath, nil)
+	resp := httptest.NewRecorder()
+	checker.ServeHTTP(resp, req)
+	if resp.Code != http.StatusOK {
+		t.Errorf("Expected 200 when readiness check passes, got %d", resp.Code)
+	}
+
+	ready = false
+	resp = httptest.NewRecorder()
+	checker.ServeHTTP(resp, req)
+	if resp.Code != http.StatusServiceUnavailable {
+		t.Errorf("Expected 503 when readiness check fails, got %d", resp.Code)
+	}
+}
+
 func TestHTTPHealthAffectedByStop(t *testing.T) {
 	t.Parallel()
 	patterns := []struct {


### PR DESCRIPTION
Part of #2152

## What this PR does

Adds a readiness-only health check that returns 503 when SSE connections reach the configured threshold (default 95% of `--sse-max-connections`). This removes the pod from Kubernetes Endpoints and GCLB NEG, stopping new connections from being routed to saturated pods while keeping existing SSE connections alive.

## Background

When a pod hits its SSE connection limit, it returns 503 but the readiness probe continues to return 200. GCLB keeps sending new connections to the saturated pod, causing 503 errors until HPA scale-out catches up. The existing Envoy circuit breaker does not detect SSE connection saturation due to HTTP/2 multiplexing.

This readiness probe reads `Dispatcher.ActiveConns()` directly to detect saturation.

Verified in dev: 1M SSE load test showed **15x reduction in 5xx rate** (867/min vs 13.3K/min baseline).

## Points

- Only affects readiness, not liveness — pod is never restarted due to high connection count
- New `--sse-readiness-threshold` flag (default: 0.95) controls the fraction at which readiness starts failing
- With `--sse-max-connections=16000` and threshold 0.95, readiness fails at 15,200 — leaving an 800-connection buffer for probe propagation delay (~3-5s)
- Helm chart updated: `sseReadinessThreshold` added to `values.yaml` and `deployment.yaml`