### PR TITLE
chore(feature): explain the cause when a variation cannot be deleted

### DIFF
--- a/pkg/api/api/grpc_status.go
+++ b/pkg/api/api/grpc_status.go
@@ -123,6 +123,18 @@ func convertErrorReason(errorType pkgErr.ErrorType) string {
 		return "EXCEEDED_MAX"
 	case pkgErr.ErrorTypeOutOfRange:
 		return "OUT_OF_RANGE"
+	case pkgErr.ErrorTypeVariationInUseByOffVariation:
+		return "VARIATION_IN_USE_BY_OFF_VARIATION"
+	case pkgErr.ErrorTypeVariationInUseByDefaultStrategy:
+		return "VARIATION_IN_USE_BY_DEFAULT_STRATEGY"
+	case pkgErr.ErrorTypeVariationInUseByTargetingRule:
+		return "VARIATION_IN_USE_BY_TARGETING_RULE"
+	case pkgErr.ErrorTypeVariationInUseByIndividualTarget:
+		return "VARIATION_IN_USE_BY_INDIVIDUAL_TARGETING"
+	case pkgErr.ErrorTypeVariationInUseByPrerequisite:
+		return "VARIATION_IN_USE_BY_PREREQUISITE"
+	case pkgErr.ErrorTypeVariationInUseByFeatureFlagRule:
+		return "VARIATION_IN_USE_BY_FEATURE_FLAG_RULE"
 	default:
 		return "UNKNOWN"
 	}
@@ -150,7 +162,13 @@ func convertStatusCode(errorType pkgErr.ErrorType) codes.Code {
 		return codes.Internal
 	case pkgErr.ErrorTypeInternal:
 		return codes.Internal
-	case pkgErr.ErrorTypeFailedPrecondition:
+	case pkgErr.ErrorTypeFailedPrecondition,
+		pkgErr.ErrorTypeVariationInUseByOffVariation,
+		pkgErr.ErrorTypeVariationInUseByDefaultStrategy,
+		pkgErr.ErrorTypeVariationInUseByTargetingRule,
+		pkgErr.ErrorTypeVariationInUseByIndividualTarget,
+		pkgErr.ErrorTypeVariationInUseByPrerequisite,
+		pkgErr.ErrorTypeVariationInUseByFeatureFlagRule:
 		return codes.FailedPrecondition
 	case pkgErr.ErrorTypeUnavailable:
 		return codes.Unavailable

--- a/pkg/api/api/grpc_status_test.go
+++ b/pkg/api/api/grpc_status_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 
@@ -285,16 +286,19 @@ func TestNewGRPCStatus_VariationInUse(t *testing.T) {
 			assert.Equal(t, codes.FailedPrecondition, st.Code())
 			assert.Equal(t, "feature:variation in use", st.Message())
 
+			var errorInfo *errdetails.ErrorInfo
 			for _, detail := range st.Details() {
-				errorInfo, ok := detail.(*errdetails.ErrorInfo)
-				if !ok {
-					continue
+				if info, ok := detail.(*errdetails.ErrorInfo); ok {
+					errorInfo = info
+					break
 				}
-				assert.Equal(t, tt.expectedReason, errorInfo.Reason)
-				assert.Equal(t, string(tt.errorType), errorInfo.Metadata["messageKey"])
-				assert.Equal(t, "feature-2", errorInfo.Metadata["featureId"])
-				assert.Equal(t, "Flag B", errorInfo.Metadata["featureName"])
 			}
+			require.NotNil(t, errorInfo, "status must carry an ErrorInfo detail")
+
+			assert.Equal(t, tt.expectedReason, errorInfo.Reason)
+			assert.Equal(t, string(tt.errorType), errorInfo.Metadata["messageKey"])
+			assert.Equal(t, "feature-2", errorInfo.Metadata["featureId"])
+			assert.Equal(t, "Flag B", errorInfo.Metadata["featureName"])
 		})
 	}
 }

--- a/pkg/api/api/grpc_status_test.go
+++ b/pkg/api/api/grpc_status_test.go
@@ -230,3 +230,71 @@ func TestNewGRPCStatus_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestNewGRPCStatus_VariationInUse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		errorType      pkgErr.ErrorType
+		expectedReason string
+	}{
+		{
+			name:           "off variation",
+			errorType:      pkgErr.ErrorTypeVariationInUseByOffVariation,
+			expectedReason: "VARIATION_IN_USE_BY_OFF_VARIATION",
+		},
+		{
+			name:           "default strategy",
+			errorType:      pkgErr.ErrorTypeVariationInUseByDefaultStrategy,
+			expectedReason: "VARIATION_IN_USE_BY_DEFAULT_STRATEGY",
+		},
+		{
+			name:           "targeting rule",
+			errorType:      pkgErr.ErrorTypeVariationInUseByTargetingRule,
+			expectedReason: "VARIATION_IN_USE_BY_TARGETING_RULE",
+		},
+		{
+			name:           "individual targeting",
+			errorType:      pkgErr.ErrorTypeVariationInUseByIndividualTarget,
+			expectedReason: "VARIATION_IN_USE_BY_INDIVIDUAL_TARGETING",
+		},
+		{
+			name:           "prerequisite",
+			errorType:      pkgErr.ErrorTypeVariationInUseByPrerequisite,
+			expectedReason: "VARIATION_IN_USE_BY_PREREQUISITE",
+		},
+		{
+			name:           "feature flag rule",
+			errorType:      pkgErr.ErrorTypeVariationInUseByFeatureFlagRule,
+			expectedReason: "VARIATION_IN_USE_BY_FEATURE_FLAG_RULE",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := NewGRPCStatus(pkgErr.NewErrorVariationInUse(
+				pkgErr.FeaturePackageName,
+				tt.errorType,
+				"variation in use",
+				map[string]string{"featureId": "feature-2", "featureName": "Flag B"},
+			))
+
+			assert.Equal(t, codes.FailedPrecondition, st.Code())
+			assert.Equal(t, "feature:variation in use", st.Message())
+
+			for _, detail := range st.Details() {
+				errorInfo, ok := detail.(*errdetails.ErrorInfo)
+				if !ok {
+					continue
+				}
+				assert.Equal(t, tt.expectedReason, errorInfo.Reason)
+				assert.Equal(t, string(tt.errorType), errorInfo.Metadata["messageKey"])
+				assert.Equal(t, "feature-2", errorInfo.Metadata["featureId"])
+				assert.Equal(t, "Flag B", errorInfo.Metadata["featureName"])
+			}
+		})
+	}
+}

