### PR TITLE
test(api): fix flaky GetEvaluations tests caused by CreatedAt

### DIFF
--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -2360,7 +2360,7 @@ func TestGrpcGetEvaluationsValidation(t *testing.T) {
 			})
 			actual, err := gs.GetEvaluations(ctx, p.input)
 			if p.expected != nil && actual != nil {
-				normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, actual.Evaluations, "%s", p.desc)
+				normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, actual.Evaluations)
 			}
 			assert.Equal(t, p.expected, actual, "%s", p.desc)
 			assert.Equal(t, p.expectedErr, err, "%s", p.desc)
@@ -2413,7 +2413,7 @@ func TestGrpcGetEvaluationsZeroFeature(t *testing.T) {
 			"authorization": []string{"test-key"},
 		})
 		actual, err := gs.GetEvaluations(ctx, p.input)
-		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, actual.Evaluations, "%s", p.desc)
+		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, actual.Evaluations)
 		assert.Equal(t, p.expected, actual, "%s", p.desc)
 		assert.Equal(t, p.expected.State, actual.State, "%s", p.desc)
 		assert.Equal(t, p.expectedErr, err, "%s", p.desc)
@@ -4963,17 +4963,15 @@ func emptyUserEvaluations(t *testing.T) *featureproto.UserEvaluations {
 	}
 }
 
-// normalizeUserEvaluationsCreatedAt asserts CreatedAt is roughly now, then aligns expected so Equal stays stable.
-func normalizeUserEvaluationsCreatedAt(
-	t *testing.T,
-	expected, actual *featureproto.UserEvaluations,
-	msgAndArgs ...interface{},
-) {
+// CreatedAt is stamped by the service while the test runs, so it can differ from the value
+// the expectation was built with and make a plain Equal flaky. Check it only loosely, then
+// align expected with it so the remaining fields are still compared exactly.
+func normalizeUserEvaluationsCreatedAt(t *testing.T, expected, actual *featureproto.UserEvaluations) {
 	t.Helper()
 	if expected == nil || actual == nil {
 		return
 	}
-	assert.InDelta(t, time.Now().Unix(), actual.CreatedAt, 5, msgAndArgs...)
+	assert.InDelta(t, time.Now().Unix(), actual.CreatedAt, 5)
 	expected.CreatedAt = actual.CreatedAt
 }
 

--- a/pkg/api/api/api_grpc_test.go
+++ b/pkg/api/api/api_grpc_test.go
@@ -2359,6 +2359,9 @@ func TestGrpcGetEvaluationsValidation(t *testing.T) {
 				"authorization": []string{"test-key"},
 			})
 			actual, err := gs.GetEvaluations(ctx, p.input)
+			if p.expected != nil && actual != nil {
+				normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, actual.Evaluations, "%s", p.desc)
+			}
 			assert.Equal(t, p.expected, actual, "%s", p.desc)
 			assert.Equal(t, p.expectedErr, err, "%s", p.desc)
 		})
@@ -2410,6 +2413,7 @@ func TestGrpcGetEvaluationsZeroFeature(t *testing.T) {
 			"authorization": []string{"test-key"},
 		})
 		actual, err := gs.GetEvaluations(ctx, p.input)
+		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, actual.Evaluations, "%s", p.desc)
 		assert.Equal(t, p.expected, actual, "%s", p.desc)
 		assert.Equal(t, p.expected.State, actual.State, "%s", p.desc)
 		assert.Equal(t, p.expectedErr, err, "%s", p.desc)
@@ -4957,6 +4961,20 @@ func emptyUserEvaluations(t *testing.T) *featureproto.UserEvaluations {
 		ArchivedFeatureIds: []string{},
 		ForceUpdate:        false,
 	}
