### PR TITLE
fix(ui/dashboard): show discard confirmation when removing user segment values

### DIFF
--- a/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
+++ b/ui/dashboard/src/pages/feature-flag-details/targeting/utils.ts
@@ -1044,7 +1044,8 @@ const diffClauses = (
 
     const isCompare =
       currentClause.operator === FeatureRuleClauseOperator.EQUALS ||
-      currentClause.type === RuleClauseType.COMPARE;
+      currentClause.type === RuleClauseType.COMPARE ||
+      currentClause.type === RuleClauseType.SEGMENT;
 
     const removedValue = preValues.filter(v => !currentValues.includes(v));
     const addValue = currentValues.filter(v => !preValues.includes(v));


### PR DESCRIPTION
### Summary
Fix the "Discard changes" confirmation dialog not appearing when a user-segment clause on a custom targeting rule has its value(s) removed.

The dirty-check correctly showed the discard icon, but clicking it silently discarded the change instead of confirming, because `diffClauses` only recorded a "value removed" diff entry when `isCompare` was true, and `isCompare` did not account for SEGMENT-type clauses.

### Root cause
In `diffClauses`, `isCompare` was computed from `FeatureRuleClauseOperator.EQUALS` and `RuleClauseType.COMPARE` only. Removing all segments from a SEGMENT clause left `isCompare` false, so the `removedValue.length && isCompare` check never fired and no diff entry was produced. With an empty diff, `handleDiscardChanges` took its "nothing to confirm" fast path and discarded the change directly instead of opening `DiscardChangeModal`.

### Fix
Add `RuleClauseType.SEGMENT` to the `isCompare` check so removed values on a segment clause are recognized as a real diff. `getValueLabel` already resolves segment IDs to names for both add/remove cases, so the confirmation dialog renders correctly for segment clauses too.

### Test plan
On a custom targeting rule, add a user-segment clause, save, then remove the selected segment(s) and click "Discard changes" — confirm the popup now appears with the correct removed-segment label.