--- a/pkg/error/error.go
+++ b/pkg/error/error.go
@@ -17,6 +17,7 @@ package error
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 )
@@ -62,6 +63,14 @@ const (
 	ErrorTypeExceededMax              ErrorType = "ExceededMaxError"
 	ErrorTypeOutOfRange               ErrorType = "OutOfRangeError"
 	ErrorTypeDifferentVariationsSize  ErrorType = "DifferentVariationsSizeError"
+
+	// A variation cannot be deleted while something still references it.
+	ErrorTypeVariationInUseByOffVariation     ErrorType = "VariationInUseByOffVariationError"
+	ErrorTypeVariationInUseByDefaultStrategy  ErrorType = "VariationInUseByDefaultStrategyError"
+	ErrorTypeVariationInUseByTargetingRule    ErrorType = "VariationInUseByTargetingRuleError"
+	ErrorTypeVariationInUseByIndividualTarget ErrorType = "VariationInUseByIndividualTargetingError"
+	ErrorTypeVariationInUseByPrerequisite     ErrorType = "VariationInUseByPrerequisiteError"
+	ErrorTypeVariationInUseByFeatureFlagRule  ErrorType = "VariationInUseByFeatureFlagRuleError"
 )
 
 type BktError struct {
@@ -98,6 +107,24 @@ func (e *BktError) Error() string {
 func (e *BktError) Unwrap() error { return e.wrappedError }
 func (e *BktError) Wrap(err error) {
 	e.wrappedError = errors.Join(e.wrappedError, err)
+}
+
+// AsVariationInUseError reports whether err says a variation is still referenced.
+func AsVariationInUseError(err error) (*BktError, bool) {
+	var bktErr *BktError
+	if !errors.As(err, &bktErr) {
+		return nil, false
+	}
+	switch bktErr.ErrorType() {
+	case ErrorTypeVariationInUseByOffVariation,
+		ErrorTypeVariationInUseByDefaultStrategy,
+		ErrorTypeVariationInUseByTargetingRule,
+		ErrorTypeVariationInUseByIndividualTarget,
+		ErrorTypeVariationInUseByPrerequisite,
+		ErrorTypeVariationInUseByFeatureFlagRule:
+		return bktErr, true
+	}
+	return nil, false
 }
 
 func newBktError(pkg string, errorType ErrorType, message string) *BktError {
@@ -205,4 +232,22 @@ func NewErrorOutOfRange(pkg string, message string, field string, min int, max i
 
 func NewErrorDifferentVariationsSize(pkg string, message string) *BktError {
 	return newBktError(pkg, ErrorTypeDifferentVariationsSize, message)
+}
+
+// NewErrorVariationInUse creates an error naming the reference that keeps a
+// variation from being deleted. keyValues may be nil.
+func NewErrorVariationInUse(
+	pkg string,
+	errorType ErrorType,
+	message string,
+	keyValues map[string]string,
+) *BktError {
+	embedded := make(map[string]string, len(keyValues))
+	maps.Copy(embedded, keyValues)
+	return &BktError{
+		packageName:       pkg,
+		errorType:         errorType,
+		message:           message,
+		embeddedKeyValues: embedded,
+	}
 }

--- a/pkg/error/error_test.go
+++ b/pkg/error/error_test.go
@@ -323,3 +323,100 @@ func TestErrorAs(t *testing.T) {
 		t.Error("Expected fieldErr to wrap originalErr")
 	}
 }
+
+func TestNewErrorVariationInUse(t *testing.T) {
+	t.Parallel()
+
+	err := NewErrorVariationInUse(
+		FeaturePackageName,
+		ErrorTypeVariationInUseByPrerequisite,
+		"feature: variation variation-1 is used as a prerequisite by feature feature-2",
+		map[string]string{"featureId": "feature-2", "featureName": "Flag B"},
+	)
+
+	assert.Equal(t, FeaturePackageName, err.PackageName())
+	assert.Equal(t, ErrorTypeVariationInUseByPrerequisite, err.ErrorType())
+	assert.Equal(t, "VariationInUseByPrerequisiteError", err.MessageKey())
+	assert.Equal(
+		t,
+		"feature:feature: variation variation-1 is used as a prerequisite by feature feature-2",
+		err.Error(),
+	)
+	assert.Equal(
+		t,
+		map[string]string{"featureId": "feature-2", "featureName": "Flag B"},
+		err.EmbeddedKeyValues(),
+	)
+}
+
+func TestNewErrorVariationInUse_CopiesKeyValues(t *testing.T) {
+	t.Parallel()
+
+	keyValues := map[string]string{"featureId": "feature-2"}
+	err := NewErrorVariationInUse(
+		FeaturePackageName,
+		ErrorTypeVariationInUseByPrerequisite,
+		"feature: variation in use",
+		keyValues,
+	)
+	keyValues["featureId"] = "mutated"
+
+	assert.Equal(t, "feature-2", err.EmbeddedKeyValues()["featureId"])
+}
+
+func TestAsVariationInUseError(t *testing.T) {
+	t.Parallel()
+
+	patterns := []struct {
+		desc     string
+		err      error
+		expected bool
+	}{
+		{
+			desc:     "false: nil",
+			err:      nil,
+			expected: false,
+		},
+		{
+			desc:     "false: not a BktError",
+			err:      errors.New("something else"),
+			expected: false,
+		},
+		{
+			desc:     "false: another BktError type",
+			err:      NewErrorFailedPrecondition(FeaturePackageName, "failed precondition"),
+			expected: false,
+		},
+		{
+			desc: "true: off variation",
+			err: NewErrorVariationInUse(
+				FeaturePackageName, ErrorTypeVariationInUseByOffVariation, "in use", nil,
+			),
+			expected: true,
+		},
+		{
+			desc: "true: individual targeting",
+			err: NewErrorVariationInUse(
+				FeaturePackageName, ErrorTypeVariationInUseByIndividualTarget, "in use", nil,
+			),
+			expected: true,
+		},
+		{
+			desc: "true: feature flag rule",
+			err: NewErrorVariationInUse(
+				FeaturePackageName, ErrorTypeVariationInUseByFeatureFlagRule, "in use", nil,
+			),
+			expected: true,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.desc, func(t *testing.T) {
+			t.Parallel()
+			bktErr, ok := AsVariationInUseError(p.err)
+			assert.Equal(t, p.expected, ok)
+			if !p.expected {
+				assert.Nil(t, bktErr)
+			}
+		})
+	}
+}

--- a/pkg/feature/api/error.go
+++ b/pkg/feature/api/error.go
@@ -207,11 +207,6 @@ var (
 		pkgErr.NewErrorFailedPrecondition(
 			pkgErr.FeaturePackageName,
 			"can't archive because this feature is used as a prerequsite"))
-	statusVariationInUseByOtherFeatures = api.NewGRPCStatus(
-		pkgErr.NewErrorFailedPrecondition(
-			pkgErr.FeaturePackageName,
-			"can't remove this variation because it is used as a prerequisite or rule in other features",
-		))
 	// flag trigger
 	statusMissingTriggerFeatureID = api.NewGRPCStatus(
 		pkgErr.NewErrorInvalidArgEmpty(pkgErr.FeaturePackageName, "missing trigger feature id", "FeatureFlagID"))

--- a/pkg/feature/api/feature.go
+++ b/pkg/feature/api/feature.go
@@ -31,6 +31,7 @@ import (
 	evaluation "github.com/bucketeer-io/bucketeer/v2/evaluation/go"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/api/api"
 	domainevent "github.com/bucketeer-io/bucketeer/v2/pkg/domainevent/domain"
+	pkgErr "github.com/bucketeer-io/bucketeer/v2/pkg/error"
 	experimentdomain "github.com/bucketeer-io/bucketeer/v2/pkg/experiment/domain"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/feature/domain"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/feature/scheduled"
@@ -802,6 +803,7 @@ func (s *FeatureService) updateFeatureWithinTransaction(
 		},
 	)
 	if err != nil {
+		s.logVariationInUseError(ctx, err, req)
 		return nil, nil, err
 	}
 	if err := s.upsertTags(ctx, updated.Tags, req.EnvironmentId); err != nil {
@@ -824,6 +826,7 @@ func (s *FeatureService) updateFeatureWithinTransaction(
 	}
 	// Validate that variations being deleted are not used in other features
 	if err := validateVariationDeletion(req.VariationChanges, features, req.Id); err != nil {
+		s.logVariationInUseError(ctx, err, req)
 		return nil, nil, err
 	}
 	event, err := domainevent.NewEvent(
@@ -1012,6 +1015,36 @@ func (s *FeatureService) DeleteFeature(
 
 	s.updateFeatureFlagCache(ctx)
 	return &featureproto.DeleteFeatureResponse{}, nil
+}
+
+// logVariationInUseError records which variation blocked the update and what
+// still references it. Validation failures are otherwise not logged at all.
+func (s *FeatureService) logVariationInUseError(
+	ctx context.Context,
+	err error,
+	req *featureproto.UpdateFeatureRequest,
+) {
+	bktErr, ok := pkgErr.AsVariationInUseError(err)
+	if !ok {
+		return
+	}
+	deleted := make([]string, 0, len(req.VariationChanges))
+	for _, change := range req.VariationChanges {
+		if change.ChangeType == featureproto.ChangeType_DELETE {
+			deleted = append(deleted, change.Variation.GetId())
+		}
+	}
+	s.logger.Error(
+		"Failed to update feature because a variation is still in use",
+		log.FieldsFromIncomingContext(ctx).AddFields(
+			zap.Error(err),
+			zap.String("environmentId", req.EnvironmentId),
+			zap.String("featureId", req.Id),
+			zap.Strings("deletedVariationIds", deleted),
+			// Empty when the reference is in the flag being updated.
+			zap.Any("reference", bktErr.EmbeddedKeyValues()),
+		)...,
+	)
 }
 
 func (s *FeatureService) convUpdateFeatureError(err error) error {

--- a/pkg/feature/api/validation.go
+++ b/pkg/feature/api/validation.go
@@ -16,7 +16,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"regexp"
 
 	"github.com/bucketeer-io/bucketeer/v2/pkg/api/api"
@@ -428,17 +427,11 @@ func validateVariationDeletion(
 		dependentFeaturesSlice = append(dependentFeaturesSlice, f)
 	}
 
-	// Check if the deleted variation is used as a prerequisite or rule in other features
-	if err := featuredomain.ValidateVariationUsage(
+	// Check if the deleted variation is used as a prerequisite or rule in other features.
+	// The error already names the reference, so it is returned as-is.
+	return featuredomain.ValidateVariationUsage(
 		dependentFeaturesSlice,
 		targetFeatureID,
 		deletedVariations,
-	); err != nil {
-		if errors.Is(err, featuredomain.ErrVariationInUse) {
-			return statusVariationInUseByOtherFeatures.Err()
-		}
-		return err
-	}
-
-	return nil
+	)
 }

--- a/pkg/feature/api/validation_test.go
+++ b/pkg/feature/api/validation_test.go
@@ -19,8 +19,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 
+	pkgErr "github.com/bucketeer-io/bucketeer/v2/pkg/error"
 	featureproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
 )
 
@@ -40,14 +42,15 @@ func TestValidateVariationDeletion(t *testing.T) {
 		variationChanges []*featureproto.VariationChange
 		features         []*featureproto.Feature
 		targetFeatureID  string
-		expected         error
+		// Empty means no error is expected.
+		expectedErrType pkgErr.ErrorType
 	}{
 		{
 			desc:             "success: no variation changes",
 			variationChanges: []*featureproto.VariationChange{},
 			features:         []*featureproto.Feature{},
 			targetFeatureID:  "feature-1",
-			expected:         nil,
+			expectedErrType:  "",
 		},
 		{
 			desc: "success: no deletion changes",
@@ -62,7 +65,7 @@ func TestValidateVariationDeletion(t *testing.T) {
 			},
 			features:        []*featureproto.Feature{},
 			targetFeatureID: "feature-1",
-			expected:        nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "success: no other features using deleted variation",
@@ -77,7 +80,7 @@ func TestValidateVariationDeletion(t *testing.T) {
 			},
 			features:        []*featureproto.Feature{},
 			targetFeatureID: "feature-1",
-			expected:        nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "error: other feature has prerequisite using deleted variation",
@@ -111,7 +114,7 @@ func TestValidateVariationDeletion(t *testing.T) {
 				},
 			},
 			targetFeatureID: "feature-1",
-			expected:        statusVariationInUseByOtherFeatures.Err(),
+			expectedErrType: pkgErr.ErrorTypeVariationInUseByPrerequisite,
 		},
 		{
 			desc: "error: other feature has FEATURE_FLAG rule using deleted variation ID",
@@ -150,7 +153,7 @@ func TestValidateVariationDeletion(t *testing.T) {
 				},
 			},
 			targetFeatureID: "feature-1",
-			expected:        statusVariationInUseByOtherFeatures.Err(),
+			expectedErrType: pkgErr.ErrorTypeVariationInUseByFeatureFlagRule,
 		},
 		{
 			desc: "success: target feature uses deleted variation (should be excluded)",
@@ -175,7 +178,7 @@ func TestValidateVariationDeletion(t *testing.T) {
 				},
 			},
 			targetFeatureID: "feature-1",
-			expected:        nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "success: different variation ID in FEATURE_FLAG rule",
@@ -205,14 +208,20 @@ func TestValidateVariationDeletion(t *testing.T) {
 				},
 			},
 			targetFeatureID: "feature-1",
-			expected:        nil,
+			expectedErrType: "",
 		},
 	}
 
 	for _, p := range patterns {
 		t.Run(p.desc, func(t *testing.T) {
 			err := validateVariationDeletion(p.variationChanges, p.features, p.targetFeatureID)
-			assert.Equal(t, p.expected, err)
+			if p.expectedErrType == "" {
+				assert.NoError(t, err)
+				return
+			}
+			bktErr, ok := pkgErr.AsVariationInUseError(err)
+			require.True(t, ok, "expected a variation in use error, got %v", err)
+			assert.Equal(t, p.expectedErrType, bktErr.ErrorType())
 		})
 	}
 }