+}
+
+// normalizeUserEvaluationsCreatedAt asserts CreatedAt is roughly now, then aligns expected so Equal stays stable.
+func normalizeUserEvaluationsCreatedAt(
+	t *testing.T,
+	expected, actual *featureproto.UserEvaluations,
+	msgAndArgs ...interface{},
+) {
+	t.Helper()
+	if expected == nil || actual == nil {
+		return
+	}
+	assert.InDelta(t, time.Now().Unix(), actual.CreatedAt, 5, msgAndArgs...)
+	expected.CreatedAt = actual.CreatedAt
 }
 
 func TestGrpcListFeatures(t *testing.T) {

--- a/pkg/api/api/api_test.go
+++ b/pkg/api/api/api_test.go
@@ -716,7 +716,7 @@ func TestGetEvaluationsValidation(t *testing.T) {
 		decoded := decodeSuccessResponse(t, actual.Body)
 		err := json.Unmarshal(decoded, &respBody)
 		assert.NoError(t, err)
-		// FIXME: This is a flaky test. CreateAt may not be equal ocasionally.
+		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, respBody.Evaluations, "%s", p.desc)
 		assert.Equal(t, p.expected, &respBody, "%s", p.desc)
 	}
 }
@@ -779,6 +779,7 @@ func TestGetEvaluationsZeroFeature(t *testing.T) {
 		decoded := decodeSuccessResponse(t, actual.Body)
 		err := json.Unmarshal(decoded, &respBody)
 		assert.NoError(t, err)
+		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, respBody.Evaluations, "%s", p.desc)
 		assert.Equal(t, p.expected, &respBody, "%s", p.desc)
 	}
 }

--- a/pkg/api/api/api_test.go
+++ b/pkg/api/api/api_test.go
@@ -716,7 +716,7 @@ func TestGetEvaluationsValidation(t *testing.T) {
 		decoded := decodeSuccessResponse(t, actual.Body)
 		err := json.Unmarshal(decoded, &respBody)
 		assert.NoError(t, err)
-		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, respBody.Evaluations, "%s", p.desc)
+		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, respBody.Evaluations)
 		assert.Equal(t, p.expected, &respBody, "%s", p.desc)
 	}
 }
@@ -779,7 +779,7 @@ func TestGetEvaluationsZeroFeature(t *testing.T) {
 		decoded := decodeSuccessResponse(t, actual.Body)
 		err := json.Unmarshal(decoded, &respBody)
 		assert.NoError(t, err)
-		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, respBody.Evaluations, "%s", p.desc)
+		normalizeUserEvaluationsCreatedAt(t, p.expected.Evaluations, respBody.Evaluations)
 		assert.Equal(t, p.expected, &respBody, "%s", p.desc)
 	}
 }


### PR DESCRIPTION
Fixes #1023

## What this PR does

Removes the flakiness in the `GetEvaluations` tests by asserting `UserEvaluations.CreatedAt` with a time tolerance instead of an exact equality check.

## Background / Why this PR is needed

`UserEvaluations.CreatedAt` is stamped at request time inside the handler, so the hard-coded expectation and the actual value differ whenever the second boundary is crossed between building the expectation and running the request. The tests compared the whole response with `assert.Equal`, so this occasionally failed. `api_test.go` carried a `FIXME: This is a flaky test. CreateAt may not be equal ocasionally.` comment acknowledging the problem without fixing it; that comment is now removed.

## Points

- `normalizeUserEvaluationsCreatedAt` asserts the actual `CreatedAt` is within 5 seconds of `time.Now().Unix()`, then copies it into the expected value so the subsequent `assert.Equal` still verifies every other field. This keeps the field covered rather than ignoring it.
- The 5-second delta is a deliberately loose bound: these are in-process handler calls that finish in milliseconds, so the tolerance only needs to absorb clock-boundary skew and CI scheduling stalls, not real latency.
- Applied to all four affected tests: `TestGrpcGetEvaluationsValidation`, `TestGrpcGetEvaluationsZeroFeature` (gRPC) and `TestGetEvaluationsValidation`, `TestGetEvaluationsZeroFeature` (HTTP).
- The helper is a no-op when either side is nil, so the error-path cases that expect a nil response are unaffected.
- Test-only change: no production code is touched.
- #1023 reports the failure at `pkg/gateway/api/api_grpc_test.go`; that package has since moved to `pkg/api/api/`, and the failing test is the same `TestGrpcGetEvaluationsValidation/success` case fixed here.
