### PR TITLE
feat(migration): resolve admin_audit_log organizations in a working table

### DIFF
--- a/migration/mysql/20260907000000_create_audit_log_migration_table.sql
+++ b/migration/mysql/20260907000000_create_audit_log_migration_table.sql
@@ -1,5 +1,8 @@
 -- Resolve the organization for the frozen admin_audit_log history in a working table.
 -- The merge into audit_log is a follow-up migration, after the resolved_by counts are reviewed.
+-- A row can still reach admin_audit_log after this snapshot (the persister keeps a temporary
+-- fallback for events published by producers that predate organization_id); the follow-up
+-- migration delta-copies such late rows and re-runs these rules, which are idempotent.
 -- No-op where admin_audit_log is empty; each UPDATE only touches rows still unresolved (organization_id = '').
 
 CREATE TABLE audit_log_migration LIKE admin_audit_log;
@@ -72,7 +75,10 @@ SET m.organization_id = r.organization_id,
     m.resolved_by     = '6-role-payload';
 
 -- 7. Account rows (entity_type 3, and 9 — some account events were mislabeled PUSH):
--- entity_id is an email; only when it maps to exactly one organization.
+-- entity_id is an email; only when it maps to exactly one organization. account_v2 is
+-- current state and deletion removes rows, so an email that moved organizations can map
+-- uniquely to the wrong one; decline when rows of this log already resolved the same
+-- email to a different organization.
 UPDATE audit_log_migration m
   JOIN (
     SELECT email, MIN(organization_id) AS organization_id
@@ -80,9 +86,15 @@ UPDATE audit_log_migration m
     GROUP BY email
     HAVING COUNT(DISTINCT organization_id) = 1
   ) av ON av.email = m.entity_id
+  LEFT JOIN (
+    SELECT DISTINCT entity_id, organization_id
+    FROM audit_log_migration
+    WHERE organization_id <> ''
+  ) conflict ON conflict.entity_id = m.entity_id AND conflict.organization_id <> av.organization_id
 SET m.organization_id = av.organization_id,
     m.resolved_by     = '7-account'
-WHERE m.organization_id = '' AND m.entity_type IN (3, 9);
+WHERE m.organization_id = '' AND m.entity_type IN (3, 9)
+  AND conflict.entity_id IS NULL;
 
 -- 8. Same email already resolved on another row of this log (unique org only). Must run last.
 UPDATE audit_log_migration m