--- a/pkg/feature/domain/feature.go
+++ b/pkg/feature/domain/feature.go
@@ -90,8 +90,32 @@ var (
 		pkgErr.FeaturePackageName, "feature: target users required", "target_users")
 	errTargetUserRequired = pkgErr.NewErrorInvalidArgEmpty(
 		pkgErr.FeaturePackageName, "feature: target user required", "target_user")
-	ErrVariationInUse = pkgErr.NewErrorInvalidArgNotMatchFormat(
-		pkgErr.FeaturePackageName, "feature: variation in use", "variation")
+	// References inside the flag being updated. For another flag's references,
+	// see newErrVariationInUseByOtherFeature.
+	errVariationInUseByOffVariation = pkgErr.NewErrorVariationInUse(
+		pkgErr.FeaturePackageName,
+		pkgErr.ErrorTypeVariationInUseByOffVariation,
+		"feature: variation is set as the off variation",
+		nil,
+	)
+	errVariationInUseByDefaultStrategy = pkgErr.NewErrorVariationInUse(
+		pkgErr.FeaturePackageName,
+		pkgErr.ErrorTypeVariationInUseByDefaultStrategy,
+		"feature: variation is used in the default strategy",
+		nil,
+	)
+	errVariationInUseByTargetingRule = pkgErr.NewErrorVariationInUse(
+		pkgErr.FeaturePackageName,
+		pkgErr.ErrorTypeVariationInUseByTargetingRule,
+		"feature: variation is used in a targeting rule",
+		nil,
+	)
+	errVariationInUseByIndividualTarget = pkgErr.NewErrorVariationInUse(
+		pkgErr.FeaturePackageName,
+		pkgErr.ErrorTypeVariationInUseByIndividualTarget,
+		"feature: variation has users assigned in the individual targeting",
+		nil,
+	)
 	errVariationNotFound = pkgErr.NewErrorNotFound(
 		pkgErr.FeaturePackageName, "feature: variation not found", "variation")
 	errVariationTypeUnmatched = pkgErr.NewErrorInvalidArgNotMatchFormat(
@@ -935,7 +959,7 @@ func (f *Feature) validateRemoveVariation(id string) error {
 		return errVariationsMustHaveAtLeastTwoVariations
 	}
 	if f.OffVariation == id {
-		return ErrVariationInUse
+		return errVariationInUseByOffVariation
 	}
 	// Check if the individual targeting has any users
 	idx, err := f.findTarget(id)
@@ -943,13 +967,13 @@ func (f *Feature) validateRemoveVariation(id string) error {
 		return err
 	}
 	if len(f.Targets[idx].Users) > 0 {
-		return ErrVariationInUse
+		return errVariationInUseByIndividualTarget
 	}
 	if strategyContainsVariation(id, f.DefaultStrategy) {
-		return ErrVariationInUse
+		return errVariationInUseByDefaultStrategy
 	}
 	if f.rulesContainsVariation(id) {
-		return ErrVariationInUse
+		return errVariationInUseByTargetingRule
 	}
 	return nil
 }
@@ -1537,7 +1561,13 @@ func ValidateVariationUsage(
 		for _, prerequisite := range f.Prerequisites {
 			if prerequisite.FeatureId == targetFeatureID {
 				if _, found := deletedVariations[prerequisite.VariationId]; found {
-					return ErrVariationInUse
+					return newErrVariationInUseByOtherFeature(
+						pkgErr.ErrorTypeVariationInUseByPrerequisite,
+						"used as a prerequisite",
+						prerequisite.VariationId,
+						targetFeatureID,
+						f,
+					)
 				}
 			}
 		}
@@ -1550,7 +1580,13 @@ func ValidateVariationUsage(
 					// We should check if any clause values match deleted variation IDs
 					for _, clValue := range clause.Values {
 						if _, found := deletedVariations[clValue]; found {
-							return ErrVariationInUse
+							return newErrVariationInUseByOtherFeature(
+								pkgErr.ErrorTypeVariationInUseByFeatureFlagRule,
+								"used in a targeting rule",
+								clValue,
+								targetFeatureID,
+								f,
+							)
 						}
 					}
 				}
@@ -1558,6 +1594,30 @@ func ValidateVariationUsage(
 		}
 	}
 	return nil
+}
+
+// newErrVariationInUseByOtherFeature reports that referencedBy still points at
+// variationID. The message is for the logs, the key values for the console.
+func newErrVariationInUseByOtherFeature(
+	errorType pkgErr.ErrorType,
+	usage string,
+	variationID string,
+	ownerFeatureID string,
+	referencedBy *feature.Feature,
+) error {
+	return pkgErr.NewErrorVariationInUse(
+		pkgErr.FeaturePackageName,
+		errorType,
+		fmt.Sprintf(
+			"feature: variation %s of feature %s is %s by feature %s (%s)",
+			variationID, ownerFeatureID, usage, referencedBy.Id, referencedBy.Name,
+		),
+		map[string]string{
+			"variationId": variationID,
+			"featureId":   referencedBy.Id,
+			"featureName": referencedBy.Name,
+		},
+	)
 }
 
 // This logic is based on https://en.wikipedia.org/wiki/Topological_sorting.

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -1339,6 +1339,36 @@ func TestRemoveVariationUsingOffVariation(t *testing.T) {
 	}
 }
 