--- a/migration/mysql/20260907000000_create_audit_log_migration_table.sql
+++ b/migration/mysql/20260907000000_create_audit_log_migration_table.sql
@@ -1,0 +1,98 @@
+-- Resolve the organization for the frozen admin_audit_log history in a working table.
+-- The merge into audit_log is a follow-up migration, after the resolved_by counts are reviewed.
+-- No-op where admin_audit_log is empty; each UPDATE only touches rows still unresolved (organization_id = '').
+
+CREATE TABLE audit_log_migration LIKE admin_audit_log;
+
+ALTER TABLE audit_log_migration
+  ADD COLUMN organization_id varchar(255) NOT NULL DEFAULT '',
+  ADD COLUMN resolved_by varchar(32) NOT NULL DEFAULT '';
+
+INSERT INTO audit_log_migration
+  (id, timestamp, entity_type, entity_id, type, event, editor, options,
+   entity_data, previous_entity_data)
+SELECT id, timestamp, entity_type, entity_id, type, event, editor, options,
+       entity_data, previous_entity_data
+FROM admin_audit_log;
+
+-- 1. Organization in the entity snapshot (JSON_VALID required: entity_data is text, often empty).
+UPDATE audit_log_migration
+SET organization_id = JSON_UNQUOTE(JSON_EXTRACT(entity_data, '$.organization_id')),
+    resolved_by     = '1-entity-data'
+WHERE organization_id = ''
+  AND JSON_VALID(entity_data)
+  AND COALESCE(JSON_UNQUOTE(JSON_EXTRACT(entity_data, '$.organization_id')), '') <> '';
+
+-- 2. Organization in the previous snapshot.
+UPDATE audit_log_migration
+SET organization_id = JSON_UNQUOTE(JSON_EXTRACT(previous_entity_data, '$.organization_id')),
+    resolved_by     = '2-previous-entity-data'
+WHERE organization_id = ''
+  AND JSON_VALID(previous_entity_data)
+  AND COALESCE(JSON_UNQUOTE(JSON_EXTRACT(previous_entity_data, '$.organization_id')), '') <> '';
+
+-- 3. The row is itself an organization (entity_type 15), so entity_id is the organization ID.
+UPDATE audit_log_migration
+SET organization_id = COALESCE(
+      NULLIF(CASE WHEN JSON_VALID(entity_data)
+                  THEN JSON_UNQUOTE(JSON_EXTRACT(entity_data, '$.id')) END, ''),
+      entity_id),
+    resolved_by = '3-organization-row'
+WHERE organization_id = '' AND entity_type = 15;
+
+-- 4. Environment row (entity_type 6): entity_id is an environment ID.
+UPDATE audit_log_migration m
+  JOIN environment_v2 e ON e.id = m.entity_id
+SET m.organization_id = e.organization_id,
+    m.resolved_by     = '4-environment'
+WHERE m.organization_id = '' AND m.entity_type = 6;
+
+-- 5. Project row (entity_type 12): entity_id is a project ID.
+UPDATE audit_log_migration m
+  JOIN project p ON p.id = m.entity_id
+SET m.organization_id = p.organization_id,
+    m.resolved_by     = '5-project'
+WHERE m.organization_id = '' AND m.entity_type = 12;
+
+-- 6. Type 309 (environment roles changed): find environment IDs in the decoded payload.
+-- The 0x0A+length prefix anchors the match to a protobuf string field;
+-- accepted only when all matches agree on one organization.
+UPDATE audit_log_migration m
+  JOIN (
+    SELECT m2.id, MIN(e.organization_id) AS organization_id
+    FROM audit_log_migration m2
+    JOIN environment_v2 e
+      ON LOCATE(CONCAT(UNHEX('0A'), UNHEX(LPAD(HEX(LENGTH(e.id)), 2, '0')), e.id),
+                FROM_BASE64(JSON_UNQUOTE(JSON_EXTRACT(m2.event, '$.value')))) > 0
+    WHERE m2.organization_id = '' AND m2.type = 309
+    GROUP BY m2.id
+    HAVING COUNT(DISTINCT e.organization_id) = 1
+  ) r ON r.id = m.id
+SET m.organization_id = r.organization_id,
+    m.resolved_by     = '6-role-payload';
+
+-- 7. Account rows (entity_type 3, and 9 — some account events were mislabeled PUSH):
+-- entity_id is an email; only when it maps to exactly one organization.
+UPDATE audit_log_migration m
+  JOIN (
+    SELECT email, MIN(organization_id) AS organization_id
+    FROM account_v2
+    GROUP BY email
+    HAVING COUNT(DISTINCT organization_id) = 1
+  ) av ON av.email = m.entity_id
+SET m.organization_id = av.organization_id,
+    m.resolved_by     = '7-account'
+WHERE m.organization_id = '' AND m.entity_type IN (3, 9);
+
+-- 8. Same email already resolved on another row of this log (unique org only). Must run last.
+UPDATE audit_log_migration m
+  JOIN (
+    SELECT entity_id, MIN(organization_id) AS organization_id
+    FROM audit_log_migration
+    WHERE organization_id <> '' AND entity_type IN (3, 9)
+    GROUP BY entity_id
+    HAVING COUNT(DISTINCT organization_id) = 1
+  ) x ON x.entity_id = m.entity_id
+SET m.organization_id = x.organization_id,
+    m.resolved_by     = '8-email-elsewhere'
+WHERE m.organization_id = '' AND m.entity_type IN (3, 9);

--- a/migration/mysql/20260907000000_create_audit_log_migration_table.sql
+++ b/migration/mysql/20260907000000_create_audit_log_migration_table.sql
@@ -1,9 +1,19 @@
+-- atlas:txmode none
+
 -- Resolve the organization for the frozen admin_audit_log history in a working table.