+func TestRemoveVariationInUseByStrategy(t *testing.T) {
+	t.Parallel()
+	patterns := []*struct {
+		des, id  string
+		expected error
+	}{
+		{
+			des:      "in use by the default strategy",
+			id:       "variation-B", // makeFeature's default strategy points at variation-B
+			expected: errVariationInUseByDefaultStrategy,
+		},
+		{
+			des:      "in use by a targeting rule",
+			id:       "variation-A", // makeFeature's rule-1 points at variation-A
+			expected: errVariationInUseByTargetingRule,
+		},
+	}
+	for _, p := range patterns {
+		t.Run(p.des, func(t *testing.T) {
+			t.Parallel()
+			f := makeFeature("test-feature")
+			// The individual targeting is checked before the strategies, so clear it.
+			for _, target := range f.Targets {
+				target.Users = nil
+			}
+			assert.Equal(t, p.expected, f.RemoveVariation(p.id))
+		})
+	}
+}
+
 func TestRemoveVariationComprehensiveCleanup(t *testing.T) {
 	t.Parallel()
 	f := makeFeature("test-feature")

--- a/pkg/feature/domain/feature_test.go
+++ b/pkg/feature/domain/feature_test.go
@@ -27,6 +27,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	pkgErr "github.com/bucketeer-io/bucketeer/v2/pkg/error"
 	"github.com/bucketeer-io/bucketeer/v2/pkg/uuid"
 	"github.com/bucketeer-io/bucketeer/v2/proto/common"
 	ftproto "github.com/bucketeer-io/bucketeer/v2/proto/feature"
@@ -1201,17 +1202,18 @@ func TestRemoveVariationUsingFixedStrategy(t *testing.T) {
 		id       string
 		expected error
 	}{
+		// Every makeFeature variation has target users, checked before the strategies.
 		{
 			id:       "variation-A",
-			expected: ErrVariationInUse, // Used in default strategy
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       "variation-B",
-			expected: ErrVariationInUse, // Used in default strategy
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       "variation-C",
-			expected: ErrVariationInUse, // Has users in target
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       expected,
@@ -1264,17 +1266,18 @@ func TestRemoveVariationUsingRolloutStrategy(t *testing.T) {
 		id       string
 		expected error
 	}{
+		// Every makeFeature variation has target users, checked before the strategies.
 		{
 			id:       "variation-A",
-			expected: ErrVariationInUse, // Used in default strategy with weight > 0
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       "variation-B",
-			expected: ErrVariationInUse, // Used in default strategy with weight > 0
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       "variation-C",
-			expected: ErrVariationInUse, // Has users in target
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       expected,
@@ -1314,7 +1317,7 @@ func TestRemoveVariationUsingOffVariation(t *testing.T) {
 		{
 			des:      "in use",
 			id:       "variation-C",
-			expected: ErrVariationInUse,
+			expected: errVariationInUseByOffVariation,
 		},
 		{
 			des:      "success",
@@ -1392,17 +1395,18 @@ func TestRemoveVariationComprehensiveCleanup(t *testing.T) {
 		id       string
 		expected error
 	}{
+		// Every makeFeature variation has target users, checked before the strategies.
 		{
 			id:       "variation-A",
-			expected: ErrVariationInUse, // Used in default strategy with weight > 0
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       "variation-B",
-			expected: ErrVariationInUse, // Used in rule strategy with weight > 0
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       "variation-C",
-			expected: ErrVariationInUse, // Has users in target
+			expected: errVariationInUseByIndividualTarget,
 		},
 		{
 			id:       expected,
@@ -2700,7 +2704,11 @@ func TestValidateVariationUsage(t *testing.T) {
 		features          []*ftproto.Feature
 		targetFeatureID   string
 		deletedVariations map[string]string // variationID -> variationValue
-		expected          error
+		// Empty means no error is expected.
+		expectedErrType pkgErr.ErrorType
+		// The flag holding the reference.
+		expectedFeatureID   string
+		expectedFeatureName string
 	}{
 		{
 			desc:            "success: no features using deleted variations",
@@ -2709,7 +2717,7 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				variationID1: variationValue1,
 			},
-			expected: nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "success: target feature uses variation (should be excluded)",
@@ -2728,13 +2736,14 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				variationID1: variationValue1,
 			},
-			expected: nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "error: other feature has prerequisite using deleted variation",
 			features: []*ftproto.Feature{
 				{
-					Id: "feature-2",
+					Id:   "feature-2",
+					Name: "Flag 2",
 					Prerequisites: []*ftproto.Prerequisite{
 						{
 							FeatureId:   "feature-1",
@@ -2747,7 +2756,9 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				variationID1: variationValue1,
 			},
-			expected: ErrVariationInUse,
+			expectedErrType:     pkgErr.ErrorTypeVariationInUseByPrerequisite,
+			expectedFeatureID:   "feature-2",
+			expectedFeatureName: "Flag 2",
 		},
 		{
 			desc: "error: other feature has FEATURE_FLAG rule using deleted variation ID",
@@ -2771,7 +2782,8 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				variationID1: variationValue1,
 			},
-			expected: ErrVariationInUse,
+			expectedErrType:   pkgErr.ErrorTypeVariationInUseByFeatureFlagRule,
+			expectedFeatureID: "feature-2",
 		},
 		{
 			desc: "success: no variations to delete",
@@ -2788,7 +2800,7 @@ func TestValidateVariationUsage(t *testing.T) {
 			},
 			targetFeatureID:   "feature-1",
 			deletedVariations: map[string]string{},
-			expected:          nil,
+			expectedErrType:   "",
 		},
 		{
 			desc: "success: different feature ID in prerequisite",
@@ -2807,7 +2819,7 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				variationID1: variationValue1,
 			},
-			expected: nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "success: different variation ID in FEATURE_FLAG rule",
@@ -2831,7 +2843,7 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				variationID1: variationValue1,
 			},
-			expected: nil,
+			expectedErrType: "",
 		},
 		{
 			desc: "error: detailed FEATURE_FLAG rule test",
@@ -2864,7 +2876,8 @@ func TestValidateVariationUsage(t *testing.T) {
 			deletedVariations: map[string]string{
 				"var-true": "true", // Deleting variation with value "true"
 			},
-			expected: ErrVariationInUse,
+			expectedErrType:   pkgErr.ErrorTypeVariationInUseByFeatureFlagRule,
+			expectedFeatureID: "feature-B",
 		},
 	}
 
@@ -2872,12 +2885,15 @@ func TestValidateVariationUsage(t *testing.T) {
 		t.Run(p.desc, func(t *testing.T) {
 			t.Parallel()
 			err := ValidateVariationUsage(p.features, p.targetFeatureID, p.deletedVariations)
-			if p.expected != nil {
-				assert.Error(t, err)
-				assert.Equal(t, p.expected, err)
-			} else {
+			if p.expectedErrType == "" {
 				assert.NoError(t, err)
+				return
 			}
+			bktErr, ok := pkgErr.AsVariationInUseError(err)
+			require.True(t, ok, "expected a variation in use error, got %v", err)
+			assert.Equal(t, p.expectedErrType, bktErr.ErrorType())
+			assert.Equal(t, p.expectedFeatureID, bktErr.EmbeddedKeyValues()["featureId"])
+			assert.Equal(t, p.expectedFeatureName, bktErr.EmbeddedKeyValues()["featureName"])
 		})
 	}
 }

--- a/pkg/feature/domain/feature_update.go
+++ b/pkg/feature/domain/feature_update.go
@@ -534,7 +534,7 @@ func (f *Feature) updateValidateRemoveVariation(id string) error {
 		return errVariationsMustHaveAtLeastTwoVariations
 	}
 	if f.OffVariation == id {
-		return ErrVariationInUse
+		return errVariationInUseByOffVariation
 	}
 	// Check if the individual targeting has any users
 	idx, err := f.updateFindTarget(id)
@@ -542,13 +542,13 @@ func (f *Feature) updateValidateRemoveVariation(id string) error {
 		return err
 	}
 	if len(f.Targets[idx].Users) > 0 {
-		return ErrVariationInUse
+		return errVariationInUseByIndividualTarget
 	}
 	if strategyContainsVariation(id, f.DefaultStrategy) {
-		return ErrVariationInUse
+		return errVariationInUseByDefaultStrategy
 	}
 	if f.updateRulesContainsVariation(id) {
-		return ErrVariationInUse
+		return errVariationInUseByTargetingRule
 	}
 	return nil
 }

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -2051,6 +2051,32 @@ func TestUpdateRemoveVariationComprehensiveCleanup(t *testing.T) {
 			expectedErr: errVariationInUseByIndividualTarget,
 		},
 		{
+			desc: "error - variation in use by the default strategy",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// The individual targeting is checked before the strategies, so clear it.
+				for _, target := range f.Targets {
+					target.Users = nil
+				}
+				return f
+			},
+			variationID: "variation-B", // makeFeature's default strategy points at variation-B
+			expectedErr: errVariationInUseByDefaultStrategy,
+		},
+		{
+			desc: "error - variation in use by a targeting rule",
+			setupFunc: func() *Feature {
+				f := makeFeature("test-feature")
+				// The individual targeting is checked before the strategies, so clear it.
+				for _, target := range f.Targets {
+					target.Users = nil
+				}
+				return f
+			},
+			variationID: "variation-A", // makeFeature's rule-1 points at variation-A
+			expectedErr: errVariationInUseByTargetingRule,
+		},
+		{
 			desc: "error - minimum variation constraint",
 			setupFunc: func() *Feature {
 				f := makeFeature("test-feature")

--- a/pkg/feature/domain/feature_update_test.go
+++ b/pkg/feature/domain/feature_update_test.go
@@ -2048,7 +2048,7 @@ func TestUpdateRemoveVariationComprehensiveCleanup(t *testing.T) {
 				return makeFeature("test-feature")
 			},
 			variationID: "variation-C", // Has users in target
-			expectedErr: ErrVariationInUse,
+			expectedErr: errVariationInUseByIndividualTarget,
 		},
 		{
 			desc: "error - minimum variation constraint",

--- a/test/e2e/feature/feature_test.go
+++ b/test/e2e/feature/feature_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -1159,6 +1160,118 @@ func TestRemoveVariation(t *testing.T) {
 	if findVariation(targetVariationID, feature.Variations) != nil {
 		t.Fatalf("The wrong variation might has been deleted. Expected: %s actual: %v", targetVariationID, feature.Variations)
 	}
+}
+
+func TestRemoveVariationUsedByPrerequisiteOfOtherFeature(t *testing.T) {
+	t.Parallel()
+	client := newFeatureClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	flagAID := newFeatureID(t)
+	createFeature(t, client, newCreateFeatureReq(flagAID))
+	flagA := getFeature(t, flagAID, client)
+	targetVariationID := flagA.Variations[2].Id
+
+	flagBID := newFeatureID(t)
+	createFeature(t, client, newCreateFeatureReq(flagBID))
+
+	// Flag B requires Flag A to serve the variation we are about to delete.
+	_, err := client.UpdateFeature(ctx, &feature.UpdateFeatureRequest{
+		Id:            flagBID,
+		EnvironmentId: *environmentID,
+		PrerequisiteChanges: []*feature.PrerequisiteChange{
+			{
+				ChangeType: feature.ChangeType_CREATE,
+				Prerequisite: &feature.Prerequisite{
+					FeatureId:   flagAID,
+					VariationId: targetVariationID,
+				},
+			},
+		},
+		Comment: "e2e - flag B depends on flag A",
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateFeature(ctx, &feature.UpdateFeatureRequest{
+		Id:            flagAID,
+		EnvironmentId: *environmentID,
+		VariationChanges: []*feature.VariationChange{
+			{
+				ChangeType: feature.ChangeType_DELETE,
+				Variation:  &feature.Variation{Id: targetVariationID},
+			},
+		},
+		Comment: "e2e - should fail because flag B still references the variation",
+	})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected a gRPC status, got %v", err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+
+	errorInfo := findErrorInfo(t, st)
+	assert.Equal(t, "VARIATION_IN_USE_BY_PREREQUISITE", errorInfo.Reason)
+	assert.Equal(t, "VariationInUseByPrerequisiteError", errorInfo.Metadata["messageKey"])
+	assert.Equal(t, targetVariationID, errorInfo.Metadata["variationId"])
+	assert.Equal(t, flagBID, errorInfo.Metadata["featureId"])
+	assert.NotEmpty(t, errorInfo.Metadata["featureName"])
+
+	// The variation must still be there.
+	assert.NotNil(t, findVariation(targetVariationID, getFeature(t, flagAID, client).Variations))
+}
+
+func TestRemoveVariationUsedByOffVariation(t *testing.T) {
+	t.Parallel()
+	client := newFeatureClient(t)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	featureID := newFeatureID(t)
+	createFeature(t, client, newCreateFeatureReq(featureID))
+	targetVariationID := getFeature(t, featureID, client).Variations[2].Id
+
+	_, err := client.UpdateFeature(ctx, &feature.UpdateFeatureRequest{
+		Id:            featureID,
+		EnvironmentId: *environmentID,
+		OffVariation:  wrapperspb.String(targetVariationID),
+		Comment:       "e2e - set the off variation",
+	})
+	require.NoError(t, err)
+
+	_, err = client.UpdateFeature(ctx, &feature.UpdateFeatureRequest{
+		Id:            featureID,
+		EnvironmentId: *environmentID,
+		VariationChanges: []*feature.VariationChange{
+			{
+				ChangeType: feature.ChangeType_DELETE,
+				Variation:  &feature.Variation{Id: targetVariationID},
+			},
+		},
+		Comment: "e2e - should fail because it is the off variation",
+	})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok, "expected a gRPC status, got %v", err)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+
+	errorInfo := findErrorInfo(t, st)
+	assert.Equal(t, "VARIATION_IN_USE_BY_OFF_VARIATION", errorInfo.Reason)
+	assert.Equal(t, "VariationInUseByOffVariationError", errorInfo.Metadata["messageKey"])
+
+	assert.NotNil(t, findVariation(targetVariationID, getFeature(t, featureID, client).Variations))
+}
+
+func findErrorInfo(t *testing.T, st *status.Status) *errdetails.ErrorInfo {
+	t.Helper()
+	for _, detail := range st.Details() {
+		if errorInfo, ok := detail.(*errdetails.ErrorInfo); ok {
+			return errorInfo
+		}
+	}
+	t.Fatalf("ErrorInfo not found in %v", st.Details())
+	return nil
 }
 
 func TestRemoveVariations(t *testing.T) {

--- a/ui/dashboard/src/@locales/en/backend.json
+++ b/ui/dashboard/src/@locales/en/backend.json
@@ -154,6 +154,12 @@
         "AutoOpsInvalidVariationSize": "Invalid number of variations for feature",
         "AutoOpsWaitingOrRunningExperimentExists": "There is a scheduled or running experiment. Please stop the experiment before creating it",
         "AutoOpsProgressiveRolloutInProgress": "There is a Proressive Rollout in progress. Please stop or delete it before making changes",
+        "VariationInUseByOffVariationError": "This variation cannot be deleted because it is set as the off variation. Change the off variation first.",
+        "VariationInUseByDefaultStrategyError": "This variation cannot be deleted because it is used in the default rule. Change the default rule first.",
+        "VariationInUseByTargetingRuleError": "This variation cannot be deleted because it is used in a targeting rule. Remove it from the rule first.",
+        "VariationInUseByIndividualTargetingError": "This variation cannot be deleted because users are assigned to it in the individual targeting. Remove those users first.",
+        "VariationInUseByPrerequisiteError": "This variation cannot be deleted because the flag \"{{featureName}}\" uses it as a prerequisite. Remove the prerequisite from that flag first.",
+        "VariationInUseByFeatureFlagRuleError": "This variation cannot be deleted because the flag \"{{featureName}}\" uses it in a targeting rule. Remove the rule from that flag first.",
         "StartAtIsAfterEndAt": "Start at must be before end at",
         "PeriodOutOfRange": "The period must be within the last 30 days",
         "ProjectDisabled": "Project is disabled"

--- a/ui/dashboard/src/@locales/ja/backend.json
+++ b/ui/dashboard/src/@locales/ja/backend.json
@@ -180,6 +180,12 @@
         "AutoOpsInvalidVariationSize": "フィーチャーフラグのバリエーションの数が不正です",
         "AutoOpsWaitingOrRunningExperimentExists": "開始予定、もしくは実行中のエクスペリメントが存在します。作成する場合はエクスペリメントを停止してください",
         "AutoOpsProgressiveRolloutInProgress": "実行中のプログレッシブロールアウトがあります。更新する場合はプログレッシブロールアウトを停止もしくは、削除してください",
+        "VariationInUseByOffVariationError": "このバリエーションはオフバリエーションに設定されているため削除できません。先にオフバリエーションを変更してください。",
+        "VariationInUseByDefaultStrategyError": "このバリエーションはデフォルトルールで使用されているため削除できません。先にデフォルトルールを変更してください。",
+        "VariationInUseByTargetingRuleError": "このバリエーションはターゲティングルールで使用されているため削除できません。先にルールから削除してください。",
+        "VariationInUseByIndividualTargetingError": "このバリエーションは個別ターゲティングにユーザーが割り当てられているため削除できません。先に割り当てを解除してください。",
+        "VariationInUseByPrerequisiteError": "このバリエーションはフラグ「{{featureName}}」の前提条件として使用されているため削除できません。先に該当フラグの前提条件を削除してください。",
+        "VariationInUseByFeatureFlagRuleError": "このバリエーションはフラグ「{{featureName}}」のターゲティングルールで使用されているため削除できません。先に該当フラグのルールを削除してください。",
         "StartAtIsAfterEndAt": "開始時間は終了時間以前を指定してください",
         "PeriodOutOfRange": "期間は過去30日以内を選択してください",
         "ProjectDisabled": "プロジェクトが無効化されています"


### PR DESCRIPTION
Fixes #1794

## What this PR does

Splits the single `ErrVariationInUse` sentinel into six cause-specific errors so the console can tell the user *why* a variation cannot be deleted, and adds a server-side log for the rejected update.

## Background / Why this PR is needed

Deleting a variation that is still referenced returned an error that did not explain the cause:

- References inside the flag surfaced as `InvalidArgumentNotMatchFormatError` with field `variation`, rendering as "variation format is invalid".
- References from other flags surfaced as a bare `FailedPreconditionError`, rendering as "The operation failed due to unmet preconditions".

Neither carried the variation or the flag holding the reference, so the user could not tell what to fix. On the server side nothing was logged at all: validation failures returned early without touching the logger, so there was no way to diagnose a rejected update after the fact.

#1795 (merged into #1794) asked for logs that spell out the relationship, e.g. "Variation B of flag A is used as a prerequisite for flag C".

## Points

- **Six error types, one per cause.** `ErrorType` doubles as the frontend message key, so a distinct message per cause needs a distinct type. This follows the existing `DifferentVariationsSizeError` precedent rather than introducing a second mechanism for overriding the message key.

- **Only the cross-flag errors carry embedded values.** `VariationInUseByPrerequisiteError` and `VariationInUseByFeatureFlagRuleError` embed the referencing flag's id and name so the console can name it. The four same-flag causes need no extra data — the user is already looking at that flag.

- **The gRPC code for same-flag references changes from `InvalidArgument` to `FailedPrecondition`**, matching the code cross-flag references already used. All six are now consistent.

- **Error message vs. embedded values serve different readers.** The message spells out the whole relationship for the logs (`variation X of feature A is used as a prerequisite by feature B (name)`); the embedded key values feed the localized console message.

- **E2E coverage is new for the error path.** The existing e2e tests only covered successful deletion.