+--
+-- txmode none: every statement commits on its own, so shared locks taken on
+-- admin_audit_log (INSERT ... SELECT) and on the lookup tables (rules 4-7) are held per
+-- statement instead of for the whole file. Safe because the file only builds a working
+-- table: on any failure it can simply be re-applied — DROP + re-create rebuilds it from
+-- scratch, and the rules re-resolve everything.
 -- The merge into audit_log is a follow-up migration, after the resolved_by counts are reviewed.
 -- A row can still reach admin_audit_log after this snapshot (the persister keeps a temporary
 -- fallback for events published by producers that predate organization_id); the follow-up
 -- migration delta-copies such late rows and re-runs these rules, which are idempotent.
 -- No-op where admin_audit_log is empty; each UPDATE only touches rows still unresolved (organization_id = '').
+
+DROP TABLE IF EXISTS audit_log_migration;
 
 CREATE TABLE audit_log_migration LIKE admin_audit_log;
 

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:iMAYnvjxNjUeHphsWuweS3oXEZSGOU+I/mTU+On1nxM=
+h1:yXlIp0ioFZke+HNnNsTLseF6zdFQF84ep4CTnVI9IUQ=
 20240626022133_initialization.sql h1:reSmqMhqnsrdIdPU2ezv/PXSL0COlRFX4gQA4U3/wMo=
 20240708065726_update_audit_log_table.sql h1:fi8Xxw4WfSlHDyvq2Ni/8JUiZW8z/0qWWyWm6jFdUy8=
 20240815043128_update_auto_ops_rule_table.sql h1:IKSW9W/XO6SWAYl5WPLJSg6KdsfcZ3rfQhIrf7aOnYc=
@@ -44,4 +44,4 @@ h1:iMAYnvjxNjUeHphsWuweS3oXEZSGOU+I/mTU+On1nxM=
 20260713000000_create_notification_tables.sql h1:87SKJUcoNMMv48953z5QyaS9c/AxzJamnf+SZ6/SMJU=
 20260728000000_add_notification_deleted.sql h1:yky/5yXtjVf4Vl9si/FJ5ODUSPzjC1NfUsyfLCTh97I=
 20260826000000_add_audit_log_organization_id.sql h1:rgjKMBWwGhPyBpm7UrSaQMNjW+YuMWpqD3ELK9rZaWo=
-20260907000000_create_audit_log_migration_table.sql h1:6I/z9wuYYole0hroW7gBLLkgFx7t0yEjo2+J1TIc/8s=
+20260907000000_create_audit_log_migration_table.sql h1:8MxUlYgVsHjv3k36D3tx4ktXdRzOA0xniXV9ah0aWZs=

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:sS2p63rku0jPZajD6/sreQgblM6HPitbdC5vlWn+gNE=
+h1:iMAYnvjxNjUeHphsWuweS3oXEZSGOU+I/mTU+On1nxM=
 20240626022133_initialization.sql h1:reSmqMhqnsrdIdPU2ezv/PXSL0COlRFX4gQA4U3/wMo=
 20240708065726_update_audit_log_table.sql h1:fi8Xxw4WfSlHDyvq2Ni/8JUiZW8z/0qWWyWm6jFdUy8=
 20240815043128_update_auto_ops_rule_table.sql h1:IKSW9W/XO6SWAYl5WPLJSg6KdsfcZ3rfQhIrf7aOnYc=
@@ -44,3 +44,4 @@ h1:sS2p63rku0jPZajD6/sreQgblM6HPitbdC5vlWn+gNE=
 20260713000000_create_notification_tables.sql h1:87SKJUcoNMMv48953z5QyaS9c/AxzJamnf+SZ6/SMJU=
 20260728000000_add_notification_deleted.sql h1:yky/5yXtjVf4Vl9si/FJ5ODUSPzjC1NfUsyfLCTh97I=
 20260826000000_add_audit_log_organization_id.sql h1:rgjKMBWwGhPyBpm7UrSaQMNjW+YuMWpqD3ELK9rZaWo=
+20260907000000_create_audit_log_migration_table.sql h1:6I/z9wuYYole0hroW7gBLLkgFx7t0yEjo2+J1TIc/8s=

--- a/migration/mysql/atlas.sum
+++ b/migration/mysql/atlas.sum
@@ -1,4 +1,4 @@
-h1:yXlIp0ioFZke+HNnNsTLseF6zdFQF84ep4CTnVI9IUQ=
+h1:tTTey3gnWNWe7OqCS2ju8G/KD7BqBy5E0/nS3WLN3Fo=
 20240626022133_initialization.sql h1:reSmqMhqnsrdIdPU2ezv/PXSL0COlRFX4gQA4U3/wMo=
 20240708065726_update_audit_log_table.sql h1:fi8Xxw4WfSlHDyvq2Ni/8JUiZW8z/0qWWyWm6jFdUy8=
 20240815043128_update_auto_ops_rule_table.sql h1:IKSW9W/XO6SWAYl5WPLJSg6KdsfcZ3rfQhIrf7aOnYc=
@@ -44,4 +44,4 @@ h1:yXlIp0ioFZke+HNnNsTLseF6zdFQF84ep4CTnVI9IUQ=
 20260713000000_create_notification_tables.sql h1:87SKJUcoNMMv48953z5QyaS9c/AxzJamnf+SZ6/SMJU=
 20260728000000_add_notification_deleted.sql h1:yky/5yXtjVf4Vl9si/FJ5ODUSPzjC1NfUsyfLCTh97I=
 20260826000000_add_audit_log_organization_id.sql h1:rgjKMBWwGhPyBpm7UrSaQMNjW+YuMWpqD3ELK9rZaWo=
-20260907000000_create_audit_log_migration_table.sql h1:8MxUlYgVsHjv3k36D3tx4ktXdRzOA0xniXV9ah0aWZs=
+20260907000000_create_audit_log_migration_table.sql h1:tkvhFUhcB9ci19/0TAmKO+gVWtlCA885kHueqkfFK1E=


### PR DESCRIPTION
Part of #1982, Follows #2791

## What this PR does

Copies the frozen `admin_audit_log` into a new `audit_log_migration` working table and fills in each row's `organization_id` using eight ordered UPDATE rules. Each row also records which rule resolved it (`resolved_by`). Nothing is merged into `audit_log` yet — that's a follow-up PR, after the counts are reviewed.

## Background

Since #2791, organization-level events are written to `audit_log` scoped by `organization_id`, and `admin_audit_log` is frozen. Its history must move to `audit_log` too, but those old rows never recorded an organization — it has to be worked out from what each row does contain. This PR does that resolution in a working table so the result can be reviewed per installation before anything touches `audit_log`.

How each rule finds the organization:

| # | rows it targets | where the organization comes from |
|---|---|---|
| 1 | any | `organization_id` in the `entity_data` snapshot |
| 2 | any | same, in `previous_entity_data` |
| 3 | organizations | the row is the organization, so `entity_id` is the ID |
| 4 | environments | `entity_id` → `environment_v2` |
| 5 | projects | `entity_id` → `project` |
| 6 | env-role changes | environment IDs found in the decoded event payload |
| 7 | accounts | `entity_id` is an email → `account_v2` |
| 8 | accounts | same email already resolved on another row of this log |

## Points

- **Rules never guess.** Each reads an exact identifier or declines: 7 and 8 only accept an email that maps to exactly one organization, and 6 only accepts a payload whose matches all agree. A wrong organization would put one tenant's row in another tenant's audit log, so unresolved is always better than wrong.
- **Order matters, and every UPDATE filters on `organization_id = ''`** — each rule only sees what the earlier ones left, so the per-rule row counts in `resolved_by` double as the review report. Rule 8 reads the working table itself, so it must run last.
- **Rule 6 is the unusual one**: it base64-decodes the protobuf event payload in SQL and searches for environment IDs anchored by the `0x0A` field tag + length byte. The anchor is required — unanchored, a short environment ID like `dev` matches inside a longer one and resolves to the wrong organization.
- **Safe everywhere**: the file is a no-op on installations with an empty `admin_audit_log` (new/self-hosted installs just get an empty working table, dropped in a later migration), it never modifies `admin_audit_log` or any other table, and no organization ID is hardcoded.
- Rows that stay unresolved are expected: system-level entities (`ADMIN_ACCOUNT`, `ADMIN_SUBSCRIPTION`) legitimately have no organization.